### PR TITLE
fix(chat): read oversized messages without CursorWindow

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/library/MemoryAutoSaveScheduler.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/library/MemoryAutoSaveScheduler.kt
@@ -86,7 +86,7 @@ class MemoryAutoSaveScheduler(
         val toolHandler = AIToolHandler.getInstance(context)
         val memoryService =
             EnhancedAIService.getAIServiceForFunction(context, FunctionType.MEMORY)
-        val messageDao = AppDatabase.getDatabase(context).messageDao()
+        val chatContentDao = AppDatabase.getDatabase(context).chatContentDao()
         val nowMs = System.currentTimeMillis()
 
         for (profileId in profileIds) {
@@ -144,7 +144,7 @@ class MemoryAutoSaveScheduler(
                         chatId = chatId,
                         candidates = selectedUserCandidates,
                         repository = repository,
-                        messageDao = messageDao,
+                        chatContentDao = chatContentDao,
                         toolHandler = toolHandler,
                         memoryService = memoryService
                     )
@@ -155,7 +155,7 @@ class MemoryAutoSaveScheduler(
                         chatId = chatId,
                         candidates = automaticCandidates,
                         repository = repository,
-                        messageDao = messageDao,
+                        chatContentDao = chatContentDao,
                         toolHandler = toolHandler,
                         memoryService = memoryService
                     )
@@ -193,7 +193,7 @@ class MemoryAutoSaveScheduler(
         chatId: String,
         candidates: List<MemoryAutoSaveCandidate>,
         repository: MemoryAutoSaveCandidateRepository,
-        messageDao: com.ai.assistance.operit.data.dao.MessageDao,
+        chatContentDao: com.ai.assistance.operit.data.dao.ChatContentDao,
         toolHandler: AIToolHandler,
         memoryService: com.ai.assistance.operit.api.chat.llmprovider.AIService
     ) {
@@ -213,7 +213,7 @@ class MemoryAutoSaveScheduler(
                         withContext(Dispatchers.IO) {
                             candidates
                                 .mapNotNull { candidate ->
-                                    messageDao.getMessageByTimestamp(
+                                    chatContentDao.getMessageByTimestamp(
                                         chatId = chatId,
                                         timestamp = candidate.triggerMessageTimestamp
                                     )?.toChatMessage()
@@ -225,7 +225,7 @@ class MemoryAutoSaveScheduler(
                 } else {
                     val latestTriggerTimestamp = candidates.maxOf { it.triggerMessageTimestamp }
                     withContext(Dispatchers.IO) {
-                        messageDao.getMessagesForChatBeforeTimestampDesc(
+                        chatContentDao.getMessagesForChatBeforeTimestampDesc(
                             chatId = chatId,
                             maxTimestamp = latestTriggerTimestamp,
                             limit = MAX_MESSAGES_PER_BATCH

--- a/app/src/main/java/com/ai/assistance/operit/data/dao/ChatContentDao.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/dao/ChatContentDao.kt
@@ -1,0 +1,422 @@
+package com.ai.assistance.operit.data.dao
+
+import androidx.room.Dao
+import androidx.room.Embedded
+import androidx.room.Query
+import androidx.room.Transaction
+import com.ai.assistance.operit.data.model.MessageEntity
+import com.ai.assistance.operit.data.model.MessageVariantEntity
+
+// SQLite LENGTH/SUBSTR count characters, and this bound keeps every returned text row well below CursorWindow size.
+private const val CONTENT_CHUNK_CHARACTER_COUNT = 65_536
+
+private const val MESSAGE_CONTENT_ROW_QUERY =
+    """
+    SELECT
+        messageId,
+        chatId,
+        sender,
+        SUBSTR(content, 1, $CONTENT_CHUNK_CHARACTER_COUNT) AS content,
+        timestamp,
+        orderIndex,
+        roleName,
+        selectedVariantIndex,
+        provider,
+        modelName,
+        inputTokens,
+        outputTokens,
+        cachedInputTokens,
+        sentAt,
+        outputDurationMs,
+        waitDurationMs,
+        completedAt,
+        displayMode,
+        isFavorite,
+        LENGTH(content) AS contentCharacterCount
+    FROM messages
+    """
+
+private const val MESSAGE_VARIANT_CONTENT_ROW_QUERY =
+    """
+    SELECT
+        variantId,
+        chatId,
+        messageTimestamp,
+        variantIndex,
+        SUBSTR(content, 1, $CONTENT_CHUNK_CHARACTER_COUNT) AS content,
+        roleName,
+        provider,
+        modelName,
+        inputTokens,
+        outputTokens,
+        cachedInputTokens,
+        sentAt,
+        outputDurationMs,
+        waitDurationMs,
+        completedAt,
+        LENGTH(content) AS contentCharacterCount
+    FROM message_variants
+    """
+
+data class MessageContentRow(
+    @Embedded val message: MessageEntity,
+    val contentCharacterCount: Long,
+)
+
+data class MessageVariantContentRow(
+    @Embedded val variant: MessageVariantEntity,
+    val contentCharacterCount: Long,
+)
+
+/** Reads message text in bounded rows so a single large message cannot overflow CursorWindow. */
+@Dao
+abstract class ChatContentDao {
+    @Query(MESSAGE_CONTENT_ROW_QUERY + " WHERE chatId = :chatId ORDER BY timestamp ASC")
+    protected abstract suspend fun queryMessagesForChat(chatId: String): List<MessageContentRow>
+
+    @Query(
+        MESSAGE_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId AND timestamp >= :startTimestampInclusive ORDER BY timestamp ASC"
+    )
+    protected abstract suspend fun queryMessagesForChatFromTimestampAsc(
+        chatId: String,
+        startTimestampInclusive: Long,
+    ): List<MessageContentRow>
+
+    @Query(
+        MESSAGE_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId AND timestamp >= :startTimestampInclusive" +
+            " AND timestamp <= :endTimestampInclusive ORDER BY timestamp ASC"
+    )
+    protected abstract suspend fun queryMessagesForChatWindowAsc(
+        chatId: String,
+        startTimestampInclusive: Long,
+        endTimestampInclusive: Long,
+    ): List<MessageContentRow>
+
+    @Query(MESSAGE_CONTENT_ROW_QUERY + " WHERE chatId = :chatId ORDER BY timestamp ASC LIMIT :limit")
+    protected abstract suspend fun queryMessagesForChatAsc(
+        chatId: String,
+        limit: Int,
+    ): List<MessageContentRow>
+
+    @Query(MESSAGE_CONTENT_ROW_QUERY + " WHERE chatId = :chatId ORDER BY timestamp DESC LIMIT :limit")
+    protected abstract suspend fun queryMessagesForChatDesc(
+        chatId: String,
+        limit: Int,
+    ): List<MessageContentRow>
+
+    @Query(
+        MESSAGE_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId ORDER BY timestamp ASC LIMIT :limit OFFSET :offset"
+    )
+    protected abstract suspend fun queryMessagesForChatAscRange(
+        chatId: String,
+        offset: Int,
+        limit: Int,
+    ): List<MessageContentRow>
+
+    @Query(
+        MESSAGE_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId ORDER BY timestamp DESC LIMIT :limit OFFSET :offset"
+    )
+    protected abstract suspend fun queryMessagesForChatDescRange(
+        chatId: String,
+        offset: Int,
+        limit: Int,
+    ): List<MessageContentRow>
+
+    @Query(
+        MESSAGE_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId AND timestamp > :afterTimestampExclusive" +
+            " ORDER BY timestamp ASC LIMIT :limit"
+    )
+    protected abstract suspend fun queryMessagesForChatAfterTimestampExclusiveAsc(
+        chatId: String,
+        afterTimestampExclusive: Long,
+        limit: Int,
+    ): List<MessageContentRow>
+
+    @Query(
+        MESSAGE_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId" +
+            " AND (:afterTimestampExclusive IS NULL OR timestamp > :afterTimestampExclusive)" +
+            " AND (:beforeTimestampExclusive IS NULL OR timestamp < :beforeTimestampExclusive)" +
+            " AND (:upToTimestampInclusive IS NULL OR timestamp <= :upToTimestampInclusive)" +
+            " ORDER BY timestamp ASC"
+    )
+    protected abstract suspend fun queryMessagesForChatInRangeAsc(
+        chatId: String,
+        afterTimestampExclusive: Long?,
+        beforeTimestampExclusive: Long?,
+        upToTimestampInclusive: Long?,
+    ): List<MessageContentRow>
+
+    @Query(
+        MESSAGE_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId AND timestamp <= :maxTimestamp" +
+            " ORDER BY timestamp DESC LIMIT :limit"
+    )
+    protected abstract suspend fun queryMessagesForChatBeforeTimestampDesc(
+        chatId: String,
+        maxTimestamp: Long,
+        limit: Int,
+    ): List<MessageContentRow>
+
+    @Query(
+        MESSAGE_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId AND timestamp < :beforeTimestampExclusive" +
+            " ORDER BY timestamp DESC LIMIT :limit"
+    )
+    protected abstract suspend fun queryMessagesForChatBeforeTimestampExclusiveDesc(
+        chatId: String,
+        beforeTimestampExclusive: Long,
+        limit: Int,
+    ): List<MessageContentRow>
+
+    @Query(
+        MESSAGE_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId AND timestamp = :timestamp LIMIT 1"
+    )
+    protected abstract suspend fun queryMessageByTimestamp(
+        chatId: String,
+        timestamp: Long,
+    ): MessageContentRow?
+
+    @Query(
+        "SELECT SUBSTR(content, :startCharacter, :characterCount)" +
+            " FROM messages WHERE messageId = :messageId"
+    )
+    protected abstract suspend fun queryMessageContentChunk(
+        messageId: Long,
+        startCharacter: Long,
+        characterCount: Int,
+    ): String?
+
+    @Query(
+        MESSAGE_VARIANT_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId ORDER BY messageTimestamp ASC, variantIndex ASC"
+    )
+    protected abstract suspend fun queryVariantsForChat(chatId: String): List<MessageVariantContentRow>
+
+    @Query(
+        MESSAGE_VARIANT_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId AND messageTimestamp IN (:messageTimestamps)" +
+            " ORDER BY messageTimestamp ASC, variantIndex ASC"
+    )
+    protected abstract suspend fun queryVariantsForMessages(
+        chatId: String,
+        messageTimestamps: List<Long>,
+    ): List<MessageVariantContentRow>
+
+    @Query(
+        MESSAGE_VARIANT_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId AND messageTimestamp = :messageTimestamp" +
+            " ORDER BY variantIndex ASC"
+    )
+    protected abstract suspend fun queryVariantsForMessage(
+        chatId: String,
+        messageTimestamp: Long,
+    ): List<MessageVariantContentRow>
+
+    @Query(
+        MESSAGE_VARIANT_CONTENT_ROW_QUERY +
+            " WHERE chatId = :chatId AND messageTimestamp = :messageTimestamp" +
+            " AND variantIndex = :variantIndex LIMIT 1"
+    )
+    protected abstract suspend fun queryVariantForMessage(
+        chatId: String,
+        messageTimestamp: Long,
+        variantIndex: Int,
+    ): MessageVariantContentRow?
+
+    @Query(
+        "SELECT SUBSTR(content, :startCharacter, :characterCount)" +
+            " FROM message_variants WHERE variantId = :variantId"
+    )
+    protected abstract suspend fun queryMessageVariantContentChunk(
+        variantId: Long,
+        startCharacter: Long,
+        characterCount: Int,
+    ): String?
+
+    @Transaction
+    open suspend fun getMessagesForChat(chatId: String): List<MessageEntity> =
+        materializeMessages(queryMessagesForChat(chatId))
+
+    @Transaction
+    open suspend fun getMessagesForChatFromTimestampAsc(
+        chatId: String,
+        startTimestampInclusive: Long,
+    ): List<MessageEntity> =
+        materializeMessages(queryMessagesForChatFromTimestampAsc(chatId, startTimestampInclusive))
+
+    @Transaction
+    open suspend fun getMessagesForChatWindowAsc(
+        chatId: String,
+        startTimestampInclusive: Long,
+        endTimestampInclusive: Long,
+    ): List<MessageEntity> =
+        materializeMessages(
+            queryMessagesForChatWindowAsc(chatId, startTimestampInclusive, endTimestampInclusive)
+        )
+
+    @Transaction
+    open suspend fun getMessagesForChatAsc(chatId: String, limit: Int): List<MessageEntity> =
+        materializeMessages(queryMessagesForChatAsc(chatId, limit))
+
+    @Transaction
+    open suspend fun getMessagesForChatDesc(chatId: String, limit: Int): List<MessageEntity> =
+        materializeMessages(queryMessagesForChatDesc(chatId, limit))
+
+    @Transaction
+    open suspend fun getMessagesForChatAscRange(
+        chatId: String,
+        offset: Int,
+        limit: Int,
+    ): List<MessageEntity> = materializeMessages(queryMessagesForChatAscRange(chatId, offset, limit))
+
+    @Transaction
+    open suspend fun getMessagesForChatDescRange(
+        chatId: String,
+        offset: Int,
+        limit: Int,
+    ): List<MessageEntity> = materializeMessages(queryMessagesForChatDescRange(chatId, offset, limit))
+
+    @Transaction
+    open suspend fun getMessagesForChatAfterTimestampExclusiveAsc(
+        chatId: String,
+        afterTimestampExclusive: Long,
+        limit: Int,
+    ): List<MessageEntity> =
+        materializeMessages(
+            queryMessagesForChatAfterTimestampExclusiveAsc(chatId, afterTimestampExclusive, limit)
+        )
+
+    @Transaction
+    open suspend fun getMessagesForChatInRangeAsc(
+        chatId: String,
+        afterTimestampExclusive: Long?,
+        beforeTimestampExclusive: Long?,
+        upToTimestampInclusive: Long?,
+    ): List<MessageEntity> =
+        materializeMessages(
+            queryMessagesForChatInRangeAsc(
+                chatId,
+                afterTimestampExclusive,
+                beforeTimestampExclusive,
+                upToTimestampInclusive,
+            )
+        )
+
+    @Transaction
+    open suspend fun getMessagesForChatBeforeTimestampDesc(
+        chatId: String,
+        maxTimestamp: Long,
+        limit: Int,
+    ): List<MessageEntity> =
+        materializeMessages(queryMessagesForChatBeforeTimestampDesc(chatId, maxTimestamp, limit))
+
+    @Transaction
+    open suspend fun getMessagesForChatBeforeTimestampExclusiveDesc(
+        chatId: String,
+        beforeTimestampExclusive: Long,
+        limit: Int,
+    ): List<MessageEntity> =
+        materializeMessages(
+            queryMessagesForChatBeforeTimestampExclusiveDesc(chatId, beforeTimestampExclusive, limit)
+        )
+
+    @Transaction
+    open suspend fun getMessageByTimestamp(chatId: String, timestamp: Long): MessageEntity? =
+        queryMessageByTimestamp(chatId, timestamp)?.let { materializeMessage(it) }
+
+    @Transaction
+    open suspend fun getVariantsForChat(chatId: String): List<MessageVariantEntity> =
+        materializeVariants(queryVariantsForChat(chatId))
+
+    @Transaction
+    open suspend fun getVariantsForMessages(
+        chatId: String,
+        messageTimestamps: List<Long>,
+    ): List<MessageVariantEntity> =
+        materializeVariants(queryVariantsForMessages(chatId, messageTimestamps))
+
+    @Transaction
+    open suspend fun getVariantsForMessage(
+        chatId: String,
+        messageTimestamp: Long,
+    ): List<MessageVariantEntity> =
+        materializeVariants(queryVariantsForMessage(chatId, messageTimestamp))
+
+    @Transaction
+    open suspend fun getVariantForMessage(
+        chatId: String,
+        messageTimestamp: Long,
+        variantIndex: Int,
+    ): MessageVariantEntity? =
+        queryVariantForMessage(chatId, messageTimestamp, variantIndex)?.let {
+            materializeVariant(it)
+        }
+
+    private suspend fun materializeMessages(rows: List<MessageContentRow>): List<MessageEntity> =
+        rows.map { materializeMessage(it) }
+
+    private suspend fun materializeMessage(row: MessageContentRow): MessageEntity {
+        if (row.contentCharacterCount <= CONTENT_CHUNK_CHARACTER_COUNT) {
+            return row.message
+        }
+
+        val content = StringBuilder(row.message.content)
+        var startCharacter = CONTENT_CHUNK_CHARACTER_COUNT.toLong() + 1L
+        while (startCharacter <= row.contentCharacterCount) {
+            val chunk =
+                checkNotNull(
+                    queryMessageContentChunk(
+                        row.message.messageId,
+                        startCharacter,
+                        CONTENT_CHUNK_CHARACTER_COUNT,
+                    )
+                ) {
+                    "Message disappeared while reading content: messageId=${row.message.messageId}"
+                }
+            check(chunk.isNotEmpty()) {
+                "Message content ended before its recorded length: messageId=${row.message.messageId}"
+            }
+            content.append(chunk)
+            startCharacter += CONTENT_CHUNK_CHARACTER_COUNT
+        }
+        return row.message.copy(content = content.toString())
+    }
+
+    private suspend fun materializeVariants(
+        rows: List<MessageVariantContentRow>
+    ): List<MessageVariantEntity> = rows.map { materializeVariant(it) }
+
+    private suspend fun materializeVariant(row: MessageVariantContentRow): MessageVariantEntity {
+        if (row.contentCharacterCount <= CONTENT_CHUNK_CHARACTER_COUNT) {
+            return row.variant
+        }
+
+        val content = StringBuilder(row.variant.content)
+        var startCharacter = CONTENT_CHUNK_CHARACTER_COUNT.toLong() + 1L
+        while (startCharacter <= row.contentCharacterCount) {
+            val chunk =
+                checkNotNull(
+                    queryMessageVariantContentChunk(
+                        row.variant.variantId,
+                        startCharacter,
+                        CONTENT_CHUNK_CHARACTER_COUNT,
+                    )
+                ) {
+                    "Message variant disappeared while reading content: variantId=${row.variant.variantId}"
+                }
+            check(chunk.isNotEmpty()) {
+                "Message variant content ended before its recorded length: variantId=${row.variant.variantId}"
+            }
+            content.append(chunk)
+            startCharacter += CONTENT_CHUNK_CHARACTER_COUNT
+        }
+        return row.variant.copy(content = content.toString())
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/data/dao/MessageDao.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/dao/MessageDao.kt
@@ -15,10 +15,6 @@ interface MessageDao {
     @Query("SELECT COUNT(*) FROM messages")
     suspend fun getTotalMessageCount(): Int
 
-    /** 获取指定聊天的所有消息，按时间戳排序 */
-    @Query("SELECT * FROM messages WHERE chatId = :chatId ORDER BY timestamp ASC")
-    suspend fun getMessagesForChat(chatId: String): List<MessageEntity>
-
     @Query(
         "SELECT COUNT(*) FROM messages WHERE chatId = :chatId AND (:upToTimestampInclusive IS NULL OR timestamp <= :upToTimestampInclusive)"
     )
@@ -91,85 +87,6 @@ interface MessageDao {
     ): List<ChatMessageLocatorPreview>
 
     @Query(
-        "SELECT * FROM messages WHERE chatId = :chatId AND timestamp >= :startTimestampInclusive ORDER BY timestamp ASC"
-    )
-    suspend fun getMessagesForChatFromTimestampAsc(
-        chatId: String,
-        startTimestampInclusive: Long,
-    ): List<MessageEntity>
-
-    @Query(
-        """
-        SELECT * FROM messages
-        WHERE chatId = :chatId
-            AND timestamp >= :startTimestampInclusive
-            AND timestamp <= :endTimestampInclusive
-        ORDER BY timestamp ASC
-        """
-    )
-    suspend fun getMessagesForChatWindowAsc(
-        chatId: String,
-        startTimestampInclusive: Long,
-        endTimestampInclusive: Long,
-    ): List<MessageEntity>
-
-    @Query("SELECT * FROM messages WHERE chatId = :chatId ORDER BY timestamp ASC LIMIT :limit")
-    suspend fun getMessagesForChatAsc(chatId: String, limit: Int): List<MessageEntity>
-
-    @Query("SELECT * FROM messages WHERE chatId = :chatId ORDER BY timestamp DESC LIMIT :limit")
-    suspend fun getMessagesForChatDesc(chatId: String, limit: Int): List<MessageEntity>
-
-    @Query("SELECT * FROM messages WHERE chatId = :chatId ORDER BY timestamp ASC LIMIT :limit OFFSET :offset")
-    suspend fun getMessagesForChatAscRange(chatId: String, offset: Int, limit: Int): List<MessageEntity>
-
-    @Query("SELECT * FROM messages WHERE chatId = :chatId ORDER BY timestamp DESC LIMIT :limit OFFSET :offset")
-    suspend fun getMessagesForChatDescRange(chatId: String, offset: Int, limit: Int): List<MessageEntity>
-
-    @Query(
-        "SELECT * FROM messages WHERE chatId = :chatId AND timestamp > :afterTimestampExclusive ORDER BY timestamp ASC LIMIT :limit"
-    )
-    suspend fun getMessagesForChatAfterTimestampExclusiveAsc(
-        chatId: String,
-        afterTimestampExclusive: Long,
-        limit: Int,
-    ): List<MessageEntity>
-
-    @Query(
-        """
-        SELECT * FROM messages
-        WHERE chatId = :chatId
-            AND (:afterTimestampExclusive IS NULL OR timestamp > :afterTimestampExclusive)
-            AND (:beforeTimestampExclusive IS NULL OR timestamp < :beforeTimestampExclusive)
-            AND (:upToTimestampInclusive IS NULL OR timestamp <= :upToTimestampInclusive)
-        ORDER BY timestamp ASC
-        """
-    )
-    suspend fun getMessagesForChatInRangeAsc(
-        chatId: String,
-        afterTimestampExclusive: Long?,
-        beforeTimestampExclusive: Long?,
-        upToTimestampInclusive: Long?,
-    ): List<MessageEntity>
-
-    @Query(
-        "SELECT * FROM messages WHERE chatId = :chatId AND timestamp <= :maxTimestamp ORDER BY timestamp DESC LIMIT :limit"
-    )
-    suspend fun getMessagesForChatBeforeTimestampDesc(
-        chatId: String,
-        maxTimestamp: Long,
-        limit: Int
-    ): List<MessageEntity>
-
-    @Query(
-        "SELECT * FROM messages WHERE chatId = :chatId AND timestamp < :beforeTimestampExclusive ORDER BY timestamp DESC LIMIT :limit"
-    )
-    suspend fun getMessagesForChatBeforeTimestampExclusiveDesc(
-        chatId: String,
-        beforeTimestampExclusive: Long,
-        limit: Int,
-    ): List<MessageEntity>
-
-    @Query(
         "SELECT EXISTS(SELECT 1 FROM messages WHERE chatId = :chatId AND timestamp < :beforeTimestampExclusive LIMIT 1)"
     )
     suspend fun existsMessagesBeforeTimestamp(
@@ -210,6 +127,9 @@ interface MessageDao {
         "SELECT EXISTS(SELECT 1 FROM messages WHERE chatId = :chatId AND sender = 'user' LIMIT 1)"
     )
     suspend fun existsUserMessage(chatId: String): Boolean
+
+    @Query("SELECT EXISTS(SELECT 1 FROM messages WHERE chatId = :chatId LIMIT 1)")
+    suspend fun existsAnyMessage(chatId: String): Boolean
 
     @Query("SELECT chatId AS chatId, COUNT(*) AS count FROM messages GROUP BY chatId")
     suspend fun getMessageCountsByChatId(): List<ChatMessageCount>
@@ -289,10 +209,6 @@ interface MessageDao {
     /** 删除指定聊天的所有消息 */
     @Query("DELETE FROM messages WHERE chatId = :chatId")
     suspend fun deleteAllMessagesForChat(chatId: String)
-
-    /** 根据时间戳查找消息 */
-    @Query("SELECT * FROM messages WHERE chatId = :chatId AND timestamp = :timestamp LIMIT 1")
-    suspend fun getMessageByTimestamp(chatId: String, timestamp: Long): MessageEntity?
 
     /** 删除指定聊天中从某个时间戳开始的所有消息 */
     @Query("DELETE FROM messages WHERE chatId = :chatId AND timestamp >= :timestamp")

--- a/app/src/main/java/com/ai/assistance/operit/data/dao/MessageVariantDao.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/dao/MessageVariantDao.kt
@@ -9,36 +9,6 @@ import com.ai.assistance.operit.data.model.MessageVariantEntity
 
 @Dao
 interface MessageVariantDao {
-    @Query(
-        "SELECT * FROM message_variants WHERE chatId = :chatId ORDER BY messageTimestamp ASC, variantIndex ASC"
-    )
-    suspend fun getVariantsForChat(chatId: String): List<MessageVariantEntity>
-
-    @Query(
-        "SELECT * FROM message_variants WHERE chatId = :chatId AND messageTimestamp IN (:messageTimestamps) ORDER BY messageTimestamp ASC, variantIndex ASC"
-    )
-    suspend fun getVariantsForMessages(
-        chatId: String,
-        messageTimestamps: List<Long>,
-    ): List<MessageVariantEntity>
-
-    @Query(
-        "SELECT * FROM message_variants WHERE chatId = :chatId AND messageTimestamp = :messageTimestamp ORDER BY variantIndex ASC"
-    )
-    suspend fun getVariantsForMessage(
-        chatId: String,
-        messageTimestamp: Long,
-    ): List<MessageVariantEntity>
-
-    @Query(
-        "SELECT * FROM message_variants WHERE chatId = :chatId AND messageTimestamp = :messageTimestamp AND variantIndex = :variantIndex LIMIT 1"
-    )
-    suspend fun getVariantForMessage(
-        chatId: String,
-        messageTimestamp: Long,
-        variantIndex: Int,
-    ): MessageVariantEntity?
-
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertVariant(variant: MessageVariantEntity): Long
 

--- a/app/src/main/java/com/ai/assistance/operit/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/db/AppDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.ai.assistance.operit.data.dao.ChatContentDao
 import com.ai.assistance.operit.data.dao.ChatDao
 import com.ai.assistance.operit.data.dao.MessageDao
 import com.ai.assistance.operit.data.dao.MessageVariantDao
@@ -28,6 +29,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun messageDao(): MessageDao
 
     abstract fun messageVariantDao(): MessageVariantDao
+
+    abstract fun chatContentDao(): ChatContentDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/ai/assistance/operit/data/repository/ChatHistoryManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/repository/ChatHistoryManager.kt
@@ -94,6 +94,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
     private val chatDao = database.chatDao()
     private val messageDao = database.messageDao()
     private val messageVariantDao = database.messageVariantDao()
+    private val chatContentDao = database.chatContentDao()
     private val operitArchiveJson =
         Json {
             prettyPrint = true
@@ -144,7 +145,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
             return emptyList()
         }
         val visibleTimestamps = messageEntities.map { it.timestamp }
-        val variants = messageVariantDao.getVariantsForMessages(chatId, visibleTimestamps)
+        val variants = chatContentDao.getVariantsForMessages(chatId, visibleTimestamps)
         return hydrateMessages(messageEntities, variants)
     }
 
@@ -162,9 +163,9 @@ class ChatHistoryManager private constructor(private val context: Context) {
     }
 
     private suspend fun buildOperitArchivedChat(chatHistory: ChatHistory): OperitArchivedChat {
-        val messageEntities = messageDao.getMessagesForChat(chatHistory.id)
+        val messageEntities = chatContentDao.getMessagesForChat(chatHistory.id)
         val variantsByTimestamp =
-            messageVariantDao.getVariantsForChat(chatHistory.id).groupBy { it.messageTimestamp }
+            chatContentDao.getVariantsForChat(chatHistory.id).groupBy { it.messageTimestamp }
         val archivedMessages =
             messageEntities.map { messageEntity ->
                 val messageVariants = variantsByTimestamp[messageEntity.timestamp].orEmpty()
@@ -671,7 +672,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
         afterTimestamp: Long?,
     ): ChatMessage? {
         if (beforeTimestamp == null && afterTimestamp == null) {
-            val hasAnyMessages = messageDao.getMessagesForChatAsc(chatId, 1).isNotEmpty()
+            val hasAnyMessages = messageDao.existsAnyMessage(chatId)
             return if (hasAnyMessages) {
                 AppLogger.w(TAG, "缺少插入锚点，拒绝在非空聊天中插入消息: chatId=$chatId")
                 null
@@ -682,9 +683,9 @@ class ChatHistoryManager private constructor(private val context: Context) {
 
         val beforeMessage =
             when {
-                beforeTimestamp != null -> messageDao.getMessageByTimestamp(chatId, beforeTimestamp)
+                beforeTimestamp != null -> chatContentDao.getMessageByTimestamp(chatId, beforeTimestamp)
                 afterTimestamp != null ->
-                    messageDao
+                    chatContentDao
                         .getMessagesForChatBeforeTimestampExclusiveDesc(
                             chatId,
                             afterTimestamp,
@@ -696,13 +697,13 @@ class ChatHistoryManager private constructor(private val context: Context) {
         val afterMessage =
             when {
                 beforeTimestamp != null && afterTimestamp == null ->
-                    messageDao
+                    chatContentDao
                         .getMessagesForChatAfterTimestampExclusiveAsc(
                             chatId,
                             beforeTimestamp,
                             1,
                         ).firstOrNull()
-                afterTimestamp != null -> messageDao.getMessageByTimestamp(chatId, afterTimestamp)
+                afterTimestamp != null -> chatContentDao.getMessageByTimestamp(chatId, afterTimestamp)
                 else -> null
             }
 
@@ -775,9 +776,9 @@ class ChatHistoryManager private constructor(private val context: Context) {
             try {
                 val beforeMessage =
                     when {
-                        beforeTimestamp != null -> messageDao.getMessageByTimestamp(chatId, beforeTimestamp)
+                        beforeTimestamp != null -> chatContentDao.getMessageByTimestamp(chatId, beforeTimestamp)
                         afterTimestamp != null ->
-                            messageDao
+                            chatContentDao
                                 .getMessagesForChatBeforeTimestampExclusiveDesc(
                                     chatId,
                                     afterTimestamp,
@@ -788,13 +789,13 @@ class ChatHistoryManager private constructor(private val context: Context) {
                 val afterMessage =
                     when {
                         beforeTimestamp != null && afterTimestamp == null ->
-                            messageDao
+                            chatContentDao
                                 .getMessagesForChatAfterTimestampExclusiveAsc(
                                     chatId,
                                     beforeTimestamp,
                                     1,
                                 ).firstOrNull()
-                        afterTimestamp != null -> messageDao.getMessageByTimestamp(chatId, afterTimestamp)
+                        afterTimestamp != null -> chatContentDao.getMessageByTimestamp(chatId, afterTimestamp)
                         else -> null
                     }
 
@@ -963,7 +964,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
         chatMutex(chatId).withLock {
             try {
                 val baseMessage =
-                    messageDao.getMessageByTimestamp(chatId, messageTimestamp)
+                    chatContentDao.getMessageByTimestamp(chatId, messageTimestamp)
                         ?: throw IllegalArgumentException(
                             "Message $messageTimestamp does not exist in chat $chatId",
                         )
@@ -972,7 +973,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
                 }
 
                 val variants =
-                    messageVariantDao.getVariantsForMessage(chatId, messageTimestamp)
+                    chatContentDao.getVariantsForMessage(chatId, messageTimestamp)
                         .sortedBy { it.variantIndex }
                 if (variants.isEmpty()) {
                     throw IllegalStateException("Message $messageTimestamp has no deletable variants")
@@ -1070,12 +1071,12 @@ class ChatHistoryManager private constructor(private val context: Context) {
         chatMutex(chatId).withLock {
             try {
                 // 找到相应的消息实体
-                val existingMessage = messageDao.getMessageByTimestamp(chatId, message.timestamp)
+                val existingMessage = chatContentDao.getMessageByTimestamp(chatId, message.timestamp)
 
                 if (existingMessage != null) {
                     if (message.selectedVariantIndex > 0) {
                         val existingVariant =
-                            messageVariantDao.getVariantForMessage(
+                            chatContentDao.getVariantForMessage(
                                 chatId,
                                 message.timestamp,
                                 message.selectedVariantIndex,
@@ -1168,7 +1169,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
         chatMutex(chatId).withLock {
             try {
                 val existingMessage =
-                    messageDao.getMessageByTimestamp(chatId, timestamp) ?: return@withLock
+                    chatContentDao.getMessageByTimestamp(chatId, timestamp) ?: return@withLock
                 if (existingMessage.isFavorite == isFavorite) {
                     return@withLock
                 }
@@ -1191,13 +1192,13 @@ class ChatHistoryManager private constructor(private val context: Context) {
     ): Int {
         return chatMutex(chatId).withLock {
             val baseMessage =
-                messageDao.getMessageByTimestamp(chatId, messageTimestamp)
+                chatContentDao.getMessageByTimestamp(chatId, messageTimestamp)
                     ?: throw IllegalArgumentException("Message $messageTimestamp does not exist in chat $chatId")
             if (baseMessage.sender != "ai") {
                 throw IllegalArgumentException("Only AI messages can have regenerated variants")
             }
             val nextVariantIndex =
-                messageVariantDao.getVariantsForMessage(chatId, messageTimestamp).size + 1
+                chatContentDao.getVariantsForMessage(chatId, messageTimestamp).size + 1
             messageVariantDao.insertVariant(
                 MessageVariantEntity.fromChatMessage(
                     chatId = chatId,
@@ -1227,10 +1228,10 @@ class ChatHistoryManager private constructor(private val context: Context) {
         selectedVariantIndex: Int,
     ) {
         chatMutex(chatId).withLock {
-            messageDao.getMessageByTimestamp(chatId, messageTimestamp)
+            chatContentDao.getMessageByTimestamp(chatId, messageTimestamp)
                 ?: throw IllegalArgumentException("Message $messageTimestamp does not exist in chat $chatId")
             if (selectedVariantIndex > 0) {
-                messageVariantDao.getVariantForMessage(chatId, messageTimestamp, selectedVariantIndex)
+                chatContentDao.getVariantForMessage(chatId, messageTimestamp, selectedVariantIndex)
                     ?: throw IllegalArgumentException(
                         "Variant $selectedVariantIndex does not exist for message $messageTimestamp",
                     )
@@ -1579,7 +1580,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
         return kotlinx.coroutines.withContext(Dispatchers.IO) {
             try {
                 // AppLogger.d(TAG, "直接从数据库加载聊天 $chatId 的消息")
-                val messageEntities = messageDao.getMessagesForChat(chatId)
+                val messageEntities = chatContentDao.getMessagesForChat(chatId)
                 // AppLogger.d(TAG, "聊天 $chatId 共加载 ${messages.size} 条消息")
                 hydrateMessages(chatId, messageEntities)
             } catch (e: Exception) {
@@ -1602,17 +1603,17 @@ class ChatHistoryManager private constructor(private val context: Context) {
                 val messageEntities = when (normalizedOrder) {
                     "desc" -> {
                         if (effectiveLimit != null) {
-                            messageDao.getMessagesForChatDesc(chatId, effectiveLimit)
+                            chatContentDao.getMessagesForChatDesc(chatId, effectiveLimit)
                         } else {
-                            messageDao.getMessagesForChat(chatId).asReversed()
+                            chatContentDao.getMessagesForChat(chatId).asReversed()
                         }
                     }
 
                     else -> {
                         if (effectiveLimit != null) {
-                            messageDao.getMessagesForChatAsc(chatId, effectiveLimit)
+                            chatContentDao.getMessagesForChatAsc(chatId, effectiveLimit)
                         } else {
-                            messageDao.getMessagesForChat(chatId)
+                            chatContentDao.getMessagesForChat(chatId)
                         }
                     }
                 }
@@ -1637,8 +1638,8 @@ class ChatHistoryManager private constructor(private val context: Context) {
                 val limit = end - start + 1
 
                 val messageEntities = when (normalizedOrder) {
-                    "desc" -> messageDao.getMessagesForChatDescRange(chatId, start, limit)
-                    else -> messageDao.getMessagesForChatAscRange(chatId, start, limit)
+                    "desc" -> chatContentDao.getMessagesForChatDescRange(chatId, start, limit)
+                    else -> chatContentDao.getMessagesForChatAscRange(chatId, start, limit)
                 }
 
                 hydrateMessages(chatId, messageEntities)
@@ -1832,6 +1833,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
      */
     suspend fun exportChatHistoriesToDownloads(format: ExportFormat): String? =
         withContext(Dispatchers.IO) {
+            var pendingExportFile: File? = null
             try {
                 val chatHistoriesBasic = chatHistoriesFlow.first()
 
@@ -1844,6 +1846,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
                     ExportFormat.MARKDOWN -> {
                         val completeHistories = loadDisplayHistories(chatHistoriesBasic)
                         val zipFile = File(exportDir, "chat_backup_$timestamp.zip")
+                        pendingExportFile = zipFile
                         val usedNames = HashSet<String>()
                         ZipOutputStream(BufferedOutputStream(FileOutputStream(zipFile))).use { zos ->
                             for (history in completeHistories) {
@@ -1875,6 +1878,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
 
                     ExportFormat.JSON -> {
                         val file = File(exportDir, "chat_backup_$timestamp.json")
+                        pendingExportFile = file
                         exportOperitArchiveJsonStream(file, chatHistoriesBasic)
                         file
                     }
@@ -1882,6 +1886,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
                     ExportFormat.HTML -> {
                         val completeHistories = loadDisplayHistories(chatHistoriesBasic)
                         val file = File(exportDir, "chat_backup_$timestamp.html")
+                        pendingExportFile = file
                         file.writeText(HtmlExporter.exportMultiple(context, completeHistories))
                         file
                     }
@@ -1889,19 +1894,27 @@ class ChatHistoryManager private constructor(private val context: Context) {
                     ExportFormat.TXT -> {
                         val completeHistories = loadDisplayHistories(chatHistoriesBasic)
                         val file = File(exportDir, "chat_backup_$timestamp.txt")
+                        pendingExportFile = file
                         file.writeText(TextExporter.exportMultiple(context, completeHistories))
                         file
                     }
 
                     ExportFormat.CSV -> {
                         val file = File(exportDir, "chat_backup_$timestamp.json")
+                        pendingExportFile = file
                         exportOperitArchiveJsonStream(file, chatHistoriesBasic)
                         file
                     }
                 }
 
+                pendingExportFile = null
                 exportFile.absolutePath
             } catch (e: Exception) {
+                pendingExportFile?.let { incompleteFile ->
+                    if (incompleteFile.exists() && !incompleteFile.delete()) {
+                        AppLogger.w(TAG, "无法删除未完成的聊天导出文件: ${incompleteFile.absolutePath}")
+                    }
+                }
                 AppLogger.e(TAG, "导出聊天记录失败", e)
                 null
             }
@@ -2150,7 +2163,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
                         else -> messageDao.getLatestSummaryTimestamp(chatId)
                     }
                 val messageEntities =
-                    messageDao.getMessagesForChatInRangeAsc(
+                    chatContentDao.getMessagesForChatInRangeAsc(
                         chatId = chatId,
                         afterTimestampExclusive = latestSummaryTimestamp,
                         beforeTimestampExclusive = beforeTimestampExclusive,
@@ -2181,9 +2194,9 @@ class ChatHistoryManager private constructor(private val context: Context) {
                 val latestSummaryTimestamp = messageDao.getLatestSummaryTimestamp(chatId)
                 val messageEntities =
                     if (latestSummaryTimestamp != null) {
-                        messageDao.getMessagesForChatFromTimestampAsc(chatId, latestSummaryTimestamp)
+                        chatContentDao.getMessagesForChatFromTimestampAsc(chatId, latestSummaryTimestamp)
                     } else {
-                        messageDao.getMessagesForChat(chatId)
+                        chatContentDao.getMessagesForChat(chatId)
                     }
                 hydrateMessages(chatId, messageEntities)
             } catch (e: Exception) {
@@ -2202,13 +2215,13 @@ class ChatHistoryManager private constructor(private val context: Context) {
                 messageDao.getLatestSummaryTimestampUpTo(chatId, upToTimestampInclusive)
             val messageEntities =
                 if (latestSummaryTimestamp != null) {
-                    messageDao.getMessagesForChatWindowAsc(
+                    chatContentDao.getMessagesForChatWindowAsc(
                         chatId = chatId,
                         startTimestampInclusive = latestSummaryTimestamp,
                         endTimestampInclusive = upToTimestampInclusive
                     )
                 } else {
-                    messageDao.getMessagesForChatInRangeAsc(
+                    chatContentDao.getMessagesForChatInRangeAsc(
                         chatId = chatId,
                         afterTimestampExclusive = null,
                         beforeTimestampExclusive = null,
@@ -2249,7 +2262,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
         return withContext(Dispatchers.IO) {
             try {
                 val messageEntities =
-                    messageDao.getMessagesForChatFromTimestampAsc(chatId, startTimestampInclusive)
+                    chatContentDao.getMessagesForChatFromTimestampAsc(chatId, startTimestampInclusive)
                 hydrateMessages(chatId, messageEntities)
             } catch (e: Exception) {
                 AppLogger.e(TAG, "按起始时间加载聊天消息失败", e)
@@ -2266,7 +2279,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
         return withContext(Dispatchers.IO) {
             try {
                 val messageEntities =
-                    messageDao.getMessagesForChatWindowAsc(
+                    chatContentDao.getMessagesForChatWindowAsc(
                         chatId = chatId,
                         startTimestampInclusive = startTimestampInclusive,
                         endTimestampInclusive = endTimestampInclusive,
@@ -2287,7 +2300,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
         return withContext(Dispatchers.IO) {
             try {
                 val messageEntities =
-                    messageDao.getMessagesForChatAfterTimestampExclusiveAsc(
+                    chatContentDao.getMessagesForChatAfterTimestampExclusiveAsc(
                         chatId,
                         afterTimestampExclusive,
                         limit,
@@ -2308,7 +2321,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
         return withContext(Dispatchers.IO) {
             try {
                 val messageEntities =
-                    messageDao
+                    chatContentDao
                         .getMessagesForChatBeforeTimestampExclusiveDesc(
                             chatId,
                             beforeTimestampExclusive,
@@ -2359,13 +2372,13 @@ class ChatHistoryManager private constructor(private val context: Context) {
             try {
                 val messageEntities =
                     if (beforeTimestampExclusive != null) {
-                        messageDao.getMessagesForChatBeforeTimestampExclusiveDesc(
+                        chatContentDao.getMessagesForChatBeforeTimestampExclusiveDesc(
                             chatId,
                             beforeTimestampExclusive,
                             limit,
                         )
                     } else {
-                        messageDao.getMessagesForChatDesc(chatId, limit)
+                        chatContentDao.getMessagesForChatDesc(chatId, limit)
                     }
                 hydrateMessages(chatId, messageEntities)
             } catch (e: Exception) {
@@ -2383,7 +2396,7 @@ class ChatHistoryManager private constructor(private val context: Context) {
         return withContext(Dispatchers.IO) {
             try {
                 val messageEntities =
-                    messageDao.getMessagesForChatBeforeTimestampDesc(
+                    chatContentDao.getMessagesForChatBeforeTimestampDesc(
                         chatId,
                         maxTimestampInclusive,
                         limit,

--- a/docs/TODO/chat_large_message_io_20260806/index.md
+++ b/docs/TODO/chat_large_message_io_20260806/index.md
@@ -1,0 +1,32 @@
+---
+fork: https://github.com/luojiaping/Operit
+branch: fix/chat-large-message-io
+status: implementation-complete
+---
+
+# 超大聊天消息读取修复
+
+## 原状
+
+聊天消息和消息变体通过 `SELECT *` 直接装入 Android `CursorWindow`。单条 `content` 超过窗口容量时会抛出 `SQLiteBlobTooBigException`。聊天导出因此中断；对话窗口查询又把异常转换为空列表，最终表现为切换对话后内容空白。
+
+## 修改意图
+
+完整保留现有数据库内容和导出格式，不截断消息，也不调整设备相关的 `CursorWindow` 容量。读取查询只返回固定大小的首段文本和完整字符数，超出部分在同一 Room 事务内继续分段读取并重组。
+
+## 作用域
+
+- 新增 `ChatContentDao`，统一读取消息及消息变体的完整文本
+- 对话展示、运行时上下文、消息变体操作、长期记忆和聊天导出改用安全读取路径
+- 移除 `MessageDao` 与 `MessageVariantDao` 中会直接返回完整大文本行的查询
+- 导出失败时删除已经创建但尚未完成的文件
+- 数据库实体、表结构、版本号和归档 JSON 结构保持不变
+
+## 验收条件
+
+- 包含超过 Android `CursorWindow` 单行容量消息的对话可以正常切换和显示
+- JSON 导出可完整保留该消息及其变体，导入后内容一致
+- 普通消息继续通过一次查询完成读取
+- 导出异常不会在备份目录留下截断文件
+
+实现已完成。[DONE]


### PR DESCRIPTION
## 变更说明 / Description

修复单条聊天消息或消息变体超过 Android `CursorWindow` 容量时，聊天导出失败以及切换对话后消息区域显示为空白的问题。

### 背景与动机 / Context and motivation

Issue #404 曾记录相同的 `SQLiteBlobTooBigException`。此前通过限制部分工具输出降低了触发概率，但日志表明其他来源的超大消息仍会触发根因：

`Row too big to fit into CursorWindow requiredPos=837, totalRows=838`

原实现通过 `SELECT *` 将完整 `content` 装入 CursorWindow。查询失败后又被转换为空消息列表，导致数据库中的消息仍然存在，但 UI 显示为空；聊天导出也会在读取同一行时中断。

### 改动范围 / Changes

- 新增 `ChatContentDao`，只在首个查询中读取固定大小的文本片段
- 对超出片段大小的消息和消息变体，在同一 Room 事务内分段读取并无损重组
- 对话展示、运行时上下文、长期记忆、变体操作和聊天导出统一使用安全读取路径
- 移除 `MessageDao`、`MessageVariantDao` 中直接返回完整大文本行的查询
- 导出失败时删除未完成的 JSON、ZIP、HTML 或 TXT 文件
- 不包含消息长度限制、存储格式重构或 UI 布局调整

### 兼容性与风险 / Compatibility and risks

- 不修改数据库实体、表结构或数据库版本，无需数据迁移
- 不修改聊天归档 JSON 格式，现有导入与导出接口保持不变
- 已持久化的超大消息可以直接通过新读取路径恢复
- 普通消息仍由一次内容查询完成；仅超大消息产生额外分段查询
- 超大内容仍会在内存中重组为完整字符串，内存开销与原始内容大小成正比
- 配置、安全和公开 API 无变化

## 关联 Issue / Related issue

/no

## 验证方式 / Verification

```text
检查或命令：
- git diff --check
- Operit Builder Sync + Build Nightly

环境与变体：
- 分支：fix/chat-large-message-io
- 提交：3e9a40093c07654b8fcdfedf70391cfdc973008e
- Android Nightly

结果：
- git diff --check 通过
- Room KAPT、Kotlin、Java、DEX 和 APK 打包通过
- Nightly 构建成功，耗时 168.61 秒
- APK 大小 402,227,750 字节
- 未执行原始异常数据库的设备端回归，原因是日志对应的数据库样本不可用
```

## 证据 / Evidence

- 修复前日志：聊天导出在 `MessageDao.getMessagesForChat()` 抛出 `SQLiteBlobTooBigException`
- 修复前行为：数据库查询异常被解释为空消息列表，切换后 UI 显示空白
- 修复后构建：Nightly 完整构建成功，Room DAO 代码生成和 Kotlin 编译通过
- 协作记录：`docs/TODO/chat_large_message_io_20260806/index.md`

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
```