### PR TITLE
docs: plan DeepSeek reasoning markup safety

### DIFF
--- a/docs/TODO/deepseek_reasoning_markup/1_CodecAndProvider.md
+++ b/docs/TODO/deepseek_reasoning_markup/1_CodecAndProvider.md
@@ -1,4 +1,14 @@
-# Codec and Provider boundary
+---
+title: Codec、canonical grammar 与 Provider 历史投影
+status: draft
+document_type: implementation-step
+step: 1
+depends_on: []
+fork_repository: https://github.com/CATMIAOZHI/Operit
+last_reviewed: 2026-07-17
+---
+
+# Codec、canonical grammar 与 Provider 历史投影
 
 - 新增 DeepSeek 专用、版本化的 `xml-text-v1` codec
 - 编码顺序固定为 `&`、`<`、`>`，解码为严格、非递归的单次扫描
@@ -9,6 +19,41 @@
 - 原生工具调用保持在已关闭的 think block 外
 - `enableToolCall` 只决定工具协议，不改变 reasoning 的结构安全处理
 
+## Canonical wire format
+
+新格式只接受以下精确结构：
+
+```xml
+<think data-operit-content-encoding="xml-text-v1">ENCODED_BODY</think>
+```
+
+- opening tag 必须与上述字符串完全一致：属性名、双引号、属性顺序和空格均固定，不允许附加属性
+- closing tag 固定为 `</think>`；canonical producer 在正常结束、流结束和工具调用边界都必须闭合
+- `ENCODED_BODY` 按 `&` → `&amp;`、`<` → `&lt;`、`>` → `&gt;` 的顺序编码
+- 解码器只识别 `&amp;`、`&lt;`、`&gt;`，并以非递归单次扫描恢复；未知实体逐字符保留
+- 未闭合的 v1 marker 属于 malformed canonical data：不得解码，也不得投影为普通正文或工具输入
+- 未知版本、额外属性或被编辑过的 marker 不按 v1 解码；它们作为 opaque think block 隔离，不进入普通正文或工具输入
+- 相邻 v1 block 按源顺序逐字符拼接，不插入分隔符
+- 混合历史按源顺序处理：v1 body 逐字符追加；旧 `<think>`/`<thinking>` body 维持现有 `trim()` 语义，并在已有 reasoning 后追加旧格式分隔换行
+- visual 编辑器只编辑已隔离的 body，不暴露 marker；raw 编辑导致 marker 不再精确匹配时，按 opaque think block 处理
+
 ## Storage contract
 
 `streamBuffer`、`PromptTurn`、数据库和工具解析输入始终保持编码态。普通 `content` 不编码，以免改变现有 XML 工具协议。
+
+## Cross-provider history projection
+
+`xml-text-v1` 是共享 canonical 历史格式，不是 DeepSeek 请求私有格式。DeepSeek 负责在响应边界编码，但所有 Provider 在构建请求历史和 token 输入前必须通过同一共享 projector 解释 canonical assistant turns。
+
+- DeepSeek → DeepSeek：v1 body 解码到 `reasoning_content`，普通正文进入 `content`
+- DeepSeek → Kimi 或其他有独立 reasoning 字段的 Provider：v1 body 解码到对应 reasoning 字段
+- DeepSeek → 通用 OpenAI：v1 block 从 wire `content` 剥离；除非该 Provider 明确定义了安全 reasoning 通道，否则不发送 reasoning
+- DeepSeek → 不支持 reasoning 的 Provider：v1 block 从请求历史剥离，不转换成普通正文
+- `preserveThinkInHistory=false`：剥离所有 reasoning；`true` 只允许通过目标 Provider 明确支持的安全表示保留，不得原样发送 canonical marker 或 encoded body
+- 旧无 marker 历史继续遵循现有 Provider 行为；共享 projector 不把旧实体文本按 v1 解码
+- token 统计必须使用最终 Provider wire projection，不能使用投影前 canonical 字符串
+- ToolCall 开关两种状态必须复用同一投影结果，工具解析只能接收已移除 think block 的普通正文
+
+## Completion
+
+状态：未完成。实现共享 projector 并完成授权验证后，在一级标题末尾添加 `[DONE]`。

--- a/docs/TODO/deepseek_reasoning_markup/1_CodecAndProvider.md
+++ b/docs/TODO/deepseek_reasoning_markup/1_CodecAndProvider.md
@@ -13,7 +13,7 @@ last_reviewed: 2026-07-17
 - 新增 DeepSeek 专用、版本化的 `xml-text-v1` codec
 - 编码顺序固定为 `&`、`<`、`>`，解码为严格、非递归的单次扫描
 - OpenAI Provider 只提供默认无行为变化的 reasoning emission seam
-- DeepSeek 流式与非流式输出统一编码，token 统计使用编码前原文
+- DeepSeek 流式与非流式输出统一编码，响应输出 token 统计使用编码前原文
 - DeepSeek 历史只对精确版本 marker 解码
 - 工具子轮次逐字符保留 reasoning，不 trim、不插入换行
 - 原生工具调用保持在已关闭的 think block 外
@@ -31,11 +31,25 @@ last_reviewed: 2026-07-17
 - closing tag 固定为 `</think>`；canonical producer 在正常结束、流结束和工具调用边界都必须闭合
 - `ENCODED_BODY` 按 `&` → `&amp;`、`<` → `&lt;`、`>` → `&gt;` 的顺序编码
 - 解码器只识别 `&amp;`、`&lt;`、`&gt;`，并以非递归单次扫描恢复；未知实体逐字符保留
-- 未闭合的 v1 marker 属于 malformed canonical data：不得解码，也不得投影为普通正文或工具输入
-- 未知版本、额外属性或被编辑过的 marker 不按 v1 解码；它们作为 opaque think block 隔离，不进入普通正文或工具输入
+- 未闭合的 v1 marker 属于 malformed canonical data：不得解码，并从 marker 起隔离到当前 assistant turn 末尾
+- 未知版本、额外属性或被编辑过的 reserved marker 不按 v1 解码；它们按下述 grammar 作为 opaque think block 隔离
 - 相邻 v1 block 按源顺序逐字符拼接，不插入分隔符
 - 混合历史按源顺序处理：v1 body 逐字符追加；旧 `<think>`/`<thinking>` body 维持现有 `trim()` 语义，并在已有 reasoning 后追加旧格式分隔换行
 - visual 编辑器只编辑已隔离的 body，不暴露 marker；raw 编辑导致 marker 不再精确匹配时，按 opaque think block 处理
+
+### Reserved marker-shaped grammar
+
+共享 projector 按以下确定性规则识别需要隔离但不得解码的 marker：
+
+1. candidate 必须以字面量 `<think` 开始，且 `think` 后紧跟 ASCII whitespace（U+0009、U+000A、U+000C、U+000D 或 U+0020）；projector 只检查该位置到当前 assistant turn 内第一个 `>` 之间的 opening-tag 区域，没有 `>` 时检查到 turn 末尾。
+2. opening-tag 区域包含精确属性名字面量 `data-operit-content-encoding` 时，该 candidate 是 reserved marker-shaped block。
+3. opening tag 与 v1 opening tag 完全一致时，只有找到后续第一个字面量 `</think>` 才按 v1 解码。
+4. 含保留属性但使用未知版本、单引号、额外属性、不同空格、缺失引号或其他非精确写法时，作为 opaque block，不执行实体解码。
+5. 已闭合 opaque block 从 candidate 起隔离到后续第一个字面量 `</think>` 结束；opening tag 没有 `>`，或之后没有 `</think>` 时，从 candidate 起隔离到当前 assistant turn 末尾。
+6. 隔离范围内的全部字符，包括未闭合 marker 后出现的 `<tool>`、`<tool_result>` 或其他 markup，均不得进入普通正文、工具解析输入或 Provider reasoning 字段。
+7. 不含保留属性的精确旧 `<think>`/`<thinking>` 继续走现有旧历史逻辑；`<think class="foo">` 等既非 reserved marker、也非精确旧标签的内容不由 v1 projector 重新解释。
+
+该 scanner 不推断嵌套 XML，也不搜索 assistant turn 之外的 closing tag。
 
 ## Storage contract
 
@@ -46,12 +60,12 @@ last_reviewed: 2026-07-17
 `xml-text-v1` 是共享 canonical 历史格式，不是 DeepSeek 请求私有格式。DeepSeek 负责在响应边界编码，但所有 Provider 在构建请求历史和 token 输入前必须通过同一共享 projector 解释 canonical assistant turns。
 
 - DeepSeek → DeepSeek：v1 body 解码到 `reasoning_content`，普通正文进入 `content`
-- DeepSeek → Kimi 或其他有独立 reasoning 字段的 Provider：v1 body 解码到对应 reasoning 字段
+- DeepSeek → Kimi，以及显式注册了安全 history reasoning projector 的 Provider：v1 body 解码到对应 reasoning 字段
 - DeepSeek → 通用 OpenAI：v1 block 从 wire `content` 剥离；除非该 Provider 明确定义了安全 reasoning 通道，否则不发送 reasoning
 - DeepSeek → 不支持 reasoning 的 Provider：v1 block 从请求历史剥离，不转换成普通正文
-- `preserveThinkInHistory=false`：剥离所有 reasoning；`true` 只允许通过目标 Provider 明确支持的安全表示保留，不得原样发送 canonical marker 或 encoded body
-- 旧无 marker 历史继续遵循现有 Provider 行为；共享 projector 不把旧实体文本按 v1 解码
-- token 统计必须使用最终 Provider wire projection，不能使用投影前 canonical 字符串
+- 对 v1 block，`preserveThinkInHistory=false` 时剥离 v1 reasoning；`true` 时只允许通过目标 Provider 显式注册的安全表示保留，不得原样发送 canonical marker 或 encoded body
+- 旧无 marker `<think>`/`<thinking>` 历史不受上述 v1 开关规则影响，继续委托给各 Provider 的现有兼容逻辑；共享 projector 不 trim、重排或按 v1 解码旧实体文本
+- DeepSeek 响应输出 token 估算使用编码前的原始 reasoning；历史输入 token 估算使用目标 Provider 的最终 wire projection，不能使用投影前 canonical 字符串
 - ToolCall 开关两种状态必须复用同一投影结果，工具解析只能接收已移除 think block 的普通正文
 
 ## Completion

--- a/docs/TODO/deepseek_reasoning_markup/1_CodecAndProvider.md
+++ b/docs/TODO/deepseek_reasoning_markup/1_CodecAndProvider.md
@@ -1,0 +1,14 @@
+# Codec and Provider boundary
+
+- 新增 DeepSeek 专用、版本化的 `xml-text-v1` codec
+- 编码顺序固定为 `&`、`<`、`>`，解码为严格、非递归的单次扫描
+- OpenAI Provider 只提供默认无行为变化的 reasoning emission seam
+- DeepSeek 流式与非流式输出统一编码，token 统计使用编码前原文
+- DeepSeek 历史只对精确版本 marker 解码
+- 工具子轮次逐字符保留 reasoning，不 trim、不插入换行
+- 原生工具调用保持在已关闭的 think block 外
+- `enableToolCall` 只决定工具协议，不改变 reasoning 的结构安全处理
+
+## Storage contract
+
+`streamBuffer`、`PromptTurn`、数据库和工具解析输入始终保持编码态。普通 `content` 不编码，以免改变现有 XML 工具协议。

--- a/docs/TODO/deepseek_reasoning_markup/2_Presentation.md
+++ b/docs/TODO/deepseek_reasoning_markup/2_Presentation.md
@@ -1,4 +1,15 @@
-# Presentation boundaries
+---
+title: 展示与编辑边界
+status: draft
+document_type: implementation-step
+step: 2
+depends_on:
+  - 1
+fork_repository: https://github.com/CATMIAOZHI/Operit
+last_reviewed: 2026-07-17
+---
+
+# 展示与编辑边界
 
 - Android 静态和流式 think body 在隔离结构后解码
 - rollback/replay 从 canonical snapshot 重建流式 decoder 状态
@@ -6,5 +17,10 @@
 - Web Chat structured block 输出语义正文并保留 canonical raw content
 - TXT 和 HTML 可读导出显示解码后的 reasoning
 - 未带精确 marker 的旧历史维持现有解释规则，不按新格式解码
+- 未知版本、附加属性、raw 编辑后的 marker 和未闭合 marker 显示为 opaque think body，不执行 v1 解码
 
-展示层不得对 canonical 编码体做通用 HTML/XML 解码，也不得扩大 marker 匹配范围。
+展示层不得对 canonical 编码体做通用 HTML/XML 解码，也不得扩大 v1 decoder 的精确 marker 匹配范围；更宽的结构隔离只能把未知 block 视为 opaque，不能触发解码。
+
+## Completion
+
+状态：未完成。完成静态、流式、rollback/replay、编辑器和导出验证后，在一级标题末尾添加 `[DONE]`。

--- a/docs/TODO/deepseek_reasoning_markup/2_Presentation.md
+++ b/docs/TODO/deepseek_reasoning_markup/2_Presentation.md
@@ -1,0 +1,10 @@
+# Presentation boundaries
+
+- Android 静态和流式 think body 在隔离结构后解码
+- rollback/replay 从 canonical snapshot 重建流式 decoder 状态
+- 消息编辑器 visual 模式解码，重组时重新编码
+- Web Chat structured block 输出语义正文并保留 canonical raw content
+- TXT 和 HTML 可读导出显示解码后的 reasoning
+- 未带精确 marker 的旧历史维持现有解释规则，不按新格式解码
+
+展示层不得对 canonical 编码体做通用 HTML/XML 解码，也不得扩大 marker 匹配范围。

--- a/docs/TODO/deepseek_reasoning_markup/2_Presentation.md
+++ b/docs/TODO/deepseek_reasoning_markup/2_Presentation.md
@@ -17,7 +17,7 @@ last_reviewed: 2026-07-17
 - Web Chat structured block 输出语义正文并保留 canonical raw content
 - TXT 和 HTML 可读导出显示解码后的 reasoning
 - 未带精确 marker 的旧历史维持现有解释规则，不按新格式解码
-- 未知版本、附加属性、raw 编辑后的 marker 和未闭合 marker 显示为 opaque think body，不执行 v1 解码
+- 含保留属性的未知版本、附加属性、raw 编辑后的 marker 和未闭合 marker 按步骤 1 的 reserved grammar 显示为 opaque think body，不执行 v1 解码
 
 展示层不得对 canonical 编码体做通用 HTML/XML 解码，也不得扩大 v1 decoder 的精确 marker 匹配范围；更宽的结构隔离只能把未知 block 视为 opaque，不能触发解码。
 

--- a/docs/TODO/deepseek_reasoning_markup/3_Verification.md
+++ b/docs/TODO/deepseek_reasoning_markup/3_Verification.md
@@ -1,0 +1,30 @@
+# Compatibility and verification
+
+## Codec
+
+- 覆盖 `&`、`<`、`>`、未知实体和非递归单次解码
+- 覆盖任意 reasoning SSE chunk 切分，包括标签与实体被逐字符拆分
+- 覆盖纯空白、换行、制表符和 Unicode 的逐字符 round-trip
+- 验证旧无 marker 历史解释规则不变
+
+## Provider
+
+- 覆盖 DeepSeek 流式和非流式 `reasoning_content`
+- 覆盖 `enableToolCall` 开启和关闭两种状态
+- 验证编码输出不改变 token 统计所使用的原始 reasoning
+- 验证工具子轮次恢复出的 `reasoning_content` 与原文逐字符一致
+- 验证其他 OpenAI-compatible Provider 的 reasoning 和工具顺序不变
+
+## Tool isolation
+
+- 验证 reasoning 内字面量 `<tool>`、`</think>` 不进入工具执行器
+- 验证 Provider 生成的真实原生工具调用只执行一次
+- 验证真实工具调用位于已关闭的 canonical think block 外
+
+## Presentation and build
+
+- 覆盖静态 UI、流式 UI、rollback/replay 和消息编辑器 round-trip
+- 检查 Web Chat、TXT 和 HTML 导出的语义显示
+- 通过 fork 的 GitHub Action 运行专项回归测试并构建 debug APK
+
+完成全部验证并记录结果后再在文档末尾添加 `[DONE]`。

--- a/docs/TODO/deepseek_reasoning_markup/3_Verification.md
+++ b/docs/TODO/deepseek_reasoning_markup/3_Verification.md
@@ -24,9 +24,10 @@ last_reviewed: 2026-07-17
 
 - 覆盖 DeepSeek 流式和非流式 `reasoning_content`
 - 覆盖 `enableToolCall` 开启和关闭两种状态
-- 验证编码输出不改变 token 统计所使用的原始 reasoning
+- 验证编码输出不改变 DeepSeek 响应输出 token 统计所使用的原始 reasoning
 - 验证工具子轮次恢复出的 `reasoning_content` 与原文逐字符一致
 - 验证其他 OpenAI-compatible Provider 的 reasoning 和工具顺序不变
+- 分别断言 DeepSeek 响应输出 token 使用编码前 reasoning、历史输入 token 使用目标 Provider 最终 wire projection
 
 ## Provider switching matrix
 
@@ -35,18 +36,33 @@ last_reviewed: 2026-07-17
 | Target Provider | Expected v1 projection |
 | --- | --- |
 | DeepSeek | decoded body → `reasoning_content` |
-| Kimi / reasoning-capable compatible Provider | decoded body → provider reasoning field |
+| Kimi / explicitly registered safe history projector | decoded body → provider reasoning field |
 | generic OpenAI Chat Completions | omit v1 block from wire `content` |
 | Provider without reasoning support | omit v1 block from request history |
 
 每个目标覆盖以下组合和内容：
 
-- `preserveThinkInHistory=true` / `false`
+- 对 v1 block 覆盖 `preserveThinkInHistory=true` / `false`；对旧无 marker block 验证仍委托给目标 Provider 现有逻辑
 - `enableToolCall=true` / `false`
 - reasoning 包含 `</think>`、`<tool>`、`&lt;`、`&amp;lt;` 和未知实体
 - 相邻 v1 block、新旧 block 混合、未知 `xml-text-v2` 和未闭合 marker
 - 切换模型后继续对话，检查请求正文、reasoning 字段和 token 输入完全使用同一投影
 - 确认目标 Provider 不会看到 `data-operit-content-encoding` 或 v1 encoded body
+
+## Marker isolation expectations
+
+| Input form | Expected projection |
+| --- | --- |
+| exact, closed `xml-text-v1` | with preserve enabled, decode only for an explicitly registered safe reasoning projector; with preserve disabled or no safe projector, omit the whole block |
+| closed `xml-text-v2` | opaque; omit through the first `</think>` from content, tools, and reasoning |
+| single-quoted v1 or v1 with extra attributes | opaque; omit through the first `</think>` from content, tools, and reasoning |
+| reserved opening tag without `>` | opaque; omit from candidate start through assistant turn end |
+| exact or opaque opening tag without `</think>` | opaque; omit from candidate start through assistant turn end |
+| `<tool>` after an unclosed reserved marker | remains inside the isolated suffix and never reaches tool parsing |
+| exact legacy `<think>` / `<thinking>` without the reserved attribute | unchanged target-Provider legacy behavior |
+| `<think class="foo">` without the reserved attribute | outside v1 projection; unchanged existing content behavior |
+
+每项同时断言普通正文、reasoning 字段、工具解析输入和 token 输入，不能只检查 UI 输出。
 
 ## Tool isolation
 

--- a/docs/TODO/deepseek_reasoning_markup/3_Verification.md
+++ b/docs/TODO/deepseek_reasoning_markup/3_Verification.md
@@ -1,4 +1,16 @@
-# Compatibility and verification
+---
+title: 兼容性与验证矩阵
+status: draft
+document_type: implementation-step
+step: 3
+depends_on:
+  - 1
+  - 2
+fork_repository: https://github.com/CATMIAOZHI/Operit
+last_reviewed: 2026-07-17
+---
+
+# 兼容性与验证矩阵
 
 ## Codec
 
@@ -6,6 +18,7 @@
 - 覆盖任意 reasoning SSE chunk 切分，包括标签与实体被逐字符拆分
 - 覆盖纯空白、换行、制表符和 Unicode 的逐字符 round-trip
 - 验证旧无 marker 历史解释规则不变
+- 覆盖相邻 v1 block、新旧 block 混合、未闭合 marker、附加属性和未知 `xml-text-v2`
 
 ## Provider
 
@@ -14,6 +27,26 @@
 - 验证编码输出不改变 token 统计所使用的原始 reasoning
 - 验证工具子轮次恢复出的 `reasoning_content` 与原文逐字符一致
 - 验证其他 OpenAI-compatible Provider 的 reasoning 和工具顺序不变
+
+## Provider switching matrix
+
+用同一条由 DeepSeek 生成的 canonical assistant history，分别继续请求：
+
+| Target Provider | Expected v1 projection |
+| --- | --- |
+| DeepSeek | decoded body → `reasoning_content` |
+| Kimi / reasoning-capable compatible Provider | decoded body → provider reasoning field |
+| generic OpenAI Chat Completions | omit v1 block from wire `content` |
+| Provider without reasoning support | omit v1 block from request history |
+
+每个目标覆盖以下组合和内容：
+
+- `preserveThinkInHistory=true` / `false`
+- `enableToolCall=true` / `false`
+- reasoning 包含 `</think>`、`<tool>`、`&lt;`、`&amp;lt;` 和未知实体
+- 相邻 v1 block、新旧 block 混合、未知 `xml-text-v2` 和未闭合 marker
+- 切换模型后继续对话，检查请求正文、reasoning 字段和 token 输入完全使用同一投影
+- 确认目标 Provider 不会看到 `data-operit-content-encoding` 或 v1 encoded body
 
 ## Tool isolation
 
@@ -27,4 +60,6 @@
 - 检查 Web Chat、TXT 和 HTML 导出的语义显示
 - 通过 fork 的 GitHub Action 运行专项回归测试并构建 debug APK
 
-完成全部验证并记录结果后再在文档末尾添加 `[DONE]`。
+## Completion
+
+状态：未完成。完成全部验证并记录结果后，在一级标题末尾添加 `[DONE]`。

--- a/docs/TODO/deepseek_reasoning_markup/index.md
+++ b/docs/TODO/deepseek_reasoning_markup/index.md
@@ -27,7 +27,7 @@ fork 上已有参考实现，供方案审查和验证使用；它早于本次跨
 - Android、Web Chat、消息编辑器和可读导出
 - 新格式测试及旧历史兼容测试
 
-本任务不处理普通正文 XML provenance、#685/#699、其他 Provider 的 reasoning 或 `tool_call_id` 持久化。
+本任务不处理普通正文 XML provenance、#685/#699、`tool_call_id` 持久化，也不改变其他 Provider 自身 reasoning 响应的 canonical 编码方式；跨 Provider 部分只处理 DeepSeek v1 历史向目标 Provider 请求格式的安全投影。
 
 ## Steps
 

--- a/docs/TODO/deepseek_reasoning_markup/index.md
+++ b/docs/TODO/deepseek_reasoning_markup/index.md
@@ -1,0 +1,30 @@
+---
+fork: https://github.com/CATMIAOZHI/Operit
+branch: fix/deepseek-reasoning-markup
+status: in-progress
+issue: https://github.com/AAswordman/Operit/issues/727
+reference_implementation: https://github.com/CATMIAOZHI/Operit/commit/9723b5c5
+---
+
+# DeepSeek reasoning markup safety
+
+DeepSeek 的 `reasoning_content` 当前会被直接放入 Operit 内部 `<think>` 标签。模型返回字面量 `</think>` 时，该文本会被误认为内部结构，继而影响流式显示和工具解析。
+
+本任务计划在 Provider 边界引入版本化 XML text codec。canonical 消息、历史、数据库和工具解析保持编码态，只在 DeepSeek 请求字段和已隔离的展示正文中解码。
+
+fork 上已有参考实现，供方案审查和验证使用；该实现不属于此 docs-only PR，上游接受处理边界后再单独提交代码 PR。
+
+## Scope
+
+- DeepSeek 流式与非流式 reasoning 输出
+- ToolCall 开启和关闭时的历史 round-trip
+- Android、Web Chat、消息编辑器和可读导出
+- 新格式测试及旧历史兼容测试
+
+本任务不处理普通正文 XML provenance、#685/#699、其他 Provider 的 reasoning 或 `tool_call_id` 持久化。
+
+## Steps
+
+- [Codec and provider boundary](1_CodecAndProvider.md)
+- [Presentation boundaries](2_Presentation.md)
+- [Compatibility and verification](3_Verification.md)

--- a/docs/TODO/deepseek_reasoning_markup/index.md
+++ b/docs/TODO/deepseek_reasoning_markup/index.md
@@ -1,23 +1,29 @@
 ---
-fork: https://github.com/CATMIAOZHI/Operit
+title: DeepSeek reasoning markup safety
+status: draft
+document_type: bugfix-plan-index
+step: 0
+depends_on: []
+fork_repository: https://github.com/CATMIAOZHI/Operit
 branch: fix/deepseek-reasoning-markup
-status: in-progress
 issue: https://github.com/AAswordman/Operit/issues/727
 reference_implementation: https://github.com/CATMIAOZHI/Operit/commit/9723b5c5
+last_reviewed: 2026-07-17
 ---
 
 # DeepSeek reasoning markup safety
 
 DeepSeek 的 `reasoning_content` 当前会被直接放入 Operit 内部 `<think>` 标签。模型返回字面量 `</think>` 时，该文本会被误认为内部结构，继而影响流式显示和工具解析。
 
-本任务计划在 Provider 边界引入版本化 XML text codec。canonical 消息、历史、数据库和工具解析保持编码态，只在 DeepSeek 请求字段和已隔离的展示正文中解码。
+本任务计划在 Provider 边界引入版本化 XML text codec。canonical 消息、历史、数据库和工具解析保持编码态，只在共享历史投影、支持 reasoning 的 Provider 请求字段和已隔离的展示正文中解码。
 
-fork 上已有参考实现，供方案审查和验证使用；该实现不属于此 docs-only PR，上游接受处理边界后再单独提交代码 PR。
+fork 上已有参考实现，供方案审查和验证使用；它早于本次跨 Provider 契约修订，尚未实现共享历史投影，也不属于此 docs-only PR。上游接受处理边界后再修订并单独提交代码 PR。
 
 ## Scope
 
 - DeepSeek 流式与非流式 reasoning 输出
-- ToolCall 开启和关闭时的历史 round-trip
+- 对话切换到 Kimi、通用 OpenAI 或不支持 reasoning 的 Provider 时的历史投影
+- `preserveThinkInHistory` 和 ToolCall 开关组合下的历史 round-trip
 - Android、Web Chat、消息编辑器和可读导出
 - 新格式测试及旧历史兼容测试
 
@@ -28,3 +34,7 @@ fork 上已有参考实现，供方案审查和验证使用；该实现不属于
 - [Codec and provider boundary](1_CodecAndProvider.md)
 - [Presentation boundaries](2_Presentation.md)
 - [Compatibility and verification](3_Verification.md)
+
+## Completion
+
+本计划尚未完成。代码、文档和授权验证全部完成后，在各步骤文档的一级标题末尾添加 `[DONE]`。


### PR DESCRIPTION
## Summary

- define the exact versioned canonical grammar for DeepSeek `reasoning_content`
- require a shared history projector before every Provider request and token estimate
- define safe projections for DeepSeek, Kimi, generic OpenAI, and Providers without reasoning support
- specify presentation, malformed-marker, legacy-history, ToolCall isolation, and model-switching verification contracts

## Scope

This is a docs-only planning PR. It does not change production behavior. The linked reference implementation predates the cross-Provider contract and does not yet satisfy it; implementation changes will be submitted separately after these boundaries are agreed.

## Review focus

- exact canonical grammar and malformed/unknown-version behavior
- shared cross-Provider projection semantics, including `preserveThinkInHistory`
- provider-switching and ToolCall verification matrix
- preservation of legacy unmarked history behavior

Related to #727