### PR TITLE
Add Atlas Cloud as an OpenAI-compatible provider

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIServiceFactory.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIServiceFactory.kt
@@ -302,6 +302,7 @@ object AIServiceFactory {
             // OpenAI格式，支持原生和兼容OpenAI API的服务
             ApiProviderType.OPENAI,
             ApiProviderType.OPENAI_GENERIC,
+            ApiProviderType.ATLASCLOUD,
             ApiProviderType.OPENAI_LOCAL ->
                 OpenAIProvider(
                     apiEndpoint = config.apiEndpoint,

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
@@ -68,6 +68,7 @@ object ModelListFetcher {
                     ApiProviderType.OPENAI_RESPONSES,
                     ApiProviderType.OPENAI_RESPONSES_GENERIC,
                     ApiProviderType.OPENAI_GENERIC,
+                    ApiProviderType.ATLASCLOUD,
                     ApiProviderType.OPENAI_LOCAL -> "${extractBaseUrl(apiEndpoint)}/v1/models"
                     ApiProviderType.ANTHROPIC,
                     ApiProviderType.ANTHROPIC_GENERIC -> "${extractBaseUrl(apiEndpoint)}/v1/models"

--- a/app/src/main/java/com/ai/assistance/operit/data/collects/ApiProviderConfigCollect.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/collects/ApiProviderConfigCollect.kt
@@ -39,6 +39,11 @@ object ApiProviderConfigs {
             defaultApiEndpoint = ""
         ),
         ProviderApiConfig(
+            providerType = ApiProviderType.ATLASCLOUD,
+            defaultModelName = "qwen/qwen3.5-flash",
+            defaultApiEndpoint = "https://api.atlascloud.ai/v1/chat/completions"
+        ),
+        ProviderApiConfig(
             providerType = ApiProviderType.ANTHROPIC,
             defaultModelName = "claude-3-opus-20240229",
             defaultApiEndpoint = "https://api.anthropic.com/v1/messages"

--- a/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
@@ -9,6 +9,7 @@ enum class ApiProviderType {
         OPENAI_RESPONSES, // OpenAI Responses API
         OPENAI_RESPONSES_GENERIC, // OpenAI Responses通用（自定义端点）
         OPENAI_GENERIC, // OpenAI通用（自定义端点）
+        ATLASCLOUD, // Atlas Cloud OpenAI兼容API
         ANTHROPIC, // Anthropic (Claude系列)
         ANTHROPIC_GENERIC, // Anthropic通用（自定义端点）
         GOOGLE, // Google (Gemini系列)

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
@@ -1056,6 +1056,7 @@ private fun getBuiltInProviderDisplayName(provider: ApiProviderType, context: an
         ApiProviderType.OPENAI_RESPONSES -> context.getString(R.string.provider_openai_responses)
         ApiProviderType.OPENAI_RESPONSES_GENERIC -> context.getString(R.string.provider_openai_responses_generic)
         ApiProviderType.OPENAI_GENERIC -> context.getString(R.string.provider_openai_generic)
+        ApiProviderType.ATLASCLOUD -> context.getString(R.string.provider_atlascloud)
         ApiProviderType.ANTHROPIC -> context.getString(R.string.provider_anthropic)
         ApiProviderType.ANTHROPIC_GENERIC -> context.getString(R.string.provider_anthropic_generic)
         ApiProviderType.GOOGLE -> context.getString(R.string.provider_google)
@@ -1712,6 +1713,7 @@ private fun getProviderColor(providerTypeId: String): androidx.compose.ui.graphi
         ApiProviderType.OPENAI_RESPONSES -> MaterialTheme.colorScheme.primary.copy(alpha = 0.92f)
         ApiProviderType.OPENAI_RESPONSES_GENERIC -> MaterialTheme.colorScheme.primary.copy(alpha = 0.88f)
         ApiProviderType.OPENAI_GENERIC -> MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
+        ApiProviderType.ATLASCLOUD -> MaterialTheme.colorScheme.primary.copy(alpha = 0.76f)
         ApiProviderType.ANTHROPIC -> MaterialTheme.colorScheme.tertiary
         ApiProviderType.ANTHROPIC_GENERIC -> MaterialTheme.colorScheme.tertiary.copy(alpha = 0.85f)
         ApiProviderType.GOOGLE -> MaterialTheme.colorScheme.secondary

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3844,6 +3844,7 @@
     <string name="provider_openai">OpenAI (GPT系列)</string>
     <string name="provider_openai_responses">OpenAI (Responses API)</string>
     <string name="provider_openai_responses_generic">OpenAI Responses通用</string>
+    <string name="provider_atlascloud">Atlas Cloud</string>
     <string name="provider_anthropic">Anthropic (Claude系列)</string>
     <string name="provider_anthropic_generic">Anthropic通用</string>
     <string name="provider_google">Google (Gemini系列)</string>

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/EndpointCompleterProviderSpecificTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/EndpointCompleterProviderSpecificTest.kt
@@ -20,6 +20,13 @@ class EndpointCompleterProviderSpecificTest {
         )
     }
 
+    @Test fun atlasCloud_usesOpenAiCompatibleChatCompletion() {
+        assertEquals(
+            "https://api.atlascloud.ai/v1/chat/completions",
+            EndpointCompleter.completeEndpoint("https://api.atlascloud.ai/v1", ApiProviderType.ATLASCLOUD)
+        )
+    }
+
     @Test fun googleProvider_withHashReturnsRawUrlWithoutHash() {
         assertEquals(
             "https://example.com",

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcherAtlasCloudTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcherAtlasCloudTest.kt
@@ -1,0 +1,18 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import com.ai.assistance.operit.data.model.ApiProviderType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ModelListFetcherAtlasCloudTest {
+
+    @Test fun atlasCloud_usesOpenAiCompatibleModelsEndpoint() {
+        assertEquals(
+            "https://api.atlascloud.ai/v1/models",
+            ModelListFetcher.getModelsListUrl(
+                "https://api.atlascloud.ai/v1/chat/completions",
+                ApiProviderType.ATLASCLOUD
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a built-in OpenAI-compatible chat provider option
- set the default endpoint to https://api.atlascloud.ai/v1/chat/completions with qwen/qwen3.5-flash as the starter model
- route Atlas Cloud through the existing OpenAIProvider path and include focused endpoint/model-list tests

## Validation
- parsed app/src/main/res/values/strings.xml successfully
- checked the focused diff for enum, config, factory, model-list URL, display name, and tests
- confirmed Atlas Cloud /v1/models returns qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro

No README changes.