### PR TITLE
为consume hooks 添加 `clearInput` 选项

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/plugins/toolpkg/ToolPkgChatInputHookBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/plugins/toolpkg/ToolPkgChatInputHookBridge.kt
@@ -191,6 +191,7 @@ internal object ToolPkgChatInputHookBridge {
                     action = action,
                     text = textValue,
                     message = decoded["message"]?.toString(),
+                    clearInput = decoded["clearInput"] == true,
                     metadata = metadata
                 )
             }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/common/ChatInputHookRegistry.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/common/ChatInputHookRegistry.kt
@@ -42,6 +42,7 @@ data class ChatInputHookResult(
     val action: String = ChatInputSubmitActions.ALLOW,
     val text: String? = null,
     val message: String? = null,
+    val clearInput: Boolean = false,
     val metadata: Map<String, Any?> = emptyMap()
 )
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -1768,6 +1768,10 @@ private fun ChatInputBottomBar(
                     return@launch
                 }
                 ChatInputSubmitActions.CONSUME -> {
+                    if (submitDecision.clearInput) {
+                        actualViewModel.updateUserMessage(TextFieldValue(""))
+                        actualViewModel.resetAttachmentPanelState()
+                    }
                     showChatInputHookMessage(submitDecision.message)
                     return@launch
                 }

--- a/docs/package_dev/toolpkg.md
+++ b/docs/package_dev/toolpkg.md
@@ -352,7 +352,7 @@ interface PromptTurn {
 - `{ action: 'allow' }`
 - `{ action: 'block', message?: string }`
 - `{ action: 'replace', text: string }`
-- `{ action: 'consume', message?: string }`
+- `{ action: 'consume', message?: string, clearInput?: boolean }`
 - 或对应的 `Promise`
 
 ### Prompt 相关返回

--- a/examples/types/toolpkg.d.ts
+++ b/examples/types/toolpkg.d.ts
@@ -130,6 +130,7 @@ export namespace ToolPkg {
         action?: "allow" | "block" | "replace" | "consume";
         text?: string;
         message?: string;
+        clearInput?: boolean;
         metadata?: JsonObject;
     }
 


### PR DESCRIPTION
为 ChatInputHook 的 consume 返回结果增加可选 `clearInput` 字段。

当 ToolPkg 在 `submit_requested` 阶段返回 `{ action: "consume", clearInput: true }` 时，聊天输入框会清空当前草稿并收起附件面板，同时仍然消费本次发送事件。

默认 consume 行为保持不变；插件只有显式返回 `clearInput: true` 时才会清空输入框。

验证：
- 已运行 `git diff --check`
- 当前 Release 手动验证：`consume` 能拦截发送，但默认会保留草稿；本改动用于补齐插件主动清空草稿的能力
<img width="1080" height="1339" alt="Screenshot_2026-05-15-17-41-29-833_com ai assista" src="https://github.com/user-attachments/assets/838fd739-54a0-4525-a348-f15c747d82d1" />

