### PR TITLE
fix: 修复 ClaudeProvider qualityLevelToString 编译错误

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
@@ -1153,6 +1153,10 @@ class ClaudeProvider(
         )
     }
 
+    /**
+     * 将质量等级整数转换为 API quality 参数字符串
+     */
+    private fun qualityLevelToString(qualityLevel: Int): String {
         return when (qualityLevel.coerceIn(1, 4)) {
             1 -> "low"
             2 -> "medium"


### PR DESCRIPTION
## 问题

PR #568 (pr_claude_thinking) 合并后，`ClaudeProvider.kt` 中 `qualityLevelToString()` 函数体裸露在类顶层，导致 CI 构建失败：

```
e: ClaudeProvider.kt:1160:15 Unexpected tokens
e: ClaudeProvider.kt:1161:13 Expecting an element
e: ClaudeProvider.kt:1928:1 Expecting a top level declaration
```

## 修复

将孤立的 `return when(qualityLevel.coerceIn(...))` 包裹进正确的 `qualityLevelToString()` 函数中。

## 变更

仅修改 `ClaudeProvider.kt` 一个文件，+4 行（函数头 + 注释），0 行删除。

## 验证

✅ CI 构建通过（Run #50 on fix/dead-code-qualitylevel）

/cc @luojiaping
