### PR TITLE
feat(market): support revision submissions after review changes

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
@@ -243,7 +243,13 @@ data class MarketV2PublisherEntrySummary(
     val updatedAt: String = "",
     val reasonCodes: List<String> = emptyList(),
     val reviewDetail: String? = null,
-    val reviewDetailUpdatedAt: String? = null
+    val reviewDetailUpdatedAt: String? = null,
+    /**
+     * Server-computed time at which a changes-requested revision may be
+     * submitted.  It is intentionally optional for older private shards and
+     * for entries that are not currently waiting for changes.
+     */
+    val revisionAvailableAt: String? = null
 )
 
 @Serializable
@@ -831,6 +837,25 @@ class MarketStatsApiService {
             }
         }
 
+    /**
+     * Loads the authenticated publisher's full entry data, including an unpublished
+     * latest version. This is required to prepare a revision after review changes.
+     */
+    suspend fun getMyEntryDetail(entryId: String): Result<MarketV2Entry> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val resolvedEntryId = entryId.trim().ifBlank { error("Missing entry id") }
+                requestDynamic(
+                    method = "GET",
+                    pathSegments = listOf("market", "v2", "my", "entries", resolvedEntryId, "detail"),
+                    label = "getMyEntryDetail entryId=$resolvedEntryId"
+                ) { body, _ ->
+                    val response = json.decodeFromString(MarketV2EntryResponse.serializer(), body)
+                    response.item ?: response.entry ?: error("Entry detail not found")
+                }
+            }
+        }
+
     suspend fun getPublisherEntries(authorId: String): Result<List<MarketV2PublisherEntrySummary>> =
         withContext(Dispatchers.IO) {
             runCatching {
@@ -976,20 +1001,6 @@ class MarketStatsApiService {
                 ) { _, _ ->
                     (getEntry(entryId).getOrNull() ?: MarketV2Entry(id = entryId, stateCode = "withdrawn"))
                         .copy(stateCode = "withdrawn")
-                }
-            }
-        }
-
-    suspend fun resubmitEntry(entryId: String): Result<MarketV2Entry> =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                requestDynamic(
-                    method = "POST",
-                    pathSegments = listOf("market", "v2", "entries", entryId, "resubmit"),
-                    label = "resubmitEntry entryId=$entryId"
-                ) { _, _ ->
-                    (getEntry(entryId).getOrNull() ?: MarketV2Entry(id = entryId, stateCode = "pending"))
-                        .copy(stateCode = "pending")
                 }
             }
         }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/ArtifactMarketModels.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/ArtifactMarketModels.kt
@@ -152,7 +152,8 @@ data class ArtifactPublishClusterContext(
     val lockedDisplayName: String,
     val projectDisplayName: String,
     val projectDescription: String,
-    val categoryId: String = ""
+    val categoryId: String = "",
+    val canEditEntry: Boolean = false
 )
 
 data class PublishArtifactDescriptor(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/GitHubForgePublishService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/GitHubForgePublishService.kt
@@ -256,7 +256,8 @@ class GitHubForgePublishService(
             val entry =
                 registerMarketEntry(
                     payload = payload,
-                    existingEntryId = request.publishContext?.entryId
+                    existingEntryId = request.publishContext?.entryId,
+                    includeEntryPatch = request.publishContext?.canEditEntry ?: true
                 ).getOrElse { error ->
                     resolvedAsset.releaseWasCreated?.let { releaseWasCreated ->
                         rollbackFailedMarketRegistration(
@@ -450,7 +451,8 @@ class GitHubForgePublishService(
 
     private suspend fun registerMarketEntry(
         payload: MarketRegistrationPayload,
-        existingEntryId: String?
+        existingEntryId: String?,
+        includeEntryPatch: Boolean
     ): Result<MarketV2Entry> {
         val request =
             MarketV2PublishRequest(
@@ -484,7 +486,7 @@ class GitHubForgePublishService(
         return marketStatsApiService.publishNewVersion(
             entryId = resolvedEntryId,
             request = request,
-            includeEntryPatch = true
+            includeEntryPatch = includeEntryPatch
         ).map { response ->
             MarketV2Entry(
                 type = payload.type.wireValue,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
@@ -101,7 +101,9 @@ private fun com.ai.assistance.operit.data.api.MarketV2Entry.toArtifactPublishEdi
     )
 }
 
-fun com.ai.assistance.operit.data.api.MarketV2Entry.toArtifactPublishClusterContext(): ArtifactPublishClusterContext {
+fun com.ai.assistance.operit.data.api.MarketV2Entry.toArtifactPublishClusterContext(
+    canEditEntry: Boolean = false
+): ArtifactPublishClusterContext {
     val versionValue = latestVersion
     return ArtifactPublishClusterContext(
         entryId = id,
@@ -110,7 +112,8 @@ fun com.ai.assistance.operit.data.api.MarketV2Entry.toArtifactPublishClusterCont
         lockedDisplayName = title,
         projectDisplayName = title,
         projectDescription = detail.ifBlank { description },
-        categoryId = categoryId
+        categoryId = categoryId,
+        canEditEntry = canEditEntry
     )
 }
 
@@ -149,7 +152,8 @@ fun ArtifactPublishScreen(
     val isContinuationMode = activePublishContext != null
     val lockedRuntimePackageId = initialInfo?.runtimePackageId?.ifBlank { initialInfo.normalizedId }.orEmpty()
     val lockedDisplayName = activePublishContext?.lockedDisplayName?.trim().orEmpty()
-    val isDisplayNameLocked = !isEditMode && lockedDisplayName.isNotBlank()
+    val canEditContinuationEntry = activePublishContext?.canEditEntry ?: true
+    val isDisplayNameLocked = !isEditMode && lockedDisplayName.isNotBlank() && !canEditContinuationEntry
     val continuationDescription =
         stringResource(R.string.artifact_publish_continuation_description)
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/RepoMarketPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/RepoMarketPublishScreen.kt
@@ -60,7 +60,8 @@ fun RepoMarketPublishScreen(
     type: MarketStatsType,
     onNavigateBack: () -> Unit,
     editingEntry: MarketV2Entry? = null,
-    publishVersionOnly: Boolean = false
+    publishVersionOnly: Boolean = false,
+    canEditEntry: Boolean = false
 ) {
     require(type == MarketStatsType.SKILL || type == MarketStatsType.MCP) {
         "Repo market publish only supports skill and mcp"
@@ -98,6 +99,7 @@ fun RepoMarketPublishScreen(
     var showConfirmationDialog by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var categories by remember { mutableStateOf<List<MarketV2ManifestCategory>>(emptyList()) }
+    val isEntryMetadataLocked = isVersionMode && !canEditEntry
 
     if (!isEditMode) {
         LaunchedEffect(title, description, detail, repositoryUrl, installConfig, category, allowPublicUpdates) {
@@ -139,6 +141,7 @@ fun RepoMarketPublishScreen(
             label = { Text(repoNameLabel(type)) },
             modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
             singleLine = true,
+            enabled = !isEntryMetadataLocked,
             isError = title.isBlank()
         )
 
@@ -149,6 +152,7 @@ fun RepoMarketPublishScreen(
             modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
             minLines = 3,
             maxLines = 6,
+            enabled = !isEntryMetadataLocked,
             isError = description.isBlank()
         )
 
@@ -158,7 +162,8 @@ fun RepoMarketPublishScreen(
             label = { Text(stringResource(R.string.market_detail_section_details)) },
             modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
             minLines = 4,
-            maxLines = 10
+            maxLines = 10,
+            enabled = !isEntryMetadataLocked
         )
 
         OutlinedTextField(
@@ -181,7 +186,7 @@ fun RepoMarketPublishScreen(
             selectedCategory = category,
             categories = categories,
             onCategorySelected = { category = it },
-            enabled = true,
+            enabled = !isEntryMetadataLocked,
             modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
         )
 
@@ -368,7 +373,8 @@ fun RepoMarketPublishScreen(
                                     category = category,
                                     allowPublicUpdates = allowPublicUpdates,
                                     version = version,
-                                    installConfig = installConfig
+                                    installConfig = installConfig,
+                                    canEditEntry = canEditEntry
                                 )
                             } else {
                                 viewModel.publish(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/UnifiedMarketManageScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/UnifiedMarketManageScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.NewReleases
 import androidx.compose.material.icons.filled.Store
-import androidx.compose.material.icons.filled.UploadFile
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -39,7 +38,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -79,8 +77,8 @@ private enum class ManageTypeTab(val kind: UnifiedMarketManageKind, val labelRes
 fun UnifiedMarketManageScreen(
     onNavigateToEditArtifact: (MarketV2Entry) -> Unit,
     onNavigateToEditRepo: (MarketStatsType, MarketV2Entry) -> Unit,
-    onNavigateToPublishArtifactVersion: (MarketV2Entry) -> Unit,
-    onNavigateToPublishRepoVersion: (MarketStatsType, MarketV2Entry) -> Unit,
+    onNavigateToPublishArtifactVersion: (MarketV2Entry, Boolean) -> Unit,
+    onNavigateToPublishRepoVersion: (MarketStatsType, MarketV2Entry, Boolean) -> Unit,
     onNavigateToPublishArtifact: () -> Unit,
     onNavigateToPublishRepo: (MarketStatsType) -> Unit,
     onNavigateToDetail: (MarketV2Entry) -> Unit
@@ -103,10 +101,8 @@ fun UnifiedMarketManageScreen(
     val entries by viewModel.entries.collectAsState()
     val hasLoaded by viewModel.hasLoaded.collectAsState()
     val isRefreshing by viewModel.isRefreshing.collectAsState()
-    val resubmittingEntryId by viewModel.resubmittingEntryId.collectAsState()
 
     var showDeleteDialog by remember { mutableStateOf<MarketV2PublisherEntrySummary?>(null) }
-    var showResubmitDialog by remember { mutableStateOf<MarketV2PublisherEntrySummary?>(null) }
     var showReviewDialog by remember { mutableStateOf<MarketV2PublisherEntrySummary?>(null) }
     var showGitHubLogin by remember { mutableStateOf(false) }
     var showPublishDialog by remember { mutableStateOf(false) }
@@ -120,6 +116,7 @@ fun UnifiedMarketManageScreen(
     }
 
     val showManageLoading = isLoggedIn && !hasLoaded && entries.isEmpty()
+    val showRequestLoading = isLoggedIn && hasLoaded && isLoading
     val showEmptyState = hasLoaded && errorMessage == null && entries.isEmpty()
     val ownedEntries = remember(entries) { entries.filter { it.isOwnerRelation() } }
     val contributedEntries = remember(entries) { entries.filter { it.isContributorRelation() } }
@@ -184,7 +181,17 @@ fun UnifiedMarketManageScreen(
                                 onNavigateToEditRepo = onNavigateToEditRepo,
                                 onNavigateToPublishArtifactVersion = onNavigateToPublishArtifactVersion,
                                 onNavigateToPublishRepoVersion = onNavigateToPublishRepoVersion,
-                                onRequestResubmit = { showResubmitDialog = it },
+                                onRequestRevision = { target ->
+                                    viewModel.openEntryForRevision(target) { fullEntry ->
+                                        when (val type = fullEntry.marketStatsType()) {
+                                            MarketStatsType.SCRIPT,
+                                            MarketStatsType.PACKAGE -> onNavigateToPublishArtifactVersion(fullEntry, target.relation == "owner")
+                                            MarketStatsType.SKILL,
+                                            MarketStatsType.MCP -> onNavigateToPublishRepoVersion(type, fullEntry, target.relation == "owner")
+                                            null -> Unit
+                                        }
+                                    }
+                                },
                                 onShowReview = { showReviewDialog = it },
                                 onDelete = { showDeleteDialog = it }
                             )
@@ -207,7 +214,17 @@ fun UnifiedMarketManageScreen(
                                 onNavigateToEditRepo = onNavigateToEditRepo,
                                 onNavigateToPublishArtifactVersion = onNavigateToPublishArtifactVersion,
                                 onNavigateToPublishRepoVersion = onNavigateToPublishRepoVersion,
-                                onRequestResubmit = { showResubmitDialog = it },
+                                onRequestRevision = { target ->
+                                    viewModel.openEntryForRevision(target) { fullEntry ->
+                                        when (val type = fullEntry.marketStatsType()) {
+                                            MarketStatsType.SCRIPT,
+                                            MarketStatsType.PACKAGE -> onNavigateToPublishArtifactVersion(fullEntry, target.relation == "owner")
+                                            MarketStatsType.SKILL,
+                                            MarketStatsType.MCP -> onNavigateToPublishRepoVersion(type, fullEntry, target.relation == "owner")
+                                            null -> Unit
+                                        }
+                                    }
+                                },
                                 onShowReview = { showReviewDialog = it },
                                 onDelete = { showDeleteDialog = it }
                             )
@@ -249,15 +266,8 @@ fun UnifiedMarketManageScreen(
         )
     }
 
-    showResubmitDialog?.let { entry ->
-        MarketManageResubmitDialog(
-            entry = entry,
-            onConfirm = {
-                viewModel.resubmitEntry(entry)
-                showResubmitDialog = null
-            },
-            onDismiss = { showResubmitDialog = null }
-        )
+    if (showRequestLoading) {
+        MarketManageRequestLoadingDialog()
     }
 
     showReviewDialog?.let { entry ->
@@ -267,11 +277,27 @@ fun UnifiedMarketManageScreen(
         )
     }
 
-    if (resubmittingEntryId != null) {
-        MarketManageBlockingProgressDialog(
-            text = stringResource(R.string.market_manage_resubmitting_message)
-        )
-    }
+}
+
+@Composable
+private fun MarketManageRequestLoadingDialog() {
+    AlertDialog(
+        onDismissRequest = {},
+        title = { Text(stringResource(R.string.market_manage_loading_request_title)) },
+        text = {
+            Row(
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp
+                )
+                Text(stringResource(R.string.market_manage_loading_request_message))
+            }
+        },
+        confirmButton = {}
+    )
 }
 
 @Composable
@@ -281,57 +307,6 @@ private fun ManageSectionTitle(text: String) {
         modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 2.dp),
         style = MaterialTheme.typography.titleSmall,
         color = MaterialTheme.colorScheme.primary
-    )
-}
-
-@Composable
-private fun MarketManageBlockingProgressDialog(text: String) {
-    AlertDialog(
-        onDismissRequest = {},
-        title = { Text(stringResource(R.string.market_manage_resubmitting_title)) },
-        text = {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                Spacer(modifier = Modifier.width(14.dp))
-                Text(text = text)
-            }
-        },
-        confirmButton = {}
-    )
-}
-
-@Composable
-private fun MarketManageResubmitDialog(
-    entry: MarketV2PublisherEntrySummary,
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.market_manage_resubmit_confirm_title)) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(stringResource(R.string.market_manage_resubmit_confirm_message, entry.title))
-                MarketManageReviewDialogContent(entry = entry)
-                Text(
-                    text = stringResource(R.string.market_manage_resubmit_confirm_warning),
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onConfirm) {
-                Text(stringResource(R.string.market_manage_resubmit_confirm_action))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.cancel))
-            }
-        }
     )
 }
 
@@ -393,21 +368,22 @@ private fun ManagedEntryCard(
     onNavigateToDetail: (MarketV2Entry) -> Unit,
     onNavigateToEditArtifact: (MarketV2Entry) -> Unit,
     onNavigateToEditRepo: (MarketStatsType, MarketV2Entry) -> Unit,
-    onNavigateToPublishArtifactVersion: (MarketV2Entry) -> Unit,
-    onNavigateToPublishRepoVersion: (MarketStatsType, MarketV2Entry) -> Unit,
-    onRequestResubmit: (MarketV2PublisherEntrySummary) -> Unit,
+    onNavigateToPublishArtifactVersion: (MarketV2Entry, Boolean) -> Unit,
+    onNavigateToPublishRepoVersion: (MarketStatsType, MarketV2Entry, Boolean) -> Unit,
+    onRequestRevision: (MarketV2PublisherEntrySummary) -> Unit,
     onShowReview: (MarketV2PublisherEntrySummary) -> Unit,
     onDelete: (MarketV2PublisherEntrySummary) -> Unit
 ) {
     val review = remember(entry) { entry.resolveMarketReviewSnapshot() }
     val reviewDetail = entry.reviewDetail?.trim().orEmpty()
+    val canSubmitRevision = review.state == MarketReviewState.CHANGES_REQUESTED
     // A pending listing has no public detail shard, so public-detail actions cannot be opened yet.
     val canOpenPublicEntry = entry.isOpen() && entry.listingState != "pending_listing"
     MarketManageItemCard(
         title = entry.title,
         description = entry.manageSummaryText(),
         isOpen = canOpenPublicEntry,
-        showActions = canManageEntry || canOpenPublicEntry,
+        showActions = canManageEntry || canOpenPublicEntry || canSubmitRevision,
         onClick = {
             if (canOpenPublicEntry) {
                 viewModel.openEntryDetail(entry, onNavigateToDetail)
@@ -468,29 +444,28 @@ private fun ManagedEntryCard(
                         viewModel.openEntryDetail(entry) { fullEntry ->
                             when (val type = fullEntry.marketStatsType()) {
                                 MarketStatsType.SCRIPT,
-                                MarketStatsType.PACKAGE -> onNavigateToPublishArtifactVersion(fullEntry)
+                                MarketStatsType.PACKAGE -> onNavigateToPublishArtifactVersion(fullEntry, canManageEntry)
                                 MarketStatsType.SKILL,
-                                MarketStatsType.MCP -> onNavigateToPublishRepoVersion(type, fullEntry)
+                                MarketStatsType.MCP -> onNavigateToPublishRepoVersion(type, fullEntry, canManageEntry)
                                 null -> Unit
                             }
                         }
                     }
                 )
             }
-            if (canManageEntry) {
-                if (entry.isOpen()) {
-                    MarketManageDangerActionButton(
-                        label = stringResource(R.string.remove),
-                        icon = Icons.Default.Delete,
-                        onClick = { onDelete(entry) }
-                    )
-                } else if (review.state == MarketReviewState.CHANGES_REQUESTED) {
-                    MarketManagePrimaryActionButton(
-                        label = stringResource(R.string.market_manage_resubmit),
-                        icon = Icons.Default.UploadFile,
-                        onClick = { onRequestResubmit(entry) }
-                    )
-                }
+            if (canManageEntry && entry.isOpen()) {
+                MarketManageDangerActionButton(
+                    label = stringResource(R.string.remove),
+                    icon = Icons.Default.Delete,
+                    onClick = { onDelete(entry) }
+                )
+            }
+            if (canSubmitRevision) {
+                MarketManagePrimaryActionButton(
+                    label = stringResource(R.string.market_manage_submit_revision),
+                    icon = Icons.Default.NewReleases,
+                    onClick = { onRequestRevision(entry) }
+                )
             }
         }
     )
@@ -640,5 +615,4 @@ private fun MarketV2Entry.marketStatsType(): MarketStatsType? {
 private fun MarketV2PublisherEntrySummary.marketStatsType(): MarketStatsType? {
     return MarketStatsType.entries.firstOrNull { it.wireValue == type.lowercase() }
 }
-
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/artifact/viewmodel/ArtifactMarketViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/artifact/viewmodel/ArtifactMarketViewModel.kt
@@ -157,7 +157,8 @@ class ArtifactMarketViewModel(
         }
 
         val resolvedDisplayName =
-            publishContext?.lockedDisplayName
+            publishContext?.takeUnless { it.canEditEntry }
+                ?.lockedDisplayName
                 ?.trim()
                 ?.takeIf { it.isNotBlank() }
                 ?: displayName
@@ -542,7 +543,7 @@ class ArtifactMarketViewModel(
     }
     private fun resolvePublishDisplayName(request: PublishArtifactRequest): String {
         val lockedDisplayName = request.publishContext?.lockedDisplayName?.trim().orEmpty()
-        if (request.publishContext != null) {
+        if (request.publishContext != null && !request.publishContext.canEditEntry) {
             if (lockedDisplayName.isBlank()) {
                 throw IllegalStateException(getText(R.string.artifact_publish_locked_name_required))
             }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/market/viewmodel/RepoMarketPublishViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/market/viewmodel/RepoMarketPublishViewModel.kt
@@ -146,15 +146,17 @@ class RepoMarketPublishViewModel(
         category: String,
         allowPublicUpdates: Boolean,
         version: String,
-        installConfig: String = ""
+        installConfig: String = "",
+        canEditEntry: Boolean = false
     ): Result<Unit> {
         validateNewVersion(entry, version)
-        val hasEntryPatch =
+        val hasEntryPatch = canEditEntry && (
             title != entry.title ||
                 description != entry.description ||
                 detail != entry.detail ||
                 category != entry.categoryId ||
                 allowPublicUpdates != entry.allowPublicUpdates
+            )
         return submit(
             entryId = entry.id,
             title = title,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/market/viewmodel/UnifiedMarketManageViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/market/viewmodel/UnifiedMarketManageViewModel.kt
@@ -5,14 +5,13 @@ import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.ai.assistance.operit.BuildConfig
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.data.api.MarketStatsApiService
 import com.ai.assistance.operit.data.api.MarketV2Entry
 import com.ai.assistance.operit.data.api.MarketV2PublisherEntrySummary
 import com.ai.assistance.operit.data.preferences.GitHubAuthPreferences
 import com.ai.assistance.operit.ui.features.packages.market.MarketStatsType
-import com.ai.assistance.operit.ui.features.packages.market.MarketReviewState
-import com.ai.assistance.operit.ui.features.packages.market.resolveMarketReviewSnapshot
 import com.ai.assistance.operit.util.AppLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -52,9 +51,6 @@ class UnifiedMarketManageViewModel(
 
     private val _hasLoaded = MutableStateFlow(false)
     val hasLoaded: StateFlow<Boolean> = _hasLoaded.asStateFlow()
-
-    private val _resubmittingEntryId = MutableStateFlow<String?>(null)
-    val resubmittingEntryId: StateFlow<String?> = _resubmittingEntryId.asStateFlow()
 
     val isLoggedIn: StateFlow<Boolean> =
         githubAuth.isLoggedInFlow.stateIn(
@@ -97,7 +93,6 @@ class UnifiedMarketManageViewModel(
                             .distinctBy { it.id }
                             .sortedByDescending { it.updatedAt }
                     }
-                recordVisibleReviewLocks(loaded)
                 _entries.value = loaded
             } catch (e: Exception) {
                 _errorMessage.value = e.message ?: context.getString(R.string.market_error_load_failed)
@@ -164,30 +159,112 @@ class UnifiedMarketManageViewModel(
         )
     }
 
-    fun resubmitEntry(entry: MarketV2PublisherEntrySummary) {
-        val blockMessage = resolveResubmitBlockMessage(entry)
-        if (blockMessage != null) {
-            _errorMessage.value = blockMessage
-            Toast.makeText(context, blockMessage, Toast.LENGTH_SHORT).show()
+    fun openEntryForRevision(
+        entry: MarketV2PublisherEntrySummary,
+        onLoaded: (MarketV2Entry) -> Unit
+    ) {
+        val revisionAvailableAtForLog = entry.revisionAvailableAt ?: "<null>"
+        AppLogger.i(
+            TAG,
+            "revision_gate click entryId=${entry.id} stateCode=${entry.stateCode} " +
+                "revisionAvailableAt=$revisionAvailableAtForLog " +
+                "updatedAt=${entry.updatedAt} appVersion=${BuildConfig.VERSION_NAME}(${BuildConfig.VERSION_CODE})"
+        )
+        revisionCooldownMessage(entry)?.let { message ->
+            AppLogger.i(TAG, "revision_gate decision=blocked entryId=${entry.id} reason=cooldown message=$message")
+            _errorMessage.value = message
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
             return
         }
+        AppLogger.i(TAG, "revision_gate decision=allowed entryId=${entry.id} next=getMyEntryDetail")
+        viewModelScope.launch {
+            if (!githubAuth.isLoggedIn()) {
+                _errorMessage.value = context.getString(R.string.skillmarket_github_login_required)
+                return@launch
+            }
+            if (entry.id.isBlank()) {
+                _errorMessage.value = context.getString(R.string.skillmarket_remove_failed, "entry not found")
+                return@launch
+            }
 
-        updateEntryState(
-            entry = entry,
-            stateCode = "pending",
-            action = { marketStatsApiService.resubmitEntry(entry.id) },
-            successMessage = context.getString(R.string.market_manage_resubmitted, entry.title),
-            loadingEntryId = entry.id
+            _isLoading.value = true
+            _errorMessage.value = null
+            try {
+                val fullEntry =
+                    withContext(Dispatchers.IO) {
+                        marketStatsApiService.getMyEntryDetail(entry.id).getOrThrow()
+                    }
+                onLoaded(fullEntry)
+            } catch (e: Exception) {
+                _errorMessage.value = e.message ?: context.getString(R.string.market_error_load_failed)
+                AppLogger.e(TAG, "Failed to load revision detail for managed market entry ${entry.id}", e)
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    private fun revisionCooldownMessage(entry: MarketV2PublisherEntrySummary): String? {
+        if (entry.stateCode != "changes_requested") {
+            AppLogger.i(
+                TAG,
+                "revision_gate evaluation entryId=${entry.id} decision=allowed " +
+                    "reason=state_not_changes_requested stateCode=${entry.stateCode}"
+            )
+            return null
+        }
+        val availableAt =
+            entry.revisionAvailableAt
+                ?.let { value ->
+                    runCatching { java.time.Instant.parse(value).toEpochMilli() }
+                        .onFailure {
+                            AppLogger.i(
+                                TAG,
+                                "revision_gate evaluation entryId=${entry.id} decision=allowed " +
+                                    "reason=invalid_revisionAvailableAt value=$value"
+                            )
+                        }
+                        .getOrNull()
+                }
+                ?: run {
+                    AppLogger.i(
+                        TAG,
+                        "revision_gate evaluation entryId=${entry.id} decision=allowed " +
+                            "reason=missing_revisionAvailableAt stateCode=${entry.stateCode}"
+                    )
+                    return null
+                }
+        val remainingMillis = availableAt - System.currentTimeMillis()
+        if (remainingMillis <= 0L) {
+            AppLogger.i(
+                TAG,
+                "revision_gate evaluation entryId=${entry.id} decision=allowed " +
+                    "reason=cooldown_expired availableAtEpochMs=$availableAt remainingMs=$remainingMillis"
+            )
+            return null
+        }
+        AppLogger.i(
+            TAG,
+            "revision_gate evaluation entryId=${entry.id} decision=blocked " +
+                "reason=cooldown_active availableAtEpochMs=$availableAt remainingMs=$remainingMillis"
         )
+        val totalMinutes = ((remainingMillis + 59_999L) / 60_000L).coerceAtLeast(1L)
+        val hours = totalMinutes / 60L
+        val minutes = totalMinutes % 60L
+        val remainingText =
+            when {
+                hours > 0L && minutes > 0L -> "${hours}小时${minutes}分钟"
+                hours > 0L -> "${hours}小时"
+                else -> "${minutes}分钟"
+            }
+        return context.getString(R.string.market_manage_revision_cooldown, remainingText)
     }
 
     private fun updateEntryState(
         entry: MarketV2PublisherEntrySummary,
         stateCode: String,
         action: suspend () -> Result<MarketV2Entry>,
-        successMessage: String,
-        onSuccess: (() -> Unit)? = null,
-        loadingEntryId: String? = null
+        successMessage: String
     ) {
         viewModelScope.launch {
             if (!githubAuth.isLoggedIn()) {
@@ -200,9 +277,6 @@ class UnifiedMarketManageViewModel(
             }
 
             _isLoading.value = true
-            if (loadingEntryId != null) {
-                _resubmittingEntryId.value = loadingEntryId
-            }
             _errorMessage.value = null
             try {
                 action().fold(
@@ -211,7 +285,6 @@ class UnifiedMarketManageViewModel(
                             _entries.value.map { existing ->
                                 if (existing.id == entry.id) existing.copy(stateCode = stateCode) else existing
                             }
-                        onSuccess?.invoke()
                         Toast.makeText(context, successMessage, Toast.LENGTH_SHORT).show()
                     },
                     onFailure = { error ->
@@ -222,83 +295,8 @@ class UnifiedMarketManageViewModel(
                 _errorMessage.value = e.message ?: context.getString(R.string.market_error_action_failed)
                 AppLogger.e(TAG, "Failed to update managed market entry", e)
             } finally {
-                if (loadingEntryId != null && _resubmittingEntryId.value == loadingEntryId) {
-                    _resubmittingEntryId.value = null
-                }
                 _isLoading.value = false
             }
-        }
-    }
-
-    private fun resolveResubmitBlockMessage(entry: MarketV2PublisherEntrySummary): String? {
-        val review = entry.resolveMarketReviewSnapshot()
-        if (review.state == MarketReviewState.REJECTED || resubmitPreferences().getBoolean(rejectedKey(entry.id), false)) {
-            return context.getString(R.string.market_manage_resubmit_rejected_blocked)
-        }
-        if (review.state != MarketReviewState.CHANGES_REQUESTED) {
-            return context.getString(R.string.market_manage_resubmit_state_blocked)
-        }
-
-        val cooldownUntil = getResubmitCooldownUntil(entry)
-        val now = System.currentTimeMillis()
-        if (cooldownUntil > now) {
-            return context.getString(
-                R.string.market_manage_resubmit_cooldown_message,
-                formatRemainingCooldown(cooldownUntil - now)
-            )
-        }
-        return null
-    }
-
-    private fun recordVisibleReviewLocks(entries: List<MarketV2PublisherEntrySummary>) {
-        val preferences = resubmitPreferences()
-        val editor = preferences.edit()
-        for (entry in entries) {
-            when (entry.resolveMarketReviewSnapshot().state) {
-                MarketReviewState.CHANGES_REQUESTED -> {
-                    val key = cooldownKey(entry)
-                    if (!preferences.contains(key)) {
-                        editor.putLong(key, reviewCooldownUntil(entry))
-                    }
-                }
-                MarketReviewState.REJECTED -> {
-                    editor.putBoolean(rejectedKey(entry.id), true)
-                }
-                MarketReviewState.PENDING,
-                MarketReviewState.APPROVED,
-                MarketReviewState.WITHDRAWN -> Unit
-            }
-        }
-        editor.apply()
-    }
-
-    private fun getResubmitCooldownUntil(entry: MarketV2PublisherEntrySummary): Long {
-        return resubmitPreferences().getLong(cooldownKey(entry), 0L)
-    }
-
-    private fun reviewCooldownUntil(entry: MarketV2PublisherEntrySummary): Long {
-        return java.time.Instant.parse(entry.updatedAt).toEpochMilli() + RESUBMIT_COOLDOWN_MILLIS
-    }
-
-    private fun resubmitPreferences() =
-        context.getSharedPreferences(RESUBMIT_PREFS_NAME, Context.MODE_PRIVATE)
-
-    private fun cooldownKey(entry: MarketV2PublisherEntrySummary): String {
-        return "changes_requested_until_${entry.id}_${entry.updatedAt}"
-    }
-
-    private fun rejectedKey(entryId: String): String {
-        return "rejected_$entryId"
-    }
-
-    private fun formatRemainingCooldown(remainingMillis: Long): String {
-        val totalMinutes = ((remainingMillis + 59_999L) / 60_000L).coerceAtLeast(1L)
-        val hours = totalMinutes / 60L
-        val minutes = totalMinutes % 60L
-        return when {
-            hours > 0L && minutes > 0L -> "${hours}小时${minutes}分钟"
-            hours > 0L -> "${hours}小时"
-            else -> "${minutes}分钟"
         }
     }
 
@@ -317,8 +315,6 @@ class UnifiedMarketManageViewModel(
 
     companion object {
         private const val TAG = "UnifiedMarketManageViewModel"
-        private const val RESUBMIT_PREFS_NAME = "market_resubmit_cooldowns"
-        private const val RESUBMIT_COOLDOWN_MILLIS = 12L * 60L * 60L * 1000L
     }
 }
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/main/screens/OperitScreens.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/main/screens/OperitScreens.kt
@@ -366,11 +366,11 @@ sealed class Screen(
                 onNavigateToEditRepo = { type, issue ->
                     navigateTo(RepoEdit(type, issue))
                 },
-                onNavigateToPublishArtifactVersion = { issue ->
-                    navigateTo(ArtifactContinuePublish(issue.toArtifactPublishClusterContext()))
+                onNavigateToPublishArtifactVersion = { issue, canEditEntry ->
+                    navigateTo(ArtifactContinuePublish(issue.toArtifactPublishClusterContext(canEditEntry)))
                 },
-                onNavigateToPublishRepoVersion = { type, issue ->
-                    navigateTo(RepoPublishVersion(type, issue))
+                onNavigateToPublishRepoVersion = { type, issue, canEditEntry ->
+                    navigateTo(RepoPublishVersion(type, issue, canEditEntry))
                 },
                 onNavigateToPublishArtifact = { navigateTo(ArtifactPublish) },
                 onNavigateToPublishRepo = { type -> navigateTo(RepoPublish(type)) },
@@ -499,7 +499,8 @@ sealed class Screen(
 
     data class RepoPublishVersion(
         val type: MarketStatsType,
-        val editingEntry: com.ai.assistance.operit.data.api.MarketV2Entry
+        val editingEntry: com.ai.assistance.operit.data.api.MarketV2Entry,
+        val canEditEntry: Boolean = false
     ) : Screen(navItem = NavItem.Packages) {
         @Composable
         override fun Content(
@@ -515,7 +516,8 @@ sealed class Screen(
                 type = type,
                 onNavigateBack = onGoBack,
                 editingEntry = editingEntry,
-                publishVersionOnly = true
+                publishVersionOnly = true,
+                canEditEntry = canEditEntry
             )
         }
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -7984,6 +7984,7 @@
     <string name="artifact_publish_encrypt_market_toolpkg_title">Minify and Obfuscate for Publishing</string>
 
     <string name="market_manage_resubmit">Resubmit</string>
+    <string name="market_manage_revision_cooldown">Revision submission is cooling down after the review return. Please wait %1$s.</string>
     <string name="market_manage_resubmitting_title">Resubmitting</string>
     <string name="market_manage_resubmitting_message">Submitting review request, please wait…</string>
     <string name="market_manage_resubmit_cooldown_message">This entry is in local cooldown. Remaining %1$s before resubmission.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4312,6 +4312,10 @@
     <string name="market_manage_removed">已提交移除「%1$s」的请求</string>
     <string name="market_manage_resubmitted">已提交重新上架「%1$s」的请求</string>
     <string name="market_manage_resubmit">重新提交</string>
+    <string name="market_manage_submit_revision">修改后提交新版本</string>
+    <string name="market_manage_revision_cooldown">被打回后的修改版提交仍在冷却中，还需等待 %1$s。</string>
+    <string name="market_manage_loading_request_title">正在加载请求</string>
+    <string name="market_manage_loading_request_message">请求正在处理中，请稍候…</string>
     <string name="market_manage_resubmitting_title">正在重新提交</string>
     <string name="market_manage_resubmitting_message">正在提交审核请求，请稍候…</string>
     <string name="market_manage_resubmit_cooldown_message">该条目已进入本地冷却期，剩余 %1$s 后才能再次提交。</string>


### PR DESCRIPTION
## 变更说明 / Description

支持在市场审核要求修改后加载完整私有条目，并进入版本发布页面提交修订版。

### 背景与动机 / Context and motivation

此前管理页的重新提交流程依赖本地冷却状态，无法根据服务端的修订可用时间准备待修订条目的完整数据。

### 改动范围 / Changes

- 新增获取当前发布者条目详情的接口，并读取服务端修订可用时间。
- 管理页根据服务端冷却时间提供修订提交入口与加载状态。
- 将修订条目的编辑权限传递至制品和仓库发布流程，并更新中英文文案。

### 兼容性与风险 / Compatibility and risks

保留已有发布流程；修订入口仅在审核要求修改时出现。服务端未提供修订可用时间时不会阻止该入口。

## 关联 Issue / Related issue

N/A — 市场审核后修订提交流程改进。

## 验证方式 / Verification

检查或命令：git diff --check
环境与变体：本地 Git 工作区
结果：通过；未运行构建或测试（仓库准则要求须由用户明确要求）。

## 证据 / Evidence

静态差异检查通过。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided