### PR TITLE
Remove hardcoded default DeepSeek API Key and clean up code

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ApiPreferences.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ApiPreferences.kt
@@ -198,18 +198,6 @@ class ApiPreferences private constructor(private val context: Context) {
         // API 配置默认值
         const val DEFAULT_API_ENDPOINT = "https://api.deepseek.com/v1/chat/completions"
         const val DEFAULT_MODEL_NAME = "deepseek-v4-flash"
-        private const val ENCODED_API_KEY = "c2stNmI4NTYyMjUzNmFjNDhjMDgwYzUwNDhhYjVmNWQxYmQ="
-        val DEFAULT_API_KEY: String by lazy { decodeApiKey(ENCODED_API_KEY) }
-
-        private fun decodeApiKey(encodedKey: String): String {
-            return try {
-                android.util.Base64.decode(encodedKey, android.util.Base64.NO_WRAP)
-                    .toString(Charsets.UTF_8)
-            } catch (e: Exception) {
-                com.ai.assistance.operit.util.AppLogger.e("ApiPreferences", "Failed to decode API key", e)
-                ""
-            }
-        }
     }
 
     @Serializable

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
@@ -92,7 +92,7 @@ class ModelConfigManager(private val context: Context) {
         return ModelConfigData(
                 id = DEFAULT_CONFIG_ID,
                 name = context.getString(R.string.model_config_default_name),
-                apiKey = ApiPreferences.DEFAULT_API_KEY,
+                apiKey = "",
                 apiEndpoint = ApiPreferences.DEFAULT_API_ENDPOINT,
                 modelName = ApiPreferences.DEFAULT_MODEL_NAME,
                 apiProviderType = DEFAULT_API_PROVIDER_TYPE,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -398,7 +398,7 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
                     TextButton(onClick = {
                         showModelSuggestionDialog = false
                         // 如果用户已输入token，直接保存配置
-                        actualViewModel.updateApiKey(ApiPreferences.DEFAULT_API_KEY)
+                        actualViewModel.updateApiKey("")
                         actualViewModel.updateApiEndpoint(ApiPreferences.DEFAULT_API_ENDPOINT)
                         actualViewModel.updateModelName(ApiPreferences.DEFAULT_MODEL_NAME)
                         actualViewModel.updateApiProviderType(ApiProviderType.DEEPSEEK)
@@ -581,9 +581,7 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
         // 只有当apiKey有效值时才执行逻辑，防止初始化阶段的不正确判断
         if (apiKey.isNotBlank()) {
             // 如果使用的是自定义配置，标记为已确认，不显示配置界面
-            if (apiKey != ApiPreferences.DEFAULT_API_KEY) {
-                ConfigurationStateHolder.hasConfirmedDefaultInSession = true
-            }
+            ConfigurationStateHolder.hasConfirmedDefaultInSession = true
         }
     }
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/ConfigurationScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/ConfigurationScreen.kt
@@ -58,14 +58,12 @@ fun ConfigurationScreen(
         val isUsingDefaultApiKey by
                 remember(apiKeyInput) {
                         derivedStateOf {
-                                apiKeyInput == ApiPreferences.DEFAULT_API_KEY ||
-                                        (apiKeyInput.isBlank() && isUsingDefault)
+                                apiKeyInput.isBlank() && isUsingDefault
                         }
                 }
 
         // 检测用户是否输入了自己的token
-        val hasEnteredToken =
-                apiKeyInput.isNotBlank() && apiKeyInput != ApiPreferences.DEFAULT_API_KEY
+        val hasEnteredToken = apiKeyInput.isNotBlank()
 
         // 导航处理
         LaunchedEffect(isUsingDefault) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/ChatViewModel.kt
@@ -30,7 +30,6 @@ import com.ai.assistance.operit.data.model.ChatHistory
 import com.ai.assistance.operit.data.model.ChatMessage
 import com.ai.assistance.operit.data.model.ChatMessageLocatorPreview
 import com.ai.assistance.operit.data.model.FunctionType
-import com.ai.assistance.operit.data.preferences.ApiPreferences
 import com.ai.assistance.operit.data.model.PromptFunctionType
 import com.ai.assistance.operit.data.model.ToolParameter
 import com.ai.assistance.operit.R
@@ -437,7 +436,7 @@ class ChatViewModel(private val context: Context) : ViewModel() {
                         currentProviderType,
                         currentApiEndpoint
                     ) &&
-                    currentApiKey == ApiPreferences.DEFAULT_API_KEY
+                    currentApiKey.isBlank()
             }.collect { shouldShow ->
                 _shouldShowConfigDialog.value = shouldShow
             }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
@@ -52,7 +52,6 @@ import com.ai.assistance.operit.data.collects.ApiProviderConfigs
 import com.ai.assistance.operit.data.model.ApiProviderType
 import com.ai.assistance.operit.data.model.ModelConfigData
 import com.ai.assistance.operit.data.model.ModelOption
-import com.ai.assistance.operit.data.preferences.ApiPreferences
 import com.ai.assistance.operit.data.preferences.ModelConfigManager
 import com.ai.assistance.operit.plugins.toolpkg.ToolPkgAiProviderRegistry
 import com.ai.assistance.operit.ui.common.input.bringIntoViewOnImeFocus
@@ -339,8 +338,8 @@ fun ModelApiSettingsSection(
     var modelLoadError by remember { mutableStateOf<String?>(null) }
     var showEndpointDialog by remember(config.id) { mutableStateOf(false) }
 
-    // 检查是否使用默认API密钥（仅用于UI显示）
-    val isUsingDefaultApiKey = apiKeyInput == ApiPreferences.DEFAULT_API_KEY
+    // 检查是否未填写API密钥（仅用于UI显示）
+    val isUsingDefaultApiKey = apiKeyInput.isBlank()
     val providerRequiresApiKey =
         ApiProviderConfigs.requiresApiKey(selectedProviderTypeId, apiEndpointInput)
     val isMnnProvider = selectedApiProvider == ApiProviderType.MNN


### PR DESCRIPTION
- 删除 ApiPreferences 中的 ENCODED_API_KEY、DEFAULT_API_KEY 和 decodeApiKey
- 默认配置 apiKey 改为空字符串
- 所有 DEFAULT_API_KEY 引用改为 isBlank() 判断
- 清理不再使用的 ApiPreferences import