### PR TITLE
fix: 修复DashScope兼容模式音频识别400错误

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -791,7 +791,11 @@ open class OpenAIProvider(
                     put(
                         "input_audio",
                         JSONObject().apply {
-                            put("data", link.base64Data)
+                            put("data", if (providerType == ApiProviderType.ALIYUN) {
+                                "data:${link.mimeType};base64,${link.base64Data}"
+                            } else {
+                                link.base64Data
+                            })
                             put("format", audioFormatFromMime(link.mimeType))
                         }
                     )


### PR DESCRIPTION
## 问题

DashScope 兼容模式的 `input_audio.data` 字段要求 URL 格式（公网 URL 或 data URL），不接受裸 base64 字符串。

当前 Operit 将音频以裸 base64 字符串直接放入 `input_audio.data`，导致 DashScope 返回 400：
```
<400> InternalError.Algo.InvalidParameter: The provided URL does not appear to be valid.
```

## 修复

对 `ALIYUN` provider 将 base64 包装为 `data:audio/{mimeType};base64,...` 格式，其他 provider 保持原有裸 base64 格式不变。

## 测试

用 DashScope API Key 实测：
- 裸 base64：Status 400（The provided URL does not appear to be valid）
- data URL：Status 200 ✅（正确返回音频分析结果）

## 影响范围

仅影响 `OpenAIProvider.kt` 中 `buildContentField` 方法的音频部分，只对 `ApiProviderType.ALIYUN` 生效，其他 provider 不受影响。

Fixes #600