### PR TITLE
feat(settings): modernize default model settings for long-context models

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
@@ -54,12 +54,12 @@ enum class ApiProviderType {
 }
 
 object ModelConfigDefaults {
-        const val DEFAULT_CONTEXT_LENGTH = 64.0f
-        const val DEFAULT_MAX_CONTEXT_LENGTH = 200.0f
+        const val DEFAULT_CONTEXT_LENGTH = 400.0f
+        const val DEFAULT_MAX_CONTEXT_LENGTH = 1000.0f
         const val DEFAULT_ENABLE_MAX_CONTEXT_MODE = false
-        const val DEFAULT_SUMMARY_TOKEN_THRESHOLD = 0.70f
+        const val DEFAULT_SUMMARY_TOKEN_THRESHOLD = 0.90f
         const val DEFAULT_ENABLE_SUMMARY = true
-        const val DEFAULT_ENABLE_SUMMARY_BY_MESSAGE_COUNT = true
+        const val DEFAULT_ENABLE_SUMMARY_BY_MESSAGE_COUNT = false
         const val DEFAULT_SUMMARY_MESSAGE_COUNT_THRESHOLD = 16
 }
 
@@ -152,7 +152,7 @@ data class ModelConfigData(
         val enableClaude1hPromptCache: Boolean = false, // 是否启用1小时提示缓存TTL (仅Claude支持)
 
         // Tool Call配置
-        val enableToolCall: Boolean = false, // 是否启用Tool Call接口调用工具（使用模型原生工具调用而非XML格式）
+        val enableToolCall: Boolean = true, // 是否启用Tool Call接口调用工具（使用模型原生工具调用而非XML格式）
 
         // 请求频率限制配置
         val requestLimitPerMinute: Int = 0, // 每分钟最大请求次数，0表示不限流


### PR DESCRIPTION
## Summary
将默认模型配置现代化，适配当前主流长上下文模型（DeepSeek V4 Flash (0731)，1M context window）。

仅修改 `ModelConfigData.kt` 中 5 处默认值，无其他文件改动：

| 配置项 | 旧默认值 | 新默认值 |
|---|---|---|
| DEFAULT_CONTEXT_LENGTH | 64K | 400K |
| DEFAULT_MAX_CONTEXT_LENGTH | 200K | 1000K |
| DEFAULT_SUMMARY_TOKEN_THRESHOLD | 70% | 90% |
| DEFAULT_ENABLE_SUMMARY_BY_MESSAGE_COUNT | true | false |
| enableToolCall | false | true |

## Rationale
- 400K ≈ DeepSeek V4 Flash 1M 窗口的 40%，为输出与工具调用中间步骤保留余量；1000K 供最大模式接近全窗口
- 长上下文下"16 条消息即触发总结"会过早截断有效上下文，改为主要依赖 90% token 阈值
- #856 已实证：DeepSeek V4 默认输出 DSML，与旧式提示词 XML 工具协议不兼容，开启原生 Tool Call 后恢复

## Compatibility
- 新用户直接获得新默认值；老用户未显式保存的字段回退新默认值，已保存值不受影响

Closes #866
Addresses #856