### PR TITLE
fix(ui): persist LazyListState to preserve scroll position on state update (#709)

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslGeneratedRenderers.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslGeneratedRenderers.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -37,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -359,7 +361,7 @@ internal fun renderLazyColumnNode(
     val spacing = props.dp("spacing")
     val reverseLayout = props.bool("reverseLayout", false)
     val autoScrollToEnd = props.bool("autoScrollToEnd", false)
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val contentNodes = node.slotChildren("content", fallbackToChildren = true)
     val autoScrollSignature =
         if (!autoScrollToEnd) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatHistorySelector.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatHistorySelector.kt
@@ -81,6 +81,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -561,7 +562,7 @@ fun ChatHistorySelector(
             is ActivePrompt.CharacterGroup -> null
         }
     }
-    val actualLazyListState = lazyListState ?: rememberLazyListState()
+    val actualLazyListState = lazyListState ?: rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val ungroupedText = stringResource(R.string.ungrouped)
 
     // 当搜索查询改变时，执行内容搜索（带防抖延迟）

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollNavigator.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollNavigator.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -50,6 +51,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -618,7 +620,7 @@ private fun ChatMessageLocatorDialog(
             .takeIf { it >= 0 }
             ?.let { (it - 2).coerceAtLeast(0) }
             ?: 0
-    val listState = rememberLazyListState(initialFirstVisibleItemIndex = initialIndex)
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState(initialFirstVisibleItemIndex = initialIndex) }
     var searchQuery by remember { mutableStateOf("") }
     var searchEntries by remember { mutableStateOf<List<ChatMessageLocatorPreview>>(emptyList()) }
     var isLoadingSearchEntries by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/DialogComponents.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/DialogComponents.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -116,7 +117,7 @@ fun ContentDetailDialog(
                         )
                         .padding(8.dp)
                 ) {
-                    val dialogListState = rememberLazyListState()
+                    val dialogListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
                     val lines = remember(content) { content.lines() }
 
                     LaunchedEffect(lines.size) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/common/ToolPromptManagerDialog.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/common/ToolPromptManagerDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
@@ -24,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -67,7 +69,7 @@ fun ToolPromptManagerDialog(
         mutableStateOf(manageableTools)
     }
 
-    val lazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val lazyListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
         orderedTools = orderedTools.toMutableList().apply {
             add(to.index, removeAt(from.index))

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Code
@@ -455,7 +456,7 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
 
     // UI state
     val scrollState = rememberScrollState()
-    val historyListState = rememberLazyListState()
+    val historyListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val coroutineScope = rememberCoroutineScope()
     val characterCardManager = remember { CharacterCardManager.getInstance(context) }
     val characterGroupCardManager = remember { CharacterGroupCardManager.getInstance(context) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/WorkspaceManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/WorkspaceManager.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -26,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -1226,7 +1228,7 @@ private fun WorkspaceCommandExecutionDialog(
     onCancel: () -> Unit,
     onCopyOutput: (String) -> Unit
 ) {
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val outputText = remember(state.outputEntries) {
         state.outputEntries.joinToString(separator = "\n")
     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/editor/completion/CompletionPopup.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/editor/completion/CompletionPopup.kt
@@ -6,11 +6,13 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,7 +39,7 @@ fun CompletionPopup(
 ) {
     if (completionItems.isEmpty()) return
     
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     
     Popup(
         alignment = Alignment.TopStart,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseList.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseList.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -47,6 +48,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -113,10 +115,12 @@ fun <T> MarketBrowseList(
     onScrollPositionChanged: (Int, Int) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier
 ) {
-    val listState = rememberLazyListState(
-        initialFirstVisibleItemIndex = initialFirstVisibleItemIndex,
-        initialFirstVisibleItemScrollOffset = initialFirstVisibleItemScrollOffset
-    )
+    val listState = rememberSaveable(saver = LazyListState.Saver) {
+        LazyListState(
+            initialFirstVisibleItemIndex = initialFirstVisibleItemIndex,
+            initialFirstVisibleItemScrollOffset = initialFirstVisibleItemScrollOffset
+        )
+    }
     val pullToRefreshState = rememberPullToRefreshState()
     val showInitialLoading = isLoading && items.isEmpty()
     val lastLoadMoreIndex = remember { mutableStateOf(-1) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -62,6 +63,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -198,7 +200,7 @@ fun UnifiedMarketDetailScreen(
     modifier: Modifier = Modifier
 ) {
     var selectedTabIndex by remember { mutableIntStateOf(0) }
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val pullToRefreshState = rememberPullToRefreshState()
     val tabHeaderIndex = 2
     val shouldPinTitle by remember {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PluginTabContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PluginTabContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Apps
@@ -32,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -71,7 +73,7 @@ fun PluginTabContent(
         mutableStateOf(orderedPluginList)
     }
 
-    val lazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val lazyListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
         orderedItems = orderedItems.toMutableList().apply {
             add(to.index, removeAt(from.index))

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/SkillConfigScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/SkillConfigScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -61,6 +62,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -250,7 +252,7 @@ fun SkillConfigScreen(
                 var orderedSkills by remember(displayedSkills) {
                     mutableStateOf(displayedSkills)
                 }
-                val lazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
+                val lazyListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
                 val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
                     orderedSkills = orderedSkills.toMutableList().apply {
                         add(to.index, removeAt(from.index))

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/mcp/components/MCPDeployProgressDialog.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/mcp/components/MCPDeployProgressDialog.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -14,6 +15,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,7 +39,7 @@ fun MCPDeployProgressDialog(
         onEnvironmentVariablesChange: ((Map<String, String>) -> Unit)? = null
 ) {
     var showEnvVarsDialog by remember { mutableStateOf(false) }
-    val logListState = rememberLazyListState()
+    val logListState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
 
     LaunchedEffect(outputMessages.size) {
         if (outputMessages.isNotEmpty()) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/ModelConfigScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/ModelConfigScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -147,7 +148,7 @@ fun ModelConfigScreen(
     val configManager = remember { ModelConfigManager(context) }
     val functionalConfigManager = remember { FunctionalConfigManager(context) }
     val scope = rememberCoroutineScope()
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val saveCoordinator = rememberModelConfigSaveCoordinator()
 
     // 配置状态

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/PersonaCardGenerationScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/PersonaCardGenerationScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -178,7 +179,7 @@ fun PersonaCardGenerationScreen(
         }
     }
 
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val chatMessages = remember { mutableStateListOf<CharacterChatMessage>() }
     var userInput by remember { mutableStateOf("") }
     var isGenerating by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/UserPreferencesSettingsScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/UserPreferencesSettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -18,6 +19,7 @@ import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.ai.assistance.operit.ui.components.CustomScaffold
@@ -113,7 +115,7 @@ fun UserPreferencesSettingsScreen(
     val dateFormatter = SimpleDateFormat(stringResource(R.string.date_format_chinese), Locale.getDefault())
 
     // 动画状态
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
 
     // 加载选中的配置文件
     LaunchedEffect(selectedProfileId) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/filemanager/FileManagerScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/filemanager/FileManagerScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
@@ -17,6 +18,7 @@ import androidx.compose.material.icons.filled.SdCard
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -186,7 +188,7 @@ fun FileManagerScreen(navController: NavController) {
     }
 
     // 为当前目录创建LazyListState
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
 
     // 当前可见的第一个项目的索引
     val firstVisibleItemIndex by remember { derivedStateOf { listState.firstVisibleItemIndex } }

--- a/app/src/main/java/com/ai/assistance/operit/ui/floating/ui/fullscreen/components/MessageDisplay.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/floating/ui/fullscreen/components/MessageDisplay.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
@@ -59,7 +61,7 @@ fun MessageDisplay(
         preferencesManager.bubbleAiContentPaddingLeft.collectAsState(initial = 12f)
     val bubbleAiContentPaddingRight by
         preferencesManager.bubbleAiContentPaddingRight.collectAsState(initial = 12f)
-    val listState = rememberLazyListState()
+    val listState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val displayMessages =
         messages
             .filter { it.sender != "think" }

--- a/app/src/main/java/com/ai/assistance/operit/ui/floating/ui/window/screen/FloatingChatWindowScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/floating/ui/window/screen/FloatingChatWindowScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -696,7 +697,7 @@ private fun ChatMessagesView(
     val hasOlderDisplayHistory = hasOlderDisplayHistoryState.value
     val hasNewerDisplayHistory = hasNewerDisplayHistoryState.value
     val isLoadingDisplayWindow = isLoadingDisplayWindowState.value
-    val scrollState = rememberLazyListState()
+    val scrollState = rememberSaveable(saver = LazyListState.Saver) { LazyListState() }
     val messagesCount = floatContext.messages.size
     val displayMessages =
         floatContext.messages


### PR DESCRIPTION
## 闂
鍙粴鍔ㄥ垪琛紙LazyColumn / 璁剧疆椤碉級鍦ㄧ偣鍑昏Е鍙戠姸鎬佹洿鏂帮紙閲嶇粍 / 鍙鎬у垏鎹級鍚庢粴鍔ㄤ綅缃噸缃埌椤堕儴銆傛牴鍥狅細LazyListState 鍦ㄩ噸缁勬垨缁勫悎椤硅閿€姣侀噸寤烘椂涓㈠け锛屾櫘閫?emember 鎸佹湁鐨勭姸鎬佽涓㈠純銆傝瑙?#709銆?

## 淇
灏嗗叏浠撳簱 19 澶勫眬閮?ememberLazyListState() 缁熶竴鏀逛负鏄惧紡 ememberSaveable(saver = LazyListState.Saver) { LazyListState(...) }锛屼娇鐘舵€佸湪銆岄噸缁勩€嶄笌銆岀粍鍚堥」琚攢姣佸悗閲嶅缓銆嶏紙濡傚垪琛ㄨ鏀捐繘 if / AnimatedVisibility锛変袱绉嶆儏鍐典笅閮藉瓨娲汇€傝鑼冨紡涓庨」鐩嚜瀹氫箟 lazy 鍖呬繚鎸佷竴鑷淬€?

## 鏀瑰姩鑼冨洿锛?9 涓枃浠讹級
瑕嗙洊璁剧疆椤点€佷富鑱婂ぉ鐣岄潰銆佸悇 Dialog / 寮圭獥鍒楄〃銆佸伐鍏?/ 甯傚満銆佹枃浠剁鐞嗗櫒绛夛紙瀹屾暣娓呭崟瑙?PR 鏂囦欢鍒楄〃锛夈€?

## 楠岃瘉
- 鏈幆澧冩棤娉?gradle 缂栬瘧锛堢己 Android SDK / NDK锛夛紝鏀逛负闈欐€佸鏌ワ細鍏ㄩ噺 diff 閫氳 + 澶氱淮搴?Grep锛坕mport 瑙ｆ瀽銆丼aver 寮曠敤璁℃暟銆佸弻瀵煎叆姝т箟銆侀仐婕忓舰寮忋€佹樉寮?scroll 璋冪敤锛夈€?
- 浠ｇ爜灞傛纭€т笌涓€鑷存€у凡纭锛涜鍦ㄥ悎鍏ュ墠璺戜竴娆?./gradlew compileDebugKotlin 涓?lintDebug 纭鏃犲鍏?/ 绫诲瀷閿欒銆?

### 缁存姢鑰呮墜鍔ㄩ獙璇佹竻鍗?
1. 璁剧疆椤?/ 鑱婂ぉ椤碉細婊氬姩鍒颁腑娈?鈫?鐐瑰嚮瑙﹀彂鐘舵€佹洿鏂扮殑鍏冪礌 鈫?婊氬姩浣嶇疆搴斾繚鎸佷笉鍥為《銆?
2. 鍚?Dialog / 寮圭獥鍒楄〃锛氫氦浜?/ 鐘舵€佹洿鏂板悗涓嶅洖椤朵笖鑷姩璺熼殢鏈銆?
3. 鏃嬭浆灞忓箷锛坈onfiguration change锛夊悗婊氬姩浣嶇疆搴旇 ememberSaveable 鎭㈠銆?
4. 鏂版秷鎭?/ 鏃ュ織鍒版潵鏃讹紝鑷姩婊氬埌搴曢儴 / 鏈鐨勮窡闅忚涓轰笉鍙楀奖鍝嶃€?

Fixes #709