### PR TITLE
fix: correct function name grepCodeWithRipgrep -> grepCodeWithNativeRipgrep

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/LinuxFileSystemTools.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/LinuxFileSystemTools.kt
@@ -1173,7 +1173,7 @@ class LinuxFileSystemTools(context: Context) : StandardFileSystemTools(context) 
             )
         }
 
-        return grepCodeWithRipgrep(
+        return grepCodeWithNativeRipgrep(
             toolName = tool.name,
             path = path,
             pattern = pattern,


### PR DESCRIPTION
## Fix: `grepCodeWithRipgrep` → `grepCodeWithNativeRipgrep`

### Problem

`LinuxFileSystemTools.kt:1176` calls `grepCodeWithRipgrep(...)`, but this function does not exist. The actual function name is `grepCodeWithNativeRipgrep`, defined in `StandardFileSystemTools.kt:532`.

This causes a **compile-time error** — the project cannot be built from source.

### Root Cause

Introduced in commit `181e4e37cc7d` (2026-03-11, `feat: replace grep with ripgrep`). The same commit correctly wrote `grepCodeWithNativeRipgrep` in `StandardFileSystemTools.kt:4659` but missed the `Native` in `LinuxFileSystemTools.kt:1176`.

### Affected Versions

| Release | Tag Date | Contains Typo |
|---------|----------|---------------|
| v1.10.0 | 2026-03-18 | Yes |
| v1.10.1 | — | Yes |
| v1.11.0 | — | Yes |
| v1.12.0 | — | Yes |

All 4 releases since 2026-03-11 are affected. The typo went unnoticed because the repository has no CI workflow to catch compile errors.

### Fix

One-line change:

```diff
--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/LinuxFileSystemTools.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/LinuxFileSystemTools.kt
@@ -1173,7 +1173,7 @@
-        return grepCodeWithRipgrep(
+        return grepCodeWithNativeRipgrep(
             toolName = tool.name,
```

### Verification

Compiled successfully via GitHub Actions CI:

- **Run 11** ✅ Success
- URL: https://github.com/CATMIAOZHI/Operit/actions/runs/28904445796
- Build command: `./gradlew :app:assembleDebug -x lint --build-cache`
- Java 21 (Temurin), Android SDK 36, NDK (runner pre-installed)

### Related

Fixes #688