### PR TITLE
refactor: 重构主题系统，统一背景色并修复状态栏/导航栏图标颜色

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenHeader.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenHeader.kt
@@ -31,6 +31,7 @@ import com.ai.assistance.operit.data.model.ActivePrompt
 import com.ai.assistance.operit.data.preferences.UserPreferencesManager
 import com.ai.assistance.operit.ui.features.chat.viewmodel.ChatViewModel
 import com.ai.assistance.operit.ui.floating.FloatingMode
+import com.ai.assistance.operit.ui.theme.LocalMonochromeBackground
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOf
 
@@ -139,13 +140,18 @@ fun ChatScreenHeader(
 
     val launchFloatingWindow = useFloatingWindowLauncher(actualViewModel, permissionLauncher)
 
+    val monochromeBg = LocalMonochromeBackground.current
+
     Row(
             modifier =
                     modifier
                             .fillMaxWidth()
                             .background(
-                                    if (chatHeaderTransparent) Color.Transparent
-                                    else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f)
+                                    when {
+                                        chatHeaderTransparent -> Color.Transparent
+                                        monochromeBg -> MaterialTheme.colorScheme.surface
+                                        else -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f)
+                                    }
                             )
                             .padding(horizontal = 16.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
@@ -153,6 +153,7 @@ import com.ai.assistance.operit.ui.theme.isLiquidGlassSupported
 import com.ai.assistance.operit.ui.theme.isWaterGlassSupported
 import com.ai.assistance.operit.ui.theme.liquidGlass
 import com.ai.assistance.operit.ui.theme.waterGlass
+import com.ai.assistance.operit.ui.theme.LocalMonochromeBackground
 import com.ai.assistance.operit.util.ChatUtils
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -497,12 +498,17 @@ fun AgentChatInputSection(
     }
 
     val isDarkTheme = MaterialTheme.colorScheme.onSurface.luminance() > 0.5f
+    val monochromeBg = LocalMonochromeBackground.current
     val darkModeInputColor =
-        lerp(
-            MaterialTheme.colorScheme.surface,
-            MaterialTheme.colorScheme.onSurface,
-            0.08f,
-        )
+        if (monochromeBg) {
+            MaterialTheme.colorScheme.surface
+        } else {
+            lerp(
+                MaterialTheme.colorScheme.surface,
+                MaterialTheme.colorScheme.onSurface,
+                0.08f,
+            )
+        }
 
     val inputContainerColor =
         when {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/theme/ThemeSettingsBasicTab.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/theme/ThemeSettingsBasicTab.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.toArgb
 import com.ai.assistance.operit.ui.features.settings.components.ColorPickerDialog
 import com.ai.assistance.operit.ui.features.settings.sections.ThemeSettingsCharacterBindingInfoCard
 import com.ai.assistance.operit.ui.features.settings.sections.ThemeSettingsColorContentMode
+import com.ai.assistance.operit.ui.features.settings.sections.ThemeSettingsPresetsSection
 import com.ai.assistance.operit.ui.features.settings.sections.ThemeSettingsColorCustomizationSection
 import com.ai.assistance.operit.ui.features.settings.sections.ThemeSettingsFontSection
 import com.ai.assistance.operit.ui.features.settings.sections.ThemeSettingsThemeModeSection
@@ -314,6 +315,14 @@ private fun ThemeSettingsBasicColorPanel(
         pipIconColorInput = pipIconColor ?: defaultHeaderIconColor
         onColorModeInput = onColorMode
     }
+
+    ThemeSettingsPresetsSection(
+        cardColors = cardColors,
+        preferencesManager = preferencesManager,
+        saveThemeSettingsWithCharacterCard = shared.saveThemeSettingsWithCharacterCard,
+        primaryColorInput = primaryColorInput,
+        secondaryColorInput = secondaryColorInput,
+    )
 
     ThemeSettingsColorCustomizationSection(
         cardColors = cardColors,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/theme/ThemeSettingsContentEditor.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/theme/ThemeSettingsContentEditor.kt
@@ -99,7 +99,7 @@ internal fun ThemeSettingsContentEditor(
             ?: flowOf(null)
     }.collectAsState(initial = null)
     val cardColors = CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        containerColor = MaterialTheme.colorScheme.surface,
     )
     var selectedThemeTab by remember { mutableStateOf(ThemeSettingsTab.BASIC) }
     var showSaveSuccessMessage by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ThemeSettingsPresetSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ThemeSettingsPresetSection.kt
@@ -1,0 +1,104 @@
+package com.ai.assistance.operit.ui.features.settings.sections
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.ai.assistance.operit.data.preferences.UserPreferencesManager
+import com.ai.assistance.operit.ui.theme.ThemePreset
+import com.ai.assistance.operit.ui.theme.themePresets
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun ThemeSettingsPresetsSection(
+    cardColors: CardColors,
+    preferencesManager: UserPreferencesManager,
+    saveThemeSettingsWithCharacterCard: SaveThemeSettingsAction,
+    primaryColorInput: Int,
+    secondaryColorInput: Int,
+) {
+    ThemeSettingsSectionTitle(
+        title = "主题预设",
+        icon = Icons.Default.Palette,
+    )
+
+    Card(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp), colors = cardColors) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "快速切换预定义配色方案",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 12.dp),
+            )
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                themePresets.forEach { preset ->
+                    ThemePresetChip(
+                        preset = preset,
+                        isSelected = primaryColorInput == preset.primaryArgb
+                                && secondaryColorInput == preset.secondaryArgb,
+                        onClick = {
+                            saveThemeSettingsWithCharacterCard {
+                                preferencesManager.saveThemeSettings(
+                                    useCustomColors = true,
+                                    customPrimaryColor = preset.primaryArgb,
+                                    customSecondaryColor = preset.secondaryArgb,
+                                )
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThemePresetChip(
+    preset: ThemePreset,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    FilterChip(
+        selected = isSelected,
+        onClick = onClick,
+        label = { Text(preset.name) },
+        leadingIcon = {
+            Box(
+                modifier = Modifier
+                    .size(14.dp)
+                    .clip(CircleShape)
+                    .background(Color(preset.primaryArgb)),
+            )
+        },
+        shape = RoundedCornerShape(8.dp),
+        colors = FilterChipDefaults.filterChipColors(
+            selectedContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+        ),
+    )
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/main/components/AppContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/main/components/AppContent.kt
@@ -80,6 +80,7 @@ import androidx.compose.animation.core.updateTransition
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.runtime.setValue
 import com.ai.assistance.operit.ui.components.CustomScaffold
+import com.ai.assistance.operit.ui.theme.LocalMonochromeBackground
 import androidx.compose.foundation.layout.ime
 import androidx.compose.ui.platform.LocalDensity
 import com.ai.assistance.operit.api.chat.AIForegroundService
@@ -175,6 +176,7 @@ fun AppContent(
     // Get toolbar transparency setting
     val toolbarTransparent =
             preferencesManager.toolbarTransparent.collectAsState(initial = false).value
+    val monochromeBackground = LocalMonochromeBackground.current
     
     // Get AppBar custom color settings
     val useCustomAppBarColor =
@@ -343,6 +345,7 @@ fun AppContent(
                     TopAppBarDefaults.topAppBarColors(
                         containerColor =
                         when {
+                            monochromeBackground -> Color.Transparent
                             toolbarTransparent -> Color.Transparent
                             useCustomAppBarColor && customAppBarColor != null -> Color(customAppBarColor)
                             else -> MaterialTheme.colorScheme.primary

--- a/app/src/main/java/com/ai/assistance/operit/ui/theme/Color.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/theme/Color.kt
@@ -9,3 +9,17 @@ val Pink80 = Color(0xFFEFB8C8)
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
+
+data class ThemePreset(
+    val id: String,
+    val name: String,
+    val primaryArgb: Int,
+    val secondaryArgb: Int,
+    val backgroundMode: String, // "light" | "dark" | "oled"
+)
+
+val themePresets = listOf(
+    ThemePreset("light-mono", "浅色纯色", 0xFFB0B0B4.toInt(), 0xFF9E9EA3.toInt(), "light"),
+    ThemePreset("dark-mono",  "深色纯色", 0xFF636366.toInt(), 0xFF8E8E93.toInt(), "dark"),
+    ThemePreset("oled-mono",  "OLED纯黑", 0xFF48484A.toInt(), 0xFF636366.toInt(), "oled"),
+)

--- a/app/src/main/java/com/ai/assistance/operit/ui/theme/Theme.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/theme/Theme.kt
@@ -65,6 +65,7 @@ import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
 import io.github.fletchmckee.liquid.liquefiable
 import io.github.fletchmckee.liquid.rememberLiquidState
+import androidx.compose.runtime.staticCompositionLocalOf
 
 private val DarkColorScheme =
         darkColorScheme(primary = Purple80, secondary = PurpleGrey80, tertiary = Pink80)
@@ -85,6 +86,8 @@ private val LightColorScheme =
                 onSurface = Color(0xFF1C1B1F),
                 */
                 )
+
+val LocalMonochromeBackground = staticCompositionLocalOf { false }
 
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
@@ -178,16 +181,22 @@ fun OperitTheme(content: @Composable () -> Unit) {
             }
 
     // 应用自定义颜色和文本颜色
+    var monochromeBackground = false
     if (useCustomColors) {
         customPrimaryColor?.let { primaryArgb ->
             val primary = Color(primaryArgb)
             val secondary = customSecondaryColor?.let { Color(it) } ?: colorScheme.secondary
 
-            colorScheme = if (darkTheme) {
+            val matchedPreset = themePresets.find { it.primaryArgb == primaryArgb }
+            monochromeBackground = matchedPreset != null
+
+            colorScheme = if (matchedPreset != null) {
+                generateColorScheme(primary, secondary, onColorMode, matchedPreset.backgroundMode)
+            } else if (darkTheme) {
                 generateDarkColorScheme(primary, secondary, onColorMode)
-                    } else {
+            } else {
                 generateLightColorScheme(primary, secondary, onColorMode)
-                    }
+            }
         }
     }
 
@@ -215,16 +224,16 @@ fun OperitTheme(content: @Composable () -> Unit) {
                 // 状态栏颜色和图标颜色控制
                 val statusBarColor = when {
                     statusBarTransparent -> Color.Transparent.toArgb()
-                    useBackgroundImage && backgroundImageUri != null -> Color.Transparent.toArgb()  // 有背景时透明
+                    useBackgroundImage && backgroundImageUri != null -> Color.Transparent.toArgb()
                     useCustomStatusBarColor && customStatusBarColorValue != null -> customStatusBarColorValue!!.toInt()
-                    else -> colorScheme.primary.toArgb()
+                    monochromeBackground -> Color.Transparent.toArgb()
+                    else -> colorScheme.surface.toArgb()
                 }
                 window.statusBarColor = statusBarColor
 
-                // 根据状态栏背景色动态设置状态栏图标颜色
-                // isAppearanceLightStatusBars = true 表示图标为深色（适用于浅色背景）
-                // isAppearanceLightStatusBars = false 表示图标为浅色（适用于深色背景）
-                insetsController?.isAppearanceLightStatusBars = !isColorLight(Color(statusBarColor))
+                val effectiveStatusBarColor = if (statusBarColor == Color.Transparent.toArgb())
+                    colorScheme.background else Color(statusBarColor)
+                insetsController?.isAppearanceLightStatusBars = isColorLight(effectiveStatusBarColor)
             }
             
             // 设置导航栏颜色（底部小白条所在的区域）
@@ -247,7 +256,7 @@ fun OperitTheme(content: @Composable () -> Unit) {
                 // 根据导航栏背景色动态设置导航栏图标颜色
                 // isAppearanceLightNavigationBars = true 表示图标为深色（适用于浅色背景）
                 // isAppearanceLightNavigationBars = false 表示图标为浅色（适用于深色背景）
-                insetsController?.isAppearanceLightNavigationBars = !isColorLight(colorScheme.background)
+                insetsController?.isAppearanceLightNavigationBars = isColorLight(colorScheme.background)
             }
         }
     }
@@ -357,6 +366,7 @@ fun OperitTheme(content: @Composable () -> Unit) {
         CompositionLocalProvider(
             LocalLiquidGlassBackdrop provides liquidGlassBackdrop,
             LocalWaterGlassState provides waterGlassState,
+            LocalMonochromeBackground provides monochromeBackground,
         ) {
             Box(
                 modifier = Modifier.fillMaxSize().layerBackdrop(liquidGlassBackdrop)
@@ -365,7 +375,7 @@ fun OperitTheme(content: @Composable () -> Unit) {
                     modifier =
                         Modifier
                             .fillMaxSize()
-                            .background(if (darkTheme) Color.Black else Color.White)
+                            .background(colorScheme.background)
                             .then(
                                 if (waterGlassState != null) {
                                     Modifier.liquefiable(waterGlassState)
@@ -552,25 +562,38 @@ private fun generateLightColorScheme(
         else -> getContrastingTextColor(secondaryColor)
     }
 
+    val bg = Color(0xFFF5F5F7)
     val primaryContainer = lightenColor(primaryColor, 0.7f)
     val onPrimaryContainer = getContrastingTextColor(primaryContainer)
     val secondaryContainer = lightenColor(secondaryColor, 0.7f)
     val onSecondaryContainer = getContrastingTextColor(secondaryContainer)
 
-    // Return a complete color scheme, ensuring onSurface and onSurfaceVariant are consistent
+    val tertiaryColor = blendColors(primaryColor, secondaryColor, 0.5f)
+    val tertiaryContainer = lightenColor(tertiaryColor, 0.85f)
+    val onTertiary = getContrastingTextColor(tertiaryColor)
+    val onTertiaryContainer = getContrastingTextColor(tertiaryContainer)
+
     return LightColorScheme.copy(
-            primary = primaryColor,
-            onPrimary = onPrimary,
-            primaryContainer = primaryContainer,
-            onPrimaryContainer = onPrimaryContainer,
-            secondary = secondaryColor,
-            onSecondary = onSecondary,
-            secondaryContainer = secondaryContainer,
-            onSecondaryContainer = onSecondaryContainer,
-        // Ensure other colors are consistent with a light theme
+        primary = primaryColor,
+        onPrimary = onPrimary,
+        primaryContainer = primaryContainer,
+        onPrimaryContainer = onPrimaryContainer,
+        secondary = secondaryColor,
+        onSecondary = onSecondary,
+        secondaryContainer = secondaryContainer,
+        onSecondaryContainer = onSecondaryContainer,
+        tertiary = tertiaryColor,
+        onTertiary = onTertiary,
+        tertiaryContainer = tertiaryContainer,
+        onTertiaryContainer = onTertiaryContainer,
+        background = bg,
+        onBackground = Color.Black.copy(alpha = 0.85f),
+        surface = Color.White,
         onSurface = Color.Black,
-        onSurfaceVariant = Color.Black.copy(alpha = 0.7f),
-        onBackground = Color.Black
+        surfaceVariant = Color(0xFFF0F1F3),
+        onSurfaceVariant = Color.Black.copy(alpha = 0.38f),
+        outline = Color.Black.copy(alpha = 0.08f),
+        outlineVariant = Color.Black.copy(alpha = 0.04f),
     )
 }
 
@@ -580,6 +603,7 @@ private fun generateDarkColorScheme(
     secondaryColor: Color,
     onColorMode: String
 ): ColorScheme {
+    val bg = Color(0xFF1A1B1E)
     val adjustedPrimaryColor = lightenColor(primaryColor, 0.2f)
     val adjustedSecondaryColor = lightenColor(secondaryColor, 0.2f)
 
@@ -594,25 +618,170 @@ private fun generateDarkColorScheme(
         else -> getContrastingTextColor(adjustedSecondaryColor)
     }
 
+    val tertiaryColor = blendColors(adjustedPrimaryColor, adjustedSecondaryColor, 0.5f)
+    val onTertiary = getContrastingTextColor(tertiaryColor, forceLight = true)
+
     val primaryContainer = darkenColor(primaryColor, 0.3f)
     val onPrimaryContainer = getContrastingTextColor(primaryContainer, forceLight = true)
     val secondaryContainer = darkenColor(secondaryColor, 0.3f)
     val onSecondaryContainer = getContrastingTextColor(secondaryContainer, forceLight = true)
+    val tertiaryContainer = darkenColor(tertiaryColor, 0.3f)
+    val onTertiaryContainer = getContrastingTextColor(tertiaryContainer, forceLight = true)
 
-    // Return a complete color scheme, ensuring onSurface and onSurfaceVariant are consistent
     return DarkColorScheme.copy(
-            primary = adjustedPrimaryColor,
-            onPrimary = onPrimary,
-            primaryContainer = primaryContainer,
-            onPrimaryContainer = onPrimaryContainer,
-            secondary = adjustedSecondaryColor,
-            onSecondary = onSecondary,
-            secondaryContainer = secondaryContainer,
-            onSecondaryContainer = onSecondaryContainer,
-        // Ensure other colors are consistent with a dark theme
+        primary = adjustedPrimaryColor,
+        onPrimary = onPrimary,
+        primaryContainer = primaryContainer,
+        onPrimaryContainer = onPrimaryContainer,
+        secondary = adjustedSecondaryColor,
+        onSecondary = onSecondary,
+        secondaryContainer = secondaryContainer,
+        onSecondaryContainer = onSecondaryContainer,
+        tertiary = tertiaryColor,
+        onTertiary = onTertiary,
+        tertiaryContainer = tertiaryContainer,
+        onTertiaryContainer = onTertiaryContainer,
+        background = bg,
+        onBackground = Color.White.copy(alpha = 0.88f),
+        surface = bg,
         onSurface = Color.White,
-        onSurfaceVariant = Color.White.copy(alpha = 0.7f),
-        onBackground = Color.White
+        surfaceVariant = Color(0xFF2C2C2E),
+        onSurfaceVariant = Color.White.copy(alpha = 0.55f),
+        outline = Color.White.copy(alpha = 0.10f),
+        outlineVariant = Color.White.copy(alpha = 0.05f),
+    )
+}
+
+/** 为3种单色主题预设生成完整颜色方案 */
+private fun generateColorScheme(
+    primaryColor: Color,
+    secondaryColor: Color,
+    onColorMode: String,
+    backgroundMode: String, // "light" | "dark" | "oled"
+): ColorScheme {
+    val onPrimary = when (onColorMode) {
+        ON_COLOR_MODE_LIGHT -> Color.White
+        ON_COLOR_MODE_DARK -> Color.Black
+        else -> getContrastingTextColor(primaryColor)
+    }
+    val onSecondary = when (onColorMode) {
+        ON_COLOR_MODE_LIGHT -> Color.White
+        ON_COLOR_MODE_DARK -> Color.Black
+        else -> getContrastingTextColor(secondaryColor)
+    }
+
+    val bg: Color
+    val surface: Color
+    val surfaceContainer: Color
+    val surfaceVariantVal: Color
+    val surfaceContainerHigh: Color
+    val surfaceContainerHighest: Color
+    val surfaceContainerLow: Color
+    val surfaceContainerLowest: Color
+    val outline: Color
+    val outlineVariant: Color
+    val onBackground: Color
+    val onSurface: Color
+    val onSurfaceVariant: Color
+    val tertiary: Color
+
+    when (backgroundMode) {
+        "light" -> {
+            bg = Color(0xFFF5F5F7)
+            surface = Color(0xFFFFFFFF)
+            surfaceContainer = Color(0xFFF5F5F7)
+            surfaceVariantVal = Color(0xFFF0F1F3)
+            surfaceContainerHigh = Color(0xFFE8E8EA)
+            surfaceContainerHighest = Color(0xFFDEDFE1)
+            surfaceContainerLow = Color(0xFFF8F8FA)
+            surfaceContainerLowest = Color(0xFFFFFFFF)
+            outline = Color(0xFFD1D1D6)
+            outlineVariant = Color(0xFFE5E5EA)
+            onBackground = Color(0xFF111111)
+            onSurface = Color(0xFF111111)
+            onSurfaceVariant = Color(0xFF636366)
+            tertiary = blendColors(primaryColor, secondaryColor, 0.5f)
+        }
+        "dark" -> {
+            bg = Color(0xFF1A1B1E)
+            surface = Color(0xFF202124)
+            surfaceContainer = Color(0xFF202124)
+            surfaceVariantVal = Color(0xFF2A2B2F)
+            surfaceContainerHigh = Color(0xFF2A2B2F)
+            surfaceContainerHighest = Color(0xFF303135)
+            surfaceContainerLow = Color(0xFF1E1F22)
+            surfaceContainerLowest = Color(0xFF1A1B1E)
+            outline = Color(0xFF3A3B40)
+            outlineVariant = Color(0xFF2A2B2F)
+            onBackground = Color(0xFFE8E8E8)
+            onSurface = Color(0xFFE8E8E8)
+            onSurfaceVariant = Color(0xFFB8B8B8)
+            tertiary = Color(0xFF8A8D93)
+        }
+        "oled" -> {
+            bg = Color(0xFF000000)
+            surface = Color(0xFF0A0A0A)
+            surfaceContainer = Color(0xFF0A0A0A)
+            surfaceVariantVal = Color(0xFF141414)
+            surfaceContainerHigh = Color(0xFF141414)
+            surfaceContainerHighest = Color(0xFF1A1A1E)
+            surfaceContainerLow = Color(0xFF060606)
+            surfaceContainerLowest = Color(0xFF000000)
+            outline = Color(0xFF2A2A2E)
+            outlineVariant = Color(0xFF1A1A1E)
+            onBackground = Color(0xFFE8E8E8)
+            onSurface = Color(0xFFE8E8E8)
+            onSurfaceVariant = Color(0xFFB8B8B8)
+            tertiary = Color(0xFF8A8D93)
+        }
+        else -> {
+            bg = Color(0xFF1A1B1E)
+            surface = Color(0xFF202124)
+            surfaceContainer = Color(0xFF202124)
+            surfaceVariantVal = Color(0xFF2A2B2F)
+            surfaceContainerHigh = Color(0xFF2A2B2F)
+            surfaceContainerHighest = Color(0xFF303135)
+            surfaceContainerLow = Color(0xFF1E1F22)
+            surfaceContainerLowest = Color(0xFF1A1B1E)
+            outline = Color(0xFF3A3B40)
+            outlineVariant = Color(0xFF2A2B2F)
+            onBackground = Color(0xFFE8E8E8)
+            onSurface = Color(0xFFE8E8E8)
+            onSurfaceVariant = Color(0xFFB8B8B8)
+            tertiary = Color(0xFF8A8D93)
+        }
+    }
+
+    return DarkColorScheme.copy(
+        primary = primaryColor,
+        onPrimary = onPrimary,
+        primaryContainer = surfaceVariantVal,
+        onPrimaryContainer = onSurface,
+        secondary = secondaryColor,
+        onSecondary = onSecondary,
+        secondaryContainer = surfaceContainerHigh,
+        onSecondaryContainer = onSurfaceVariant,
+        tertiary = tertiary,
+        onTertiary = onSurface,
+        tertiaryContainer = surfaceContainerHigh,
+        onTertiaryContainer = onSurfaceVariant,
+        background = bg,
+        onBackground = onBackground,
+        surface = surface,
+        onSurface = onSurface,
+        surfaceVariant = surfaceVariantVal,
+        onSurfaceVariant = onSurfaceVariant,
+        surfaceContainerLowest = surfaceContainerLowest,
+        surfaceContainerLow = surfaceContainerLow,
+        surfaceContainer = surfaceContainer,
+        surfaceContainerHigh = surfaceContainerHigh,
+        surfaceContainerHighest = surfaceContainerHighest,
+        outline = outline,
+        outlineVariant = outlineVariant,
+        surfaceTint = Color.Transparent,
+        inverseSurface = bg,
+        inversePrimary = primaryColor,
+        inverseOnSurface = onSurface,
     )
 }
 


### PR DESCRIPTION
## 改动内容

### Theme.kt
- 新增 \generateColorScheme\ 函数，支持 3 种 backgroundMode（light/dark/oled）
- 每个模式覆盖完整的 surface container 系列颜色
- 修复导航栏图标颜色取反 bug（\!isColorLight\ → \isColorLight\）
- 修复状态栏透明时图标颜色判断逻辑

### AppContent.kt
- TopAppBar 在单色模式下设为透明

### ThemeSettingsContentEditor.kt
- 卡片颜色从 \surfaceContainerLow\ 改为 \surface\

### Color.kt
- \ThemePreset\ 改为 3 个预设（浅色/深色/OLED），每个带 \ackgroundMode\ 字段