### PR TITLE
fix(markdown): preserve table scroll during streaming

### DIFF
--- a/app/src/androidTest/java/com/ai/assistance/operit/ui/common/markdown/EnhancedTableBlockAndroidTest.kt
+++ b/app/src/androidTest/java/com/ai/assistance/operit/ui/common/markdown/EnhancedTableBlockAndroidTest.kt
@@ -1,0 +1,99 @@
+package com.ai.assistance.operit.ui.common.markdown
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.ai.assistance.operit.R
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EnhancedTableBlockAndroidTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun streamingContentUpdate_keepsHorizontalScrollInteractive() {
+        val content = mutableStateOf(WIDE_TABLE)
+        val tableDescription =
+            InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.table_block)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                Column(
+                    modifier =
+                        Modifier
+                            .width(240.dp)
+                            .height(300.dp)
+                            .verticalScroll(rememberScrollState())
+                ) {
+                    EnhancedTableBlock(tableContent = content.value)
+                    Spacer(modifier = Modifier.height(500.dp))
+                }
+            }
+        }
+
+        val table = composeTestRule.onNodeWithContentDescription(tableDescription)
+        table.assertIsDisplayed()
+        val initialImage = table.captureToImage().asAndroidBitmap()
+
+        table.performTouchInput {
+            swipe(
+                start = center + Offset(80f, 0f),
+                end = center - Offset(80f, 0f),
+                durationMillis = 2_000L,
+            )
+        }
+        composeTestRule.waitForIdle()
+        val afterFirstSwipe = table.captureToImage().asAndroidBitmap()
+        assertFalse(initialImage.sameAs(afterFirstSwipe))
+
+        composeTestRule.runOnIdle {
+            content.value = "$WIDE_TABLE\n"
+        }
+        composeTestRule.waitForIdle()
+        val afterStreamingUpdate = table.captureToImage().asAndroidBitmap()
+        assertTrue(afterFirstSwipe.sameAs(afterStreamingUpdate))
+
+        table.performTouchInput {
+            swipe(
+                start = center - Offset(80f, 0f),
+                end = center + Offset(80f, 0f),
+                durationMillis = 2_000L,
+            )
+        }
+        composeTestRule.waitForIdle()
+        val afterSecondSwipe = table.captureToImage().asAndroidBitmap()
+        assertFalse(afterStreamingUpdate.sameAs(afterSecondSwipe))
+    }
+
+    private companion object {
+        val WIDE_TABLE =
+            """
+            | Package identifier with a long value | Recommendation with detailed status | Reason for the recommendation | Application category | Discovery source | Additional notes |
+            | --- | --- | --- | --- | --- | --- |
+            | com.example.application.identifier | Keep installed for system behavior | Required by a core device service | System application | Package manager | Do not disable this package |
+            """.trimIndent()
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/EnhancedTableBlock.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/EnhancedTableBlock.kt
@@ -93,7 +93,6 @@ fun EnhancedTableBlock(
     val density = LocalDensity.current
     val typography = MaterialTheme.typography
     val textLayoutSettings = LocalAiMarkdownTextLayoutSettings.current
-    val coroutineScope = rememberCoroutineScope()
     val fontFamily = typography.bodyMedium.fontFamily
     val resolver = LocalFontFamilyResolver.current
     val normalTypeface = remember(resolver, fontFamily) {
@@ -109,10 +108,12 @@ fun EnhancedTableBlock(
 
     if (tableData.rows.isEmpty()) return
 
-    var scrollOffsetPx by remember(tableContent) { mutableStateOf(0f) }
-    var dragVelocityPxPerSec by remember(tableContent) { mutableStateOf(0f) }
-    var lastDragEventTimeMs by remember(tableContent) { mutableStateOf(0L) }
-    var flingJob by remember(tableContent) { mutableStateOf<Job?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+    // Streaming appends change tableContent repeatedly; the surrounding node identity scopes this state.
+    var scrollOffsetPx by remember { mutableStateOf(0f) }
+    var dragVelocityPxPerSec by remember { mutableStateOf(0f) }
+    var lastDragEventTimeMs by remember { mutableStateOf(0L) }
+    var flingJob by remember { mutableStateOf<Job?>(null) }
     val tableBlockDesc = stringResource(R.string.table_block)
     val borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
     val headerBackground = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRenderer.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRenderer.kt
@@ -904,6 +904,8 @@ fun StreamMarkdownRenderer(
 
                     // 移除UI更新时间相关日志
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 AppLogger.e(TAG, "【静态渲染】解析Markdown内容出错: ${e.message}", e)
             }


### PR DESCRIPTION

## 变更说明 / Description

修复流式生成 Markdown 表格时，横向滚动状态可能被重置、拖动失效的问题。同时修正正常协程取消被误记为 Markdown 解析错误的日志。

### 背景与动机 / Context and motivation

Issue #792 报告气泡聊天风格下，部分正在生成的宽表格无法横向拖动。该问题无法稳定复现，但代码中存在明确的状态生命周期缺陷：

- 表格交互状态使用 `remember(tableContent)` 保存，流式内容更新会反复重建状态并将滚动偏移归零。
- 手势协程仅以 `maxScrollPx` 为 key。当内容变化但表格总宽度不变时，手势可能继续修改旧状态，而 Canvas 使用新状态绘制。
- 附件日志中的 `LeftCompositionCancellationException` 是组件离开 Composition 时的正常取消，与表格故障无关，但被错误记录为 Markdown 解析失败。

### 改动范围 / Changes

- 让表格滚动偏移、拖动速度和 fling 状态在流式内容更新期间保持稳定。
- 将表格协程作用域限制在有效表格分支，表格失效时自动取消 fling。
- 静态 Markdown 解析遇到 `CancellationException` 时直接重抛，不再输出误导性错误日志。
- 新增 Compose 仪器回归测试，覆盖内容更新前后滚动偏移保持及手势继续生效。
- 不修改 Markdown 表格语法、聊天样式布局、数据格式或配置项。

### 兼容性与风险 / Compatibility and risks

不涉及公开 API、持久化数据、配置或消息格式变更。

交互状态仍由现有 Markdown 节点身份隔离，内容或 viewport 变窄时继续使用原有边界限制。风险主要集中在自定义 Canvas 表格滚动行为，已添加针对该时序的回归测试。

## 关联 Issue / Related issue

Fixes #792

## 验证方式 / Verification

```text
检查或命令：git diff --check；完整 diff 静态审查
环境与变体：未执行 Android 构建或仪器测试
结果：静态检查通过；已添加 EnhancedTableBlockAndroidTest。按仓库本地工作流约束，
```

## 证据 / Evidence

- Issue 截图显示表格右侧列已溢出视口，且当时 AI 仍处于流式生成状态。
- 回归测试在受限宽度及父级纵向滚动容器中先横向拖动表格，再更新 `tableContent` 且保持布局宽度不变，验证偏移不会复位且后续拖动仍有效。
- 附件日志中的 5 条 MarkdownRenderer 错误均为 `LeftCompositionCancellationException`，未发现真正的 Markdown 语法解析异常。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [ ] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [ ] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
```