### PR TITLE
feat: add context_limiter_c and debug_msg_dump toolpkg examples

### DIFF
--- a/examples/context_limiter_c/main.js
+++ b/examples/context_limiter_c/main.js
@@ -1,0 +1,168 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.registerToolPkg = registerToolPkg;
+exports.onFinalize = onFinalize;
+exports.onInputMenuToggle = onInputMenuToggle;
+
+// 楼层限制数（与子包共享，通过全局变量）
+var floorLimit = 5;
+var limiterEnabled = true;
+
+// 可选的楼层数循环列表
+var FLOOR_OPTIONS = [3, 5, 8, 10, 15, 20, 30, 50, 100];
+
+// 暴露给子包访问
+if (typeof globalThis !== "undefined") {
+    globalThis.__ctx_limiter_c_getLimit = function() { return floorLimit; };
+    globalThis.__ctx_limiter_c_setLimit = function(n) { floorLimit = n; };
+    globalThis.__ctx_limiter_c_getEnabled = function() { return limiterEnabled; };
+    globalThis.__ctx_limiter_c_setEnabled = function(v) { limiterEnabled = v; };
+}
+
+function registerToolPkg() {
+    // 注册 before_finalize_prompt hook
+    ToolPkg.registerPromptFinalizeHook({
+        id: "ctx_limiter_c_finalize",
+        function: onFinalize,
+    });
+
+    // 注册菜单开关
+    ToolPkg.registerInputMenuTogglePlugin({
+        id: "ctx_limiter_c_menu",
+        function: onInputMenuToggle,
+    });
+
+    return true;
+}
+
+function onInputMenuToggle(event) {
+    var payload = event.eventPayload || {};
+    var action = payload.action;
+
+    if (action === "create") {
+        // 创建菜单项
+        return {
+            toggles: [
+                {
+                    id: "ctx_limiter_toggle",
+                    title: "楼层限制器",
+                    description: limiterEnabled
+                        ? "已开启 · 保留最近 " + floorLimit + " 层"
+                        : "已关闭",
+                    isChecked: limiterEnabled
+                },
+                {
+                    id: "ctx_limiter_adjust",
+                    title: "调节楼层数 ▶ " + floorLimit,
+                    description: "点击切换: " + FLOOR_OPTIONS.join("/"),
+                    isChecked: true
+                }
+            ]
+        };
+    }
+
+    if (action === "toggle") {
+        var toggleId = payload.toggleId;
+
+        if (toggleId === "ctx_limiter_toggle") {
+            // 开关限制器
+            limiterEnabled = !limiterEnabled;
+            if (typeof globalThis !== "undefined" && typeof globalThis.__ctx_limiter_c_setEnabled === "function") {
+                globalThis.__ctx_limiter_c_setEnabled(limiterEnabled);
+            }
+            return { ok: true };
+        }
+
+        if (toggleId === "ctx_limiter_adjust") {
+            // 循环切换楼层数
+            var currentIdx = FLOOR_OPTIONS.indexOf(floorLimit);
+            var nextIdx = (currentIdx + 1) % FLOOR_OPTIONS.length;
+            floorLimit = FLOOR_OPTIONS[nextIdx];
+            if (typeof globalThis !== "undefined" && typeof globalThis.__ctx_limiter_c_setLimit === "function") {
+                globalThis.__ctx_limiter_c_setLimit(floorLimit);
+            }
+            return { ok: true };
+        }
+    }
+
+    return { ok: false };
+}
+
+function onFinalize(input) {
+    var payload = input.eventPayload || {};
+    var history = payload.preparedHistory || payload.chatHistory || [];
+
+    if (!history || history.length === 0) return null;
+
+    // 读取最新状态（可能被子包工具或菜单修改过）
+    if (typeof globalThis !== "undefined") {
+        if (typeof globalThis.__ctx_limiter_c_getLimit === "function") {
+            floorLimit = globalThis.__ctx_limiter_c_getLimit();
+        }
+        if (typeof globalThis.__ctx_limiter_c_getEnabled === "function") {
+            limiterEnabled = globalThis.__ctx_limiter_c_getEnabled();
+        }
+    }
+
+    // 如果限制器被关闭，不做任何处理
+    if (!limiterEnabled) {
+        console.log("[limiter_c] disabled, pass through " + history.length + " msgs");
+        return null;
+    }
+
+    // 1. 分离 SYSTEM 消息和 非SYSTEM 消息
+    var systemMsgs = [];
+    var chatMsgs = [];
+    for (var i = 0; i < history.length; i++) {
+        if (history[i].kind === "SYSTEM") {
+            systemMsgs.push(history[i]);
+        } else {
+            chatMsgs.push(history[i]);
+        }
+    }
+
+    // 2. 只保留 USER 和 ASSISTANT 消息
+    var uaMsgs = [];
+    for (var i = 0; i < chatMsgs.length; i++) {
+        var kind = chatMsgs[i].kind;
+        if (kind === "USER" || kind === "ASSISTANT") {
+            uaMsgs.push(chatMsgs[i]);
+        }
+    }
+
+    // 3. 计算 USER 消息数（= 楼层数）
+    var userCount = 0;
+    for (var i = 0; i < uaMsgs.length; i++) {
+        if (uaMsgs[i].kind === "USER") userCount++;
+    }
+
+    // 4. 如果楼层数不超过限制，不裁剪，但仍然只保留 SYSTEM + USER + ASSISTANT
+    if (userCount <= floorLimit) {
+        var result = systemMsgs.concat(uaMsgs);
+        console.log("[limiter_c] " + userCount + " floors <= limit " + floorLimit + ", no trim, msgs: " + history.length + " -> " + result.length);
+        return { preparedHistory: result };
+    }
+
+    // 5. 从后往前找到第 N 个 USER 消息的位置
+    var keepFromIndex = 0;
+    var countFromEnd = 0;
+    for (var i = uaMsgs.length - 1; i >= 0; i--) {
+        if (uaMsgs[i].kind === "USER") {
+            countFromEnd++;
+            if (countFromEnd === floorLimit) {
+                keepFromIndex = i;
+                break;
+            }
+        }
+    }
+
+    // 6. 截取最近 N 层
+    var keptMsgs = uaMsgs.slice(keepFromIndex);
+
+    // 7. 组合：SYSTEM 在前 + 截取的 USER/ASSISTANT 在后
+    var finalMsgs = systemMsgs.concat(keptMsgs);
+
+    console.log("[limiter_c] floors: " + userCount + ", limit: " + floorLimit + ", msgs: " + history.length + " -> " + finalMsgs.length + " (" + systemMsgs.length + " sys + " + keptMsgs.length + " chat)");
+
+    return { preparedHistory: finalMsgs };
+}

--- a/examples/context_limiter_c/manifest.json
+++ b/examples/context_limiter_c/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "toolpkg_id": "com.operit.context_limiter_c",
+  "version": "1.0.0",
+  "main": "main.js",
+  "display_name": "楼层限制器 C",
+  "description": "截取最近N层上下文，保留SYSTEM+最近N层USER/ASSISTANT。通过工具调节N。",
+  "subpackages": [
+    {
+      "id": "ctx_limiter_c",
+      "entry": "packages/ctx_limiter_c.js",
+      "enabled_by_default": true,
+      "display_name": "楼层限制器 C",
+      "description": "截取最近N层上下文"
+    }
+  ]
+}

--- a/examples/context_limiter_c/packages/ctx_limiter_c.js
+++ b/examples/context_limiter_c/packages/ctx_limiter_c.js
@@ -1,0 +1,48 @@
+/* METADATA
+{
+    "name": "ctx_limiter_c",
+    "description": "截取最近N层上下文，保留SYSTEM消息+最近N层USER/ASSISTANT",
+    "tools": [
+        {
+            "name": "set_floor_limit",
+            "description": "设置保留的最近楼层数",
+            "parameters": [
+                {
+                    "name": "n",
+                    "description": "保留最近N个楼层（默认5）",
+                    "type": "number",
+                    "required": true
+                }
+            ]
+        },
+        {
+            "name": "get_floor_limit",
+            "description": "查看当前楼层数限制",
+            "parameters": []
+        }
+    ]
+}
+*/
+
+function set_floor_limit(params) {
+    var n = parseInt(params.n);
+    if (isNaN(n) || n < 1) {
+        complete({ success: false, error: "n 必须是大于0的整数" });
+        return;
+    }
+    if (typeof globalThis !== "undefined" && typeof globalThis.__ctx_limiter_c_setLimit === "function") {
+        globalThis.__ctx_limiter_c_setLimit(n);
+    }
+    complete({ success: true, floor_limit: n, message: "已设置保留最近 " + n + " 个楼层" });
+}
+
+function get_floor_limit(params) {
+    var current = 5;
+    if (typeof globalThis !== "undefined" && typeof globalThis.__ctx_limiter_c_getLimit === "function") {
+        current = globalThis.__ctx_limiter_c_getLimit();
+    }
+    complete({ success: true, floor_limit: current, message: "当前保留最近 " + current + " 个楼层" });
+}
+
+exports.set_floor_limit = set_floor_limit;
+exports.get_floor_limit = get_floor_limit;

--- a/examples/debug_msg_dump/debug_msg_dump.js
+++ b/examples/debug_msg_dump/debug_msg_dump.js
@@ -1,0 +1,112 @@
+/*
+METADATA
+{
+    "name": "DebugMessageDump",
+    "description": {
+        "zh": "调试工具：转储当前对话的所有消息到文件，用于检查 AI 实际收到了什么",
+        "en": "Debug tool: dump all messages in current chat to a file"
+    },
+    "tools": [
+        {
+            "name": "dump_current_chat",
+            "description": {
+                "zh": "将当前对话的所有消息保存到文件，方便查看 AI 收到了什么内容",
+                "en": "Save all messages in current chat to a file for inspection"
+            },
+            "parameters": [
+                {
+                    "name": "limit",
+                    "description": {
+                        "zh": "最多读取多少条消息，默认100",
+                        "en": "Max messages to read, default 100"
+                    },
+                    "type": "number",
+                    "required": false
+                }
+            ]
+        }
+    ]
+}
+*/
+
+const DebugMessageDump = (function () {
+    async function wrap(func, params) {
+        try {
+            const result = await func(params);
+            complete(result);
+        } catch (error) {
+            complete({ success: false, message: "Error: " + error.message });
+        }
+    }
+
+    async function dump_current_chat(params) {
+        const limit = params.limit || 100;
+        
+        // 获取当前对话列表，找到当前对话
+        const chatList = await Tools.Chat.listAll();
+        if (!chatList || !chatList.chats || chatList.chats.length === 0) {
+            return { success: false, message: "No chats found" };
+        }
+        
+        // 取第一个（最近的）对话
+        const currentChat = chatList.chats[0];
+        const chatId = currentChat.id || currentChat.chatId;
+        
+        // 读取消息
+        const messagesResult = await Tools.Chat.getMessages(chatId, { order: "asc", limit: limit });
+        if (!messagesResult || !messagesResult.messages) {
+            return { success: false, message: "Failed to get messages" };
+        }
+        
+        const messages = messagesResult.messages;
+        
+        var lines = [];
+        lines.push("=== CHAT MESSAGE DUMP ===");
+        lines.push("Time: " + new Date().toLocaleString());
+        lines.push("Chat ID: " + chatId);
+        lines.push("Chat Title: " + (currentChat.title || "N/A"));
+        lines.push("Total messages: " + messages.length);
+        lines.push("");
+        
+        for (var i = 0; i < messages.length; i++) {
+            var msg = messages[i];
+            lines.push("--- Message #" + (i + 1) + " ---");
+            lines.push("Kind/Role: " + (msg.kind || msg.role || "N/A"));
+            lines.push("Sender: " + (msg.sender || msg.senderName || "N/A"));
+            if (msg.toolName) lines.push("ToolName: " + msg.toolName);
+            if (msg.timestamp) lines.push("Timestamp: " + msg.timestamp);
+            
+            var content = msg.content || msg.text || "";
+            if (content.length > 2000) {
+                lines.push("Content (" + content.length + " chars, showing first 2000):");
+                lines.push(content.substring(0, 2000) + "...[TRUNCATED]");
+            } else {
+                lines.push("Content (" + content.length + " chars):");
+                lines.push(content);
+            }
+            
+            // 打印所有字段名
+            var keys = Object.keys(msg);
+            lines.push("All fields: " + keys.join(", "));
+            lines.push("");
+        }
+        
+        var timestamp = new Date().toISOString().replace(/[:.]\/g, "-");
+        var filePath = "/sdcard/Download/Operit/debug_msg_dump/chat_dump_" + timestamp + ".txt";
+        
+        await Tools.Files.writeFile(filePath, lines.join("\n"));
+        
+        return { 
+            success: true, 
+            message: "Dumped " + messages.length + " messages to " + filePath,
+            filePath: filePath,
+            messageCount: messages.length
+        };
+    }
+
+    return {
+        dump_current_chat: (params) => wrap(dump_current_chat, params),
+    };
+})();
+
+exports.dump_current_chat = DebugMessageDump.dump_current_chat;

--- a/examples/debug_msg_dump/main.js
+++ b/examples/debug_msg_dump/main.js
@@ -1,0 +1,116 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.registerToolPkg = registerToolPkg;
+exports.onPromptHistory = onPromptHistory;
+exports.onPromptFinalize = onPromptFinalize;
+
+var DUMP_DIR = "/sdcard/Download/Operit/debug_msg_dump/dumps/";
+
+function registerToolPkg() {
+    ToolPkg.registerPromptHistoryHook({
+        id: "debug_dump_history",
+        function: onPromptHistory,
+    });
+    ToolPkg.registerPromptFinalizeHook({
+        id: "debug_dump_finalize",
+        function: onPromptFinalize,
+    });
+    // 确保输出目录存在
+    try { Tools.Files.mkdir(DUMP_DIR, true); } catch(e) {}
+    return true;
+}
+
+function buildDump(tag, input) {
+    var payload = input.eventPayload || {};
+    var stage = String(payload.stage || input.eventName || "unknown");
+    var history = payload.preparedHistory || payload.chatHistory || [];
+    var systemPrompt = payload.systemPrompt || "";
+    var toolPrompt = payload.toolPrompt || "";
+
+    var lines = [];
+    lines.push("========================================");
+    lines.push("  DEBUG MSG DUMP - " + tag);
+    lines.push("  Time: " + new Date().toLocaleString());
+    lines.push("  Stage: " + stage);
+    lines.push("  Event: " + input.eventName);
+    lines.push("========================================");
+    lines.push("");
+
+    // System Prompt - 完整输出
+    lines.push("╔══════════════════════════════════════╗");
+    lines.push("║         SYSTEM PROMPT                ║");
+    lines.push("╚══════════════════════════════════════╝");
+    lines.push("Length: " + systemPrompt.length + " chars");
+    lines.push("");
+    lines.push(systemPrompt);
+    lines.push("");
+
+    // Tool Prompt - 完整输出
+    lines.push("╔══════════════════════════════════════╗");
+    lines.push("║         TOOL PROMPT                  ║");
+    lines.push("╚══════════════════════════════════════╝");
+    lines.push("Length: " + toolPrompt.length + " chars");
+    lines.push("");
+    lines.push(toolPrompt);
+    lines.push("");
+
+    // Messages - 每条完整输出，不截断
+    lines.push("╔══════════════════════════════════════╗");
+    lines.push("║    MESSAGES (Total: " + history.length + ")");
+    lines.push("╚══════════════════════════════════════╝");
+    lines.push("");
+
+    for (var i = 0; i < history.length; i++) {
+        var msg = history[i];
+        var kind = msg.kind || "N/A";
+        var content = msg.content || "";
+        lines.push("┌─── Message #" + (i + 1) + " ───┐");
+        lines.push("│ Kind: " + kind);
+        if (msg.toolName) lines.push("│ ToolName: " + msg.toolName);
+        if (msg.metadata) {
+            try {
+                lines.push("│ Metadata: " + JSON.stringify(msg.metadata));
+            } catch(e2) {
+                lines.push("│ Metadata: [stringify error]");
+            }
+        }
+        lines.push("│ Content Length: " + content.length + " chars");
+        lines.push("└──────────────────┘");
+        lines.push(content);
+        lines.push("");
+    }
+
+    lines.push("========== END OF DUMP ==========");
+    return lines.join("\n");
+}
+
+function onPromptHistory(input) {
+    var stage = String(input.eventPayload.stage || input.eventName || "");
+    if (stage !== "after_prepare_history") return null;
+
+    try {
+        var text = buildDump("HISTORY (after B pack processing)", input);
+        var ts = new Date().toISOString().replace(/[:.]\/g, "-");
+        var path = DUMP_DIR + "history_" + ts + ".txt";
+        Tools.Files.write(path, text);
+        console.log("[msg_dump] history saved to " + path);
+    } catch(e) {
+        console.log("[msg_dump] history write error: " + e.message);
+    }
+
+    return null;
+}
+
+function onPromptFinalize(input) {
+    try {
+        var text = buildDump("FINALIZE (final to model)", input);
+        var ts = new Date().toISOString().replace(/[:.]\/g, "-");
+        var path = DUMP_DIR + "finalize_" + ts + ".txt";
+        Tools.Files.write(path, text);
+        console.log("[msg_dump] finalize saved to " + path);
+    } catch(e) {
+        console.log("[msg_dump] finalize write error: " + e.message);
+    }
+
+    return null;
+}

--- a/examples/debug_msg_dump/manifest.json
+++ b/examples/debug_msg_dump/manifest.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "toolpkg_id": "com.operit.debug_msg_dump",
+  "version": "1.0.0",
+  "main": "main.js",
+  "display_name": {
+    "zh": "消息调试转储",
+    "en": "Debug Message Dump"
+  },
+  "description": {
+    "zh": "将每次发送给模型的完整消息列表保存到文件，用于调试",
+    "en": "Dump all messages sent to model into a file for debugging"
+  }
+}


### PR DESCRIPTION
## 添加两个 ToolPkg 示例插件

本 PR 向 `examples/` 目录添加了两个 ToolPkg 格式的沙盒包示例：

### 1. `context_limiter_c/` — 楼层限制器 C

截取最近 N 层上下文，保留 SYSTEM 消息 + 最近 N 层 USER/ASSISTANT 消息。

**功能特点：**
- 通过 `PromptFinalizeHook` 在发送给模型前裁剪上下文
- 通过 `InputMenuTogglePlugin` 在聊天输入栏提供开关和楼层数调节
- 子包提供 `set_floor_limit` / `get_floor_limit` 工具，AI 也可以动态调节
- 支持 3/5/8/10/15/20/30/50/100 层循环切换

**文件结构：**
```
examples/context_limiter_c/
├── manifest.json
├── main.js
└── packages/
    └── ctx_limiter_c.js
```

### 2. `debug_msg_dump/` — 消息调试转储

将每次发送给模型的完整消息列表（包括 System Prompt、Tool Prompt、所有历史消息）保存到文件，用于调试。

**功能特点：**
- 通过 `PromptHistoryHook` 和 `PromptFinalizeHook` 在两个阶段分别转储
- 输出文件保存在 `/sdcard/Download/Operit/debug_msg_dump/dumps/`
- 提供 `dump_current_chat` 工具，可手动触发当前对话的消息转储
- 中英双语描述

**文件结构：**
```
examples/debug_msg_dump/
├── manifest.json
├── main.js
└── debug_msg_dump.js
```

---

这两个插件展示了 ToolPkg 的多种高级特性：
- `registerPromptFinalizeHook` / `registerPromptHistoryHook`（Prompt Hook）
- `registerInputMenuTogglePlugin`（输入栏菜单插件）
- 子包（subpackages）与全局变量通信
- 多语言 manifest
