### PR TITLE
feat: 自定义模型参数支持JSON object/array类型

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
@@ -274,6 +274,24 @@ class ClaudeProvider(
                                     jsonObject.put(param.apiName, param.currentValue as String)
                             com.ai.assistance.operit.data.model.ParameterValueType.BOOLEAN ->
                                     jsonObject.put(param.apiName, param.currentValue as Boolean)
+                            com.ai.assistance.operit.data.model.ParameterValueType.OBJECT -> {
+                                val raw = param.currentValue.toString().trim()
+                                val parsed: Any? = try {
+                                    when {
+                                        raw.startsWith("{") -> JSONObject(raw)
+                                        raw.startsWith("[") -> JSONArray(raw)
+                                        else -> null
+                                    }
+                                } catch (e: Exception) {
+                                    Log.w("AIService", "Claude OBJECT参数解析失败: ${param.apiName}", e)
+                                    null
+                                }
+                                if (parsed != null) {
+                                    jsonObject.put(param.apiName, parsed)
+                                } else {
+                                    jsonObject.put(param.apiName, raw)
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -172,6 +172,25 @@ open class OpenAIProvider(
                             jsonObject.put(param.apiName, param.currentValue as String)
                     com.ai.assistance.operit.data.model.ParameterValueType.BOOLEAN ->
                             jsonObject.put(param.apiName, param.currentValue as Boolean)
+                    com.ai.assistance.operit.data.model.ParameterValueType.OBJECT -> {
+                        val raw = param.currentValue.toString().trim()
+                        val parsed: Any? = try {
+                            when {
+                                raw.startsWith("{") -> JSONObject(raw)
+                                raw.startsWith("[") -> JSONArray(raw)
+                                else -> null
+                            }
+                        } catch (e: Exception) {
+                            Log.w("AIService", "OBJECT参数解析失败: ${param.apiName}", e)
+                            null
+                        }
+                        if (parsed != null) {
+                            jsonObject.put(param.apiName, parsed)
+                        } else {
+                            // 解析失败则按字符串传递，避免崩溃
+                            jsonObject.put(param.apiName, raw)
+                        }
+                    }
                 }
                 Log.d("AIService", "添加参数 ${param.apiName} = ${param.currentValue}")
             }

--- a/app/src/main/java/com/ai/assistance/operit/data/model/ModelParameter.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/model/ModelParameter.kt
@@ -23,7 +23,8 @@ enum class ParameterValueType {
     INT,
     FLOAT,
     STRING,
-    BOOLEAN
+    BOOLEAN,
+    OBJECT
 }
 
 /** 参数分类枚举 */

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
@@ -488,6 +488,19 @@ class ModelConfigManager(private val context: Context) {
                                                 category = category,
                                                 isCustom = true
                                         )
+                                ParameterValueType.OBJECT ->
+                                        ModelParameter(
+                                                id = data.id,
+                                                name = data.name,
+                                                apiName = data.apiName,
+                                                description = data.description,
+                                                defaultValue = data.defaultValue,
+                                                currentValue = data.currentValue,
+                                                isEnabled = data.isEnabled,
+                                                valueType = valueType,
+                                                category = category,
+                                                isCustom = true
+                                        )
                             }
                     parameters.add(convertedParam)
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2506,6 +2506,7 @@
     <string name="value">值</string>
     <string name="range_format">范围: %1$s - %2$s</string>
     <string name="must_be_float">必须是浮点数</string>
+    <string name="must_be_valid_json">必须是有效的 JSON</string>
     <string name="default_value_format">默认值: %s</string>
     <string name="temperature_recommendation">温度推荐设置</string>
     <string name="parameter_value">参数值</string>
@@ -2545,6 +2546,7 @@
     <string name="value_type_float">小数</string>
     <string name="value_type_string">文本</string>
     <string name="value_type_boolean">布尔值</string>
+    <string name="value_type_object">对象(JSON)</string>
     <string name="other_parameters">其他参数</string>
     <string name="parameter_type">参数类型</string>
 


### PR DESCRIPTION
注意，更新了Gemini的Provider，在参数类别为“其他”时，会将参数放入请求体json的根部。

这个更新是为了解决“无法在Gemini上启用其内置的谷歌搜索和代码执行等工具”的问题，见：<https://ai.google.dev/gemini-api/docs/google-search> 为使模型能够使用这些工具，需要添加array类型的tools参数。

![d9ff483ab3bc11454041cc4d09b6cf06](https://github.com/user-attachments/assets/5d7747ac-a2d2-4d40-836a-31510f04d245)
