### PR TITLE
fix(markdown): unify LaTeX and text baseline alignment

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/CanvasMarkdownNodeRenderer.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/CanvasMarkdownNodeRenderer.kt
@@ -61,6 +61,8 @@ import com.ai.assistance.operit.util.markdown.MarkdownProcessorType
 import com.ai.assistance.operit.util.stream.Stream
 import java.util.concurrent.ConcurrentHashMap
 import android.graphics.Typeface
+import android.util.TypedValue
+import android.view.Gravity
 import android.widget.TextView
 import ru.noties.jlatexmath.JLatexMathDrawable
 import kotlin.math.floor
@@ -698,6 +700,7 @@ private fun renderNodeContent(
         
         // ========== 块级 LaTeX：保留原组件 ==========
         MarkdownProcessorType.BLOCK_LATEX -> {
+            val formulaTextSizePx = with(density) { fontSizes.bodyMedium.toPx() }
             Surface(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
                 color = Color.Transparent,
@@ -723,34 +726,46 @@ private fun renderNodeContent(
                         AndroidView(
                             factory = { context ->
                                 TextView(context).apply {
-                                    // 设置初始空白状态
-                                    text = ""
+                                    includeFontPadding = false
+                                    gravity = Gravity.CENTER
+                                    setPadding(0, 0, 0, 0)
+                                    setTextSize(TypedValue.COMPLEX_UNIT_PX, formulaTextSizePx)
                                 }
                             },
                             update = { textView ->
-                                // 在update回调中渲染LaTeX公式
                                 try {
                                     val drawable = LatexCache.getDrawable(
                                         latexContent.trim(),
                                         JLatexMathDrawable.builder(latexContent)
-                                            .textSize(14f * textView.resources.displayMetrics.density)
+                                            .textSize(formulaTextSizePx)
                                             .padding(2)
                                             .background(0x00000000)
                                             .align(JLatexMathDrawable.ALIGN_CENTER)
                                             .color(textColor.toArgb())
                                     )
-                                    
-                                    // 设置边界并添加到TextView
-                                    drawable.setBounds(0, 0, drawable.intrinsicWidth, drawable.intrinsicHeight)
-                                    textView.setCompoundDrawables(null, drawable, null, null)
+                                    val formulaText =
+                                        SpannableStringBuilder(INLINE_LATEX_PLACEHOLDER.toString())
+                                    formulaText.setSpan(
+                                        LatexDrawableSpan(drawable),
+                                        0,
+                                        formulaText.length,
+                                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                                    )
+                                    textView.apply {
+                                        includeFontPadding = false
+                                        gravity = Gravity.CENTER
+                                        setPadding(0, 0, 0, 0)
+                                        setTextSize(TypedValue.COMPLEX_UNIT_PX, formulaTextSizePx)
+                                        setTextColor(textColor.toArgb())
+                                        typeface = Typeface.DEFAULT
+                                        text = formulaText
+                                    }
                                 } catch (e: Exception) {
                                     AppLogger.w(TAG, "Block LaTeX render failed, fallback to raw text: $latexContent", e)
-                                    // 渲染失败时回退到公式原文显示，避免整页闪退
-                                    textView.setCompoundDrawables(null, null, null, null)
                                     textView.text = content.trimAll()
                                     textView.setTextColor(textColor.toArgb())
-                                    textView.textSize = 16f
-                                    textView.typeface = android.graphics.Typeface.MONOSPACE
+                                    textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, formulaTextSizePx)
+                                    textView.typeface = Typeface.MONOSPACE
                                 }
                             },
                             modifier = Modifier.wrapContentWidth(unbounded = true)

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/MarkdownInlineSpannable.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/MarkdownInlineSpannable.kt
@@ -3,12 +3,13 @@ package com.ai.assistance.operit.ui.common.markdown
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Typeface
+import android.graphics.drawable.Drawable
 import android.text.StaticLayout
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
-import android.text.style.ImageSpan
 import android.text.style.MetricAffectingSpan
+import android.text.style.ReplacementSpan
 import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
 import android.text.style.URLSpan
@@ -25,10 +26,71 @@ import com.ai.assistance.operit.util.markdown.MarkdownNodeStable
 import com.ai.assistance.operit.util.markdown.MarkdownProcessorType
 import com.ai.assistance.operit.util.streamnative.NativeMarkdownSplitter
 import ru.noties.jlatexmath.JLatexMathDrawable
+import kotlin.math.ceil
+import kotlin.math.floor
 
 private const val TAG = "MarkdownInlineSpannable"
-private const val INLINE_LATEX_PLACEHOLDER = '\uFFFC'
+internal const val INLINE_LATEX_PLACEHOLDER = '\uFFFC'
 private const val MAX_INLINE_RENDER_DEPTH = 24
+
+/**
+ * Places a formula around the surrounding text's visual center instead of aligning the
+ * drawable's bottom to the text baseline. ImageSpan.ALIGN_BASELINE treats the bottom of a
+ * formula bitmap as its baseline, which shifts fractions, integrals and subscripts upward.
+ *
+ * The same span is also used for block formulas so both rendering paths derive their height
+ * from identical drawable metrics.
+ */
+internal class LatexDrawableSpan(
+    private val drawable: Drawable,
+) : ReplacementSpan() {
+    private val width = drawable.intrinsicWidth.coerceAtLeast(1)
+    private val height = drawable.intrinsicHeight.coerceAtLeast(1)
+
+    init {
+        drawable.setBounds(0, 0, width, height)
+    }
+
+    override fun getSize(
+        paint: Paint,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        fontMetrics: Paint.FontMetricsInt?,
+    ): Int {
+        fontMetrics?.let { metrics ->
+            val textMetrics = paint.fontMetricsInt
+            val textCenter = (textMetrics.ascent + textMetrics.descent) / 2f
+            val formulaTop = floor(textCenter - height / 2f).toInt()
+            val formulaBottom = ceil(textCenter + height / 2f).toInt()
+
+            metrics.ascent = minOf(textMetrics.ascent, formulaTop)
+            metrics.descent = maxOf(textMetrics.descent, formulaBottom)
+            metrics.top = minOf(textMetrics.top, metrics.ascent)
+            metrics.bottom = maxOf(textMetrics.bottom, metrics.descent)
+        }
+        return width
+    }
+
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        baseline: Int,
+        bottom: Int,
+        paint: Paint,
+    ) {
+        val textCenter = (paint.ascent() + paint.descent()) / 2f
+        val formulaTop = baseline + textCenter - height / 2f
+        canvas.save()
+        canvas.translate(x, formulaTop)
+        drawable.draw(canvas)
+        canvas.restore()
+    }
+}
 
 private object NestedInlineNodeCache {
     private const val MAX_ENTRIES = 256
@@ -436,7 +498,7 @@ private fun appendInlineNode(
                     builder.append(INLINE_LATEX_PLACEHOLDER)
                     val end = builder.length
                     builder.setSpan(
-                        ImageSpan(drawable, ImageSpan.ALIGN_BASELINE),
+                        LatexDrawableSpan(drawable),
                         start,
                         end,
                         Spanned.SPAN_EXCLUSIVE_EXCLUSIVE


### PR DESCRIPTION
               
  Replace baseline-aligned ImageSpan rendering with a    
  shared ReplacementSpan                                 
  that centers formulas against surrounding text metrics.
  Reuse the same                                         
  measurement path for inline and block LaTeX to prevent 
  vertical offsets in                                    
  Markdown and LaTeX mixed content.  
<img width="1440" height="9522" alt="operit_share_1783791406954" src="https://github.com/user-attachments/assets/7f7ebb34-877a-44cb-b483-8e41f6dbb79f" />
