### PR TITLE
Fix cloud embedding endpoint validation

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/memory/screens/dialogs/MemorySearchSettingsDialog.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/memory/screens/dialogs/MemorySearchSettingsDialog.kt
@@ -1,5 +1,6 @@
 package com.ai.assistance.operit.ui.features.memory.screens.dialogs
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -77,6 +78,14 @@ fun MemorySearchSettingsDialog(
     var apiKey by remember(cloudConfig) { mutableStateOf(cloudConfig.apiKey) }
     var model by remember(cloudConfig) { mutableStateOf(cloudConfig.model) }
     var showApiKey by remember { mutableStateOf(false) }
+    var cloudEndpointError by remember(cloudConfig) { mutableStateOf<String?>(null) }
+
+    val context = LocalContext.current
+    val settingsSavedMessage = stringResource(R.string.settings_saved)
+    val endpointBlankError = stringResource(R.string.memory_embedding_cloud_endpoint_error_blank)
+    val endpointSchemeError = stringResource(R.string.memory_embedding_cloud_endpoint_error_scheme)
+    val endpointWhitespaceError = stringResource(R.string.memory_embedding_cloud_endpoint_error_whitespace)
+    val endpointMultipleUrlsError = stringResource(R.string.memory_embedding_cloud_endpoint_error_multiple_urls)
 
     val editedCloudConfig = CloudEmbeddingConfig(
         enabled = cloudEnabled,
@@ -188,9 +197,16 @@ fun MemorySearchSettingsDialog(
                     if (cloudEnabled) {
                         OutlinedTextField(
                             value = endpoint,
-                            onValueChange = { endpoint = it },
+                            onValueChange = {
+                                endpoint = it
+                                cloudEndpointError = null
+                            },
                             modifier = Modifier.fillMaxWidth(),
                             label = { Text(stringResource(R.string.memory_embedding_cloud_endpoint)) },
+                            isError = cloudEndpointError != null,
+                            supportingText = cloudEndpointError?.let { errorText ->
+                                { Text(errorText) }
+                            },
                             singleLine = true
                         )
                         OutlinedTextField(
@@ -299,6 +315,19 @@ fun MemorySearchSettingsDialog(
         confirmButton = {
             Button(
                 onClick = {
+                    val endpointValidationError = validateCloudEmbeddingEndpoint(
+                        endpoint = endpoint,
+                        blankError = endpointBlankError,
+                        schemeError = endpointSchemeError,
+                        whitespaceError = endpointWhitespaceError,
+                        multipleUrlsError = endpointMultipleUrlsError
+                    )
+                    if (cloudEnabled && endpointValidationError != null) {
+                        cloudEndpointError = endpointValidationError
+                        return@Button
+                    }
+
+                    cloudEndpointError = null
                     onSave(
                         MemorySearchConfig(
                             scoreMode = scoreMode,
@@ -310,6 +339,7 @@ fun MemorySearchSettingsDialog(
                         editedCloudConfig,
                         editedAutoSaveIntervalMinutes.roundToInt()
                     )
+                    Toast.makeText(context, settingsSavedMessage, Toast.LENGTH_SHORT).show()
                 }
             ) {
                 Text(stringResource(R.string.memory_save))
@@ -443,4 +473,22 @@ private fun stageText(stage: String): String {
         "done" -> stringResource(R.string.memory_embedding_stage_done)
         else -> stage
     }
+}
+
+private fun validateCloudEmbeddingEndpoint(
+    endpoint: String,
+    blankError: String,
+    schemeError: String,
+    whitespaceError: String,
+    multipleUrlsError: String
+): String? {
+    val trimmed = endpoint.trim()
+    if (trimmed.isBlank()) return blankError
+    if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) return schemeError
+    if (trimmed.any { it.isWhitespace() }) return whitespaceError
+
+    val urlMatches = Regex("https?://").findAll(trimmed).count()
+    if (urlMatches > 1) return multipleUrlsError
+
+    return null
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -5685,6 +5685,10 @@
     <string name="memory_embedding_cloud_title">Cloud Embedding Model</string>
     <string name="memory_embedding_cloud_enable">Enable cloud embedding model</string>
     <string name="memory_embedding_cloud_endpoint">Embedding API endpoint</string>
+    <string name="memory_embedding_cloud_endpoint_error_blank">Embedding API endpoint cannot be empty</string>
+    <string name="memory_embedding_cloud_endpoint_error_scheme">Embedding API endpoint must start with http:// or https://</string>
+    <string name="memory_embedding_cloud_endpoint_error_whitespace">Embedding API endpoint cannot contain spaces or line breaks</string>
+    <string name="memory_embedding_cloud_endpoint_error_multiple_urls">Embedding API endpoint must contain only one URL</string>
     <string name="memory_embedding_cloud_api_key">Embedding API key</string>
     <string name="memory_embedding_cloud_model">Embedding model name</string>
     <string name="memory_embedding_dimension_usage">Current embedding dimension usage</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5790,6 +5790,10 @@
     <string name="memory_embedding_cloud_title">云端向量模型</string>
     <string name="memory_embedding_cloud_enable">启用云端向量模型</string>
     <string name="memory_embedding_cloud_endpoint">向量API端点</string>
+    <string name="memory_embedding_cloud_endpoint_error_blank">向量API端点不能为空</string>
+    <string name="memory_embedding_cloud_endpoint_error_scheme">向量API端点必须以 http:// 或 https:// 开头</string>
+    <string name="memory_embedding_cloud_endpoint_error_whitespace">向量API端点不能包含空格或换行</string>
+    <string name="memory_embedding_cloud_endpoint_error_multiple_urls">向量API端点只能填写一个URL</string>
     <string name="memory_embedding_cloud_api_key">向量API Key</string>
     <string name="memory_embedding_cloud_model">向量模型名</string>
     <string name="memory_embedding_dimension_usage">当前向量维度使用情况</string>


### PR DESCRIPTION
## Summary
- validate the cloud embedding endpoint before saving memory search settings
- show inline endpoint errors for blank, non-http(s), whitespace, and multi-URL values
- show a saved toast after settings are successfully saved

## Context
A cloud embedding endpoint can currently persist a stale multi-line value, for example a SiliconFlow endpoint followed by an old OpenRouter URL. That makes rebuild requests hit an invalid/combined endpoint and surface as 404 or invalid-host errors. The settings dialog also closes without visible confirmation, so it is hard to tell whether the save succeeded.

## Testing
- `git diff --check`
- Attempted `bash ./gradlew :app:compileDebugKotlin --no-daemon`, but the local checkout cannot resolve project `:terminal` (`No matching variant of project :terminal was found`), before Kotlin compilation starts.
