### PR TITLE
修复市场评论与发布页的主题文字颜色

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
@@ -1154,9 +1154,12 @@ private fun UnifiedMarketDetailEmptyCommentsCard() {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            // The alpha-adjusted card cannot infer onSurfaceVariant, so keep the empty-state title
+            // from inheriting a low-contrast foreground in dark themes.
             Text(
                 text = stringResource(R.string.mcp_plugin_no_comments),
                 style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontWeight = FontWeight.Bold
             )
             Text(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
@@ -1229,6 +1229,7 @@ private fun UnifiedMarketDetailCommentCard(
                     Text(
                         text = comment.author.login,
                         style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface,
                         fontWeight = FontWeight.SemiBold
                     )
                     if (body.isNotBlank()) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
@@ -290,7 +290,8 @@ fun ArtifactPublishScreen(
     ) {
         Card(
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
             )
         ) {
             Column(
@@ -359,7 +360,8 @@ fun ArtifactPublishScreen(
         } else if (activePublishContext != null) {
             Card(
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.32f)
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.32f),
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
                 )
             ) {
                 Column(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
@@ -344,12 +344,18 @@ fun ArtifactPublishScreen(
                                 append(context.getString(R.string.artifact_publish_file_locked))
                             }
                         }.ifBlank { context.getString(R.string.artifact_publish_only_description_versions_editable) }
+                    // The translucent container cannot infer onSurfaceVariant; explicit colors prevent
+                    // these labels from inheriting a mismatched foreground in dark themes.
                     Text(
                         text = stringResource(R.string.artifact_publish_current_artifact),
                         style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontWeight = FontWeight.SemiBold
                     )
-                    Text(initialInfo.title.ifBlank { selectorDisplayName })
+                    Text(
+                        text = initialInfo.title.ifBlank { selectorDisplayName },
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                     Text(
                         text = summaryText,
                         style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
@@ -290,8 +290,7 @@ fun ArtifactPublishScreen(
     ) {
         Card(
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
             )
         ) {
             Column(
@@ -306,7 +305,7 @@ fun ArtifactPublishScreen(
                             else -> stringResource(R.string.publish_description)
                         },
                     style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.primary
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
                 )
                 Text(
                     text =
@@ -315,7 +314,8 @@ fun ArtifactPublishScreen(
                             isContinuationMode -> continuationDescription
                             else -> stringResource(R.string.artifact_publish_info_description)
                         },
-                    style = MaterialTheme.typography.bodySmall
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
                 )
             }
         }
@@ -360,8 +360,7 @@ fun ArtifactPublishScreen(
         } else if (activePublishContext != null) {
             Card(
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.32f),
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.32f)
                 )
             ) {
                 Column(
@@ -371,6 +370,7 @@ fun ArtifactPublishScreen(
                     Text(
                         text = stringResource(R.string.artifact_publish_publish_update_version),
                         style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
                         fontWeight = FontWeight.SemiBold
                     )
                     if (lockedDisplayName.isNotBlank()) {
@@ -380,13 +380,13 @@ fun ArtifactPublishScreen(
                                 lockedDisplayName
                             ),
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.onSecondaryContainer
                         )
                     }
                     Text(
                         text = stringResource(R.string.artifact_publish_package_name_auto_inherited),
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
                     )
                 }
             }


### PR DESCRIPTION
## 变更说明 / Description

修复插件市场评论区及脚本/工具包发布页在暗色主题下部分文字对比度不足的问题。

### 背景与动机 / Context and motivation

评论用户名此前没有显式指定主题颜色；多个说明卡片使用了半透明主题容器色，Material 无法由调整透明度后的颜色可靠推导对应前景色。相关文字可能继承不适合暗色背景的颜色，导致难以阅读。

### 改动范围 / Changes

- 评论用户名使用 `MaterialTheme.colorScheme.onSurface`。
- 评论空状态的 `surfaceVariant` 卡片标题使用 `onSurfaceVariant`。
- 发布页 `primaryContainer` 说明卡片使用 `onPrimaryContainer`。
- 发布页编辑态的 `surfaceVariant` 当前制品卡片使用 `onSurfaceVariant`。
- 发布更新版本的 `secondaryContainer` 卡片使用 `onSecondaryContainer`。
- 未修改布局、数据、接口或交互逻辑。

### 兼容性与风险 / Compatibility and risks

仅补充 Material 主题语义色。亮色、暗色和自定义主题会自动使用对应前景色，风险较低。

## 关联 Issue / Related issue

N/A，主题适配修复。

## 验证方式 / Verification

```text
检查或命令：
- git diff --check
- 检查最终提交差异、修改范围和远端提交 SHA

环境与变体：
- 静态代码验证
- 按仓库约束未在本地执行 Gradle/Android 构建，交由 PR CI 验证

结果：
- 修改 2 个 Compose 页面文件
- 最终差异仅包含主题文字颜色及相关意图注释
- git diff --check 通过
- PR 头提交与 Fork 远端 SHA 一致
```

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容
- [x] 改动仅限主题文字颜色