### PR TITLE
add gpt 5.6 support

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -550,20 +550,20 @@ open class OpenAIProvider(
     ): RequestBody {
         val jsonString =
             createRequestBodyInternal(context, chatHistory, modelParameters, stream, availableTools, preserveThinkInHistory)
-        if (providerType != ApiProviderType.OPENAI || !OpenAiGpt56Reasoning.supports(modelName)) {
+        if (!OpenAiGpt56Reasoning.supportsChat(providerType, modelName)) {
             return createJsonRequestBody(jsonString)
         }
         val requestJson = JSONObject(jsonString)
-        applyOfficialGpt56ChatReasoning(context, requestJson, enableThinking)
+        applyGpt56ChatReasoning(context, requestJson, enableThinking)
         return createJsonRequestBody(requestJson.toString())
     }
 
-    private fun applyOfficialGpt56ChatReasoning(
+    private fun applyGpt56ChatReasoning(
         context: Context,
         requestJson: JSONObject,
         enableThinking: Boolean
     ) {
-        if (providerType != ApiProviderType.OPENAI || !OpenAiGpt56Reasoning.supports(modelName)) {
+        if (!OpenAiGpt56Reasoning.supportsChat(providerType, modelName)) {
             return
         }
 

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -11,6 +11,7 @@ import com.ai.assistance.operit.data.model.ApiProviderType
 import com.ai.assistance.operit.data.model.ModelOption
 import com.ai.assistance.operit.data.model.ModelParameter
 import com.ai.assistance.operit.data.model.ToolPrompt
+import com.ai.assistance.operit.data.preferences.ApiPreferences
 import com.ai.assistance.operit.api.chat.llmprovider.EndpointCompleter
 import com.ai.assistance.operit.util.AppLogger
 import com.ai.assistance.operit.util.ChatMarkupRegex
@@ -38,6 +39,8 @@ import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
@@ -547,7 +550,59 @@ open class OpenAIProvider(
     ): RequestBody {
         val jsonString =
             createRequestBodyInternal(context, chatHistory, modelParameters, stream, availableTools, preserveThinkInHistory)
-        return createJsonRequestBody(jsonString)
+        if (providerType != ApiProviderType.OPENAI || !OpenAiGpt56Reasoning.supports(modelName)) {
+            return createJsonRequestBody(jsonString)
+        }
+        val requestJson = JSONObject(jsonString)
+        applyOfficialGpt56ChatReasoning(context, requestJson, enableThinking)
+        return createJsonRequestBody(requestJson.toString())
+    }
+
+    private fun applyOfficialGpt56ChatReasoning(
+        context: Context,
+        requestJson: JSONObject,
+        enableThinking: Boolean
+    ) {
+        if (providerType != ApiProviderType.OPENAI || !OpenAiGpt56Reasoning.supports(modelName)) {
+            return
+        }
+
+        val existingEffort = requestJson.optString("reasoning_effort", "").trim()
+        if (existingEffort.isNotEmpty()) {
+            AppLogger.d(
+                "OpenAIProvider",
+                "Preserving caller-supplied Chat Completions reasoning_effort=$existingEffort"
+            )
+            return
+        }
+
+        val effort = if (enableThinking) {
+            resolveGpt56ChatReasoningEffort(context)
+        } else {
+            "none"
+        } ?: return
+        requestJson.put("reasoning_effort", effort)
+        AppLogger.d(
+            "OpenAIProvider",
+            "GPT-5.6 Chat Completions reasoning_effort=$effort"
+        )
+    }
+
+    private fun resolveGpt56ChatReasoningEffort(context: Context): String? {
+        val qualityLevel = runCatching {
+            runBlocking {
+                ApiPreferences.getInstance(context).thinkingQualityLevelFlow.first()
+            }
+        }.getOrElse {
+            AppLogger.w(
+                "OpenAIProvider",
+                "Failed to read thinking quality level; reasoning_effort not applied",
+                it
+            )
+            return null
+        }
+
+        return OpenAiGpt56Reasoning.effortForQualityLevel(qualityLevel)
     }
 
     protected fun createJsonRequestBody(jsonString: String): RequestBody {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
@@ -103,9 +103,9 @@ class OpenAIResponsesProvider(
         requestJson: JSONObject,
         enableThinking: Boolean
     ) {
-        val isOfficialGpt56 = usesOfficialGpt56Model()
+        val isGpt56 = usesGpt56Model()
         val reasoningObject = requestJson.optJSONObject("reasoning")
-        if (!enableThinking && reasoningObject == null && !isOfficialGpt56) {
+        if (!enableThinking && reasoningObject == null && !isGpt56) {
             return
         }
 
@@ -123,7 +123,7 @@ class OpenAIResponsesProvider(
         if (existingEffort == null) {
             val effort = when {
                 enableThinking -> resolveResponsesReasoningEffort(context)
-                isOfficialGpt56 -> "none"
+                isGpt56 -> "none"
                 else -> null
             }
             if (effort != null) {
@@ -167,7 +167,7 @@ class OpenAIResponsesProvider(
             return null
         }
 
-        return if (usesOfficialGpt56Model()) {
+        return if (usesGpt56Model()) {
             OpenAiGpt56Reasoning.effortForQualityLevel(qualityLevel)
         } else {
             when (qualityLevel.coerceIn(1, 4)) {
@@ -180,9 +180,8 @@ class OpenAIResponsesProvider(
         }
     }
 
-    private fun usesOfficialGpt56Model(): Boolean =
-        responsesProviderType == ApiProviderType.OPENAI_RESPONSES &&
-            OpenAiGpt56Reasoning.supports(modelName)
+    private fun usesGpt56Model(): Boolean =
+        OpenAiGpt56Reasoning.supportsResponses(responsesProviderType, modelName)
 
     private fun shouldAttachPromptCacheKey(): Boolean {
         return responsesProviderType == ApiProviderType.OPENAI_RESPONSES

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
@@ -103,8 +103,9 @@ class OpenAIResponsesProvider(
         requestJson: JSONObject,
         enableThinking: Boolean
     ) {
+        val isOfficialGpt56 = usesOfficialGpt56Model()
         val reasoningObject = requestJson.optJSONObject("reasoning")
-        if (!enableThinking && reasoningObject == null) {
+        if (!enableThinking && reasoningObject == null && !isOfficialGpt56) {
             return
         }
 
@@ -119,13 +120,17 @@ class OpenAIResponsesProvider(
         val finalReasoningObject = reasoningObject ?: JSONObject()
         val existingEffort =
             finalReasoningObject.optString("effort", "").trim().takeIf { it.isNotEmpty() }
-        if (existingEffort == null && enableThinking) {
-            val effort = resolveResponsesReasoningEffort(context)
+        if (existingEffort == null) {
+            val effort = when {
+                enableThinking -> resolveResponsesReasoningEffort(context)
+                isOfficialGpt56 -> "none"
+                else -> null
+            }
             if (effort != null) {
                 finalReasoningObject.put("effort", effort)
                 AppLogger.d(
                     "OpenAIResponsesProvider",
-                    "Responses reasoning enabled via reasoning.effort=$effort"
+                    "Responses reasoning.effort=$effort"
                 )
             }
         } else {
@@ -137,7 +142,7 @@ class OpenAIResponsesProvider(
 
         val existingSummary =
             finalReasoningObject.optString("summary", "").trim().takeIf { it.isNotEmpty() }
-        if (existingSummary == null) {
+        if (enableThinking && existingSummary == null) {
             finalReasoningObject.put("summary", "auto")
             AppLogger.d(
                 "OpenAIResponsesProvider",
@@ -162,14 +167,22 @@ class OpenAIResponsesProvider(
             return null
         }
 
-        return when (qualityLevel.coerceIn(1, 4)) {
-            1 -> "low"
-            2 -> "medium"
-            3 -> "high"
-            4 -> "xhigh"
-            else -> null
+        return if (usesOfficialGpt56Model()) {
+            OpenAiGpt56Reasoning.effortForQualityLevel(qualityLevel)
+        } else {
+            when (qualityLevel.coerceIn(1, 4)) {
+                1 -> "low"
+                2 -> "medium"
+                3 -> "high"
+                4 -> "xhigh"
+                else -> null
+            }
         }
     }
+
+    private fun usesOfficialGpt56Model(): Boolean =
+        responsesProviderType == ApiProviderType.OPENAI_RESPONSES &&
+            OpenAiGpt56Reasoning.supports(modelName)
 
     private fun shouldAttachPromptCacheKey(): Boolean {
         return responsesProviderType == ApiProviderType.OPENAI_RESPONSES

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiGpt56Reasoning.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiGpt56Reasoning.kt
@@ -1,0 +1,18 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+internal object OpenAiGpt56Reasoning {
+    private val efforts = listOf("low", "medium", "high", "xhigh", "max")
+
+    private val supportedModelIds = setOf(
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna"
+    )
+
+    fun supports(modelName: String): Boolean =
+        modelName.trim().lowercase() in supportedModelIds
+
+    fun effortForQualityLevel(qualityLevel: Int): String =
+        efforts[qualityLevel.coerceIn(1, efforts.size) - 1]
+}

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiGpt56Reasoning.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiGpt56Reasoning.kt
@@ -1,7 +1,24 @@
 package com.ai.assistance.operit.api.chat.llmprovider
 
+import com.ai.assistance.operit.data.model.ApiProviderType
+
 internal object OpenAiGpt56Reasoning {
+    const val LEGACY_MAX_QUALITY_LEVEL = 4
+    const val GPT56_MAX_QUALITY_LEVEL = 5
+
     private val efforts = listOf("low", "medium", "high", "xhigh", "max")
+
+    private val chatProviderTypes = setOf(
+        ApiProviderType.OPENAI,
+        ApiProviderType.OPENAI_GENERIC
+    )
+
+    private val responsesProviderTypes = setOf(
+        ApiProviderType.OPENAI_RESPONSES,
+        ApiProviderType.OPENAI_RESPONSES_GENERIC
+    )
+
+    private val supportedProviderTypes = chatProviderTypes + responsesProviderTypes
 
     private val supportedModelIds = setOf(
         "gpt-5.6",
@@ -12,6 +29,22 @@ internal object OpenAiGpt56Reasoning {
 
     fun supports(modelName: String): Boolean =
         modelName.trim().lowercase() in supportedModelIds
+
+    fun supports(providerType: ApiProviderType?, modelName: String): Boolean =
+        providerType in supportedProviderTypes && supports(modelName)
+
+    fun supportsChat(providerType: ApiProviderType, modelName: String): Boolean =
+        providerType in chatProviderTypes && supports(modelName)
+
+    fun supportsResponses(providerType: ApiProviderType, modelName: String): Boolean =
+        providerType in responsesProviderTypes && supports(modelName)
+
+    fun maxQualityLevel(providerType: ApiProviderType?, modelName: String): Int =
+        if (supports(providerType, modelName)) {
+            GPT56_MAX_QUALITY_LEVEL
+        } else {
+            LEGACY_MAX_QUALITY_LEVEL
+        }
 
     fun effortForQualityLevel(qualityLevel: Int): String =
         efforts[qualityLevel.coerceIn(1, efforts.size) - 1]

--- a/app/src/main/java/com/ai/assistance/operit/data/collects/ScrapedModelPricingRowsCollect.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/collects/ScrapedModelPricingRowsCollect.kt
@@ -67,6 +67,10 @@ object ScrapedModelPricingRowsCollect {
         OPENAI|gpt-5.4-nano|TOKEN|0.2|1.25|0.02|USD
         OPENAI|gpt-5.4|TOKEN|2.5|15|0.25|USD
         OPENAI|gpt-5.5|TOKEN|5|30|0.5|USD
+        OPENAI|gpt-5.6|TOKEN|5|30|0.5|USD
+        OPENAI|gpt-5.6-sol|TOKEN|5|30|0.5|USD
+        OPENAI|gpt-5.6-terra|TOKEN|2.5|15|0.25|USD
+        OPENAI|gpt-5.6-luna|TOKEN|1|6|0.1|USD
         OPENAI|gpt-5|TOKEN|0.75|6|0|USD
         OPENAI|gpt-audio-2025-08-28|TOKEN|1.5|3|0|USD
         OPENAI|gpt-image-1-mini|TOKEN|1.5|4.8|0|USD
@@ -165,6 +169,10 @@ object ScrapedModelPricingRowsCollect {
         OPENAI_RESPONSES|gpt-5.4-nano|TOKEN|0.2|1.25|0.02|USD
         OPENAI_RESPONSES|gpt-5.4|TOKEN|2.5|15|0.25|USD
         OPENAI_RESPONSES|gpt-5.5|TOKEN|5|30|0.5|USD
+        OPENAI_RESPONSES|gpt-5.6|TOKEN|5|30|0.5|USD
+        OPENAI_RESPONSES|gpt-5.6-sol|TOKEN|5|30|0.5|USD
+        OPENAI_RESPONSES|gpt-5.6-terra|TOKEN|2.5|15|0.25|USD
+        OPENAI_RESPONSES|gpt-5.6-luna|TOKEN|1|6|0.1|USD
         OPENAI_RESPONSES|gpt-5|TOKEN|0.75|6|0|USD
         OPENAI_RESPONSES|gpt-audio-2025-08-28|TOKEN|1.5|3|0|USD
         OPENAI_RESPONSES|gpt-image-1-mini|TOKEN|1.5|4.8|0|USD

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ApiPreferences.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ApiPreferences.kt
@@ -171,6 +171,8 @@ class ApiPreferences private constructor(private val context: Context) {
 
         // Default values for Thinking Mode
         const val DEFAULT_ENABLE_THINKING_MODE = false
+        const val MIN_THINKING_QUALITY_LEVEL = 1
+        const val MAX_THINKING_QUALITY_LEVEL = 5
         const val DEFAULT_THINKING_QUALITY_LEVEL = 2
 
         // Default value for Memory Auto Update
@@ -280,7 +282,10 @@ class ApiPreferences private constructor(private val context: Context) {
 
     val thinkingQualityLevelFlow: Flow<Int> =
         context.apiDataStore.data.map { preferences ->
-            (preferences[THINKING_QUALITY_LEVEL] ?: DEFAULT_THINKING_QUALITY_LEVEL).coerceIn(1, 4)
+            (preferences[THINKING_QUALITY_LEVEL] ?: DEFAULT_THINKING_QUALITY_LEVEL).coerceIn(
+                MIN_THINKING_QUALITY_LEVEL,
+                MAX_THINKING_QUALITY_LEVEL
+            )
         }
 
     // Flow for Memory Auto Update
@@ -393,7 +398,10 @@ class ApiPreferences private constructor(private val context: Context) {
 
     suspend fun saveThinkingQualityLevel(level: Int) {
         context.apiDataStore.edit { preferences ->
-            preferences[THINKING_QUALITY_LEVEL] = level.coerceIn(1, 4)
+            preferences[THINKING_QUALITY_LEVEL] = level.coerceIn(
+                MIN_THINKING_QUALITY_LEVEL,
+                MAX_THINKING_QUALITY_LEVEL
+            )
         }
     }
 
@@ -404,7 +412,12 @@ class ApiPreferences private constructor(private val context: Context) {
         context.apiDataStore.edit { preferences ->
             enableThinkingMode?.let { preferences[ENABLE_THINKING_MODE] = it }
 
-            thinkingQualityLevel?.let { preferences[THINKING_QUALITY_LEVEL] = it.coerceIn(1, 4) }
+            thinkingQualityLevel?.let {
+                preferences[THINKING_QUALITY_LEVEL] = it.coerceIn(
+                    MIN_THINKING_QUALITY_LEVEL,
+                    MAX_THINKING_QUALITY_LEVEL
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
@@ -224,7 +224,8 @@ class ModelConfigManager(private val context: Context) {
                             id = config.id,
                             name = config.name,
                             modelName = config.modelName,
-                            apiEndpoint = config.apiEndpoint
+                            apiEndpoint = config.apiEndpoint,
+                            apiProviderType = config.apiProviderType
                     )
             )
         }

--- a/app/src/main/java/com/ai/assistance/operit/integrations/http/WebChatHttpBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/integrations/http/WebChatHttpBridge.kt
@@ -1557,6 +1557,7 @@ class WebChatHttpBridge(
             currentConfigName = currentConfig?.name,
             currentModelIndex = currentModelIndex,
             currentModelName = currentModelName,
+            currentProviderType = currentConfig?.apiProviderType?.name.orEmpty(),
             lockedByCharacterCard = lockedCard != null,
             lockedCharacterCardId = lockedCard?.id,
             lockedCharacterCardName = lockedCard?.name,

--- a/app/src/main/java/com/ai/assistance/operit/integrations/http/WebChatModels.kt
+++ b/app/src/main/java/com/ai/assistance/operit/integrations/http/WebChatModels.kt
@@ -477,6 +477,8 @@ data class WebModelSelectorState(
     val currentModelIndex: Int,
     @SerialName("current_model_name")
     val currentModelName: String,
+    @SerialName("current_provider_type")
+    val currentProviderType: String,
     @SerialName("locked_by_character_card")
     val lockedByCharacterCard: Boolean,
     @SerialName("locked_character_card_id")

--- a/app/src/main/java/com/ai/assistance/operit/services/core/ApiConfigDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/ApiConfigDelegate.kt
@@ -553,7 +553,10 @@ class ApiConfigDelegate(
 
     fun updateThinkingQualityLevel(level: Int) {
         configScope.launch {
-            val clampedLevel = level.coerceIn(1, 4)
+            val clampedLevel = level.coerceIn(
+                ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
+                ApiPreferences.MAX_THINKING_QUALITY_LEVEL
+            )
             apiPreferences.saveThinkingQualityLevel(clampedLevel)
             _thinkingQualityLevel.value = clampedLevel
         }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
@@ -1782,7 +1782,10 @@ private fun AgentThinkingSliderSettingItem(
     var sliderValue by remember { mutableStateOf(value.toFloat()) }
 
     LaunchedEffect(value) {
-        sliderValue = value.toFloat().coerceIn(1f, 4f)
+        sliderValue = value.toFloat().coerceIn(
+            ApiPreferences.MIN_THINKING_QUALITY_LEVEL.toFloat(),
+            ApiPreferences.MAX_THINKING_QUALITY_LEVEL.toFloat()
+        )
     }
 
     Column(
@@ -1816,7 +1819,10 @@ private fun AgentThinkingSliderSettingItem(
             )
             Spacer(modifier = Modifier.weight(1f))
             Text(
-                text = sliderValue.roundToInt().coerceIn(1, 4).toString(),
+                text = sliderValue.roundToInt().coerceIn(
+                    ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
+                    ApiPreferences.MAX_THINKING_QUALITY_LEVEL
+                ).toString(),
                 fontSize = 13.sp,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,
@@ -1827,10 +1833,17 @@ private fun AgentThinkingSliderSettingItem(
             value = sliderValue,
             onValueChange = { sliderValue = it },
             onValueChangeFinished = {
-                onValueChange(sliderValue.roundToInt().coerceIn(1, 4))
+                onValueChange(
+                    sliderValue.roundToInt().coerceIn(
+                        ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
+                        ApiPreferences.MAX_THINKING_QUALITY_LEVEL
+                    )
+                )
             },
-            valueRange = 1f..4f,
-            steps = 2,
+            valueRange =
+                ApiPreferences.MIN_THINKING_QUALITY_LEVEL.toFloat()..
+                    ApiPreferences.MAX_THINKING_QUALITY_LEVEL.toFloat(),
+            steps = 3,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
@@ -109,6 +109,7 @@ import androidx.compose.ui.window.PopupProperties
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.api.chat.EnhancedAIService
 import com.ai.assistance.operit.api.chat.library.MemoryAutoSaveScheduler
+import com.ai.assistance.operit.api.chat.llmprovider.OpenAiGpt56Reasoning
 import com.ai.assistance.operit.core.tools.ToolProgressBus
 import com.ai.assistance.operit.data.model.AttachmentInfo
 import com.ai.assistance.operit.data.model.ChatMessage
@@ -1519,6 +1520,15 @@ private fun AgentModelSelectorPopup(
         )
     }
     val inputMenuTogglesBySlot = inputMenuToggles.groupBy { InputMenuToggleSlots.normalize(it.slot) }
+    val currentConfig = configSummaries.find { it.id == currentConfigMapping.configId }
+    val currentModelName = currentConfig?.let { config ->
+        val validIndex = getValidModelIndex(config.modelName, currentConfigMapping.modelIndex)
+        getModelByIndex(config.modelName, validIndex)
+    }.orEmpty()
+    val maxThinkingQualityLevel = OpenAiGpt56Reasoning.maxQualityLevel(
+        currentConfig?.apiProviderType,
+        currentModelName
+    )
 
     Popup(
         alignment = Alignment.TopStart,
@@ -1571,7 +1581,15 @@ private fun AgentModelSelectorPopup(
                         enableThinkingMode = enableThinkingMode,
                         onToggleThinkingMode = onToggleThinkingMode,
                         thinkingQualityLevel = thinkingQualityLevel,
-                        onThinkingQualityLevelChange = onThinkingQualityLevelChange,
+                        maxThinkingQualityLevel = maxThinkingQualityLevel,
+                        onThinkingQualityLevelChange = { level ->
+                            onThinkingQualityLevelChange(
+                                level.coerceIn(
+                                    ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
+                                    maxThinkingQualityLevel
+                                )
+                            )
+                        },
                         thinkingSlotToggles = inputMenuTogglesBySlot[InputMenuToggleSlots.THINKING].orEmpty(),
                         expanded = showThinkingDropdown,
                         onExpandedChange = { showThinkingDropdown = it },
@@ -1671,6 +1689,7 @@ private fun AgentThinkingSettingsItem(
     enableThinkingMode: Boolean,
     onToggleThinkingMode: () -> Unit,
     thinkingQualityLevel: Int,
+    maxThinkingQualityLevel: Int,
     onThinkingQualityLevelChange: (Int) -> Unit,
     thinkingSlotToggles: List<InputMenuToggleDefinition>,
     expanded: Boolean,
@@ -1758,6 +1777,7 @@ private fun AgentThinkingSettingsItem(
                 AgentThinkingSliderSettingItem(
                     label = stringResource(R.string.thinking_quality),
                     value = thinkingQualityLevel,
+                    maxThinkingQualityLevel = maxThinkingQualityLevel,
                     onValueChange = onThinkingQualityLevelChange,
                     onInfoClick = onThinkingQualityInfoClick,
                 )
@@ -1776,15 +1796,16 @@ private fun AgentThinkingSettingsItem(
 private fun AgentThinkingSliderSettingItem(
     label: String,
     value: Int,
+    maxThinkingQualityLevel: Int,
     onValueChange: (Int) -> Unit,
     onInfoClick: () -> Unit,
 ) {
     var sliderValue by remember { mutableStateOf(value.toFloat()) }
 
-    LaunchedEffect(value) {
+    LaunchedEffect(value, maxThinkingQualityLevel) {
         sliderValue = value.toFloat().coerceIn(
             ApiPreferences.MIN_THINKING_QUALITY_LEVEL.toFloat(),
-            ApiPreferences.MAX_THINKING_QUALITY_LEVEL.toFloat()
+            maxThinkingQualityLevel.toFloat()
         )
     }
 
@@ -1821,7 +1842,7 @@ private fun AgentThinkingSliderSettingItem(
             Text(
                 text = sliderValue.roundToInt().coerceIn(
                     ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
-                    ApiPreferences.MAX_THINKING_QUALITY_LEVEL
+                    maxThinkingQualityLevel
                 ).toString(),
                 fontSize = 13.sp,
                 fontWeight = FontWeight.Bold,
@@ -1836,14 +1857,15 @@ private fun AgentThinkingSliderSettingItem(
                 onValueChange(
                     sliderValue.roundToInt().coerceIn(
                         ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
-                        ApiPreferences.MAX_THINKING_QUALITY_LEVEL
+                        maxThinkingQualityLevel
                     )
                 )
             },
             valueRange =
                 ApiPreferences.MIN_THINKING_QUALITY_LEVEL.toFloat()..
-                    ApiPreferences.MAX_THINKING_QUALITY_LEVEL.toFloat(),
-            steps = 3,
+                    maxThinkingQualityLevel.toFloat(),
+            steps = (maxThinkingQualityLevel -
+                ApiPreferences.MIN_THINKING_QUALITY_LEVEL - 1).coerceAtLeast(0),
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.kt
@@ -62,6 +62,7 @@ import com.ai.assistance.operit.data.model.FunctionType
 import com.ai.assistance.operit.data.model.ModelConfigSummary
 import com.ai.assistance.operit.data.model.PreferenceProfile
 import com.ai.assistance.operit.data.preferences.CharacterCardManager
+import com.ai.assistance.operit.data.preferences.ApiPreferences
 import com.ai.assistance.operit.data.preferences.ActivePromptManager
 import com.ai.assistance.operit.data.model.ActivePrompt
 import com.ai.assistance.operit.data.preferences.FunctionalConfigManager
@@ -1385,12 +1386,17 @@ private fun ThinkingSettingsItem(
                             icon = Icons.Outlined.Speed,
                             value = thinkingQualityLevel.toFloat(),
                             onValueChange = { newValue ->
-                                val intValue = newValue.toInt().coerceIn(1, 4)
+                                val intValue = newValue.toInt().coerceIn(
+                                    ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
+                                    ApiPreferences.MAX_THINKING_QUALITY_LEVEL
+                                )
                                 onThinkingQualityLevelChange(intValue)
                             },
                             onInfoClick = onThinkingQualityInfoClick,
-                            valueRange = 1f..4f,
-                            steps = 2,
+                            valueRange =
+                                ApiPreferences.MIN_THINKING_QUALITY_LEVEL.toFloat()..
+                                    ApiPreferences.MAX_THINKING_QUALITY_LEVEL.toFloat(),
+                            steps = 3,
                             decimalFormatPattern = "0"
                         )
                     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.window.PopupProperties
 import android.widget.Toast
 import com.ai.assistance.operit.api.chat.EnhancedAIService
 import com.ai.assistance.operit.api.chat.library.MemoryAutoSaveScheduler
+import com.ai.assistance.operit.api.chat.llmprovider.OpenAiGpt56Reasoning
 import com.ai.assistance.operit.data.model.CharacterCardChatModelBindingMode
 import com.ai.assistance.operit.data.model.CharacterCardMemoryProfileBindingMode
 import com.ai.assistance.operit.data.model.FunctionType
@@ -224,6 +225,10 @@ fun ClassicChatSettingsBar(
             val validIndex = getValidModelIndex(config.modelName, effectiveCurrentConfigMapping.modelIndex)
             getModelByIndex(config.modelName, validIndex).ifEmpty { stringResource(R.string.not_selected) }
         } ?: stringResource(R.string.not_selected)
+    val maxThinkingQualityLevel = OpenAiGpt56Reasoning.maxQualityLevel(
+        currentConfig?.apiProviderType,
+        currentModelName
+    )
     val toolPermissionText =
         when (if (enableTools) permissionLevel else PermissionLevel.FORBID) {
             PermissionLevel.FORBID -> stringResource(R.string.agent_menu_permission_disabled)
@@ -565,7 +570,15 @@ fun ClassicChatSettingsBar(
                                 enableThinkingMode = enableThinkingMode,
                                 onToggleThinkingMode = onToggleThinkingMode,
                                 thinkingQualityLevel = thinkingQualityLevel,
-                                onThinkingQualityLevelChange = onThinkingQualityLevelChange,
+                                maxThinkingQualityLevel = maxThinkingQualityLevel,
+                                onThinkingQualityLevelChange = { level ->
+                                    onThinkingQualityLevelChange(
+                                        level.coerceIn(
+                                            ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
+                                            maxThinkingQualityLevel
+                                        )
+                                    )
+                                },
                                 thinkingSlotToggles = inputMenuTogglesBySlot[InputMenuToggleSlots.THINKING].orEmpty(),
                                 expanded = showThinkingDropdown,
                                 onExpandedChange = { showThinkingDropdown = it },
@@ -1205,6 +1218,7 @@ private fun ThinkingSettingsItem(
     enableThinkingMode: Boolean,
     onToggleThinkingMode: () -> Unit,
     thinkingQualityLevel: Int,
+    maxThinkingQualityLevel: Int,
     onThinkingQualityLevelChange: (Int) -> Unit,
     thinkingSlotToggles: List<InputMenuToggleDefinition>,
     expanded: Boolean,
@@ -1384,19 +1398,23 @@ private fun ThinkingSettingsItem(
                         SettingSliderItem(
                             label = stringResource(R.string.thinking_quality),
                             icon = Icons.Outlined.Speed,
-                            value = thinkingQualityLevel.toFloat(),
+                            value = thinkingQualityLevel.coerceIn(
+                                ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
+                                maxThinkingQualityLevel
+                            ).toFloat(),
                             onValueChange = { newValue ->
                                 val intValue = newValue.toInt().coerceIn(
                                     ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
-                                    ApiPreferences.MAX_THINKING_QUALITY_LEVEL
+                                    maxThinkingQualityLevel
                                 )
                                 onThinkingQualityLevelChange(intValue)
                             },
                             onInfoClick = onThinkingQualityInfoClick,
                             valueRange =
                                 ApiPreferences.MIN_THINKING_QUALITY_LEVEL.toFloat()..
-                                    ApiPreferences.MAX_THINKING_QUALITY_LEVEL.toFloat(),
-                            steps = 3,
+                                    maxThinkingQualityLevel.toFloat(),
+                            steps = (maxThinkingQualityLevel -
+                                ApiPreferences.MIN_THINKING_QUALITY_LEVEL - 1).coerceAtLeast(0),
                             decimalFormatPattern = "0"
                         )
                     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -3153,7 +3153,7 @@
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">Thinking intensity</string>
-    <string name="thinking_quality_desc">Only effective in thinking mode. Four levels are available; higher means deeper reasoning, and level 1 uses auto.</string>
+    <string name="thinking_quality_desc">Only effective in thinking mode. Five levels are available; higher values use deeper reasoning. Supported levels vary by model.</string>
     <string name="model_config">Model Configuration</string>
     <string name="model_config_desc">Select a configured model here, or click Manage Configuration below to create or modify models</string>
     <string name="prompt">Prompt</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -3153,7 +3153,7 @@
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">Thinking intensity</string>
-    <string name="thinking_quality_desc">Only effective in thinking mode. Five levels are available; higher values use deeper reasoning. Supported levels vary by model.</string>
+    <string name="thinking_quality_desc">Only effective in thinking mode. GPT-5.6 models use five levels; other models retain the original four levels. Higher values use deeper reasoning.</string>
     <string name="model_config">Model Configuration</string>
     <string name="model_config_desc">Select a configured model here, or click Manage Configuration below to create or modify models</string>
     <string name="prompt">Prompt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1362,7 +1362,7 @@
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">Intensidad de pensamiento</string>
-    <string name="thinking_quality_desc">Solo funciona en el modo de pensamiento. Hay 4 niveles; cuanto mayor sea el valor, mas profundo razona, y el nivel 1 usa automatico.</string>
+    <string name="thinking_quality_desc">Solo funciona en el modo de pensamiento. Hay cinco niveles; cuanto mayor sea el valor, más profundo será el razonamiento. Los niveles compatibles pueden variar según el modelo.</string>
     
     <string name="provider_doubao">Doubao (Modelo Volcano)</string>
     <string name="provider_nvidia">NVIDIA (API Catalog)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1362,7 +1362,7 @@
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">Intensidad de pensamiento</string>
-    <string name="thinking_quality_desc">Solo funciona en el modo de pensamiento. Hay cinco niveles; cuanto mayor sea el valor, más profundo será el razonamiento. Los niveles compatibles pueden variar según el modelo.</string>
+    <string name="thinking_quality_desc">Solo funciona en el modo de pensamiento. Los modelos GPT-5.6 usan cinco niveles; los demás conservan los cuatro niveles originales. Un valor mayor implica un razonamiento más profundo.</string>
     
     <string name="provider_doubao">Doubao (Modelo Volcano)</string>
     <string name="provider_nvidia">NVIDIA (API Catalog)</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -2643,7 +2643,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">Tingkat Pemikiran</string>
-    <string name="thinking_quality_desc">Hanya berlaku dalam mode berpikir. Tersedia lima tingkat; semakin tinggi nilainya, semakin dalam penalarannya. Tingkat yang didukung dapat berbeda menurut model.</string>
+    <string name="thinking_quality_desc">Hanya berlaku dalam mode berpikir. Model GPT-5.6 menggunakan lima tingkat; model lain tetap menggunakan empat tingkat sebelumnya. Nilai lebih tinggi berarti penalaran lebih dalam.</string>
     <string name="model_config">Konfigurasi Model</string>
     <string name="model_config_desc">Pilih model yang sudah dikonfigurasi di sini, atau ketuk kelola konfigurasi di bawah untuk membuat atau mengubah model</string>
     <string name="prompt">Prompt</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -2643,7 +2643,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">Tingkat Pemikiran</string>
-    <string name="thinking_quality_desc">Hanya berlaku dalam mode berpikir, total 4 tingkat, semakin tinggi nilainya semakin dalam pemikirannya, 1 adalah otomatis.</string>
+    <string name="thinking_quality_desc">Hanya berlaku dalam mode berpikir. Tersedia lima tingkat; semakin tinggi nilainya, semakin dalam penalarannya. Tingkat yang didukung dapat berbeda menurut model.</string>
     <string name="model_config">Konfigurasi Model</string>
     <string name="model_config_desc">Pilih model yang sudah dikonfigurasi di sini, atau ketuk kelola konfigurasi di bawah untuk membuat atau mengubah model</string>
     <string name="prompt">Prompt</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2745,7 +2745,7 @@
     <string name="thinking_type_off">꺼짐</string>
     <string name="thinking_type_mode">모드</string>
     <string name="thinking_quality">사고 강도</string>
-    <string name="thinking_quality_desc">사고 모드에서만 적용됩니다. 5단계가 제공되며, 값이 높을수록 추론이 더 깊어집니다. 지원되는 단계는 모델에 따라 다를 수 있습니다.</string>
+    <string name="thinking_quality_desc">사고 모드에서만 적용됩니다. GPT-5.6 모델은 5단계를 사용하고 다른 모델은 기존 4단계를 유지합니다. 값이 높을수록 추론이 더 깊어집니다.</string>
     <string name="model_config">모델 구성</string>
     <string name="model_config_desc">여기에서 구성된 모델을 선택하거나 아래의 구성 관리를 클릭하여 모델을 생성 또는 수정합니다.</string>
     <string name="prompt">프롬프트</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2745,7 +2745,7 @@
     <string name="thinking_type_off">꺼짐</string>
     <string name="thinking_type_mode">모드</string>
     <string name="thinking_quality">사고 강도</string>
-    <string name="thinking_quality_desc">사고 모드에서만 효과적입니다. 4가지 레벨을 사용할 수 있습니다. 높을수록 추론이 더 깊어지고 레벨 1은 자동을 사용합니다.</string>
+    <string name="thinking_quality_desc">사고 모드에서만 적용됩니다. 5단계가 제공되며, 값이 높을수록 추론이 더 깊어집니다. 지원되는 단계는 모델에 따라 다를 수 있습니다.</string>
     <string name="model_config">모델 구성</string>
     <string name="model_config_desc">여기에서 구성된 모델을 선택하거나 아래의 구성 관리를 클릭하여 모델을 생성 또는 수정합니다.</string>
     <string name="prompt">프롬프트</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -2596,7 +2596,7 @@
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">Tahap pemikiran</string>
-    <string name="thinking_quality_desc">Hanya berkesan dalam mod berfikir. Lima tahap tersedia; nilai yang lebih tinggi bermakna penaakulan lebih mendalam. Tahap yang disokong mungkin berbeza mengikut model.</string>
+    <string name="thinking_quality_desc">Hanya berkesan dalam mod berfikir. Model GPT-5.6 menggunakan lima tahap; model lain mengekalkan empat tahap asal. Nilai lebih tinggi bermakna penaakulan lebih mendalam.</string>
     <string name="model_config">Konfigurasi model</string>
     <string name="model_config_desc">Pilih model yang telah dikonfigurasi di sini, atau klik pengurusan konfigurasi di bawah untuk mencipta atau mengubah suai model</string>
     <string name="prompt">Kata kunci</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -2596,7 +2596,7 @@
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">Tahap pemikiran</string>
-    <string name="thinking_quality_desc">Hanya berkesan dalam mod berfikir, terdapat 4 peringkat, nilai lebih tinggi bermakna pemikiran lebih mendalam, 1 adalah automatik.</string>
+    <string name="thinking_quality_desc">Hanya berkesan dalam mod berfikir. Lima tahap tersedia; nilai yang lebih tinggi bermakna penaakulan lebih mendalam. Tahap yang disokong mungkin berbeza mengikut model.</string>
     <string name="model_config">Konfigurasi model</string>
     <string name="model_config_desc">Pilih model yang telah dikonfigurasi di sini, atau klik pengurusan konfigurasi di bawah untuk mencipta atau mengubah suai model</string>
     <string name="prompt">Kata kunci</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -2648,7 +2648,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="thinking_type_off">desligado</string>
     <string name="thinking_type_mode">modo</string>
     <string name="thinking_quality">grau de pensamento</string>
-    <string name="thinking_quality_desc">Eficaz apenas no modo de pensamento. Há cinco níveis; quanto maior o valor, mais profundo o raciocínio. Os níveis compatíveis podem variar conforme o modelo.</string>
+    <string name="thinking_quality_desc">Eficaz apenas no modo de pensamento. Os modelos GPT-5.6 usam cinco níveis; os demais mantêm os quatro níveis originais. Valores maiores usam raciocínio mais profundo.</string>
     <string name="model_config">Configuração do modelo</string>
     <string name="model_config_desc">Selecione um modelo já configurado aqui ou clique em Gerenciar configuração abaixo para criar ou modificar um modelo.</string>
     <string name="prompt">palavra alerta</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -2648,7 +2648,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="thinking_type_off">desligado</string>
     <string name="thinking_type_mode">modo</string>
     <string name="thinking_quality">grau de pensamento</string>
-    <string name="thinking_quality_desc">Eficaz apenas no modo de pensamento, existem 4 níveis no total. Quanto maior o valor, mais profundo é o pensamento. 1 é automático.</string>
+    <string name="thinking_quality_desc">Eficaz apenas no modo de pensamento. Há cinco níveis; quanto maior o valor, mais profundo o raciocínio. Os níveis compatíveis podem variar conforme o modelo.</string>
     <string name="model_config">Configuração do modelo</string>
     <string name="model_config_desc">Selecione um modelo já configurado aqui ou clique em Gerenciar configuração abaixo para criar ou modificar um modelo.</string>
     <string name="prompt">palavra alerta</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3064,7 +3064,7 @@
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">思考程度</string>
-    <string name="thinking_quality_desc">仅在思考模式下生效，共 5 挡，数值越高思考越深；不同模型支持的档位可能不同。</string>
+    <string name="thinking_quality_desc">仅在思考模式下生效。GPT-5.6 系列使用 5 档，其它模型保持原有 4 档；数值越高思考越深。</string>
     <string name="model_config">模型配置</string>
     <string name="model_config_desc">在这里选择一个已经配置好的模型，或者点击下方的管理配置去新建或修改模型</string>
     <string name="prompt">提示词</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3064,7 +3064,7 @@
     <string name="thinking_type_off">off</string>
     <string name="thinking_type_mode">mode</string>
     <string name="thinking_quality">思考程度</string>
-    <string name="thinking_quality_desc">仅在思考模式下生效，共 4 挡，数值越高思考越深，1 为自动。</string>
+    <string name="thinking_quality_desc">仅在思考模式下生效，共 5 挡，数值越高思考越深；不同模型支持的档位可能不同。</string>
     <string name="model_config">模型配置</string>
     <string name="model_config_desc">在这里选择一个已经配置好的模型，或者点击下方的管理配置去新建或修改模型</string>
     <string name="prompt">提示词</string>

--- a/web-chat/src/ui/features/chat/components/style/input/agent/AgentChatInputSection.tsx
+++ b/web-chat/src/ui/features/chat/components/style/input/agent/AgentChatInputSection.tsx
@@ -59,7 +59,7 @@ const INFO_COPY = {
   },
   thinkingQuality: {
     title: '思考程度',
-    description: '仅在思考模式下生效，共 4 挡，数值越高思考越深，1 为自动。'
+    description: '仅在思考模式下生效，共 5 挡，数值越高思考越深；不同模型支持的档位可能不同。'
   },
   maxMode: {
     title: 'Max模式',
@@ -548,6 +548,7 @@ function AgentThinkingSettingsItem({
                 <option value="2">2</option>
                 <option value="3">3</option>
                 <option value="4">4</option>
+                <option value="5">5</option>
               </select>
             </AgentSettingsRow>
           ) : null}
@@ -773,7 +774,7 @@ export function AgentChatInputSection({
   const circumference = 2 * Math.PI * progressRadius;
   const dashOffset = circumference - processingProgress * circumference;
   const thinkingEnabled = inputSettings?.enable_thinking_mode ?? false;
-  const thinkingQualityLevel = Math.max(1, Math.min(4, inputSettings?.thinking_quality_level ?? 1));
+  const thinkingQualityLevel = Math.max(1, Math.min(5, inputSettings?.thinking_quality_level ?? 1));
   const enableMaxContextMode = inputSettings?.enable_max_context_mode ?? false;
   const enableMemoryAutoUpdate = inputSettings?.enable_memory_auto_update ?? false;
   const enableAutoRead = inputSettings?.enable_auto_read ?? false;

--- a/web-chat/src/ui/features/chat/components/style/input/agent/AgentChatInputSection.tsx
+++ b/web-chat/src/ui/features/chat/components/style/input/agent/AgentChatInputSection.tsx
@@ -19,6 +19,10 @@ import {
   StopIcon,
   TuneIcon
 } from '../../../../util/chatIcons';
+import {
+  clampThinkingQualityLevel,
+  getMaxThinkingQualityLevel
+} from '../../../../util/thinkingQuality';
 import { InputOverlayPopup } from '../common/InputOverlayPopup';
 import { CharacterCardModelBindingSwitchConfirmDialog } from '../common/CharacterCardModelBindingSwitchConfirmDialog';
 import { PendingMessageQueuePanel } from '../common/PendingMessageQueuePanel';
@@ -59,7 +63,7 @@ const INFO_COPY = {
   },
   thinkingQuality: {
     title: '思考程度',
-    description: '仅在思考模式下生效，共 5 挡，数值越高思考越深；不同模型支持的档位可能不同。'
+    description: '仅在思考模式下生效；GPT-5.6 系列使用 5 档，其它模型保持原有 4 档。'
   },
   maxMode: {
     title: 'Max模式',
@@ -488,6 +492,7 @@ function AgentThinkingSettingsItem({
   onQualityInfoClick,
   onToggle,
   onToggleInfoClick,
+  maxQualityLevel,
   qualityLevel
 }: {
   enabled: boolean;
@@ -498,6 +503,7 @@ function AgentThinkingSettingsItem({
   onQualityInfoClick: () => void;
   onToggle: () => void;
   onToggleInfoClick: () => void;
+  maxQualityLevel: number;
   qualityLevel: number;
 }) {
   return (
@@ -544,11 +550,11 @@ function AgentThinkingSettingsItem({
                 }}
                 value={String(qualityLevel)}
               >
-                <option value="1">1</option>
-                <option value="2">2</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-                <option value="5">5</option>
+                {Array.from({ length: maxQualityLevel }, (_, index) => index + 1).map((level) => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
               </select>
             </AgentSettingsRow>
           ) : null}
@@ -774,7 +780,14 @@ export function AgentChatInputSection({
   const circumference = 2 * Math.PI * progressRadius;
   const dashOffset = circumference - processingProgress * circumference;
   const thinkingEnabled = inputSettings?.enable_thinking_mode ?? false;
-  const thinkingQualityLevel = Math.max(1, Math.min(5, inputSettings?.thinking_quality_level ?? 1));
+  const maxThinkingQualityLevel = getMaxThinkingQualityLevel(
+    modelSelector?.current_provider_type,
+    modelSelector?.current_model_name
+  );
+  const thinkingQualityLevel = clampThinkingQualityLevel(
+    inputSettings?.thinking_quality_level ?? 1,
+    maxThinkingQualityLevel
+  );
   const enableMaxContextMode = inputSettings?.enable_max_context_mode ?? false;
   const enableMemoryAutoUpdate = inputSettings?.enable_memory_auto_update ?? false;
   const enableAutoRead = inputSettings?.enable_auto_read ?? false;
@@ -967,6 +980,7 @@ export function AgentChatInputSection({
                   void onUpdateInputSettings({ enable_thinking_mode: !thinkingEnabled });
                 }}
                 onToggleInfoClick={() => setInfoPopupContent(INFO_COPY.thinkingMode)}
+                maxQualityLevel={maxThinkingQualityLevel}
                 qualityLevel={thinkingQualityLevel}
               />
 

--- a/web-chat/src/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.tsx
+++ b/web-chat/src/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.tsx
@@ -11,6 +11,10 @@ import {
   SaveIcon,
   TuneIcon
 } from '../../../../util/chatIcons';
+import {
+  clampThinkingQualityLevel,
+  getMaxThinkingQualityLevel
+} from '../../../../util/thinkingQuality';
 import type {
   WebInputSettingsState,
   WebModelSelectorConfig,
@@ -45,7 +49,7 @@ const INFO_COPY = {
   },
   thinkingQuality: {
     title: '思考程度',
-    description: '仅在思考模式下生效，共 5 挡，数值越高思考越深；不同模型支持的档位可能不同。'
+    description: '仅在思考模式下生效；GPT-5.6 系列使用 5 档，其它模型保持原有 4 档。'
   },
   maxMode: {
     title: 'Max模式',
@@ -475,6 +479,7 @@ function ClassicThinkingSettingsItem({
   onQualityInfoClick,
   onToggle,
   onToggleInfoClick,
+  maxQualityLevel,
   qualityLevel
 }: {
   enabled: boolean;
@@ -485,6 +490,7 @@ function ClassicThinkingSettingsItem({
   onQualityInfoClick: () => void;
   onToggle: () => void;
   onToggleInfoClick: () => void;
+  maxQualityLevel: number;
   qualityLevel: number;
 }) {
   return (
@@ -530,11 +536,11 @@ function ClassicThinkingSettingsItem({
                 }}
                 value={String(qualityLevel)}
               >
-                <option value="1">1</option>
-                <option value="2">2</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-                <option value="5">5</option>
+                {Array.from({ length: maxQualityLevel }, (_, index) => index + 1).map((level) => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
               </select>
             </ClassicSettingsRow>
           ) : null}
@@ -693,7 +699,14 @@ export function ClassicChatSettingsBar({
   const [showDisableSettingsDropdown, setShowDisableSettingsDropdown] = useState(false);
   const [infoPopupContent, setInfoPopupContent] = useState<InfoContent | null>(null);
   const thinkingEnabled = inputSettings?.enable_thinking_mode ?? false;
-  const thinkingQualityLevel = Math.max(1, Math.min(5, inputSettings?.thinking_quality_level ?? 1));
+  const maxThinkingQualityLevel = getMaxThinkingQualityLevel(
+    modelSelector?.current_provider_type,
+    modelSelector?.current_model_name
+  );
+  const thinkingQualityLevel = clampThinkingQualityLevel(
+    inputSettings?.thinking_quality_level ?? 1,
+    maxThinkingQualityLevel
+  );
   const enableMaxContextMode = inputSettings?.enable_max_context_mode ?? false;
   const enableMemoryAutoUpdate = inputSettings?.enable_memory_auto_update ?? false;
   const enableAutoRead = inputSettings?.enable_auto_read ?? false;
@@ -786,6 +799,7 @@ export function ClassicChatSettingsBar({
                     void onUpdateInputSettings({ enable_thinking_mode: !thinkingEnabled });
                   }}
                   onToggleInfoClick={() => openInfo(INFO_COPY.thinkingMode)}
+                  maxQualityLevel={maxThinkingQualityLevel}
                   qualityLevel={thinkingQualityLevel}
                 />
 

--- a/web-chat/src/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.tsx
+++ b/web-chat/src/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.tsx
@@ -45,7 +45,7 @@ const INFO_COPY = {
   },
   thinkingQuality: {
     title: '思考程度',
-    description: '仅在思考模式下生效，共 4 挡，数值越高思考越深，1 为自动。'
+    description: '仅在思考模式下生效，共 5 挡，数值越高思考越深；不同模型支持的档位可能不同。'
   },
   maxMode: {
     title: 'Max模式',
@@ -534,6 +534,7 @@ function ClassicThinkingSettingsItem({
                 <option value="2">2</option>
                 <option value="3">3</option>
                 <option value="4">4</option>
+                <option value="5">5</option>
               </select>
             </ClassicSettingsRow>
           ) : null}
@@ -692,7 +693,7 @@ export function ClassicChatSettingsBar({
   const [showDisableSettingsDropdown, setShowDisableSettingsDropdown] = useState(false);
   const [infoPopupContent, setInfoPopupContent] = useState<InfoContent | null>(null);
   const thinkingEnabled = inputSettings?.enable_thinking_mode ?? false;
-  const thinkingQualityLevel = Math.max(1, Math.min(4, inputSettings?.thinking_quality_level ?? 1));
+  const thinkingQualityLevel = Math.max(1, Math.min(5, inputSettings?.thinking_quality_level ?? 1));
   const enableMaxContextMode = inputSettings?.enable_max_context_mode ?? false;
   const enableMemoryAutoUpdate = inputSettings?.enable_memory_auto_update ?? false;
   const enableAutoRead = inputSettings?.enable_auto_read ?? false;

--- a/web-chat/src/ui/features/chat/util/chatTypes.ts
+++ b/web-chat/src/ui/features/chat/util/chatTypes.ts
@@ -281,6 +281,7 @@ export interface WebModelSelectorState {
   current_config_name?: string | null;
   current_model_index: number;
   current_model_name: string;
+  current_provider_type: string;
   locked_by_character_card: boolean;
   locked_character_card_id?: string | null;
   locked_character_card_name?: string | null;

--- a/web-chat/src/ui/features/chat/util/thinkingQuality.ts
+++ b/web-chat/src/ui/features/chat/util/thinkingQuality.ts
@@ -1,0 +1,33 @@
+const GPT56_MODELS = new Set([
+  'gpt-5.6',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna'
+]);
+
+const OPENAI_PROVIDER_TYPES = new Set([
+  'OPENAI',
+  'OPENAI_GENERIC',
+  'OPENAI_RESPONSES',
+  'OPENAI_RESPONSES_GENERIC'
+]);
+
+export const MIN_THINKING_QUALITY_LEVEL = 1;
+export const LEGACY_MAX_THINKING_QUALITY_LEVEL = 4;
+export const GPT56_MAX_THINKING_QUALITY_LEVEL = 5;
+
+export function getMaxThinkingQualityLevel(
+  providerType: string | null | undefined,
+  modelName: string | null | undefined
+): number {
+  const normalizedProviderType = providerType?.trim().toUpperCase() ?? '';
+  const normalizedModelName = modelName?.trim().toLowerCase() ?? '';
+
+  return OPENAI_PROVIDER_TYPES.has(normalizedProviderType) && GPT56_MODELS.has(normalizedModelName)
+    ? GPT56_MAX_THINKING_QUALITY_LEVEL
+    : LEGACY_MAX_THINKING_QUALITY_LEVEL;
+}
+
+export function clampThinkingQualityLevel(value: number, maxLevel: number): number {
+  return Math.max(MIN_THINKING_QUALITY_LEVEL, Math.min(maxLevel, value));
+}


### PR DESCRIPTION
## 改动边界                                                
                                                         
  本次仅针对 GPT‑5.6 模型接入、推理档位和计费信息进行适                        
  配，不改变默认模型和其他提供商的既有请求逻辑。                                
                                                         
  ## 主要改动                                                
                                                         
  - 支持 GPT‑5.6 模型 ID：                                    
    - `gpt-5.6`                                          
    - `gpt-5.6-sol`                                      
    - `gpt-5.6-terra`                                    
    - `gpt-5.6-luna`                                     
  - 支持 GPT‑5.6 的五档思考强度：                                  
    - 1：`low`                                            
    - 2：`medium`                                         
    - 3：`high`                                           
    - 4：`xhigh`                                          
    - 5：`max`                                            
  - GPT‑5.6 关闭思考模式时显式发送 `none`。                          
  - 标准 OpenAI Chat Completions 使用                        
  `reasoning_effort`。                                    
  - OpenAI Responses API 使用 `reasoning.effort`。          
  - 用户手动配置的 `reasoning_effort` 优先于自动档位映                  
  射。                                                     
  - Android 经典输入栏、Agent 输入栏，以及 Web Chat 两套               
  输入界面均增加第 5 档。                                          
  - 更新思考强度相关的中英文及其他本地化说明。                                
  - 为 `OPENAI` 和 `OPENAI_RESPONSES` 增加 GPT‑5.6 三个模       
  型及 `gpt-5.6` 别名的输入、输出和缓存读取价格。                          
  - 保留现有动态 `/v1/models` 模型列表机制，不新增静态模                    
  型白名单。                                                  
                                                         
  ## 兼容范围                                                
                                                         
  - 旧模型仍沿用原有四档推理映射。                                      
  - Qwen、OpenRouter、DeepSeek、Claude 等其他提供商未改变            
  其原有推理参数规则
  - 做了5.6模型的匹配