### PR TITLE
fix: 持久化 LazyListState 避免状态更新后滚动位置重置 (#709)

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslGeneratedRenderers.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslGeneratedRenderers.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -37,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -359,7 +361,7 @@ internal fun renderLazyColumnNode(
     val spacing = props.dp("spacing")
     val reverseLayout = props.bool("reverseLayout", false)
     val autoScrollToEnd = props.bool("autoScrollToEnd", false)
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val contentNodes = node.slotChildren("content", fallbackToChildren = true)
     val autoScrollSignature =
         if (!autoScrollToEnd) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatHistorySelector.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatHistorySelector.kt
@@ -81,6 +81,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -561,7 +562,7 @@ fun ChatHistorySelector(
             is ActivePrompt.CharacterGroup -> null
         }
     }
-    val actualLazyListState = lazyListState ?: rememberLazyListState()
+    val actualLazyListState = lazyListState ?: rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val ungroupedText = stringResource(R.string.ungrouped)
 
     // 当搜索查询改变时，执行内容搜索（带防抖延迟）

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollNavigator.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollNavigator.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -50,6 +51,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -618,7 +620,7 @@ private fun ChatMessageLocatorDialog(
             .takeIf { it >= 0 }
             ?.let { (it - 2).coerceAtLeast(0) }
             ?: 0
-    val listState = rememberLazyListState(initialFirstVisibleItemIndex = initialIndex)
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState(initialFirstVisibleItemIndex = initialIndex) }
     var searchQuery by remember { mutableStateOf("") }
     var searchEntries by remember { mutableStateOf<List<ChatMessageLocatorPreview>>(emptyList()) }
     var isLoadingSearchEntries by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/DialogComponents.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/DialogComponents.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -116,7 +117,7 @@ fun ContentDetailDialog(
                         )
                         .padding(8.dp)
                 ) {
-                    val dialogListState = rememberLazyListState()
+                    val dialogListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
                     val lines = remember(content) { content.lines() }
 
                     LaunchedEffect(lines.size) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/common/ToolPromptManagerDialog.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/common/ToolPromptManagerDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
@@ -24,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -67,7 +69,7 @@ fun ToolPromptManagerDialog(
         mutableStateOf(manageableTools)
     }
 
-    val lazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val lazyListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
         orderedTools = orderedTools.toMutableList().apply {
             add(to.index, removeAt(from.index))

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Code
@@ -455,7 +456,7 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
 
     // UI state
     val scrollState = rememberScrollState()
-    val historyListState = rememberLazyListState()
+    val historyListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val coroutineScope = rememberCoroutineScope()
     val characterCardManager = remember { CharacterCardManager.getInstance(context) }
     val characterGroupCardManager = remember { CharacterGroupCardManager.getInstance(context) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/WorkspaceManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/WorkspaceManager.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -26,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -1226,7 +1228,7 @@ private fun WorkspaceCommandExecutionDialog(
     onCancel: () -> Unit,
     onCopyOutput: (String) -> Unit
 ) {
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val outputText = remember(state.outputEntries) {
         state.outputEntries.joinToString(separator = "\n")
     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/editor/completion/CompletionPopup.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/editor/completion/CompletionPopup.kt
@@ -6,11 +6,13 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,7 +39,7 @@ fun CompletionPopup(
 ) {
     if (completionItems.isEmpty()) return
     
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     
     Popup(
         alignment = Alignment.TopStart,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseList.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseList.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -47,6 +48,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -113,10 +115,12 @@ fun <T> MarketBrowseList(
     onScrollPositionChanged: (Int, Int) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier
 ) {
-    val listState = rememberLazyListState(
-        initialFirstVisibleItemIndex = initialFirstVisibleItemIndex,
-        initialFirstVisibleItemScrollOffset = initialFirstVisibleItemScrollOffset
-    )
+    val listState = rememberSaveable(saver = LazyListState.Saver) {
+        LazyListState(
+            initialFirstVisibleItemIndex = initialFirstVisibleItemIndex,
+            initialFirstVisibleItemScrollOffset = initialFirstVisibleItemScrollOffset
+        )
+    }
     val pullToRefreshState = rememberPullToRefreshState()
     val showInitialLoading = isLoading && items.isEmpty()
     val lastLoadMoreIndex = remember { mutableStateOf(-1) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -62,6 +63,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -198,7 +200,7 @@ fun UnifiedMarketDetailScreen(
     modifier: Modifier = Modifier
 ) {
     var selectedTabIndex by remember { mutableIntStateOf(0) }
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val pullToRefreshState = rememberPullToRefreshState()
     val tabHeaderIndex = 2
     val shouldPinTitle by remember {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PluginTabContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PluginTabContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Apps
@@ -32,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -71,7 +73,7 @@ fun PluginTabContent(
         mutableStateOf(orderedPluginList)
     }
 
-    val lazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val lazyListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
         orderedItems = orderedItems.toMutableList().apply {
             add(to.index, removeAt(from.index))

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/SkillConfigScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/SkillConfigScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -61,6 +62,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -250,7 +252,7 @@ fun SkillConfigScreen(
                 var orderedSkills by remember(displayedSkills) {
                     mutableStateOf(displayedSkills)
                 }
-                val lazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
+                val lazyListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
                 val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
                     orderedSkills = orderedSkills.toMutableList().apply {
                         add(to.index, removeAt(from.index))

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/mcp/components/MCPDeployProgressDialog.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/mcp/components/MCPDeployProgressDialog.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -14,6 +15,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,7 +39,7 @@ fun MCPDeployProgressDialog(
         onEnvironmentVariablesChange: ((Map<String, String>) -> Unit)? = null
 ) {
     var showEnvVarsDialog by remember { mutableStateOf(false) }
-    val logListState = rememberLazyListState()
+    val logListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
 
     LaunchedEffect(outputMessages.size) {
         if (outputMessages.isNotEmpty()) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/ModelConfigScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/ModelConfigScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -147,7 +148,7 @@ fun ModelConfigScreen(
     val configManager = remember { ModelConfigManager(context) }
     val functionalConfigManager = remember { FunctionalConfigManager(context) }
     val scope = rememberCoroutineScope()
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val saveCoordinator = rememberModelConfigSaveCoordinator()
 
     // 配置状态

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/PersonaCardGenerationScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/PersonaCardGenerationScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -178,7 +179,7 @@ fun PersonaCardGenerationScreen(
         }
     }
 
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val chatMessages = remember { mutableStateListOf<CharacterChatMessage>() }
     var userInput by remember { mutableStateOf("") }
     var isGenerating by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/UserPreferencesSettingsScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/UserPreferencesSettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -18,6 +19,7 @@ import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.ai.assistance.operit.ui.components.CustomScaffold
@@ -113,7 +115,7 @@ fun UserPreferencesSettingsScreen(
     val dateFormatter = SimpleDateFormat(stringResource(R.string.date_format_chinese), Locale.getDefault())
 
     // 动画状态
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
 
     // 加载选中的配置文件
     LaunchedEffect(selectedProfileId) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/filemanager/FileManagerScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/filemanager/FileManagerScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
@@ -17,6 +18,7 @@ import androidx.compose.material.icons.filled.SdCard
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -186,7 +188,7 @@ fun FileManagerScreen(navController: NavController) {
     }
 
     // 为当前目录创建LazyListState
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
 
     // 当前可见的第一个项目的索引
     val firstVisibleItemIndex by remember { derivedStateOf { listState.firstVisibleItemIndex } }

--- a/app/src/main/java/com/ai/assistance/operit/ui/floating/ui/fullscreen/components/MessageDisplay.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/floating/ui/fullscreen/components/MessageDisplay.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
@@ -59,7 +61,7 @@ fun MessageDisplay(
         preferencesManager.bubbleAiContentPaddingLeft.collectAsState(initial = 12f)
     val bubbleAiContentPaddingRight by
         preferencesManager.bubbleAiContentPaddingRight.collectAsState(initial = 12f)
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val displayMessages =
         messages
             .filter { it.sender != "think" }

--- a/app/src/main/java/com/ai/assistance/operit/ui/floating/ui/window/screen/FloatingChatWindowScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/floating/ui/window/screen/FloatingChatWindowScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -696,7 +697,7 @@ private fun ChatMessagesView(
     val hasOlderDisplayHistory = hasOlderDisplayHistoryState.value
     val hasNewerDisplayHistory = hasNewerDisplayHistoryState.value
     val isLoadingDisplayWindow = isLoadingDisplayWindowState.value
-    val scrollState = rememberLazyListState()
+    val scrollState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val messagesCount = floatContext.messages.size
     val displayMessages =
         floatContext.messages


### PR DESCRIPTION
## 关联 Issue
Fixes #709

## 问题
可滚动列表（LazyColumn/设置页）在点击触发状态更新后滚动位置重置到顶部。
根因：列表的 `LazyListState` 在重组 / 可见性切换重建时丢失，普通 `remember` 持有的状态即被丢弃。

## 修复方案
将全仓库 19 处使用 foundation `rememberLazyListState()` 局部创建的 `LazyListState`
统一改为显式 `rememberSaveable(saver = LazyListState.Saver) { LazyListState(...) }` 范式，
使状态在「重组」以及「组合项被销毁后重建」（如列表被放进 `if` / `AnimatedVisibility` 等由点击触发的
可见性切换中）两种情况下都存活。该范式与项目自定义 `lazy` 包（"复制回弹"修复遗留）保持一致。

## 改动范围（19 个文件）
覆盖设置页、主聊天界面、各 Dialog / 弹窗列表：
- 设置页：`ModelConfigScreen` / `UserPreferencesSettingsScreen` / `PersonaCardGenerationScreen`
- 聊天：`AIChatScreen` 历史、`ChatHistorySelector`、`ChatScrollNavigator`、`DialogComponents`、`MessageDisplay`、`FloatingChatWindowScreen`
- 工具 / 市场：`ToolPromptManagerDialog`、`MarketBrowseList`、`UnifiedMarketDetailScreen`、`PluginTabContent`、`SkillConfigScreen`
- 其他：`WorkspaceManager`、`CompletionPopup`、`MCPDeployProgressDialog`、`FileManagerScreen`、`ToolPkgComposeDslGeneratedRenderers`

自定义 `lazy` 包（已自带 saveable）与无调用的死代码 `RecyclerLazyColumn` 刻意不改。

## 验证状态
- 本环境无法 gradle 编译（缺 Android SDK / NDK），改为静态审查：
  全量 `git diff` 通读 + 多维度 Grep（import 解析、Saver 引用计数、双导入歧义、遗漏形式、显式 scroll 调用）。
- 代码层正确性与一致性已确认；建议维护者在 Android Studio 实机按下方清单验证。
- 因本环境无法编译，请合入前跑一次 `./gradlew compileDebugKotlin` 与 `lintDebug` 确认无导入 / 类型错误。

## 维护者手动验证清单
1. 设置页 / 聊天页：滚动到中段 → 点击触发状态更新的元素 → 滚动位置应保持不回顶。
2. 各 Dialog / 弹窗列表：交互 / 状态更新后不回顶且自动跟随末行。
3. 旋转屏幕（configuration change）后滚动位置应被 `rememberSaveable` 恢复。
4. 新消息 / 日志到来时，自动滚到底部 / 末行的跟随行为不受影响。
