### PR TITLE
fix(chat): reduce saveable state size to prevent TransactionTooLargeException

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/ThinkToolsXmlNodeGrouper.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/ThinkToolsXmlNodeGrouper.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -245,10 +244,10 @@ class ThinkToolsXmlNodeGrouper(
         // 流结束（包括用户取消后落为静态消息）默认自动收起。
         val shouldAutoExpand = hasLiveXmlStream && !hasNonConformingAfterGroup
 
-        var expanded by rememberSaveable(rendererId, group.stableKey, forceExpandGroups) {
+        var expanded by remember(rendererId, group.stableKey, forceExpandGroups) {
             mutableStateOf(forceExpandGroups || shouldAutoExpand)
         }
-        var userOverride by rememberSaveable(rendererId, group.stableKey, forceExpandGroups) {
+        var userOverride by remember(rendererId, group.stableKey, forceExpandGroups) {
             mutableStateOf<Boolean?>(null)
         }
         val appearedKeys = remember(rendererId, group.stableKey) { mutableStateMapOf<String, Boolean>() }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.filled.CodeOff
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.ai.assistance.operit.ui.components.CustomScaffold
@@ -327,7 +326,7 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
     val isLoadingDisplayWindow by actualViewModel.isLoadingDisplayWindow.collectAsState()
     val popupMessage by actualViewModel.popupMessage.collectAsState()
     val chatViewRuntime = if (isFloatingMode) "floating" else "main"
-    val chatViewId = rememberSaveable { UUID.randomUUID().toString() }
+    val chatViewId = remember { UUID.randomUUID().toString() }
     val currentChatView = remember(chatHistories, currentChatId) {
         chatHistories.find { it.id == currentChatId }
     }
@@ -749,7 +748,7 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
 
     var isSavingInitialConfiguration by remember { mutableStateOf(false) }
     var initialConfigurationSaveFailed by
-        rememberSaveable(activeChatConfigId) { mutableStateOf(false) }
+        remember(activeChatConfigId) { mutableStateOf(false) }
     val showConfig =
         shouldShowConfigDialog ||
             isSavingInitialConfiguration ||


### PR DESCRIPTION
## Problem

During extended chat sessions (including floating window), the app crashes with TransactionTooLargeException (data parcel size 508KB) when returning to foreground. Android Binder transaction limit is ~500KB.

Stack trace shows SaveableStateRegistry key -45knhzl34p20 stores 505KB of state.

## Root Cause

The ThinkToolsXmlNodeGrouper (tool-call foldable group component) uses ememberSaveable for each tool group's expanded/collapsed state. Although each entry is just a Boolean, the number of entries grows with chat messages. When Compose performs SaveableStateRegistry.performSave(), serialized data of all ememberSaveable entries exceeds the Binder limit.

## Changes

Changed the following ememberSaveable calls to emember:

### ThinkToolsXmlNodeGrouper.kt
- expanded - tool group collapse/expand toggle
- userOverride - user manual override of expand state

### AIChatScreen.kt
- chatViewId - temporary UUID identifier for chat view
- initialConfigurationSaveFailed - transient config save failure flag

Fixes #739