### PR TITLE
Add deferred chat input submit hook action

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/plugins/toolpkg/ToolPkgChatInputHookBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/plugins/toolpkg/ToolPkgChatInputHookBridge.kt
@@ -97,6 +97,12 @@ internal object ToolPkgChatInputHookBridge {
                 when (parsed.action) {
                     ChatInputSubmitActions.BLOCK,
                     ChatInputSubmitActions.CONSUME -> return@withContext parsed
+                    ChatInputSubmitActions.DEFER -> {
+                        return@withContext parsed.copy(
+                            action = ChatInputSubmitActions.DEFER,
+                            text = parsed.text ?: current.text
+                        )
+                    }
                     ChatInputSubmitActions.REPLACE -> {
                         val replacement = parsed.text ?: current.text
                         current =
@@ -174,6 +180,7 @@ internal object ToolPkgChatInputHookBridge {
                     when (actionValue) {
                         ChatInputSubmitActions.BLOCK -> ChatInputSubmitActions.BLOCK
                         ChatInputSubmitActions.CONSUME -> ChatInputSubmitActions.CONSUME
+                        ChatInputSubmitActions.DEFER -> ChatInputSubmitActions.DEFER
                         ChatInputSubmitActions.REPLACE -> ChatInputSubmitActions.REPLACE
                         ChatInputSubmitActions.ALLOW -> ChatInputSubmitActions.ALLOW
                         "" -> if (decoded.containsKey("text")) ChatInputSubmitActions.REPLACE else return null
@@ -192,10 +199,36 @@ internal object ToolPkgChatInputHookBridge {
                     text = textValue,
                     message = decoded["message"]?.toString(),
                     clearInput = decoded["clearInput"] == true,
+                    debounceMs = decoded["debounceMs"].asLongOrNull(),
+                    deferKey = decoded["deferKey"]?.toString(),
+                    waitUntilIdle = decoded["waitUntilIdle"].asBoolean(defaultValue = true),
                     metadata = metadata
                 )
             }
             else -> null
+        }
+    }
+
+    private fun Any?.asLongOrNull(): Long? {
+        return when (this) {
+            is Number -> toLong()
+            is String -> trim().toLongOrNull()
+            else -> null
+        }
+    }
+
+    private fun Any?.asBoolean(defaultValue: Boolean): Boolean {
+        return when (this) {
+            is Boolean -> this
+            is String -> {
+                when (trim().lowercase()) {
+                    "true", "1", "yes" -> true
+                    "false", "0", "no" -> false
+                    else -> defaultValue
+                }
+            }
+            is Number -> toInt() != 0
+            else -> defaultValue
         }
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/common/ChatInputHookRegistry.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/common/ChatInputHookRegistry.kt
@@ -21,6 +21,7 @@ object ChatInputSubmitActions {
     const val BLOCK = "block"
     const val REPLACE = "replace"
     const val CONSUME = "consume"
+    const val DEFER = "defer"
 }
 
 data class ChatInputHookContext(
@@ -43,6 +44,9 @@ data class ChatInputHookResult(
     val text: String? = null,
     val message: String? = null,
     val clearInput: Boolean = false,
+    val debounceMs: Long? = null,
+    val deferKey: String? = null,
+    val waitUntilIdle: Boolean = true,
     val metadata: Map<String, Any?> = emptyMap()
 )
 
@@ -105,6 +109,12 @@ object ChatInputHookRegistry {
             when (result.action.trim().lowercase()) {
                 ChatInputSubmitActions.BLOCK -> return result.copy(action = ChatInputSubmitActions.BLOCK)
                 ChatInputSubmitActions.CONSUME -> return result.copy(action = ChatInputSubmitActions.CONSUME)
+                ChatInputSubmitActions.DEFER -> {
+                    return result.copy(
+                        action = ChatInputSubmitActions.DEFER,
+                        text = result.text ?: current.text
+                    )
+                }
                 ChatInputSubmitActions.REPLACE -> {
                     val replacement = result.text ?: current.text
                     current =

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -59,6 +59,7 @@ import com.ai.assistance.operit.ui.features.chat.components.style.input.agent.Ag
 import com.ai.assistance.operit.ui.features.chat.components.style.input.classic.ClassicChatInputSection
 import com.ai.assistance.operit.ui.features.chat.components.style.input.common.ChatInputEvents
 import com.ai.assistance.operit.ui.features.chat.components.style.input.common.ChatInputHookContext
+import com.ai.assistance.operit.ui.features.chat.components.style.input.common.ChatInputHookResult
 import com.ai.assistance.operit.ui.features.chat.components.style.input.common.ChatInputHookRegistry
 import com.ai.assistance.operit.ui.features.chat.components.style.input.common.ChatInputSubmitActions
 import com.ai.assistance.operit.ui.features.chat.components.style.input.classic.ClassicChatSettingsBar
@@ -91,6 +92,7 @@ import com.ai.assistance.operit.ui.common.rememberLocal
 import com.ai.assistance.operit.ui.main.components.LocalIsCurrentScreen
 import com.ai.assistance.operit.ui.main.components.LocalSetScreenSoftInputMode
 import com.ai.assistance.operit.ui.main.components.LocalSetUseScreenImePadding
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import androidx.compose.ui.draw.clipToBounds
@@ -108,6 +110,9 @@ import com.ai.assistance.operit.plugins.chatview.ChatViewHookParams
 import com.ai.assistance.operit.plugins.chatview.ChatViewHookPluginRegistry
 import java.util.UUID
 
+private const val CHAT_INPUT_DEFER_DEFAULT_DEBOUNCE_MS = 1800L
+private const val CHAT_INPUT_DEFER_MAX_DEBOUNCE_MS = 60_000L
+private const val CHAT_INPUT_DEFER_DEFAULT_KEY = "default"
 
 @RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
@@ -1596,8 +1601,20 @@ private fun ChatInputBottomBar(
     var nextPendingQueueId by remember(currentChatId) { mutableStateOf(1L) }
     var wasQueueBlocked by remember(currentChatId) { mutableStateOf(false) }
     var suppressNextAutoDequeue by remember(currentChatId) { mutableStateOf(false) }
+    val deferredChatBuffers = remember(currentChatId) { mutableStateMapOf<String, MutableList<String>>() }
+    val deferredChatJobs = remember(currentChatId) { mutableStateMapOf<String, Job>() }
+    var lastChatInputChangeAt by remember(currentChatId) { mutableStateOf(0L) }
     val latestQueueBlocked = rememberUpdatedState(isQueueBlocked)
     val latestCurrentChatId = rememberUpdatedState(currentChatId)
+    val latestLastChatInputChangeAt = rememberUpdatedState(lastChatInputChangeAt)
+
+    DisposableEffect(currentChatId) {
+        onDispose {
+            deferredChatJobs.values.forEach { it.cancel() }
+            deferredChatJobs.clear()
+            deferredChatBuffers.clear()
+        }
+    }
 
     fun buildChatInputHookContext(
         eventName: String,
@@ -1626,6 +1643,7 @@ private fun ChatInputBottomBar(
     }
 
     fun handleUserMessageChange(value: TextFieldValue) {
+        lastChatInputChangeAt = System.currentTimeMillis()
         actualViewModel.updateUserMessage(value)
         ChatInputHookRegistry.dispatchNotification(
             buildChatInputHookContext(
@@ -1642,6 +1660,89 @@ private fun ChatInputBottomBar(
         if (normalizedMessage.isNotBlank()) {
             Toast.makeText(context, normalizedMessage, Toast.LENGTH_SHORT).show()
         }
+    }
+
+    fun normalizeDeferredDebounceMs(value: Long?): Long {
+        return (value ?: CHAT_INPUT_DEFER_DEFAULT_DEBOUNCE_MS)
+            .coerceIn(0L, CHAT_INPUT_DEFER_MAX_DEBOUNCE_MS)
+    }
+
+    suspend fun waitForDeferredChatFlush(debounceMs: Long, waitUntilIdle: Boolean) {
+        while (true) {
+            val lastInputChangeAt = latestLastChatInputChangeAt.value
+            val elapsed =
+                if (lastInputChangeAt > 0L) {
+                    System.currentTimeMillis() - lastInputChangeAt
+                } else {
+                    debounceMs
+                }
+            val remaining = debounceMs - elapsed
+            if (remaining > 0L) {
+                delay(remaining)
+                continue
+            }
+            if (waitUntilIdle && latestQueueBlocked.value) {
+                snapshotFlow { latestQueueBlocked.value }.first { !it }
+                delay(250)
+                continue
+            }
+            return
+        }
+    }
+
+    fun scheduleDeferredChatSubmit(
+        submitDecision: ChatInputHookResult,
+        fallbackText: String,
+        source: String
+    ) {
+        val finalText = (submitDecision.text ?: fallbackText).trim()
+        if (finalText.isBlank()) return
+
+        val deferKey =
+            submitDecision.deferKey
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+                ?: CHAT_INPUT_DEFER_DEFAULT_KEY
+        val debounceMs = normalizeDeferredDebounceMs(submitDecision.debounceMs)
+        val buffer = deferredChatBuffers.getOrPut(deferKey) { mutableListOf() }
+        buffer.add(finalText)
+        lastChatInputChangeAt = System.currentTimeMillis()
+
+        deferredChatJobs.remove(deferKey)?.cancel()
+        deferredChatJobs[deferKey] =
+            coroutineScope.launch {
+                waitForDeferredChatFlush(debounceMs, submitDecision.waitUntilIdle)
+                val pendingMessages = deferredChatBuffers.remove(deferKey)?.toList().orEmpty()
+                deferredChatJobs.remove(deferKey)
+
+                val mergedText = pendingMessages.joinToString("\n").trim()
+                if (mergedText.isBlank()) return@launch
+
+                val chatId = latestCurrentChatId.value
+                if (chatId.isNullOrBlank()) {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.chat_please_create_new_chat),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                    return@launch
+                }
+
+                focusManager.clearFocus()
+                actualViewModel.sendTextMessage(mergedText)
+                actualViewModel.resetAttachmentPanelState()
+                onRequestAutoScrollToBottom()
+                ChatInputHookRegistry.dispatchNotification(
+                    buildChatInputHookContext(
+                        eventName = ChatInputEvents.SUBMITTED,
+                        text = mergedText,
+                        selectionStart = mergedText.length,
+                        selectionEnd = mergedText.length,
+                        source = source,
+                        submitSource = "defer"
+                    )
+                )
+            }
     }
 
     fun restorePendingQueueItem(item: PendingQueueMessageItem) {
@@ -1677,6 +1778,15 @@ private fun ChatInputBottomBar(
                         return@launch
                     }
                     ChatInputSubmitActions.CONSUME -> {
+                        showChatInputHookMessage(submitDecision.message)
+                        return@launch
+                    }
+                    ChatInputSubmitActions.DEFER -> {
+                        scheduleDeferredChatSubmit(
+                            submitDecision = submitDecision,
+                            fallbackText = item.text,
+                            source = "queue"
+                        )
                         showChatInputHookMessage(submitDecision.message)
                         return@launch
                     }
@@ -1778,6 +1888,20 @@ private fun ChatInputBottomBar(
                         actualViewModel.updateUserMessage(TextFieldValue(""))
                         actualViewModel.resetAttachmentPanelState()
                     }
+                    showChatInputHookMessage(submitDecision.message)
+                    return@launch
+                }
+                ChatInputSubmitActions.DEFER -> {
+                    val originalText = userMessage.text
+                    if (submitDecision.clearInput) {
+                        actualViewModel.updateUserMessage(TextFieldValue(""))
+                        actualViewModel.resetAttachmentPanelState()
+                    }
+                    scheduleDeferredChatSubmit(
+                        submitDecision = submitDecision,
+                        fallbackText = originalText,
+                        source = inputStyle
+                    )
                     showChatInputHookMessage(submitDecision.message)
                     return@launch
                 }

--- a/docs/package_dev/toolpkg.md
+++ b/docs/package_dev/toolpkg.md
@@ -353,6 +353,7 @@ interface PromptTurn {
 - `{ action: 'block', message?: string }`
 - `{ action: 'replace', text: string }`
 - `{ action: 'consume', message?: string, clearInput?: boolean }`
+- `{ action: 'defer', text?: string, message?: string, clearInput?: boolean, debounceMs?: number, deferKey?: string, waitUntilIdle?: boolean }`：由宿主暂存本次文本，等待输入停止后合并发送。`deferKey` 相同的消息会合并；`waitUntilIdle` 默认为 `true`，表示 AI 忙时继续等待。
 - 或对应的 `Promise`
 
 ### Prompt 相关返回

--- a/examples/types/toolpkg.d.ts
+++ b/examples/types/toolpkg.d.ts
@@ -127,10 +127,13 @@ export namespace ToolPkg {
         | "view_closed";
 
     export interface ChatInputHookObjectResult extends JsonObject {
-        action?: "allow" | "block" | "replace" | "consume";
+        action?: "allow" | "block" | "replace" | "consume" | "defer";
         text?: string;
         message?: string;
         clearInput?: boolean;
+        debounceMs?: number;
+        deferKey?: string;
+        waitUntilIdle?: boolean;
         metadata?: JsonObject;
     }
 


### PR DESCRIPTION
## 说明

这个 PR 给 `ChatInputHook` 增加了一个新的提交动作：`defer`。

它用于这类输入场景：用户连续发送多条短消息时，插件可以先拦截本次发送，把文本交给宿主暂存；宿主等待用户停止输入一小段时间后，再把暂存内容合并成一条消息发送给 AI。

这样插件不需要自己在 ToolPkg 里维护后台计时器，也不需要在 hook 返回后直接调用 `Tools.Chat.sendMessage()`。之前测试时发现这两种方式都不稳定：

- `setTimeout` 在 hook 返回后不会继续触发
- 后台 worker 即使醒来，也会遇到 `Chat service not connected`

所以这次把延时、合并、等待 AI 空闲、真正发送这些动作放到宿主侧处理。

## 改动内容

- 新增 `ChatInputSubmitActions.DEFER`
- `ChatInputHookResult` 新增字段：
  - `debounceMs`：等待输入停止的时间，单位毫秒
  - `deferKey`：同一个 key 的暂存消息会合并
  - `waitUntilIdle`：AI 忙时是否继续等待，默认 `true`
- `ToolPkgChatInputHookBridge` 支持解析插件返回的 `defer` 结果
- `AIChatScreen` 增加宿主级暂存逻辑：
  - 收到 `defer` 后清空输入框
  - 把消息加入对应 `deferKey` 的暂存 buffer
  - 用户继续输入时重新等待
  - AI 忙时等待空闲
  - 最后把暂存消息用换行合并后发送
- 更新了 ToolPkg TypeScript 类型定义
- 更新了 ToolPkg 文档

## 插件返回示例

```js
return {
  action: "defer",
  text,
  clearInput: true,
  debounceMs: 1800,
  deferKey: "chat_debounce",
  waitUntilIdle: true
};
```

## 行为说明

没有插件、插件未启用、或者插件不返回 `defer` 时，原发送逻辑保持不变。

现有动作仍按原来的方式处理：

- `allow`：继续发送
- `block`：阻止发送
- `replace`：替换文本后发送
- `consume`：消费本次发送
- `defer`：由宿主暂存并延时合并发送

## 验证

本地已完成 Kotlin 编译验证：

```powershell
$env:JAVA_HOME='D:\Android\Android Studio\jbr'
$env:Path="$env:JAVA_HOME\bin;$env:Path"
.\gradlew.bat :app:compileDebugKotlin --console=plain
```

结果：

```text
BUILD SUCCESSFUL
```

## 备注

这次 PR 只提供宿主级的延时合并发送能力。

聊天区里“立即显示为待发送气泡”的 UI 展示没有包含在本次改动里，因为那会涉及消息列表渲染和临时消息状态，改动范围会明显变大。当前版本先把插件无法稳定完成的后台延时发送放到宿主侧处理。
