### PR TITLE
perf: hoist regex constants + remove dead code (optimization)

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/repository/MemoryRepository.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/repository/MemoryRepository.kt
@@ -68,6 +68,9 @@ class MemoryRepository(private val context: Context, profileId: String) {
         private const val SEARCH_KEYWORD_COVERAGE_BONUS = 0.6
         private const val SEARCH_RELEVANCE_THRESHOLD = 0.025
         private val INDEX_KEY_SANITIZE_REGEX = Regex("[^a-zA-Z0-9._-]")
+        private val WHITESPACE_SPLIT_REGEX = Regex("\\s+")
+        private val DOC_CHUNK_SPLIT_REGEX = Regex("(\\r?\\n[\\t ]*){2,}")
+        private val DOC_CHUNK_TRIM_REGEX = Regex("(?m)^[\\*\\-=_]{3,}\\s*$")
 
         fun normalizeFolderPath(folderPath: String?): String? {
             val raw = folderPath?.trim() ?: return null
@@ -190,7 +193,7 @@ class MemoryRepository(private val context: Context, profileId: String) {
         return if (query.contains('|')) {
             query.split('|').map { it.trim() }.filter { it.isNotEmpty() }
         } else {
-            query.split(Regex("\\s+")).map { it.trim() }.filter { it.isNotEmpty() }
+            query.split(WHITESPACE_SPLIT_REGEX).map { it.trim() }.filter { it.isNotEmpty() }
         }
     }
 
@@ -783,9 +786,9 @@ class MemoryRepository(private val context: Context, profileId: String) {
         }
         memoryBox.put(documentMemory)
 
-        val chunks = text.split(Regex("(\\r?\\n[\\t ]*){2,}"))
+        val chunks = text.split(DOC_CHUNK_SPLIT_REGEX)
             .mapNotNull { chunkText ->
-                val cleanedText = chunkText.replace(Regex("(?m)^[\\*\\-=_]{3,}\\s*$"), "").trim()
+                val cleanedText = chunkText.replace(DOC_CHUNK_TRIM_REGEX, "").trim()
                 if (cleanedText.isNotBlank()) {
                     DocumentChunk(content = cleanedText, chunkIndex = 0)
                 } else {

--- a/app/src/main/java/com/ai/assistance/operit/ui/floating/FloatingChatWindow.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/floating/FloatingChatWindow.kt
@@ -131,11 +131,6 @@ fun FloatingChatWindow(
             ?: remember { mutableStateOf<String?>(null) }
     val toastEvent by toastEventState
 
-    // 将窗口缩放限制在合理范围内 - 已通过回调和状态源头处理，不再需要
-    // LaunchedEffect(initialWindowScale) {
-    //     floatContext.windowScale = initialWindowScale.coerceIn(0.5f, 1.0f)
-    // }
-
     // 监听输入状态变化
     LaunchedEffect(floatContext.showInputDialog) {
         // 通知服务需要切换焦点模式


### PR DESCRIPTION
perf: hoist 3 regex constants in MemoryRepository (search/chunk hot paths) into companion object, matching existing INDEX_KEY_SANITIZE_REGEX; remove dead commented-out LaunchedEffect block in FloatingChatWindow. Both zero-risk, behavior-preserving. Part of Operit optimization (see research_report_operit_optimization.md).