### PR TITLE
针对插件市场评论区的bug修复和排序优化

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
@@ -397,7 +397,8 @@ data class MarketV2Comment(
     val author: MarketV2Author = MarketV2Author(),
     val body: String = "",
     val createdAt: String = "",
-    val updatedAt: String = ""
+    val updatedAt: String = "",
+    val likes: Int = 0
 )
 
 @Serializable

--- a/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
@@ -397,8 +397,7 @@ data class MarketV2Comment(
     val author: MarketV2Author = MarketV2Author(),
     val body: String = "",
     val createdAt: String = "",
-    val updatedAt: String = "",
-    val likes: Int = 0
+    val updatedAt: String = ""
 )
 
 @Serializable

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
@@ -167,6 +167,53 @@ data class UnifiedMarketDetailReactionsState(
     val options: List<UnifiedMarketDetailReactionOption> = emptyList()
 )
 
+enum class MarketCommentSortOption {
+    NEWEST,
+    OLDEST,
+    MOST_LIKED
+}
+
+private fun sortMarketComments(
+    comments: List<MarketV2Comment>,
+    sort: MarketCommentSortOption
+): List<MarketV2Comment> {
+    if (comments.isEmpty()) return comments
+    val ids = comments.mapTo(mutableSetOf()) { it.id }
+    val roots = mutableListOf<MarketV2Comment>()
+    val childrenByParent = mutableMapOf<String, MutableList<MarketV2Comment>>()
+    comments.forEach { comment ->
+        val parentId = comment.parentId
+        if (parentId.isNullOrBlank() || parentId == comment.id || parentId !in ids) {
+            roots.add(comment)
+        } else {
+            childrenByParent.getOrPut(parentId) { mutableListOf() }.add(comment)
+        }
+    }
+    val sortedRoots =
+        when (sort) {
+            MarketCommentSortOption.NEWEST -> roots.sortedByDescending { it.createdAt }
+            MarketCommentSortOption.OLDEST -> roots.sortedBy { it.createdAt }
+            MarketCommentSortOption.MOST_LIKED ->
+                roots.sortedWith(
+                    compareByDescending<MarketV2Comment> { it.likes }
+                        .thenByDescending { it.createdAt }
+                )
+        }
+    val result = mutableListOf<MarketV2Comment>()
+    fun appendThread(comment: MarketV2Comment) {
+        result.add(comment)
+        childrenByParent[comment.id]
+            ?.sortedBy { it.createdAt }
+            ?.forEach { appendThread(it) }
+    }
+    sortedRoots.forEach { appendThread(it) }
+    if (result.size < comments.size) {
+        val appended = result.mapTo(mutableSetOf()) { it.id }
+        comments.filterTo(result) { it.id !in appended }
+    }
+    return result
+}
+
 data class UnifiedMarketDetailCommentsState(
     val title: String,
     val comments: List<MarketV2Comment>,
@@ -203,6 +250,11 @@ fun UnifiedMarketDetailScreen(
     modifier: Modifier = Modifier
 ) {
     var selectedTabIndex by remember { mutableIntStateOf(0) }
+    var commentSortOption by remember { mutableStateOf(MarketCommentSortOption.NEWEST) }
+    val sortedComments =
+        remember(comments.comments, commentSortOption) {
+            sortMarketComments(comments.comments, commentSortOption)
+        }
     val listState = rememberLazyListState()
     val pullToRefreshState = rememberPullToRefreshState()
     val tabHeaderIndex = 2
@@ -251,7 +303,9 @@ fun UnifiedMarketDetailScreen(
             item {
                 UnifiedMarketDetailCommentsSectionHeader(
                     state = comments,
-                    reactions = reactions
+                    reactions = reactions,
+                    sortOption = commentSortOption,
+                    onSortOptionChange = { commentSortOption = it }
                 )
             }
 
@@ -260,7 +314,7 @@ fun UnifiedMarketDetailScreen(
                     UnifiedMarketDetailEmptyCommentsCard()
                 }
             } else {
-                items(comments.comments, key = { it.id }) { comment ->
+                items(sortedComments, key = { it.id }) { comment ->
                     UnifiedMarketDetailCommentCard(
                         comment = comment,
                         isReply = comment.parentId != null,
@@ -926,7 +980,9 @@ private fun UnifiedMarketDetailMetadataRow(
 @OptIn(ExperimentalMaterial3Api::class)
 private fun UnifiedMarketDetailCommentsSectionHeader(
     state: UnifiedMarketDetailCommentsState,
-    reactions: UnifiedMarketDetailReactionsState?
+    reactions: UnifiedMarketDetailReactionsState?,
+    sortOption: MarketCommentSortOption,
+    onSortOptionChange: (MarketCommentSortOption) -> Unit
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -1040,6 +1096,46 @@ private fun UnifiedMarketDetailCommentsSectionHeader(
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                listOf(
+                    MarketCommentSortOption.NEWEST to stringResource(R.string.market_comment_sort_newest),
+                    MarketCommentSortOption.OLDEST to stringResource(R.string.market_comment_sort_oldest),
+                    MarketCommentSortOption.MOST_LIKED to stringResource(R.string.market_comment_sort_most_liked)
+                ).forEach { (option, label) ->
+                    val selected = sortOption == option
+                    Surface(
+                        onClick = { onSortOptionChange(option) },
+                        shape = RoundedCornerShape(8.dp),
+                        color =
+                            if (selected) {
+                                MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+                            } else {
+                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+                            },
+                        modifier = Modifier.height(26.dp)
+                    ) {
+                        Box(
+                            modifier = Modifier.padding(horizontal = 10.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                                color =
+                                    if (selected) {
+                                        MaterialTheme.colorScheme.primary
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                    }
+                            )
+                        }
+                    }
+                }
+            }
         }
 
         if (!state.postHint.isNullOrBlank()) {
@@ -1153,6 +1249,7 @@ private fun UnifiedMarketDetailCommentCard(
                             Text(
                                 text = body,
                                 style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 maxLines =
                                     if (bodyExpanded) {
                                         Int.MAX_VALUE

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
@@ -169,8 +169,7 @@ data class UnifiedMarketDetailReactionsState(
 
 enum class MarketCommentSortOption {
     NEWEST,
-    OLDEST,
-    MOST_LIKED
+    OLDEST
 }
 
 private fun sortMarketComments(
@@ -193,11 +192,6 @@ private fun sortMarketComments(
         when (sort) {
             MarketCommentSortOption.NEWEST -> roots.sortedByDescending { it.createdAt }
             MarketCommentSortOption.OLDEST -> roots.sortedBy { it.createdAt }
-            MarketCommentSortOption.MOST_LIKED ->
-                roots.sortedWith(
-                    compareByDescending<MarketV2Comment> { it.likes }
-                        .thenByDescending { it.createdAt }
-                )
         }
     val result = mutableListOf<MarketV2Comment>()
     fun appendThread(comment: MarketV2Comment) {
@@ -1102,8 +1096,7 @@ private fun UnifiedMarketDetailCommentsSectionHeader(
             ) {
                 listOf(
                     MarketCommentSortOption.NEWEST to stringResource(R.string.market_comment_sort_newest),
-                    MarketCommentSortOption.OLDEST to stringResource(R.string.market_comment_sort_oldest),
-                    MarketCommentSortOption.MOST_LIKED to stringResource(R.string.market_comment_sort_most_liked)
+                    MarketCommentSortOption.OLDEST to stringResource(R.string.market_comment_sort_oldest)
                 ).forEach { (option, label) ->
                     val selected = sortOption == option
                     Surface(

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -7522,6 +7522,9 @@
     <string name="market_sort_updated">Recently updated</string>
     <string name="market_sort_downloads">Downloads</string>
     <string name="market_sort_likes">Likes</string>
+    <string name="market_comment_sort_newest">Newest</string>
+    <string name="market_comment_sort_oldest">Oldest</string>
+    <string name="market_comment_sort_most_liked">Most liked</string>
     <string name="market_sort_featured">Featured</string>
     <string name="market_filter_featured_only">Featured</string>
     <string name="market_stat_downloads_short">Download %1$d</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -7524,7 +7524,6 @@
     <string name="market_sort_likes">Likes</string>
     <string name="market_comment_sort_newest">Newest</string>
     <string name="market_comment_sort_oldest">Oldest</string>
-    <string name="market_comment_sort_most_liked">Most liked</string>
     <string name="market_sort_featured">Featured</string>
     <string name="market_filter_featured_only">Featured</string>
     <string name="market_stat_downloads_short">Download %1$d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4159,7 +4159,6 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="market_sort_likes">Me gusta</string>
     <string name="market_comment_sort_newest">Más recientes</string>
     <string name="market_comment_sort_oldest">Más antiguos</string>
-    <string name="market_comment_sort_most_liked">Más gustados</string>
     <string name="market_stat_downloads_short">Descargas %1$d</string>
     <string name="open_asset">Abrir recurso</string>
     <string name="metadata_title">Metadatos</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4157,6 +4157,9 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="market_sort_updated">Actualizado recientemente</string>
     <string name="market_sort_downloads">Descargas</string>
     <string name="market_sort_likes">Me gusta</string>
+    <string name="market_comment_sort_newest">Más recientes</string>
+    <string name="market_comment_sort_oldest">Más antiguos</string>
+    <string name="market_comment_sort_most_liked">Más gustados</string>
     <string name="market_stat_downloads_short">Descargas %1$d</string>
     <string name="open_asset">Abrir recurso</string>
     <string name="metadata_title">Metadatos</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -6861,7 +6861,6 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="market_sort_likes">Suka</string>
     <string name="market_comment_sort_newest">Terbaru</string>
     <string name="market_comment_sort_oldest">Terlama</string>
-    <string name="market_comment_sort_most_liked">Paling disukai</string>
     <string name="market_stat_downloads_short">Unduh %1$d</string>
     <string name="market_detail_about_title">Tentang</string>
     <string name="market_detail_status_available">Tersedia</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -6859,6 +6859,9 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="market_sort_updated">Terbaru diperbarui</string>
     <string name="market_sort_downloads">Unduhan</string>
     <string name="market_sort_likes">Suka</string>
+    <string name="market_comment_sort_newest">Terbaru</string>
+    <string name="market_comment_sort_oldest">Terlama</string>
+    <string name="market_comment_sort_most_liked">Paling disukai</string>
     <string name="market_stat_downloads_short">Unduh %1$d</string>
     <string name="market_detail_about_title">Tentang</string>
     <string name="market_detail_status_available">Tersedia</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -4057,7 +4057,6 @@
     <string name="market_sort_likes">좋아요</string>
     <string name="market_comment_sort_newest">최신순</string>
     <string name="market_comment_sort_oldest">오래된순</string>
-    <string name="market_comment_sort_most_liked">좋아요순</string>
     <string name="market_stat_downloads_short">다운로드 %1$d회</string>
     <string name="open_asset">리소스 열기</string>
     <string name="metadata_title">메타데이터</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -4055,6 +4055,9 @@
     <string name="market_sort_updated">최근 업데이트됨</string>
     <string name="market_sort_downloads">다운로드</string>
     <string name="market_sort_likes">좋아요</string>
+    <string name="market_comment_sort_newest">최신순</string>
+    <string name="market_comment_sort_oldest">오래된순</string>
+    <string name="market_comment_sort_most_liked">좋아요순</string>
     <string name="market_stat_downloads_short">다운로드 %1$d회</string>
     <string name="open_asset">리소스 열기</string>
     <string name="metadata_title">메타데이터</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -6859,7 +6859,6 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="market_sort_likes">Suka</string>
     <string name="market_comment_sort_newest">Terbaru</string>
     <string name="market_comment_sort_oldest">Terlama</string>
-    <string name="market_comment_sort_most_liked">Paling disukai</string>
     <string name="market_stat_downloads_short">Muat turun %1$d</string>
     <string name="market_detail_about_title">Pengenalan</string>
     <string name="market_detail_status_available">Tersedia</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -6857,6 +6857,9 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="market_sort_updated">Kemas Kini Terkini</string>
     <string name="market_sort_downloads">Muat Turun</string>
     <string name="market_sort_likes">Suka</string>
+    <string name="market_comment_sort_newest">Terbaru</string>
+    <string name="market_comment_sort_oldest">Terlama</string>
+    <string name="market_comment_sort_most_liked">Paling disukai</string>
     <string name="market_stat_downloads_short">Muat turun %1$d</string>
     <string name="market_detail_about_title">Pengenalan</string>
     <string name="market_detail_status_available">Tersedia</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -6544,7 +6544,6 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="market_sort_likes">Curtidas</string>
     <string name="market_comment_sort_newest">Mais recentes</string>
     <string name="market_comment_sort_oldest">Mais antigos</string>
-    <string name="market_comment_sort_most_liked">Mais curtidos</string>
     <string name="market_stat_downloads_short">%1$d downloads</string>
     <string name="open_asset">Abrir recurso</string>
     <string name="metadata_title">Metadados</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -6542,6 +6542,9 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="market_sort_updated">Atualizados recentemente</string>
     <string name="market_sort_downloads">Downloads</string>
     <string name="market_sort_likes">Curtidas</string>
+    <string name="market_comment_sort_newest">Mais recentes</string>
+    <string name="market_comment_sort_oldest">Mais antigos</string>
+    <string name="market_comment_sort_most_liked">Mais curtidos</string>
     <string name="market_stat_downloads_short">%1$d downloads</string>
     <string name="open_asset">Abrir recurso</string>
     <string name="metadata_title">Metadados</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -4632,7 +4632,6 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="market_sort_likes">Numărul de aprecieri</string>
     <string name="market_comment_sort_newest">Cele mai noi</string>
     <string name="market_comment_sort_oldest">Cele mai vechi</string>
-    <string name="market_comment_sort_most_liked">Cele mai apreciate</string>
     <string name="market_sort_featured">Selecție</string>
     <string name="market_filter_featured_only">Selecție</string>
     <string name="market_stat_downloads_short">Descărcare %1$d</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -4630,6 +4630,9 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="market_sort_updated">Ultimele actualizări</string>
     <string name="market_sort_downloads">Numărul de descărcări</string>
     <string name="market_sort_likes">Numărul de aprecieri</string>
+    <string name="market_comment_sort_newest">Cele mai noi</string>
+    <string name="market_comment_sort_oldest">Cele mai vechi</string>
+    <string name="market_comment_sort_most_liked">Cele mai apreciate</string>
     <string name="market_sort_featured">Selecție</string>
     <string name="market_filter_featured_only">Selecție</string>
     <string name="market_stat_downloads_short">Descărcare %1$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4629,6 +4629,9 @@
     <string name="market_sort_updated">最近更新</string>
     <string name="market_sort_downloads">下载量</string>
     <string name="market_sort_likes">点赞量</string>
+    <string name="market_comment_sort_newest">最新</string>
+    <string name="market_comment_sort_oldest">最旧</string>
+    <string name="market_comment_sort_most_liked">最多赞</string>
     <string name="market_sort_featured">精选</string>
     <string name="market_filter_featured_only">精选</string>
     <string name="market_stat_downloads_short">下载 %1$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4631,7 +4631,6 @@
     <string name="market_sort_likes">点赞量</string>
     <string name="market_comment_sort_newest">最新</string>
     <string name="market_comment_sort_oldest">最旧</string>
-    <string name="market_comment_sort_most_liked">最多赞</string>
     <string name="market_sort_featured">精选</string>
     <string name="market_filter_featured_only">精选</string>
     <string name="market_stat_downloads_short">下载 %1$d</string>


### PR DESCRIPTION
## 变更说明 / Description

  修复市场详情页评论回复归属错误，并改善评论内容的主题适配与排序体验。用户现在可
  以看到回复紧跟对应父评论显示，并按最新或最旧浏览顶层评论。

  ### 背景与动机 / Context and motivation

  评论接口返回的是平铺列表，原 UI 按接口顺序直接渲染，回复仅通过缩进区分，导致回
  复可能显示在最旧评论下方，无法正确归属。同时，评论正文颜色未显式跟随主题，用户
  也缺少基本的评论排序选项。

  ### 改动范围 / Changes

  - 新增 sortMarketComments()，根据 parentId 构建评论树，使每条回复递归显示在对
    应父评论正下方；无法匹配父评论的条目按顶层评论处理。

  - 评论正文使用 MaterialTheme.colorScheme.onSurfaceVariant，自动适配深色和浅色
    主题。

  - 新增 MarketCommentSortOption，支持：
      - 最新
      - 最旧

  - 排序仅作用于顶层评论；回复始终跟随父评论，并按时间正序排列。
  - 移除“最多赞”排序及相关 likes 字段、UI 按钮和多语言文案。
  - 新增全部 8 个语言环境的评论排序文案。
  - 本 PR 不涉及后端接口、评论点赞逻辑、评论提交流程或其他市场页面。

  ### 兼容性与风险 / Compatibility and risks

  - 不修改评论接口协议和现有评论数据格式。
  - 不修改评论提交、回复提交或认证流程。
  - 仅改变评论列表的客户端展示顺序和正文颜色。
  - 评论树整理和排序在客户端内存中执行，正常评论规模下性能影响可忽略。
  - 无新增配置、密钥或外部依赖。

  ## 关联 Issue / Related issue

  N/A。当前没有关联 Issue；本 PR 主要修复评论回复归属问题并补充评论排序与主题适
  配能力。

  ## 验证方式 / Verification

  检查或命令：
  `./gradlew assembleDebugClone`
  `./gradlew assembleDebug`
  均已通过

  ## 证据 / Evidence

  
<img width="1080" height="2400" alt="Screenshot_20260726-203100_Operit_AI" src="https://github.com/user-attachments/assets/c6155bec-a27b-4ef0-9632-6580e6fc3c80" />
<img width="1080" height="2400" alt="Screenshot_20260726-203046_Operit_AI" src="https://github.com/user-attachments/assets/99f4c009-5ea6-47c7-bd1f-fb253ff9dd62" />


  ## 检查清单 / Checklist

  - [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons
    for unrun checks

  - [ ] 我已确认 Candidate checks 覆盖改动范围，并会处理技术失败项 / Candidate
    checks covers the change scope and technical failures will be addressed

  - [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no
    unrelated, temporary, generated, binary, or secret content

  - [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI,
    docs/strings, or compatibility evidence is provided