### PR TITLE
fix: preserve DeepSeek V4 reasoning for relays

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -535,6 +535,14 @@ open class OpenAIProvider(
         return content
     }
 
+    private fun usesDeepseekV4ReasoningHistoryFormat(): Boolean {
+        if (useResponsesApi) return false
+
+        // Some OpenAI-compatible relays expose DeepSeek V4 models without using DeepseekProvider.
+        return Regex("(^|[^a-z0-9])deepseek-v4(\\.\\d+)?($|[^a-z0-9])", RegexOption.IGNORE_CASE)
+            .containsMatchIn(modelName)
+    }
+
     // 创建请求体
     protected open fun createRequestBody(
         context: Context,
@@ -631,13 +639,17 @@ open class OpenAIProvider(
             }
         }
 
+        val includeReasoningContent = usesDeepseekV4ReasoningHistoryFormat()
+        val effectivePreserveThinkInHistory = preserveThinkInHistory || includeReasoningContent
+
         // 使用新的核心逻辑构建消息并获取token计数
         val (messagesArray, tokenCount) = buildMessagesAndCountTokens(
             context,
             chatHistory,
             effectiveEnableToolCall,
             toolsJson,
-            preserveThinkInHistory
+            effectivePreserveThinkInHistory,
+            includeReasoningContent
         )
         jsonObject.put("messages", messagesArray)
 
@@ -856,7 +868,8 @@ open class OpenAIProvider(
         chatHistory: List<PromptTurn>,
         useToolCall: Boolean = false,
         toolsJson: String? = null,
-        preserveThinkInHistory: Boolean = false
+        preserveThinkInHistory: Boolean = false,
+        includeReasoningContent: Boolean = false
     ): Pair<JSONArray, Int> {
         val messagesArray = JSONArray()
         val providerReadyHistory = prepareHistoryForProvider(chatHistory, useToolCall)
@@ -871,6 +884,7 @@ open class OpenAIProvider(
         val effectiveHistory = providerReadyHistory
 
         var queuedAssistantToolText: String? = null
+        var queuedAssistantReasoning: String? = null
         var queuedToolCalls = JSONArray()
         val queuedToolCallIds = mutableListOf<String>()
         val openToolCallIds = mutableListOf<String>()
@@ -886,8 +900,21 @@ open class OpenAIProvider(
                 }
         }
 
-        fun queueToolCalls(textContent: String, toolCalls: JSONArray) {
+        fun appendQueuedAssistantReasoning(reasoningContent: String) {
+            if (reasoningContent.isBlank()) return
+            queuedAssistantReasoning =
+                if (queuedAssistantReasoning.isNullOrBlank()) {
+                    reasoningContent
+                } else {
+                    queuedAssistantReasoning + "\n" + reasoningContent
+                }
+        }
+
+        fun queueToolCalls(textContent: String, toolCalls: JSONArray, reasoningContent: String = "") {
             appendQueuedAssistantToolText(textContent)
+            if (includeReasoningContent) {
+                appendQueuedAssistantReasoning(reasoningContent)
+            }
             for (i in 0 until toolCalls.length()) {
                 val sourceToolCall = toolCalls.optJSONObject(i) ?: continue
                 val toolCall = JSONObject(sourceToolCall.toString())
@@ -912,11 +939,15 @@ open class OpenAIProvider(
             } else {
                 historyMessage.put("content", null)
             }
+            if (includeReasoningContent) {
+                historyMessage.put("reasoning_content", queuedAssistantReasoning.orEmpty())
+            }
             historyMessage.put("tool_calls", queuedToolCalls)
             messagesArray.put(historyMessage)
 
             openToolCallIds.addAll(queuedToolCallIds)
             queuedAssistantToolText = null
+            queuedAssistantReasoning = null
             queuedToolCalls = JSONArray()
             queuedToolCallIds.clear()
         }
@@ -970,7 +1001,13 @@ open class OpenAIProvider(
                         }
 
                         PromptTurnKind.ASSISTANT -> {
-                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content)
+                            val (assistantContent, reasoningContent) =
+                                if (includeReasoningContent) {
+                                    ChatUtils.extractThinkingContent(content)
+                                } else {
+                                    content to ""
+                                }
+                            val (textContent, parsedToolCalls) = parseXmlToolCalls(assistantContent)
                             val toolCalls =
                                 if (parsedToolCalls != null) {
                                     wrapPackageToolCallsWithProxy(parsedToolCalls)
@@ -982,18 +1019,21 @@ open class OpenAIProvider(
                                 if (openToolCallIds.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("assistant_tool_call_before_result")
                                 }
-                                queueToolCalls(textContent, toolCalls)
+                                queueToolCalls(textContent, toolCalls, reasoningContent)
                             } else {
                                 flushOpenToolCallsAsCancelled("assistant_boundary")
-                                val effectiveContent = if (content.isBlank()) {
+                                val effectiveContent = if (assistantContent.isBlank()) {
                                     AppLogger.d("AIService", "发现空的assistant消息，填充为[空消息]")
                                     "[Empty]"
                                 } else {
-                                    content
+                                    assistantContent
                                 }
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "assistant")
+                                        if (includeReasoningContent) {
+                                            put("reasoning_content", reasoningContent)
+                                        }
                                         put("content", buildContentField(context, effectiveContent))
                                     }
                                 )
@@ -1020,6 +1060,9 @@ open class OpenAIProvider(
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "assistant")
+                                        if (includeReasoningContent) {
+                                            put("reasoning_content", "")
+                                        }
                                         put("content", buildContentField(context, effectiveContent))
                                     }
                                 )


### PR DESCRIPTION
Regarding the deepseek series of models that use the openAI general interface for routing on the transfer platform, we are considering the issue of parameter transmission when invoking the thinking mode tools.
fix issue #700 