### PR TITLE
fix: add low reasoning_effort mapping for DeepSeek thinking depth

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
@@ -20,7 +20,7 @@ import org.json.JSONObject
 /**
  * 针对DeepSeek模型的特定API Provider。
  * 继承自OpenAIProvider，以重用大部分兼容逻辑，但特别处理了`reasoning_content`参数。
- * 当启用推理模式时，会将assistant消息中的<think>标签内容提取出来作为reasoning_content字段。
+ * 当启用推理模式时，会将assistant消息中的 thinking标签内容提取出来作为reasoning_content字段。
  */
 class DeepseekProvider(
     apiEndpoint: String,
@@ -163,7 +163,7 @@ class DeepseekProvider(
 
     /**
      * 构建支持reasoning_content的消息数组
-     * 对于assistant角色的消息，提取<think>标签内容作为reasoning_content
+     * 对于assistant角色的消息，提取 thinking标签内容作为reasoning_content
      */
     private fun buildMessagesWithReasoning(
         context: Context,
@@ -452,7 +452,7 @@ class DeepseekProvider(
             return null
         }
 
-        val efforts = listOf("high", "high", "max", "max", "max")
+        val efforts = listOf("low", "high", "max", "max", "max")
         val qualityIndex = qualityLevel.coerceIn(
             ApiPreferences.MIN_THINKING_QUALITY_LEVEL,
             ApiPreferences.MAX_THINKING_QUALITY_LEVEL


### PR DESCRIPTION
## Summary

修复 DeepSeek provider 的 `reasoning_effort` 映射，添加对 `low` 思考强度的支持。

## Problem

DeepSeek API 的 `reasoning_effort` 参数支持三个值：`low`、`high`、`max`（参见 [官方文档](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion)）。

但 `DeepseekProvider.resolveDeepseekThinkingEffort()` 中的映射表为：
```kotlin
val efforts = listOf("high", "high", "max", "max", "max")
```

缺失了 `low` 级别，导致用户选择最低思考质量档位时，实际发送的是 `high`。

## Fix

将映射表第一个元素从 `"high"` 改为 `"low"`：

```kotlin
val efforts = listOf("low", "high", "max", "max", "max")
```

> 注意：`deepseek-v4-pro` 暂仅支持 `high`/`max` 两档（`low` 会被服务端按 `high` 处理），预计 2026 年 8 月初支持三档。`deepseek-v4-flash` 已支持三档。

## Changed Files

- `app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt` — 1 行改动

## Testing

- [ ] 使用 `deepseek-v4-flash` + 思考质量 1 档，验证请求中 `reasoning_effort` 为 `low`
- [ ] 确认 API 正常返回 200