### PR TITLE
fix: streaming tool call rendering truncated during execution

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/RenderBatchCoordinator.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/RenderBatchCoordinator.kt
@@ -1,0 +1,43 @@
+package com.ai.assistance.operit.ui.common.markdown
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Coalesces render updates without losing the last mutation.
+ *
+ * Requests must be made after renderable state changes. Calls are serialized by the owning
+ * Compose scope, so the revision check and job teardown cannot be interleaved by another request.
+ */
+internal class RenderBatchCoordinator(
+    private val scope: CoroutineScope,
+    private val intervalMs: Long,
+    private val onFlush: () -> Unit,
+) {
+    private var requestedRevision = 0L
+    private var appliedRevision = 0L
+    private var updateJob: Job? = null
+
+    fun requestUpdate() {
+        requestedRevision++
+        if (updateJob?.isActive == true) {
+            return
+        }
+
+        updateJob =
+            scope.launch {
+                try {
+                    while (appliedRevision != requestedRevision) {
+                        delay(intervalMs)
+                        val revisionToApply = requestedRevision
+                        onFlush()
+                        appliedRevision = revisionToApply
+                    }
+                } finally {
+                    updateJob = null
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRenderer.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRenderer.kt
@@ -391,6 +391,19 @@ fun StreamMarkdownRenderer(
         id
     }
 
+    val batchUpdater =
+        remember(rendererId) {
+            BatchNodeUpdater(
+                nodes = nodes,
+                renderNodes = renderNodes,
+                conversionCache = conversionCache,
+                nodeAnimationStates = nodeAnimationStates,
+                xmlNodeStreams = xmlNodeStreams,
+                rendererId = rendererId,
+                scope = scope,
+            )
+        }
+
     // 创建一个中间流，用于拦截和批处理渲染更新
     val interceptedStream =
             remember(markdownStream) {
@@ -402,24 +415,10 @@ fun StreamMarkdownRenderer(
                                 onEach = { it } // 先使用简单的转发函数，后面再设置
                         )
 
-                // 然后创建批处理更新器
-                val batchUpdater =
-                        BatchNodeUpdater(
-                                nodes = nodes,
-                                renderNodes = renderNodes,
-                                conversionCache = conversionCache,
-                                nodeAnimationStates = nodeAnimationStates,
-                                xmlNodeStreams = xmlNodeStreams,
-                                rendererId = rendererId,
-                                isInterceptedStream = processor.interceptedStream,
-                                scope = scope
-                        )
-
-                // 最后设置拦截器的onEach函数
+                // 设置拦截器的onEach函数
                 processor.setOnEach { char ->
                     // 收集字符到 state 的 collectedContent
                     rendererState.collectedContent + char
-                    batchUpdater.startBatchUpdates()
                     char
                 }
 
@@ -448,6 +447,7 @@ fun StreamMarkdownRenderer(
                             (pendingHtmlBreakCount + 1).coerceAtMost(MAX_CONSECUTIVE_RENDERED_NEWLINES)
                     } else {
                         appendHtmlBreakNode(nodes)
+                        batchUpdater.requestUpdate()
                     }
                     return@collect
                 }
@@ -457,6 +457,7 @@ fun StreamMarkdownRenderer(
                         appendHtmlBreakNode(nodes, pendingHtmlBreakCount)
                     }
                     nodes.add(MarkdownNode(type = blockType, initialContent = "---"))
+                    batchUpdater.requestUpdate()
                     pendingHtmlBreakCount = 0
                     return@collect
                 }
@@ -478,6 +479,7 @@ fun StreamMarkdownRenderer(
 
                 if (pendingHtmlBreakCount > 0 && !mergeWithPrevious) {
                     appendHtmlBreakNode(nodes, pendingHtmlBreakCount)
+                    batchUpdater.requestUpdate()
                     pendingHtmlBreakCount = 0
                 }
 
@@ -485,7 +487,10 @@ fun StreamMarkdownRenderer(
                     if (mergeWithPrevious) {
                         nodes.last()
                     } else {
-                        MarkdownNode(type = tempBlockType).also { nodes.add(it) }
+                        MarkdownNode(type = tempBlockType).also {
+                            nodes.add(it)
+                            batchUpdater.requestUpdate()
+                        }
                     }
                 val nodeIndex = nodes.lastIndex
                 val blockStream: Stream<String> =
@@ -497,6 +502,7 @@ fun StreamMarkdownRenderer(
 
                 if (tempBlockType == MarkdownProcessorType.XML_BLOCK) {
                     xmlNodeStreams[nodeIndex] = blockStream
+                    batchUpdater.requestUpdate()
                 }
 
                 if (isInlineContainer) {
@@ -532,6 +538,7 @@ fun StreamMarkdownRenderer(
                                     chunk = chunk,
                                     pendingLineBreakState = pendingLineBreakState,
                                 )
+                            batchUpdater.requestUpdate()
                         }
 
                         if (isInlineLatex && childNode != null) {
@@ -541,6 +548,7 @@ fun StreamMarkdownRenderer(
                             val childIndex = newNode.children.lastIndexOf(childNode)
                             if (childIndex != -1) {
                                 newNode.children[childIndex] = latexChildNode
+                                batchUpdater.requestUpdate()
                             }
                         }
 
@@ -551,12 +559,13 @@ fun StreamMarkdownRenderer(
                             val lastIndex = newNode.children.lastIndex
                             if (lastIndex >= 0 && newNode.children[lastIndex] == childNode) {
                                 newNode.children.removeAt(lastIndex)
+                                batchUpdater.requestUpdate()
                             }
                         }
                     }
                 } else {
                     blockStream.collect { contentChunk ->
-                        newNode.content + contentChunk
+                        batchUpdater.appendBlockChunk(newNode, contentChunk)
                     }
                 }
 
@@ -565,6 +574,7 @@ fun StreamMarkdownRenderer(
                     val latexNode =
                         MarkdownNode(type = MarkdownProcessorType.BLOCK_LATEX, initialContent = latexContent)
                     nodes[nodeIndex] = latexNode
+                    batchUpdater.requestUpdate()
                 }
 
                 pendingHtmlBreakCount = 0
@@ -1083,33 +1093,27 @@ private fun UnifiedMarkdownCanvas(
 }
 
 /** 批量节点更新器 - 负责将原始节点列表的更新批量应用到渲染节点列表 */
-private class BatchNodeUpdater(
+internal class BatchNodeUpdater(
         private val nodes: SnapshotStateList<MarkdownNode>,
         private val renderNodes: SnapshotStateList<MarkdownNodeStable>,
         private val conversionCache: MutableMap<Int, Pair<Int, MarkdownNodeStable>>,
         private val nodeAnimationStates: MutableMap<String, Boolean>,
         private val xmlNodeStreams: MutableMap<Int, Stream<String>>,
         private val rendererId: String,
-        private val isInterceptedStream: Stream<Char>,
         private val scope: CoroutineScope
 ) {
-    private var updateJob: Job? = null
+    private val coordinator =
+        RenderBatchCoordinator(
+            scope = scope,
+            intervalMs = RENDER_INTERVAL_MS,
+            onFlush = ::performBatchUpdate,
+        )
 
-    fun startBatchUpdates() {
-        if (updateJob?.isActive == true) {
-            return
-        }
+    fun requestUpdate() = coordinator.requestUpdate()
 
-        // 创建新的更新任务
-        updateJob =
-                scope.launch {
-                    isInterceptedStream.lock()
-                    delay(RENDER_INTERVAL_MS)
-                    isInterceptedStream.unlock()
-
-                    performBatchUpdate()
-                    updateJob = null
-                }
+    fun appendBlockChunk(node: MarkdownNode, contentChunk: String) {
+        node.content + contentChunk
+        requestUpdate()
     }
 
     private fun performBatchUpdate() {

--- a/app/src/test/java/com/ai/assistance/operit/ui/common/markdown/RenderBatchCoordinatorTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/common/markdown/RenderBatchCoordinatorTest.kt
@@ -1,0 +1,87 @@
+package com.ai.assistance.operit.ui.common.markdown
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import com.ai.assistance.operit.util.markdown.MarkdownNode
+import com.ai.assistance.operit.util.markdown.MarkdownNodeStable
+import com.ai.assistance.operit.util.markdown.MarkdownProcessorType
+import com.ai.assistance.operit.util.stream.Stream
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RenderBatchCoordinatorTest {
+    @Test
+    fun requestWhileBatchIsPending_isIncludedWithoutAnotherInput() = runTest {
+        var flushCount = 0
+        val coordinator =
+            RenderBatchCoordinator(
+                scope = this,
+                intervalMs = 200,
+                onFlush = { flushCount++ },
+            )
+
+        coordinator.requestUpdate()
+        advanceTimeBy(100)
+        coordinator.requestUpdate()
+        advanceUntilIdle()
+
+        assertEquals(1, flushCount)
+    }
+
+    @Test
+    fun requestDuringFlush_isDrainedBeforeCoordinatorBecomesIdle() = runTest {
+        var flushCount = 0
+        lateinit var coordinator: RenderBatchCoordinator
+        coordinator =
+            RenderBatchCoordinator(
+                scope = this,
+                intervalMs = 200,
+                onFlush = {
+                    flushCount++
+                    if (flushCount == 1) {
+                        coordinator.requestUpdate()
+                    }
+                },
+            )
+
+        coordinator.requestUpdate()
+        advanceUntilIdle()
+
+        assertEquals(2, flushCount)
+    }
+
+    @Test
+    fun toolXmlTailMutation_isRenderedWithoutAnotherInput() = runTest {
+        val nodes = mutableStateListOf<MarkdownNode>()
+        val renderNodes = mutableStateListOf<MarkdownNodeStable>()
+        val nodeAnimationStates = mutableStateMapOf<String, Boolean>()
+        val updater =
+            BatchNodeUpdater(
+                nodes = nodes,
+                renderNodes = renderNodes,
+                conversionCache = mutableMapOf(),
+                nodeAnimationStates = nodeAnimationStates,
+                xmlNodeStreams = mutableMapOf<Int, Stream<String>>(),
+                rendererId = "tool-xml-test",
+                scope = this,
+            )
+        val toolNode = MarkdownNode(type = MarkdownProcessorType.XML_BLOCK)
+        nodes.add(toolNode)
+
+        val prefix = "<tool name=\"shell\"><param name=\"command\">echo par"
+        updater.appendBlockChunk(toolNode, prefix)
+        advanceUntilIdle()
+        assertEquals(prefix, renderNodes.single().content)
+
+        val tail = "tial</param></tool>"
+        updater.appendBlockChunk(toolNode, tail)
+        advanceUntilIdle()
+
+        assertEquals(prefix + tail, renderNodes.single().content)
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

流式输出期间，工具调用卡片的参数渲染会被截断，直到工具执行结束后才补全。此 PR 用基于 revision 的 `RenderBatchCoordinator` 替换原有的字符到达触发批量更新逻辑，确保渲染节点变更不会丢失。

### 背景与动机 / Context and motivation

详见 #833。开启流式输出时，`BatchNodeUpdater.startBatchUpdates()` 在已有刷新任务运行时直接 `return`，导致后续的节点变更（如工具 XML block 的 `command` 参数后半部分）不会被同步到 `renderNodes`。工具实际收到的参数是完整的，但 UI 卡片在执行期间显示不完整。

### 改动范围 / Changes

- 新增 `RenderBatchCoordinator`：revision-based 批量渲染协调器，循环 drain 所有 pending revision 后才退出
- 修改 `StreamMarkdownRenderer`：在每次可渲染状态变更后调用 `requestUpdate()`，替换原来的 `startBatchUpdates()`；新增 `appendBlockChunk()` 原子化追加 block 内容并请求渲染
- 新增 `RenderBatchCoordinatorTest`：3 个单元测试覆盖 coalescing、drain-on-exit 和 tool XML tail mutation 场景

不包含：打字机动画、主题偏好、Canvas 渲染器等其他改动。

### 兼容性与风险 / Compatibility and risks

- 不影响工具调用的实际参数解析与执行，仅影响流式 UI 渲染时序
- 保留了原有的批量刷新间隔和节流机制，未改为逐字符重组
- `RenderBatchCoordinator` 为 `internal` 类，不影响公开 API

## 关联 Issue / Related issue

Fixes #833

## 验证方式 / Verification

```text
检查或命令：RenderBatchCoordinatorTest（3 个测试用例）
环境与变体：Redmi K80 Pro / HyperOS 3 / Android 15 / v1.12.0+4 / DeepSeek V4 Flash / 流式输出 + 全部工具调用
结果：
- 测试 1：requestWhileBatchIsPending_isIncludedWithoutAnotherInput — 通过，同一批次内的多次 request 只触发一次 flush
- 测试 2：requestDuringFlush_isDrainedBeforeCoordinatorBecomesIdle — 通过，flush 期间的新 request 会被 drain
- 测试 3：toolXmlTailMutation_isRenderedWithoutAnotherInput — 通过，XML block 尾部追加内容后渲染节点同步更新
- 设备实测：修复前工具执行期间 command 参数未渲染，修复后执行期间已显示完整参数
```

## 证据 / Evidence

修复前截图见 #833。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided