### PR TITLE
Fix model provider display name

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
@@ -603,6 +603,24 @@ class EnhancedAIService private constructor(private val context: Context) {
         }
     }
 
+    suspend fun getDisplayProviderAndModelForFunction(
+        functionType: FunctionType,
+        chatModelConfigIdOverride: String?,
+        chatModelIndexOverride: Int?
+    ): Pair<String, String> {
+        val (provider, modelName) = getProviderAndModelForFunction(
+            functionType = functionType,
+            chatModelConfigIdOverride = chatModelConfigIdOverride,
+            chatModelIndexOverride = chatModelIndexOverride
+        )
+        val config = getModelConfigForFunction(
+            functionType = functionType,
+            chatModelConfigIdOverride = chatModelConfigIdOverride,
+            chatModelIndexOverride = chatModelIndexOverride
+        )
+        return Pair("$provider/${config.name}", modelName)
+    }
+
     suspend fun getModelConfigForFunction(
         functionType: FunctionType,
         chatModelConfigIdOverride: String? = null,

--- a/app/src/main/java/com/ai/assistance/operit/services/core/MessageProcessingDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/MessageProcessingDelegate.kt
@@ -945,7 +945,7 @@ class MessageProcessingDelegate(
                 // 获取当前使用的provider和model信息
                 val loadProviderModelStartTime = messageTimingNow()
                 val (provider, modelName) = try {
-                    service.getProviderAndModelForFunction(
+                    service.getDisplayProviderAndModelForFunction(
                         functionType = com.ai.assistance.operit.data.model.FunctionType.CHAT,
                         chatModelConfigIdOverride = chatModelConfigIdOverride,
                         chatModelIndexOverride = chatModelIndexOverride
@@ -1474,7 +1474,7 @@ class MessageProcessingDelegate(
                 }
 
             val (provider, modelName) =
-                service.getProviderAndModelForFunction(
+                service.getDisplayProviderAndModelForFunction(
                     functionType = FunctionType.CHAT,
                     chatModelConfigIdOverride = chatModelConfigIdOverride,
                     chatModelIndexOverride = chatModelIndexOverride,

--- a/web-chat/src/ui/features/chat/components/style/bubble/BubbleAiMessageComposable.tsx
+++ b/web-chat/src/ui/features/chat/components/style/bubble/BubbleAiMessageComposable.tsx
@@ -76,7 +76,11 @@ export function BubbleAiMessageComposable({
             ) : null}
             <div className="bubble-message-header-copy">
               {headerName ? <strong>{headerName}</strong> : null}
-              {headerMeta ? <span>{headerMeta}</span> : null}
+              {headerMeta ? (
+                <span className="bubble-message-provider-meta" title={headerMeta}>
+                  {headerMeta}
+                </span>
+              ) : null}
             </div>
           </div>
         ) : null}
@@ -128,7 +132,11 @@ export function BubbleAiMessageComposable({
           />
         ) : null}
         <div className={`bubble-inline-stack ai ${showAvatar ? 'has-avatar' : 'no-avatar'}`}>
-          {compactMeta ? <span className="bubble-compact-meta">{compactMeta}</span> : null}
+          {compactMeta ? (
+            <span className="bubble-compact-meta" title={compactMeta}>
+              {compactMeta}
+            </span>
+          ) : null}
           <BubbleImageBackgroundSurface
             backgroundStyle={backgroundStyle}
             className={bubbleClassName}

--- a/web-chat/src/ui/features/chat/components/style/cursor/AiMessageComposable.tsx
+++ b/web-chat/src/ui/features/chat/components/style/cursor/AiMessageComposable.tsx
@@ -18,7 +18,11 @@ export function AiMessageComposable({
     <article className="cursor-ai-message">
       <div className="cursor-message-header">
         <strong className="cursor-message-label">Response</strong>
-        {detailText ? <span className="cursor-message-detail">{detailText}</span> : null}
+        {detailText ? (
+          <span className="cursor-message-detail" title={detailText}>
+            {detailText}
+          </span>
+        ) : null}
       </div>
       <div className="chat-message-content cursor-ai-body">
         <CustomXmlRenderer

--- a/web-chat/src/ui/features/chat/util/styles/chat-messages.css
+++ b/web-chat/src/ui/features/chat/util/styles/chat-messages.css
@@ -534,10 +534,12 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  min-width: 0;
   margin-bottom: 8px;
 }
 
 .cursor-message-label {
+  flex: 0 0 auto;
   font-size: 12px;
   font-weight: 600;
   color: var(--chat-text-muted);
@@ -549,7 +551,12 @@
 }
 
 .cursor-message-detail {
-  font-size: 12px;
+  min-width: 0;
+  max-width: min(62vw, 420px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
   color: var(--chat-text-soft);
   text-align: right;
 }
@@ -989,6 +996,14 @@
   color: var(--chat-text-soft);
 }
 
+.bubble-compact-meta {
+  max-width: min(72vw, 420px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+}
+
 .bubble-user-label {
   text-align: right;
 }
@@ -1062,6 +1077,8 @@
 }
 
 .bubble-message-header-copy {
+  min-width: 0;
+  max-width: 100%;
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
@@ -1078,7 +1095,11 @@
 }
 
 .bubble-message-header-copy span {
-  font-size: 12px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
   color: var(--chat-text-soft);
 }
 


### PR DESCRIPTION
fix issue #652 
新消息的模型供应商显示改为 供应商/配置名。
示例效果：
`DEEPSEEK/默认模型`
`DEEPSEEK/deepseek`
`OPENAI_RESPONSES_GENERIC/我的中转站`
 - 模型名仍保持实际选中的模型名。
 - 未修改请求层 AIService.providerModel，不影响请求、token 统计、计费和能力判断。
 - 普通回复和重新生成/变体预览两条路径都已覆盖。

- 显示优化
   - 聊天消息 meta 文本加了 title，桌面端悬停可看完整内容。
   - 长配置名单行省略，不会撑高消息头。
   - meta 字号缩小到辅助信息层级。
   - 覆盖 bubble 宽布局、bubble 紧凑布局和 cursor 样式。
   
<img width="1440" height="1644" alt="Screenshot_2026-06-29-23-58-55-702_com ai assistance bug-edit" src="https://github.com/user-attachments/assets/19fe35f1-941f-42c5-8aa0-68e661d4d45d" />
