### PR TITLE
修复：人设卡生成界面的文本误导和抽屉交互问题

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/PersonaCardGenerationScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/PersonaCardGenerationScreen.kt
@@ -1,6 +1,7 @@
 package com.ai.assistance.operit.ui.features.settings.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -449,13 +450,33 @@ fun PersonaCardGenerationScreen(
     ModalNavigationDrawer(
         drawerState = drawerState,
         drawerContent = {
-            ModalDrawerSheet {
+            ModalDrawerSheet(windowInsets = WindowInsets(0, 0, 0, 0)) {
                 Column(
                     modifier = Modifier
                         .fillMaxHeight()
                         .verticalScroll(rememberScrollState())
                         .padding(16.dp)
                 ) {
+                    // 关闭按钮
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(48.dp)
+                                .clickable { scope.launch { drawerState.close() } }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = "关闭",
+                                modifier = Modifier.align(Alignment.CenterEnd)
+                            )
+                        }
+                    }
+
                     Text("角色卡配置", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
                     Spacer(Modifier.height(12.dp))
 
@@ -733,7 +754,7 @@ fun PersonaCardGenerationScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "角色卡生成助手", 
+                    text = "将修改的角色卡", 
                     style = MaterialTheme.typography.titleMedium, 
                     fontWeight = FontWeight.Bold
                 )


### PR DESCRIPTION
1. `角色卡生成助手`右侧显示的助手，实际上是将要修改的助手，而不是用于生成角色卡的助手，修改了可能引起误解的文本
2. 点击角色卡后，打开的抽屉需要左滑退出，如果点击返回键或左上角的返回，会退出到设置界面，导致丢失人设卡生成的对话记录。这里添加了关闭抽屉的按钮以避免这种情况