### PR TITLE
feat: 初步Tasker支持，添加可供助手触发的event

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -147,6 +147,16 @@
             android:process=":crash"
             android:theme="@style/Theme.Operit" />
         
+        <activity
+            android:name=".integrations.tasker.ActivityConfigAIAgentAction"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="AI Agent Action">
+            <intent-filter>
+                <action android:name="net.dinglisch.android.tasker.ACTION_EDIT_EVENT" />
+            </intent-filter>
+        </activity>
+        
         <!-- Floating Chat Service -->
         <service
             android:name=".services.FloatingChatService"

--- a/app/src/main/assets/packages/tasker.js
+++ b/app/src/main/assets/packages/tasker.js
@@ -1,0 +1,52 @@
+/* METADATA
+{
+  "name": "tasker",
+  "description": "集成 Tasker 插件事件触发工具，通过本包可向 Tasker 发送事件。",
+  "enabledByDefault": true,
+  "tools": [
+    {
+      "name": "trigger_tasker_event",
+      "description": "触发一个 Tasker 事件。使用 task_type 指定事件类型，可传 arg1..arg5 或 args_json。",
+      "parameters": [
+        { "name": "task_type", "description": "事件类型标识", "type": "string", "required": true },
+        { "name": "arg1", "description": "可选参数1", "type": "string", "required": false },
+        { "name": "arg2", "description": "可选参数2", "type": "string", "required": false },
+        { "name": "arg3", "description": "可选参数3", "type": "string", "required": false },
+        { "name": "arg4", "description": "可选参数4", "type": "string", "required": false },
+        { "name": "arg5", "description": "可选参数5", "type": "string", "required": false },
+        { "name": "args_json", "description": "以JSON形式传递任意键值对（若提供则优先生效）", "type": "string", "required": false }
+      ]
+    }
+  ],
+  "category": "SYSTEM_OPERATION"
+}
+*/
+
+const TaskerIntegration = (function () {
+    async function trigger_tasker_event(params) {
+        // 直接调用已注册的原生工具 trigger_tasker_event
+        // toolCall 返回结构化结果的 data 部分
+        const data = await toolCall("trigger_tasker_event", params || {});
+        return {
+            success: true,
+            message: "Tasker 事件已触发",
+            data
+        };
+    }
+
+    async function wrapToolExecution(func, params) {
+        try {
+            const result = await func(params || {});
+            complete(result);
+        } catch (error) {
+            console.error(`Tool ${func.name} failed unexpectedly`, error);
+            complete({ success: false, message: String(error && error.message ? error.message : error) });
+        }
+    }
+
+    return {
+        trigger_tasker_event: (params) => wrapToolExecution(trigger_tasker_event, params)
+    };
+})();
+
+exports.trigger_tasker_event = TaskerIntegration.trigger_tasker_event;

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/ToolRegistration.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/ToolRegistration.kt
@@ -12,6 +12,7 @@ import org.json.JSONArray
 import com.ai.assistance.operit.api.chat.EnhancedAIService
 import com.google.gson.Gson
 import kotlinx.coroutines.flow.map
+import com.ai.assistance.operit.integrations.tasker.triggerAIAgentAction
 
 /**
  * This file contains all tool registrations centralized for easier maintenance and integration It
@@ -304,6 +305,48 @@ fun registerAllTools(handler: AIToolHandler, context: Context) {
             executor = { tool ->
                 val deviceInfoTool = ToolGetter.getDeviceInfoToolExecutor(context)
                 deviceInfoTool.invoke(tool)
+            }
+    )
+
+    handler.registerTool(
+            name = "trigger_tasker_event",
+            category = ToolCategory.SYSTEM_OPERATION,
+            descriptionGenerator = { tool ->
+                val taskType = tool.parameters.find { it.name == "task_type" }?.value ?: ""
+                val arg1 = tool.parameters.find { it.name == "arg1" }?.value
+                if (!arg1.isNullOrBlank()) "触发Tasker事件: $taskType ($arg1)" else "触发Tasker事件: $taskType"
+            },
+            executor = { tool ->
+                val params = tool.parameters.associate { it.name to it.value }
+                val taskType = params["task_type"]
+                if (taskType.isNullOrBlank()) {
+                    ToolResult(
+                        toolName = tool.name,
+                        success = false,
+                        result = StringResultData(""),
+                        error = "缺少必需参数: task_type"
+                    )
+                } else {
+                    val args = params.filterKeys { it != "task_type" }
+                    try {
+                        context.triggerAIAgentAction(
+                            taskType,
+                            args
+                        )
+                        ToolResult(
+                            toolName = tool.name,
+                            success = true,
+                            result = StringResultData("Triggered Tasker event: $taskType")
+                        )
+                    } catch (e: Exception) {
+                        ToolResult(
+                            toolName = tool.name,
+                            success = false,
+                            result = StringResultData(""),
+                            error = "Failed to trigger Tasker event: ${e.message}"
+                        )
+                    }
+                }
             }
     )
 

--- a/app/src/main/java/com/ai/assistance/operit/integrations/tasker/AIAgentTasker.kt
+++ b/app/src/main/java/com/ai/assistance/operit/integrations/tasker/AIAgentTasker.kt
@@ -1,0 +1,120 @@
+package com.ai.assistance.operit.integrations.tasker
+
+import android.app.Activity
+import android.content.Context
+import android.os.Bundle
+import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfig
+import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfigHelperConditionNoInput
+import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfigNoInput
+import com.joaomgcd.taskerpluginlibrary.extensions.requestQuery
+import com.joaomgcd.taskerpluginlibrary.input.TaskerInput
+import com.joaomgcd.taskerpluginlibrary.input.TaskerInputField
+import com.joaomgcd.taskerpluginlibrary.input.TaskerInputRoot
+import com.joaomgcd.taskerpluginlibrary.condition.TaskerPluginRunnerConditionNoInput
+import com.joaomgcd.taskerpluginlibrary.output.TaskerOutputObject
+import com.joaomgcd.taskerpluginlibrary.output.TaskerOutputVariable
+import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultCondition
+import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultConditionSatisfied
+
+@TaskerInputRoot
+class AIAgentActionUpdate @JvmOverloads constructor(
+    @field:TaskerInputField("task_type")
+    var taskType: String? = null,
+
+    @field:TaskerInputField("arg1")
+    var arg1: String? = null,
+
+    @field:TaskerInputField("arg2")
+    var arg2: String? = null,
+
+    @field:TaskerInputField("arg3")
+    var arg3: String? = null,
+
+    @field:TaskerInputField("arg4")
+    var arg4: String? = null,
+
+    @field:TaskerInputField("arg5")
+    var arg5: String? = null,
+
+    @field:TaskerInputField("args_json")
+    var argsJson: String? = null
+)
+
+@TaskerOutputObject
+class AIAgentActionOutput(
+    private val taskType: String?,
+    private val arg1: String?,
+    private val arg2: String?,
+    private val arg3: String?,
+    private val arg4: String?,
+    private val arg5: String?,
+    private val argsJson: String?
+) {
+    @get:TaskerOutputVariable("task_type")
+    val outTaskType get() = taskType ?: ""
+    @get:TaskerOutputVariable("arg1")
+    val outArg1 get() = arg1 ?: ""
+    @get:TaskerOutputVariable("arg2")
+    val outArg2 get() = arg2 ?: ""
+    @get:TaskerOutputVariable("arg3")
+    val outArg3 get() = arg3 ?: ""
+    @get:TaskerOutputVariable("arg4")
+    val outArg4 get() = arg4 ?: ""
+    @get:TaskerOutputVariable("arg5")
+    val outArg5 get() = arg5 ?: ""
+    @get:TaskerOutputVariable("args_json")
+    val outArgsJson get() = argsJson ?: ""
+}
+
+class AIAgentActionEventRunner :
+    TaskerPluginRunnerConditionNoInput<AIAgentActionOutput, AIAgentActionUpdate>() {
+    override val isEvent: Boolean get() = true
+    override fun getSatisfiedCondition(
+        context: Context,
+        input: TaskerInput<Unit>,
+        update: AIAgentActionUpdate?
+    ): TaskerPluginResultCondition<AIAgentActionOutput> {
+        val u = update ?: AIAgentActionUpdate()
+        val output = AIAgentActionOutput(
+            u.taskType,
+            u.arg1,
+            u.arg2,
+            u.arg3,
+            u.arg4,
+            u.arg5,
+            u.argsJson
+        )
+        return TaskerPluginResultConditionSatisfied(context, output)
+    }
+}
+
+class AIAgentActionHelper(config: TaskerPluginConfig<Unit>) :
+    TaskerPluginConfigHelperConditionNoInput<AIAgentActionOutput, AIAgentActionUpdate, AIAgentActionEventRunner>(config) {
+    override val runnerClass = AIAgentActionEventRunner::class.java
+    override val outputClass = AIAgentActionOutput::class.java
+    override fun addToStringBlurb(input: TaskerInput<Unit>, blurbBuilder: StringBuilder) {
+        blurbBuilder.append("AI Agent Action Event")
+    }
+}
+
+class ActivityConfigAIAgentAction : Activity(), TaskerPluginConfigNoInput {
+    override val context get() = applicationContext
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        AIAgentActionHelper(this).finishForTasker()
+    }
+}
+
+fun Context.triggerAIAgentAction(taskType: String, args: Map<String, String?> = emptyMap()) {
+    val update = AIAgentActionUpdate(
+        taskType = taskType,
+        arg1 = args["arg1"],
+        arg2 = args["arg2"],
+        arg3 = args["arg3"],
+        arg4 = args["arg4"],
+        arg5 = args["arg5"],
+        argsJson = try { com.google.gson.Gson().toJson(args) } catch (_: Exception) { null }
+    )
+    ActivityConfigAIAgentAction::class.java.requestQuery(this, update)
+}


### PR DESCRIPTION
事件触发后，Tasker 可访问以下变量：
```
%task_type - 事件类型标识（必填）
%arg1 - 可选参数 1
%arg2 - 可选参数 2
%arg3 - 可选参数 3
%arg4 - 可选参数 4
%arg5 - 可选参数 5
%args_json - JSON 格式的参数对象（复杂场景，可选）
```

`com.ai.assistance.operit.core.tools`的`registerAllTools`中注册了`trigger_tasker_event`工具，并在`app\src\main\assets\packages\tasker.js`添加了调用该工具的tasker包