### PR TITLE
fix: distinguish native tool calls from AI text XML using data-origin marker (#685)

### DIFF
--- a/app/src/androidTest/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManagerTest.kt
+++ b/app/src/androidTest/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManagerTest.kt
@@ -31,4 +31,40 @@ class ToolExecutionManagerTest {
             }
         )
     }
+
+    @Test
+    fun extractToolInvocations_onlyNative_skipsUnmarkedTags() = runBlocking {
+        val response = """
+            <tool_A1 name="read_file"><param name="path">/etc/hosts</param></tool_A1>
+        """.trimIndent()
+
+        val invocations = ToolExecutionManager.extractToolInvocations(response, onlyNative = true)
+
+        assertEquals(0, invocations.size)
+    }
+
+    @Test
+    fun extractToolInvocations_onlyNative_keepsMarkedTags() = runBlocking {
+        val response = """
+            <tool_A1 name="read_file" data-origin="native_tool_call"><param name="path">/etc/hosts</param></tool_A1>
+        """.trimIndent()
+
+        val invocations = ToolExecutionManager.extractToolInvocations(response, onlyNative = true)
+
+        assertEquals(1, invocations.size)
+        assertEquals("/etc/hosts", invocations[0].tool.parameters.first { it.name == "path" }.value)
+    }
+
+    @Test
+    fun extractToolInvocations_onlyNative_skipsUnmarkedButKeepsMarked() = runBlocking {
+        val response = """
+            <tool_A1 name="read_file"><param name="path">/tmp/unmarked</param></tool_A1>
+            <tool_B2 name="read_file" data-origin="native_tool_call"><param name="path">/tmp/marked</param></tool_B2>
+        """.trimIndent()
+
+        val invocations = ToolExecutionManager.extractToolInvocations(response, onlyNative = true)
+
+        assertEquals(1, invocations.size)
+        assertEquals("/tmp/marked", invocations[0].tool.parameters.first { it.name == "path" }.value)
+    }
 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
@@ -946,6 +946,7 @@ class EnhancedAIService private constructor(private val context: Context) {
                 )
             registerExecutionContext(execContext)
             var hadFatalError = false
+            var firstRoundEnableToolCall = false
             try {
                 // 确保所有操作都在IO线程上执行
                 withContext(Dispatchers.IO) {
@@ -969,6 +970,7 @@ class EnhancedAIService private constructor(private val context: Context) {
                             chatModelConfigIdOverride,
                             chatModelIndexOverride
                         )
+                    firstRoundEnableToolCall = modelSnapshot.config.enableToolCall
 
                     // Prepare conversation history with system prompt
                     val preparedHistory =
@@ -1279,7 +1281,8 @@ class EnhancedAIService private constructor(private val context: Context) {
                                 preferenceProfileIdOverride,
                                 stream,
                                 enableGroupOrchestrationHint,
-                                disableWarning
+                                disableWarning,
+                                useToolCallApi = firstRoundEnableToolCall
                             )
                         }
                     } else if (!hadFatalError) {
@@ -1704,7 +1707,8 @@ class EnhancedAIService private constructor(private val context: Context) {
             preferenceProfileIdOverride: String? = null,
             stream: Boolean = true,
             enableGroupOrchestrationHint: Boolean = false,
-            disableWarning: Boolean = false
+            disableWarning: Boolean = false,
+            useToolCallApi: Boolean = false
     ) {
         try {
             val startTime = messageTimingNow()
@@ -1826,7 +1830,7 @@ class EnhancedAIService private constructor(private val context: Context) {
             // 预先提取工具调用信息，避免重复解析
             val extractedToolInvocations =
                     if (truncatedToolRecovery == null) {
-                        ToolExecutionManager.extractToolInvocations(finalContent)
+                        ToolExecutionManager.extractToolInvocations(finalContent, onlyNative = useToolCallApi)
                     } else {
                         emptyList()
                     }
@@ -2465,7 +2469,8 @@ class EnhancedAIService private constructor(private val context: Context) {
                     preferenceProfileIdOverride,
                     stream,
                     enableGroupOrchestrationHint,
-                    disableWarning
+                    disableWarning,
+                    useToolCallApi = modelSnapshot.config.enableToolCall
                 )
             } catch (e: CancellationException) {
                 AppLogger.d(TAG, "处理工具执行结果被取消")

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
@@ -295,9 +295,11 @@ object ToolExecutionManager {
     /**
      * 从 AI 响应中提取工具调用。
      * @param response AI 的响应字符串。
+     * @param onlyNative 如果为 true，只提取带有 data-origin="native_tool_call" 标记的 XML 标签，
+     *   跳过 AI 普通文本中的 XML 工具标签示例。用于 enableToolCall=true 时避免误执行。
      * @return 检测到的工具调用列表。
      */
-    suspend fun extractToolInvocations(response: String): List<ToolInvocation> {
+    suspend fun extractToolInvocations(response: String, onlyNative: Boolean = false): List<ToolInvocation> {
         val invocations = mutableListOf<ToolInvocation>()
         val content = response
 
@@ -313,6 +315,11 @@ object ToolExecutionManager {
 
             if (group.tag is StreamXmlPlugin) {
                 ChatMarkupRegex.toolCallPattern.findAll(chunkString).forEach { toolMatch ->
+                    // 当 onlyNative=true 时，跳过未标记为原生 tool call 的 XML 标签
+                    if (onlyNative && !ChatMarkupRegex.isNativeToolCallOrigin(toolMatch.value)) {
+                        return@forEach
+                    }
+
                     val toolName = toolMatch.groupValues.getOrNull(2) ?: return@forEach
                     val toolBody = toolMatch.groupValues.getOrNull(3).orEmpty()
 
@@ -338,7 +345,7 @@ object ToolExecutionManager {
 
         AppLogger.d(
             TAG,
-            "Found ${invocations.size} tool invocations: ${invocations.map { resolveDisplayToolName(it.tool) }}"
+            "Found ${invocations.size} tool invocations (onlyNative=$onlyNative): ${invocations.map { resolveDisplayToolName(it.tool) }}"
         )
         return invocations
     }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
@@ -1446,7 +1446,7 @@ class ClaudeProvider(
                             val toolName = block.optString("name", "")
                             if (toolName.isNotEmpty()) {
                                 val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-                fullText.append("\n<$toolTagName name=\"$toolName\" data-origin=\"${ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN}\">")
+                                fullText.append("\n<$toolTagName name=\"$toolName\" data-origin=\"${ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN}\">")
                                 val input = block.optJSONObject("input")
                                 if (input != null) {
                                     val converter = StreamingJsonXmlConverter()

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
@@ -299,12 +299,19 @@ class ClaudeProvider(
      * 解析XML格式的tool调用，转换为Claude Tool格式
      * @return Pair<文本内容, tool_use数组>
      */
-    private fun parseXmlToolCalls(content: String): Pair<String, JSONArray?> {
+    private fun parseXmlToolCalls(content: String, onlyNative: Boolean = false): Pair<String, JSONArray?> {
         if (!enableToolCall) return Pair(content, null)
 
-        val matches = ChatMarkupRegex.toolCallPattern.findAll(content)
+        val allMatches = ChatMarkupRegex.toolCallPattern.findAll(content).toList()
 
-        if (!matches.any()) {
+        // 当 onlyNative=true 时，只保留带 data-origin="native_tool_call" 标记的匹配
+        val matches = if (onlyNative) {
+            allMatches.filter { ChatMarkupRegex.isNativeToolCallOrigin(it.value) }
+        } else {
+            allMatches
+        }
+
+        if (matches.isEmpty()) {
             return Pair(content, null)
         }
 
@@ -799,7 +806,7 @@ class ClaudeProvider(
                     PromptTurnKind.SYSTEM -> Unit
 
                     PromptTurnKind.ASSISTANT -> {
-                        val (textContent, toolUses) = parseXmlToolCalls(content)
+                        val (textContent, toolUses) = parseXmlToolCalls(content, onlyNative = true)
                         if (toolUses != null && toolUses.length() > 0) {
                             if (openToolUseIds.isNotEmpty()) {
                                 flushOpenToolUsesAsCancelled("assistant_tool_use_before_result")
@@ -1439,7 +1446,7 @@ class ClaudeProvider(
                             val toolName = block.optString("name", "")
                             if (toolName.isNotEmpty()) {
                                 val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-                                fullText.append("\n<$toolTagName name=\"$toolName\">")
+                fullText.append("\n<$toolTagName name=\"$toolName\" data-origin=\"${ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN}\">")
                                 val input = block.optJSONObject("input")
                                 if (input != null) {
                                     val converter = StreamingJsonXmlConverter()
@@ -1674,8 +1681,8 @@ class ClaudeProvider(
                                                     val toolName = contentBlock.optString("name", "")
                                                     if (toolName.isNotEmpty()) {
                                                         val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-                                                        currentToolTagName = toolTagName
-                                                        val toolStartTag = "\n<$toolTagName name=\"$toolName\">"
+                currentToolTagName = toolTagName
+                val toolStartTag = "\n<$toolTagName name=\"$toolName\" data-origin=\"${ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN}\">"
                                                         emittedAny = true
                                                         emit(toolStartTag)
                                                         receivedContent.append(toolStartTag)

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
@@ -283,7 +283,7 @@ class DeepseekProvider(
 
                         PromptTurnKind.ASSISTANT -> {
                             val (content, reasoningContent) = ChatUtils.extractThinkingContent(originalContent)
-                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content)
+                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content, onlyNative = true)
                             val toolCalls =
                                 if (parsedToolCalls != null) {
                                     wrapPackageToolCallsWithProxy(parsedToolCalls)

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
@@ -287,7 +287,7 @@ class GeminiProvider(
      * 解析XML格式的tool调用，转换为Gemini FunctionCall格式
      * @return 文本内容、functionCall对象列表、以及挂在Part级别的thought signature
      */
-    private fun parseXmlToolCalls(content: String): GeminiFunctionCallPayload {
+    private fun parseXmlToolCalls(content: String, onlyNative: Boolean = false): GeminiFunctionCallPayload {
         if (!enableToolCall) {
             return GeminiFunctionCallPayload(
                 textContent = content,
@@ -298,7 +298,14 @@ class GeminiProvider(
 
         val thoughtSignaturePayload = extractGeminiThoughtSignaturePayload(content)
         val sanitizedContent = thoughtSignaturePayload.contentWithoutMeta
-        val matches = ChatMarkupRegex.toolCallPattern.findAll(sanitizedContent).toList()
+        val allMatches = ChatMarkupRegex.toolCallPattern.findAll(sanitizedContent).toList()
+
+        // 当 onlyNative=true 时，只保留带 data-origin="native_tool_call" 标记的匹配
+        val matches = if (onlyNative) {
+            allMatches.filter { ChatMarkupRegex.isNativeToolCallOrigin(it.value) }
+        } else {
+            allMatches
+        }
         
         if (matches.isEmpty()) {
             return GeminiFunctionCallPayload(
@@ -675,7 +682,7 @@ class GeminiProvider(
             if (enableToolCall) {
                 when (turn.kind) {
                     PromptTurnKind.ASSISTANT -> {
-                        val functionCallPayload = parseXmlToolCalls(content)
+                    val functionCallPayload = parseXmlToolCalls(content, onlyNative = true)
                         if (functionCallPayload.functionCalls.isNotEmpty()) {
                             if (openFunctionCallNames.isNotEmpty()) {
                                 flushOpenFunctionCallsAsCancelled("assistant_function_call_before_result")
@@ -1787,7 +1794,7 @@ class GeminiProvider(
                         
                         // 输出工具开始标签
                         val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-                        contentBuilder.append("\n<$toolTagName name=\"$toolName\">")
+                        contentBuilder.append("\n<$toolTagName name=\"$toolName\" data-origin=\"${ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN}\">")
                         
                         // 使用 StreamingJsonXmlConverter 流式转换参数
                         val args = functionCall.optJSONObject("args")

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
@@ -682,7 +682,7 @@ class GeminiProvider(
             if (enableToolCall) {
                 when (turn.kind) {
                     PromptTurnKind.ASSISTANT -> {
-                    val functionCallPayload = parseXmlToolCalls(content, onlyNative = true)
+                        val functionCallPayload = parseXmlToolCalls(content, onlyNative = true)
                         if (functionCallPayload.functionCalls.isNotEmpty()) {
                             if (openFunctionCallNames.isNotEmpty()) {
                                 flushOpenFunctionCallsAsCancelled("assistant_function_call_before_result")

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
@@ -262,7 +262,7 @@ open class KimiProvider(
 
                         PromptTurnKind.ASSISTANT -> {
                             val (content, reasoningContent) = ChatUtils.extractThinkingContent(originalContent)
-                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content)
+                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content, onlyNative = true)
                             val toolCalls =
                                 if (parsedToolCalls != null) {
                                     wrapPackageToolCallsWithProxy(parsedToolCalls)

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/MistralProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/MistralProvider.kt
@@ -30,10 +30,17 @@ class MistralProvider(
         enableToolCall = enableToolCall
     ) {
 
-    override fun parseXmlToolCalls(content: String): Pair<String, JSONArray?> {
+    override fun parseXmlToolCalls(content: String, onlyNative: Boolean): Pair<String, JSONArray?> {
         val matches = ChatMarkupRegex.toolCallPattern.findAll(content)
 
-        if (!matches.any()) {
+        // 当 onlyNative=true 时，只保留带 data-origin="native_tool_call" 标记的匹配
+        val filteredMatches = if (onlyNative) {
+            matches.filter { ChatMarkupRegex.isNativeToolCallOrigin(it.value) }.toList()
+        } else {
+            matches.toList()
+        }
+
+        if (filteredMatches.isEmpty()) {
             return Pair(content, null)
         }
 
@@ -41,7 +48,7 @@ class MistralProvider(
         var textContent = content
         var callIndex = 0
 
-        matches.forEach { match ->
+        filteredMatches.forEach { match ->
             val toolName = match.groupValues[2]
             val toolBody = match.groupValues[3]
             val params = JSONObject()

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -970,7 +970,7 @@ open class OpenAIProvider(
                         }
 
                         PromptTurnKind.ASSISTANT -> {
-                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content)
+                    val (textContent, parsedToolCalls) = parseXmlToolCalls(content, onlyNative = true)
                             val toolCalls =
                                 if (parsedToolCalls != null) {
                                     wrapPackageToolCallsWithProxy(parsedToolCalls)
@@ -1226,7 +1226,7 @@ open class OpenAIProvider(
 
             // 构建XML格式
             val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-            xml.append("\n<$toolTagName name=\"$name\">")
+            xml.append("\n<$toolTagName name=\"$name\" data-origin=\"${ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN}\">")
 
             // 添加所有参数
             val keys = params.keys()
@@ -1522,10 +1522,17 @@ open class OpenAIProvider(
      * 解析XML格式的tool调用，转换为OpenAI Tool Call格式
      * @return Pair<文本内容, tool_calls数组>
      */
-    open fun parseXmlToolCalls(content: String): Pair<String, JSONArray?> {
+    open fun parseXmlToolCalls(content: String, onlyNative: Boolean = false): Pair<String, JSONArray?> {
         val matches = ChatMarkupRegex.toolCallPattern.findAll(content)
 
-        if (!matches.any()) {
+        // 当 onlyNative=true 时，只保留带 data-origin="native_tool_call" 标记的匹配
+        val filteredMatches = if (onlyNative) {
+            matches.filter { ChatMarkupRegex.isNativeToolCallOrigin(it.value) }.toList()
+        } else {
+            matches.toList()
+        }
+
+        if (filteredMatches.isEmpty()) {
             return Pair(content, null)
         }
 
@@ -1533,7 +1540,7 @@ open class OpenAIProvider(
         var textContent = content
         var callIndex = 0
 
-        matches.forEach { match ->
+        filteredMatches.forEach { match ->
             val toolName = match.groupValues[2]
             val toolBody = match.groupValues[3]
 
@@ -1713,7 +1720,7 @@ open class OpenAIProvider(
                 val toolTagName = state.toolCallState.getTagName(index)
                 val toolStartTag = if (state.toolCallState.emitted[index] != true) {
                     state.toolCallState.emitted[index] = true
-                    "\n<$toolTagName name=\"$name\">"
+                    "\n<$toolTagName name=\"$name\" data-origin=\"${ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN}\">"
                 } else {
                     ""
                 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -970,7 +970,7 @@ open class OpenAIProvider(
                         }
 
                         PromptTurnKind.ASSISTANT -> {
-                    val (textContent, parsedToolCalls) = parseXmlToolCalls(content, onlyNative = true)
+                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content, onlyNative = true)
                             val toolCalls =
                                 if (parsedToolCalls != null) {
                                     wrapPackageToolCallsWithProxy(parsedToolCalls)

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
@@ -433,13 +433,13 @@ internal object StructuredToolCallBridge {
             }.getOrNull()
 
             val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-        xml.append("\n<")
-            .append(toolTagName)
-            .append(" name=\"")
-            .append(name)
-            .append("\" data-origin=\"")
-            .append(ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN)
-            .append("\">")
+            xml.append("\n<")
+                .append(toolTagName)
+                .append(" name=\"")
+                .append(name)
+                .append("\" data-origin=\"")
+                .append(ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN)
+                .append("\">")
 
             if (paramsObj != null) {
                 val keys = paramsObj.keys()

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
@@ -263,7 +263,7 @@ internal object StructuredToolCallBridge {
                 }
 
                 PromptTurnKind.ASSISTANT -> {
-                    val (textContent, parsedToolCalls) = parseXmlToolCalls(content)
+                    val (textContent, parsedToolCalls) = parseXmlToolCalls(content, onlyNative = true)
                     val toolCalls =
                         if (parsedToolCalls != null) {
                             wrapPackageToolCallsWithProxy(parsedToolCalls)
@@ -433,11 +433,13 @@ internal object StructuredToolCallBridge {
             }.getOrNull()
 
             val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-            xml.append("\n<")
-                .append(toolTagName)
-                .append(" name=\"")
-                .append(name)
-                .append("\">")
+        xml.append("\n<")
+            .append(toolTagName)
+            .append(" name=\"")
+            .append(name)
+            .append("\" data-origin=\"")
+            .append(ChatMarkupRegex.NATIVE_TOOL_CALL_ORIGIN)
+            .append("\">")
 
             if (paramsObj != null) {
                 val keys = paramsObj.keys()
@@ -600,7 +602,7 @@ internal object StructuredToolCallBridge {
         }
     }
 
-    private fun parseXmlToolCalls(content: String): Pair<String, JSONArray?> {
+    private fun parseXmlToolCalls(content: String, onlyNative: Boolean = false): Pair<String, JSONArray?> {
         val matches = ChatMarkupRegex.toolCallPattern.findAll(content)
         if (!matches.any()) {
             return content to null
@@ -611,6 +613,11 @@ internal object StructuredToolCallBridge {
         var callIndex = 0
 
         matches.forEach { match ->
+            // 当 onlyNative=true 时，跳过未标记为原生 tool call 的 XML 标签
+            if (onlyNative && !ChatMarkupRegex.isNativeToolCallOrigin(match.value)) {
+                return@forEach
+            }
+
             val toolName = match.groupValues[2]
             val toolBody = match.groupValues[3]
 

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/LinuxFileSystemTools.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/LinuxFileSystemTools.kt
@@ -1173,7 +1173,7 @@ class LinuxFileSystemTools(context: Context) : StandardFileSystemTools(context) 
             )
         }
 
-        return grepCodeWithRipgrep(
+        return grepCodeWithNativeRipgrep(
             toolName = tool.name,
             path = path,
             pattern = pattern,

--- a/app/src/main/java/com/ai/assistance/operit/util/ChatMarkupRegex.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/ChatMarkupRegex.kt
@@ -40,9 +40,12 @@ object ChatMarkupRegex {
 
     /**
      * 检查工具标签 XML 片段是否带有 data-origin="native_tool_call" 标记。
+     * 只检测开标签（第一个 `>` 之前），避免参数内容中的误匹配。
      */
     fun isNativeToolCallOrigin(tagXml: String): Boolean {
-        return nativeOriginAttrRegex.containsMatchIn(tagXml)
+        val openingTagEnd = tagXml.indexOf('>')
+        val openingTag = if (openingTagEnd >= 0) tagXml.substring(0, openingTagEnd + 1) else tagXml
+        return nativeOriginAttrRegex.containsMatchIn(openingTag)
     }
 
     val toolTag = Regex(

--- a/app/src/main/java/com/ai/assistance/operit/util/ChatMarkupRegex.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/ChatMarkupRegex.kt
@@ -27,6 +27,24 @@ object ChatMarkupRegex {
         setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
     )
 
+    /**
+     * 标记 XML 工具标签来源于 Provider 的原生 function calling 转换，
+     * 而非 AI 在普通文本中输出的 XML 示例。
+     */
+    const val NATIVE_TOOL_CALL_ORIGIN = "native_tool_call"
+
+    private val nativeOriginAttrRegex = Regex(
+        """\bdata-origin\s*=\s*["']$NATIVE_TOOL_CALL_ORIGIN["']""",
+        RegexOption.IGNORE_CASE
+    )
+
+    /**
+     * 检查工具标签 XML 片段是否带有 data-origin="native_tool_call" 标记。
+     */
+    fun isNativeToolCallOrigin(tagXml: String): Boolean {
+        return nativeOriginAttrRegex.containsMatchIn(tagXml)
+    }
+
     val toolTag = Regex(
         """<($TOOL_TAG_NAME_REGEX_SOURCE)\b[\s\S]*?</\1>""",
         setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)

--- a/app/src/test/java/com/ai/assistance/operit/util/ChatMarkupRegexNativeOriginTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/util/ChatMarkupRegexNativeOriginTest.kt
@@ -1,0 +1,49 @@
+package com.ai.assistance.operit.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatMarkupRegexNativeOriginTest {
+
+    @Test
+    fun isNativeToolCallOrigin_detectsMarkerInOpeningTag() {
+        val xml = "<tool_abc name=\"read_file\" data-origin=\"native_tool_call\"><param name=\"path\">/tmp</param></tool_abc>"
+        assertTrue(ChatMarkupRegex.isNativeToolCallOrigin(xml))
+    }
+
+    @Test
+    fun isNativeToolCallOrigin_returnsFalseWithoutMarker() {
+        val xml = "<tool_abc name=\"read_file\"><param name=\"path\">/tmp</param></tool_abc>"
+        assertFalse(ChatMarkupRegex.isNativeToolCallOrigin(xml))
+    }
+
+    @Test
+    fun isNativeToolCallOrigin_ignoresMarkerInParamContent() {
+        // AI writes the marker string inside a param value — should NOT match
+        val xml = "<tool_abc name=\"echo\"><param name=\"text\">data-origin=\"native_tool_call\"</param></tool_abc>"
+        assertFalse(ChatMarkupRegex.isNativeToolCallOrigin(xml))
+    }
+
+    @Test
+    fun isNativeToolCallOrigin_isCaseInsensitive() {
+        val xml = "<tool_abc name=\"read_file\" DATA-ORIGIN=\"NATIVE_TOOL_CALL\">x</tool_abc>"
+        assertTrue(ChatMarkupRegex.isNativeToolCallOrigin(xml))
+    }
+
+    @Test
+    fun isNativeToolCallOrigin_acceptsSingleQuotes() {
+        val xml = "<tool_abc name=\"read_file\" data-origin='native_tool_call'>x</tool_abc>"
+        assertTrue(ChatMarkupRegex.isNativeToolCallOrigin(xml))
+    }
+
+    @Test
+    fun isNativeToolCallOrigin_returnsFalseForEmptyInput() {
+        assertFalse(ChatMarkupRegex.isNativeToolCallOrigin(""))
+    }
+
+    @Test
+    fun isNativeToolCallOrigin_returnsFalseForPlainText() {
+        assertFalse(ChatMarkupRegex.isNativeToolCallOrigin("just some text without tags"))
+    }
+}


### PR DESCRIPTION
## Fix #685: Distinguish native tool calls from AI text XML using `data-origin` marker

### Problem

When `enableToolCall=true` (native function calling), AI text replies containing XML tool tags are parsed and executed as real tool calls by `ToolExecutionManager.extractToolInvocations()`, instead of being displayed as plain text.

### Solution

Implements the `data-origin` source marker approach suggested by @luojiaping in [#685](https://github.com/AAswordman/Operit/issues/685#issuecomment-4905597041):

1. **Provider → XML conversion**: All providers add `data-origin="native_tool_call"` attribute when converting native `tool_calls`/`functionCall`/`tool_use` to internal XML format
2. **Execution filtering**: `extractToolInvocations()` gains `onlyNative` parameter — when `true` (i.e. `enableToolCall=true`), only extracts XML tags carrying the `data-origin` marker, skipping AI text XML examples
3. **History reconstruction**: All providers' `parseXmlToolCalls()` gain `onlyNative` parameter — ASSISTANT turns pass `onlyNative=true` to avoid polluting provider history with text XML examples
4. **Zero regression**: `TOOL_CALL` turns and `enableToolCall=false` behavior is completely unchanged (default `onlyNative=false`)

### Changed Files (11)

| File | Change |
|------|--------|
| `ChatMarkupRegex.kt` | Add `NATIVE_TOOL_CALL_ORIGIN` constant + `isNativeToolCallOrigin()` detector |
| `ToolExecutionManager.kt` | `extractToolInvocations()` gains `onlyNative` param |
| `EnhancedAIService.kt` | Pass `useToolCallApi` to `extractToolInvocations`; fix variable scope for `firstRoundEnableToolCall` |
| `StructuredToolCallBridge.kt` | `convertToolCallsToXml()` adds `data-origin` marker; `parseXmlToolCalls()` gains `onlyNative` param |
| `OpenAIProvider.kt` | `convertToolCallsToXml()` + streaming tool call emit add `data-origin`; `parseXmlToolCalls()` gains `onlyNative` param |
| `MistralProvider.kt` | `override parseXmlToolCalls()` with `onlyNative` (no default value per Kotlin rules) |
| `GeminiProvider.kt` | Streaming functionCall XML adds `data-origin`; `parseXmlToolCalls()` gains `onlyNative` param |
| `ClaudeProvider.kt` | Non-streaming + streaming `tool_use` XML adds `data-origin`; `parseXmlToolCalls()` gains `onlyNative` param |
| `DeepseekProvider.kt` | ASSISTANT turn passes `onlyNative=true` |
| `KimiProvider.kt` | ASSISTANT turn passes `onlyNative=true` |
| `LinuxFileSystemTools.kt` | Fix `grepCodeWithRipgrep` → `grepCodeWithNativeRipgrep` typo (#688, also in #690) |

### Relationship to #690

This PR includes the same one-line typo fix as #690 (`grepCodeWithRipgrep` → `grepCodeWithNativeRipgrep` in `LinuxFileSystemTools.kt`). If #690 is merged first, this PR will show a trivial conflict on that line that resolves automatically via rebase (both sides make the identical change). If this PR is merged first, #690 can be closed as included.

### Testing

- **CI compilation**: Passed (GitHub Actions, Java 21 + Android SDK 36)
- **Debug APK testing**: Installed and verified on device:
  - `enableToolCall=true`: AI text XML tags are **not** executed ✅
  - Native tool calls: Execute normally ✅
  - `grep_code` (with native ripgrep): Works correctly ✅
  - `enableToolCall=false`: Behavior unchanged ✅

### Design Notes

- **Rendering layer not modified**: AI text XML without `data-origin` still renders as tool call cards in UI, but does not execute. This is intentional — the core issue is误执行 (mistaken execution), not visual presentation. Any `data-origin`-based rendering filter would risk misclassifying historical tool calls (which don't carry the marker) from the `enableToolCall=false` era.
- **MNN/Llama internal tool call**: These providers use `StructuredToolCallBridge.convertToolCallPayloadToXml()` → `convertToolCallsToXml()` which adds the marker. Their history construction uses simple role→content mapping without `parseXmlToolCalls`, so no `onlyNative` filtering is needed.