### PR TITLE
fix(export): prevent OOM and unblock long HTML/TXT exports , 然后加了个进度条

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/dao/ChatContentDao.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/dao/ChatContentDao.kt
@@ -68,6 +68,11 @@ data class MessageVariantContentRow(
     val contentCharacterCount: Long,
 )
 
+data class ChatContentCharacterCount(
+    val chatId: String,
+    val contentCharacterCount: Long,
+)
+
 /** Reads message text in bounded rows so a single large message cannot overflow CursorWindow. */
 @Dao
 abstract class ChatContentDao {
@@ -239,6 +244,31 @@ abstract class ChatContentDao {
         startCharacter: Long,
         characterCount: Int,
     ): String?
+
+    @Query(
+        """
+        SELECT
+            chats.id AS chatId,
+            COALESCE(
+                SUM(
+                    CASE
+                        WHEN messages.selectedVariantIndex = 0 THEN LENGTH(messages.content)
+                        ELSE LENGTH(selectedVariant.content)
+                    END
+                ),
+                0
+            ) AS contentCharacterCount
+        FROM chats
+        LEFT JOIN messages
+            ON messages.chatId = chats.id
+        LEFT JOIN message_variants AS selectedVariant
+            ON selectedVariant.chatId = messages.chatId
+            AND selectedVariant.messageTimestamp = messages.timestamp
+            AND selectedVariant.variantIndex = messages.selectedVariantIndex
+        GROUP BY chats.id
+        """
+    )
+    abstract suspend fun getSelectedContentCharacterCountsByChat(): List<ChatContentCharacterCount>
 
     @Transaction
     open suspend fun getMessagesForChat(chatId: String): List<MessageEntity> =

--- a/app/src/main/java/com/ai/assistance/operit/data/exporter/HtmlExporter.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/exporter/HtmlExporter.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.data.model.ChatHistory
 import com.ai.assistance.operit.data.model.ChatMessage
+import java.io.StringWriter
+import java.io.Writer
 import java.time.format.DateTimeFormatter
 
 /**
@@ -11,124 +13,191 @@ import java.time.format.DateTimeFormatter
  */
 object HtmlExporter {
 
+    private const val HTML_CONTENT_WRITE_CHUNK_CHARACTER_COUNT = 64 * 1024
+    private const val CONTENT_PROGRESS_CHARACTER_COUNT = 256 * 1024
     private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
     /**
      * 导出单个对话为 HTML
      */
     fun exportSingle(context: Context, chatHistory: ChatHistory): String {
-        val sb = StringBuilder()
-
-        appendHtmlHeader(sb, chatHistory.title)
-        appendChatContent(context, sb, chatHistory)
-        appendHtmlFooter(context, sb)
-
-        return sb.toString()
+        val writer = StringWriter()
+        writeSingleToWriter(context, chatHistory, writer)
+        return writer.toString()
     }
 
     /**
      * 导出多个对话为 HTML
      */
     fun exportMultiple(context: Context, chatHistories: List<ChatHistory>): String {
-        val sb = StringBuilder()
-
-        appendHtmlHeader(sb, context.getString(R.string.html_export_title))
-
-        sb.appendLine("<div class=\"export-info\">")
-        sb.appendLine("  <h1>${context.getString(R.string.html_export_title)}</h1>")
-        sb.appendLine("  <p><strong>${context.getString(R.string.html_export_time)}:</strong> ${java.time.LocalDateTime.now().format(dateFormatter)}</p>")
-        sb.appendLine("  <p><strong>${context.getString(R.string.html_export_conversation_count)}:</strong> ${chatHistories.size}</p>")
-        sb.appendLine("  <p><strong>${context.getString(R.string.html_export_total_messages)}:</strong> ${chatHistories.sumOf { it.messages.size }}</p>")
-        sb.appendLine("</div>")
-        sb.appendLine("<hr>")
-
-        for ((index, chatHistory) in chatHistories.withIndex()) {
-            if (index > 0) {
-                sb.appendLine("<hr class=\"conversation-divider\">")
-            }
-            appendChatContent(context, sb, chatHistory)
+        val writer = StringWriter()
+        writeMultipleHeader(
+            context = context,
+            chatHistories = chatHistories,
+            totalMessageCount = chatHistories.sumOf { it.messages.size },
+            writer = writer,
+        )
+        chatHistories.forEachIndexed { index, chatHistory ->
+            writeConversationSeparator(writer, index)
+            writeConversationToWriter(context, writer, chatHistory)
         }
+        writeMultipleFooter(context, writer)
+        return writer.toString()
+    }
 
-        appendHtmlFooter(context, sb)
+    /**
+     * 写入多个对话的 HTML 头部。
+     */
+    fun writeMultipleHeader(
+        context: Context,
+        chatHistories: List<ChatHistory>,
+        totalMessageCount: Int,
+        writer: Writer,
+    ) {
+        appendHtmlHeader(writer, context.getString(R.string.html_export_title))
 
-        return sb.toString()
+        writer.appendLine("<div class=\"export-info\">")
+        writer.appendLine("  <h1>${context.getString(R.string.html_export_title)}</h1>")
+        writer.appendLine("  <p><strong>${context.getString(R.string.html_export_time)}:</strong> ${java.time.LocalDateTime.now().format(dateFormatter)}</p>")
+        writer.appendLine("  <p><strong>${context.getString(R.string.html_export_conversation_count)}:</strong> ${chatHistories.size}</p>")
+        writer.appendLine("  <p><strong>${context.getString(R.string.html_export_total_messages)}:</strong> $totalMessageCount</p>")
+        writer.appendLine("</div>")
+        writer.appendLine("<hr>")
+    }
+
+    /**
+     * 写入对话之间的 HTML 分隔线。
+     */
+    fun writeConversationSeparator(writer: Writer, index: Int) {
+        if (index > 0) {
+            writer.appendLine("<hr class=\"conversation-divider\">")
+        }
+    }
+
+    /**
+     * 写入单个对话。
+     */
+    fun writeSingleToWriter(
+        context: Context,
+        chatHistory: ChatHistory,
+        writer: Writer,
+        onContentCharactersWritten: (Long) -> Unit = {},
+    ) {
+        appendHtmlHeader(writer, chatHistory.title)
+        writeConversationToWriter(context, writer, chatHistory, onContentCharactersWritten)
+        appendHtmlFooter(context, writer)
+    }
+
+    /**
+     * 写入单个对话内容，不包含 HTML 文档头尾。
+     */
+    fun writeConversationToWriter(
+        context: Context,
+        writer: Writer,
+        chatHistory: ChatHistory,
+        onContentCharactersWritten: (Long) -> Unit = {},
+    ) {
+        appendChatContent(context, writer, chatHistory, onContentCharactersWritten)
+    }
+
+    /**
+     * 写入多个对话的 HTML 尾部。
+     */
+    fun writeMultipleFooter(context: Context, writer: Writer) {
+        appendHtmlFooter(context, writer)
     }
     
     /**
      * 添加 HTML 头部
      */
-    private fun appendHtmlHeader(sb: StringBuilder, title: String) {
-        sb.appendLine("<!DOCTYPE html>")
-        sb.appendLine("<html lang=\"zh-CN\">")
-        sb.appendLine("<head>")
-        sb.appendLine("  <meta charset=\"UTF-8\">")
-        sb.appendLine("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">")
-        sb.appendLine("  <title>$title</title>")
-        sb.appendLine("  <style>")
-        sb.appendLine(getCss())
-        sb.appendLine("  </style>")
-        sb.appendLine("</head>")
-        sb.appendLine("<body>")
-        sb.appendLine("<div class=\"container\">")
+    private fun appendHtmlHeader(writer: Writer, title: String) {
+        writer.appendLine("<!DOCTYPE html>")
+        writer.appendLine("<html lang=\"zh-CN\">")
+        writer.appendLine("<head>")
+        writer.appendLine("  <meta charset=\"UTF-8\">")
+        writer.appendLine("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">")
+        writer.appendLine("  <title>$title</title>")
+        writer.appendLine("  <style>")
+        writer.appendLine(getCss())
+        writer.appendLine("  </style>")
+        writer.appendLine("</head>")
+        writer.appendLine("<body>")
+        writer.appendLine("<div class=\"container\">")
     }
     
     /**
      * 添加对话内容
      */
-    private fun appendChatContent(context: Context, sb: StringBuilder, chatHistory: ChatHistory) {
-        sb.appendLine("<div class=\"conversation\">")
-        sb.appendLine("  <div class=\"conversation-header\">")
-        sb.appendLine("    <h2>${escapeHtml(chatHistory.title)}</h2>")
-        sb.appendLine("    <div class=\"metadata\">")
-        sb.appendLine("      <span><strong>${context.getString(R.string.html_export_created)}:</strong> ${chatHistory.createdAt.format(dateFormatter)}</span>")
-        sb.appendLine("      <span><strong>${context.getString(R.string.html_export_updated)}:</strong> ${chatHistory.updatedAt.format(dateFormatter)}</span>")
+    private fun appendChatContent(
+        context: Context,
+        writer: Writer,
+        chatHistory: ChatHistory,
+        onContentCharactersWritten: (Long) -> Unit,
+    ) {
+        writer.appendLine("<div class=\"conversation\">")
+        writer.appendLine("  <div class=\"conversation-header\">")
+        writer.appendLine("    <h2>${escapeHtml(chatHistory.title)}</h2>")
+        writer.appendLine("    <div class=\"metadata\">")
+        writer.appendLine("      <span><strong>${context.getString(R.string.html_export_created)}:</strong> ${chatHistory.createdAt.format(dateFormatter)}</span>")
+        writer.appendLine("      <span><strong>${context.getString(R.string.html_export_updated)}:</strong> ${chatHistory.updatedAt.format(dateFormatter)}</span>")
         if (chatHistory.group != null) {
-            sb.appendLine("      <span><strong>${context.getString(R.string.html_export_group)}:</strong> ${escapeHtml(chatHistory.group)}</span>")
+            writer.appendLine("      <span><strong>${context.getString(R.string.html_export_group)}:</strong> ${escapeHtml(chatHistory.group)}</span>")
         }
-        sb.appendLine("      <span><strong>${context.getString(R.string.html_export_message_count)}:</strong> ${chatHistory.messages.size}</span>")
-        sb.appendLine("    </div>")
-        sb.appendLine("  </div>")
-        sb.appendLine("  <div class=\"messages\">")
+        writer.appendLine("      <span><strong>${context.getString(R.string.html_export_message_count)}:</strong> ${chatHistory.messages.size}</span>")
+        writer.appendLine("    </div>")
+        writer.appendLine("  </div>")
+        writer.appendLine("  <div class=\"messages\">")
 
         for (message in chatHistory.messages) {
-            appendMessageHtml(sb, message)
+            appendMessageHtml(context, writer, message, onContentCharactersWritten)
         }
 
-        sb.appendLine("  </div>")
-        sb.appendLine("</div>")
+        writer.appendLine("  </div>")
+        writer.appendLine("</div>")
     }
     
     /**
      * 添加单条消息
      */
-    private fun appendMessageHtml(sb: StringBuilder, message: ChatMessage) {
+    private fun appendMessageHtml(
+        context: Context,
+        writer: Writer,
+        message: ChatMessage,
+        onContentCharactersWritten: (Long) -> Unit,
+    ) {
         val messageClass = if (message.sender == "user") "user" else "assistant"
         val icon = if (message.sender == "user") "👤" else "🤖"
-        val role = if (message.sender == "user") "User" else "Assistant"
-        
-        sb.appendLine("    <div class=\"message $messageClass\">")
-        sb.appendLine("      <div class=\"message-header\">")
-        sb.appendLine("        <span class=\"role\">$icon $role</span>")
-        if (message.modelName.isNotEmpty() && message.modelName != "markdown" && message.modelName != "unknown") {
-            sb.appendLine("        <span class=\"model\">${escapeHtml(message.modelName)}</span>")
+        val role = if (message.sender == "user") {
+            context.getString(R.string.export_user)
+        } else {
+            context.getString(R.string.export_assistant)
         }
-        sb.appendLine("      </div>")
-        sb.appendLine("      <div class=\"message-content\">")
-        sb.appendLine("        ${formatContent(message.content)}")
-        sb.appendLine("      </div>")
-        sb.appendLine("    </div>")
+
+        writer.appendLine("    <div class=\"message $messageClass\">")
+        writer.appendLine("      <div class=\"message-header\">")
+        writer.appendLine("        <span class=\"role\">$icon $role</span>")
+        if (message.modelName.isNotEmpty() && message.modelName != "markdown" && message.modelName != "unknown") {
+            writer.appendLine("        <span class=\"model\">${escapeHtml(message.modelName)}</span>")
+        }
+        writer.appendLine("      </div>")
+        writer.appendLine("      <div class=\"message-content\">")
+        writer.append("        ")
+        writeFormattedContent(writer, message.content, onContentCharactersWritten)
+        writer.appendLine()
+        writer.appendLine("      </div>")
+        writer.appendLine("    </div>")
     }
     
     /**
      * 添加 HTML 尾部
      */
-    private fun appendHtmlFooter(context: Context, sb: StringBuilder) {
-        sb.appendLine("</div>")
-        sb.appendLine("<footer>")
-        sb.appendLine("  <p>${context.getString(R.string.html_export_footer)}</p>")
-        sb.appendLine("</footer>")
-        sb.appendLine("</body>")
-        sb.appendLine("</html>")
+    private fun appendHtmlFooter(context: Context, writer: Writer) {
+        writer.appendLine("</div>")
+        writer.appendLine("<footer>")
+        writer.appendLine("  <p>${context.getString(R.string.html_export_footer)}</p>")
+        writer.appendLine("</footer>")
+        writer.appendLine("</body>")
+        writer.appendLine("</html>")
     }
     
     /**
@@ -272,38 +341,156 @@ object HtmlExporter {
     }
     
     /**
-     * 格式化内容（保留换行，转义HTML）
+     * 逐段格式化内容（保留换行，转义HTML）。
      */
-    private fun formatContent(content: String): String {
-        // 简单的代码块检测和格式化
-        val lines = content.lines()
-        val sb = StringBuilder()
+    private fun writeFormattedContent(
+        writer: Writer,
+        content: String,
+        onContentCharactersWritten: (Long) -> Unit,
+    ) {
         var inCodeBlock = false
-        
-        for (line in lines) {
-            when {
-                line.trim().startsWith("```") -> {
-                    if (inCodeBlock) {
-                        sb.append("</code></pre>")
-                        inCodeBlock = false
-                    } else {
-                        sb.append("<pre><code>")
-                        inCodeBlock = true
-                    }
+        var lineStart = 0
+
+        while (lineStart <= content.length) {
+            val lineBreakStart = findLineBreakStart(content, lineStart)
+            val lineEnd = lineBreakStart ?: content.length
+            if (startsWithCodeFence(content, lineStart, lineEnd)) {
+                reportCharacters(lineEnd - lineStart, onContentCharactersWritten)
+                if (inCodeBlock) {
+                    writer.append("</code></pre>")
+                    inCodeBlock = false
+                } else {
+                    writer.append("<pre><code>")
+                    inCodeBlock = true
                 }
-                inCodeBlock -> {
-                    sb.append(escapeHtml(line)).append("\n")
-                }
-                else -> {
-                    sb.append(escapeHtml(line)).append("<br>")
-                }
+            } else if (inCodeBlock) {
+                writeEscapedRange(writer, content, lineStart, lineEnd, onContentCharactersWritten)
+                writer.appendLine()
+            } else {
+                writeEscapedRange(writer, content, lineStart, lineEnd, onContentCharactersWritten)
+                writer.append("<br>")
+            }
+
+            if (lineBreakStart == null) {
+                break
+            }
+            val lineBreakLength = if (
+                content[lineBreakStart] == '\r' &&
+                    lineBreakStart + 1 < content.length &&
+                    content[lineBreakStart + 1] == '\n'
+            ) {
+                2
+            } else {
+                1
+            }
+            reportCharacters(lineBreakLength, onContentCharactersWritten)
+            lineStart = lineBreakStart + lineBreakLength
+        }
+
+        if (inCodeBlock) {
+            writer.append("</code></pre>")
+        }
+    }
+
+    private fun writeEscapedRange(
+        writer: Writer,
+        content: String,
+        start: Int,
+        end: Int,
+        onContentCharactersWritten: (Long) -> Unit,
+    ) {
+        if (start == end) {
+            return
+        }
+
+        // 调试意图：逐字符拼接转义结果会让超长 HTML 消息在格式化阶段持续扩容和复制缓冲区，造成长时间无可见进度；普通文本区间直接写入 Writer，只为特殊字符生成实体字符串。
+        var offset = start
+        var processedSinceProgress = 0
+        while (offset < end) {
+            val escapedCharacter = when (content[offset]) {
+                '&' -> "&amp;"
+                '<' -> "&lt;"
+                '>' -> "&gt;"
+                '"' -> "&quot;"
+                '\'' -> "&#39;"
+                else -> null
+            }
+
+            if (escapedCharacter != null) {
+                writer.write(escapedCharacter)
+                offset++
+                processedSinceProgress++
+            } else {
+                val plainTextEnd = findNextHtmlEscapeCharacter(
+                    content = content,
+                    start = offset,
+                    end = minOf(end, offset + HTML_CONTENT_WRITE_CHUNK_CHARACTER_COUNT),
+                )
+                val plainTextLength = plainTextEnd - offset
+                writer.write(content, offset, plainTextLength)
+                offset = plainTextEnd
+                processedSinceProgress += plainTextLength
+            }
+
+            if (processedSinceProgress >= CONTENT_PROGRESS_CHARACTER_COUNT) {
+                onContentCharactersWritten(processedSinceProgress.toLong())
+                processedSinceProgress = 0
             }
         }
-        
-        if (inCodeBlock) {
-            sb.append("</code></pre>")
+
+        if (processedSinceProgress > 0) {
+            onContentCharactersWritten(processedSinceProgress.toLong())
         }
-        
-        return sb.toString()
+    }
+
+    private fun findNextHtmlEscapeCharacter(
+        content: String,
+        start: Int,
+        end: Int,
+    ): Int {
+        var offset = start
+        while (offset < end && !isHtmlEscapeCharacter(content[offset])) {
+            offset++
+        }
+        return offset
+    }
+
+    private fun isHtmlEscapeCharacter(character: Char): Boolean {
+        return when (character) {
+            '&', '<', '>', '"', '\'' -> true
+            else -> false
+        }
+    }
+
+    private fun reportCharacters(
+        characterCount: Int,
+        onContentCharactersWritten: (Long) -> Unit,
+    ) {
+        var remaining = characterCount
+        while (remaining > 0) {
+            val chunk = minOf(remaining, CONTENT_PROGRESS_CHARACTER_COUNT)
+            onContentCharactersWritten(chunk.toLong())
+            remaining -= chunk
+        }
+    }
+
+    private fun startsWithCodeFence(content: String, start: Int, end: Int): Boolean {
+        var firstNonWhitespace = start
+        while (firstNonWhitespace < end && content[firstNonWhitespace].isWhitespace()) {
+            firstNonWhitespace++
+        }
+        return firstNonWhitespace + 3 <= end && content.startsWith("```", firstNonWhitespace)
+    }
+
+    private fun findLineBreakStart(content: String, start: Int): Int? {
+        // 调试意图：分别查找两种换行符会在只有一种换行符的长文本上反复扫描剩余全文，退化为 O(n²)；单次顺序扫描保证每个字符只检查一次。
+        var offset = start
+        while (offset < content.length) {
+            when (content[offset]) {
+                '\r', '\n' -> return offset
+            }
+            offset++
+        }
+        return null
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/data/exporter/TextExporter.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/exporter/TextExporter.kt
@@ -4,111 +4,152 @@ import android.content.Context
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.data.model.ChatHistory
 import com.ai.assistance.operit.data.model.ChatMessage
+import java.io.StringWriter
+import java.io.Writer
 import java.time.format.DateTimeFormatter
 
 /**
  * 纯文本格式导出器
  */
 object TextExporter {
-    
+
+    private const val CONTENT_WRITE_CHUNK_CHARACTER_COUNT = 64 * 1024
     private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-    
+
     /**
      * 导出单个对话为纯文本
      */
     fun exportSingle(context: Context, chatHistory: ChatHistory): String {
-        val sb = StringBuilder()
-        
-        // 标题
-        sb.appendLine("=" .repeat(60))
-        sb.appendLine(chatHistory.title.center(60))
-        sb.appendLine("=".repeat(60))
-        sb.appendLine()
-        
-        // 元信息
-        sb.appendLine(
+        val writer = StringWriter()
+        writeSingleToWriter(context, chatHistory, writer)
+        return writer.toString()
+    }
+
+    /**
+     * 导出多个对话为纯文本
+     */
+    fun exportMultiple(context: Context, chatHistories: List<ChatHistory>): String {
+        val writer = StringWriter()
+        writeMultipleHeader(
+            context = context,
+            chatHistories = chatHistories,
+            totalMessageCount = chatHistories.sumOf { it.messages.size },
+            writer = writer,
+        )
+        chatHistories.forEachIndexed { index, chatHistory ->
+            writeConversationSeparator(writer, index)
+            writeSingleToWriter(context, chatHistory, writer)
+        }
+        writeMultipleFooter(context, writer)
+        return writer.toString()
+    }
+
+    /**
+     * 写入多个对话的纯文本头部。
+     *
+     * 长文本导出使用 Writer，避免把所有结果拼接成一个大字符串。
+     */
+    fun writeMultipleHeader(
+        context: Context,
+        chatHistories: List<ChatHistory>,
+        totalMessageCount: Int,
+        writer: Writer,
+    ) {
+        // 总览信息
+        writer.appendLine("=".repeat(60))
+        writer.appendLine(context.getString(R.string.export_chat_history).center(60))
+        writer.appendLine("=".repeat(60))
+        writer.appendLine()
+        writer.appendLine(
+            context.getString(
+                R.string.export_export_time,
+                java.time.LocalDateTime.now().format(dateFormatter)
+            )
+        )
+        writer.appendLine(context.getString(R.string.export_conversation_count, chatHistories.size))
+        writer.appendLine(context.getString(R.string.export_total_message_count, totalMessageCount))
+        writer.appendLine()
+        writer.appendLine("=".repeat(60))
+        writer.appendLine()
+        writer.appendLine()
+    }
+
+    /**
+     * 写入对话之间的分隔内容。
+     */
+    fun writeConversationSeparator(writer: Writer, index: Int) {
+        if (index > 0) {
+            writer.appendLine()
+            writer.appendLine()
+        }
+    }
+
+    /**
+     * 写入单个对话。
+     *
+     * 长文本按固定大小写入，避免 Writer 调用方再次创建整段正文副本。
+     */
+    fun writeSingleToWriter(
+        context: Context,
+        chatHistory: ChatHistory,
+        writer: Writer,
+        onContentCharactersWritten: (Long) -> Unit = {},
+    ) {
+        // 调试意图：直接拼接整份文本会在 StringBuilder 扩容时复制已有内容，超长导出会抬高峰值内存。
+        writer.appendLine("=".repeat(60))
+        writer.appendLine(chatHistory.title.center(60))
+        writer.appendLine("=".repeat(60))
+        writer.appendLine()
+
+        writer.appendLine(
             context.getString(
                 R.string.export_created_time,
                 chatHistory.createdAt.format(dateFormatter)
             )
         )
-        sb.appendLine(
+        writer.appendLine(
             context.getString(
                 R.string.export_updated_time,
                 chatHistory.updatedAt.format(dateFormatter)
             )
         )
         if (chatHistory.group != null) {
-            sb.appendLine(context.getString(R.string.export_group, chatHistory.group))
+            writer.appendLine(context.getString(R.string.export_group, chatHistory.group))
         }
-        sb.appendLine(context.getString(R.string.export_message_count, chatHistory.messages.size))
-        sb.appendLine()
-        sb.appendLine("-".repeat(60))
-        sb.appendLine()
-        
-        // 消息内容
+        writer.appendLine(context.getString(R.string.export_message_count, chatHistory.messages.size))
+        writer.appendLine()
+        writer.appendLine("-".repeat(60))
+        writer.appendLine()
+
         for ((index, message) in chatHistory.messages.withIndex()) {
             if (index > 0) {
-                sb.appendLine()
+                writer.appendLine()
             }
-            appendMessage(context, sb, message)
+            writeMessage(context, writer, message, onContentCharactersWritten)
         }
-        
-        sb.appendLine()
-        sb.appendLine("=".repeat(60))
-        
-        return sb.toString()
+
+        writer.appendLine()
+        writer.appendLine("=".repeat(60))
     }
-    
+
     /**
-     * 导出多个对话为纯文本
+     * 写入多个对话的纯文本尾部。
      */
-    fun exportMultiple(context: Context, chatHistories: List<ChatHistory>): String {
-        val sb = StringBuilder()
-        
-        // 总览信息
-        sb.appendLine("=" .repeat(60))
-        sb.appendLine(context.getString(R.string.export_chat_history).center(60))
-        sb.appendLine("=".repeat(60))
-        sb.appendLine()
-        sb.appendLine(
-            context.getString(
-                R.string.export_export_time,
-                java.time.LocalDateTime.now().format(dateFormatter)
-            )
-        )
-        sb.appendLine(context.getString(R.string.export_conversation_count, chatHistories.size))
-        sb.appendLine(
-            context.getString(
-                R.string.export_total_message_count,
-                chatHistories.sumOf { it.messages.size }
-            )
-        )
-        sb.appendLine()
-        sb.appendLine("=".repeat(60))
-        sb.appendLine()
-        sb.appendLine()
-        
-        for ((index, chatHistory) in chatHistories.withIndex()) {
-            if (index > 0) {
-                sb.appendLine()
-                sb.appendLine()
-            }
-            
-            sb.append(exportSingle(context, chatHistory))
-        }
-        
-        sb.appendLine()
-        sb.appendLine()
-        sb.appendLine(context.getString(R.string.export_completed))
-        
-        return sb.toString()
+    fun writeMultipleFooter(context: Context, writer: Writer) {
+        writer.appendLine()
+        writer.appendLine()
+        writer.appendLine(context.getString(R.string.export_completed))
     }
-    
+
     /**
      * 添加单条消息
      */
-    private fun appendMessage(context: Context, sb: StringBuilder, message: ChatMessage) {
+    private fun writeMessage(
+        context: Context,
+        writer: Writer,
+        message: ChatMessage,
+        onContentCharactersWritten: (Long) -> Unit,
+    ) {
         val roleIcon = if (message.sender == "user") "👤" else "🤖"
         val roleText =
             if (message.sender == "user") {
@@ -116,19 +157,37 @@ object TextExporter {
             } else {
                 context.getString(R.string.export_assistant)
             }
-        
-        sb.appendLine("[$roleIcon $roleText]")
-        
+
+        writer.appendLine("[$roleIcon $roleText]")
+
         if (message.modelName.isNotEmpty() && message.modelName != "markdown" && message.modelName != "unknown") {
-            sb.appendLine(context.getString(R.string.export_model, message.modelName))
+            writer.appendLine(context.getString(R.string.export_model, message.modelName))
         }
-        
-        sb.appendLine()
-        sb.appendLine(message.content)
-        sb.appendLine()
-        sb.appendLine("-".repeat(60))
+
+        writer.appendLine()
+        writeContent(writer, message.content, onContentCharactersWritten)
+        writer.appendLine()
+        writer.appendLine("-".repeat(60))
     }
-    
+
+    private fun writeContent(
+        writer: Writer,
+        content: String,
+        onContentCharactersWritten: (Long) -> Unit,
+    ) {
+        var offset = 0
+        while (offset < content.length) {
+            val chunkLength = minOf(
+                CONTENT_WRITE_CHUNK_CHARACTER_COUNT,
+                content.length - offset,
+            )
+            writer.write(content, offset, chunkLength)
+            onContentCharactersWritten(chunkLength.toLong())
+            offset += chunkLength
+        }
+        writer.appendLine()
+    }
+
     /**
      * 字符串居中扩展函数
      */

--- a/app/src/main/java/com/ai/assistance/operit/data/repository/ChatHistoryManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/repository/ChatHistoryManager.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -71,10 +72,20 @@ import java.util.zip.ZipOutputStream
 // 仅保留这个DataStore用于存储当前聊天ID
 private val Context.currentChatIdDataStore by preferencesDataStore(name = "current_chat_id")
 
+data class ChatExportProgress(
+    val isLongText: Boolean,
+    val progress: Float,
+    val processedCharacters: Long,
+    val totalCharacters: Long,
+)
+
 class ChatHistoryManager private constructor(private val context: Context) {
     companion object {
         private const val TAG = "ChatHistoryManager"
         private const val LOCATOR_PREVIEW_CHAR_COUNT = 48
+        private const val TEXT_EXPORT_STREAMING_THRESHOLD_CHARACTER_COUNT = 4_000_000L
+        private const val TEXT_EXPORT_WRITER_BUFFER_SIZE = 64 * 1024
+        private const val TEXT_EXPORT_PROGRESS_UPDATE_CHARACTER_COUNT = 256 * 1024L
 
         @Volatile
         private var INSTANCE: ChatHistoryManager? = null
@@ -1832,10 +1843,43 @@ class ChatHistoryManager private constructor(private val context: Context) {
      * @return 生成的文件绝对路径，失败时返回null
      */
     suspend fun exportChatHistoriesToDownloads(format: ExportFormat): String? =
+        exportChatHistoriesToDownloads(format, null)
+
+    /**
+     * 导出所有聊天记录到「下载/Operit」目录（支持进度回调）。
+     * @param format 导出格式
+     * @param onProgress 超长文本导出进度回调
+     * @return 生成的文件绝对路径，失败时返回null
+     */
+    suspend fun exportChatHistoriesToDownloads(
+        format: ExportFormat,
+        onProgress: ((ChatExportProgress) -> Unit)?,
+    ): String? =
         withContext(Dispatchers.IO) {
             var pendingExportFile: File? = null
             try {
                 val chatHistoriesBasic = chatHistoriesFlow.first()
+                val isTextExportFormat = format == ExportFormat.HTML || format == ExportFormat.TXT
+                val textCharacterCountsByChat = if (isTextExportFormat) {
+                    chatContentDao.getSelectedContentCharacterCountsByChat()
+                } else {
+                    emptyList()
+                }
+                val totalTextCharacters = textCharacterCountsByChat.sumOf { it.contentCharacterCount }
+                val useStreamingTextExport =
+                    isTextExportFormat &&
+                        totalTextCharacters >= TEXT_EXPORT_STREAMING_THRESHOLD_CHARACTER_COUNT
+
+                if (useStreamingTextExport) {
+                    onProgress?.invoke(
+                        ChatExportProgress(
+                            isLongText = true,
+                            progress = 0f,
+                            processedCharacters = 0L,
+                            totalCharacters = totalTextCharacters,
+                        )
+                    )
+                }
 
                 val exportDir = OperitBackupDirs.chatDir()
 
@@ -1884,18 +1928,40 @@ class ChatHistoryManager private constructor(private val context: Context) {
                     }
 
                     ExportFormat.HTML -> {
-                        val completeHistories = loadDisplayHistories(chatHistoriesBasic)
                         val file = File(exportDir, "chat_backup_$timestamp.html")
                         pendingExportFile = file
-                        file.writeText(HtmlExporter.exportMultiple(context, completeHistories))
+                        if (useStreamingTextExport) {
+                            exportLongTextHistories(
+                                file = file,
+                                format = format,
+                                chatHistories = chatHistoriesBasic,
+                                totalMessageCount = messageDao.getTotalMessageCount(),
+                                totalTextCharacters = totalTextCharacters,
+                                onProgress = onProgress,
+                            )
+                        } else {
+                            val completeHistories = loadDisplayHistories(chatHistoriesBasic)
+                            file.writeText(HtmlExporter.exportMultiple(context, completeHistories))
+                        }
                         file
                     }
 
                     ExportFormat.TXT -> {
-                        val completeHistories = loadDisplayHistories(chatHistoriesBasic)
                         val file = File(exportDir, "chat_backup_$timestamp.txt")
                         pendingExportFile = file
-                        file.writeText(TextExporter.exportMultiple(context, completeHistories))
+                        if (useStreamingTextExport) {
+                            exportLongTextHistories(
+                                file = file,
+                                format = format,
+                                chatHistories = chatHistoriesBasic,
+                                totalMessageCount = messageDao.getTotalMessageCount(),
+                                totalTextCharacters = totalTextCharacters,
+                                onProgress = onProgress,
+                            )
+                        } else {
+                            val completeHistories = loadDisplayHistories(chatHistoriesBasic)
+                            file.writeText(TextExporter.exportMultiple(context, completeHistories))
+                        }
                         file
                     }
 
@@ -1919,6 +1985,116 @@ class ChatHistoryManager private constructor(private val context: Context) {
                 null
             }
         }
+
+    private suspend fun exportLongTextHistories(
+        file: File,
+        format: ExportFormat,
+        chatHistories: List<ChatHistory>,
+        totalMessageCount: Int,
+        totalTextCharacters: Long,
+        onProgress: ((ChatExportProgress) -> Unit)?,
+    ) {
+        check(format == ExportFormat.HTML || format == ExportFormat.TXT)
+
+        var processedCharacters = 0L
+        var lastReportedCharacters = 0L
+
+        fun reportProgress(force: Boolean = false) {
+            val clampedProcessedCharacters = processedCharacters.coerceAtMost(totalTextCharacters)
+            val shouldReport =
+                force ||
+                    clampedProcessedCharacters - lastReportedCharacters >=
+                        TEXT_EXPORT_PROGRESS_UPDATE_CHARACTER_COUNT
+            if (!shouldReport) {
+                return
+            }
+
+            lastReportedCharacters = clampedProcessedCharacters
+            val progress = if (totalTextCharacters == 0L) {
+                1f
+            } else {
+                clampedProcessedCharacters.toFloat() / totalTextCharacters.toFloat()
+            }
+            onProgress?.invoke(
+                ChatExportProgress(
+                    isLongText = true,
+                    progress = progress.coerceIn(0f, 1f),
+                    processedCharacters = clampedProcessedCharacters,
+                    totalCharacters = totalTextCharacters,
+                )
+            )
+        }
+
+        BufferedWriter(
+            OutputStreamWriter(FileOutputStream(file), StandardCharsets.UTF_8),
+            TEXT_EXPORT_WRITER_BUFFER_SIZE,
+        ).use { writer ->
+            when (format) {
+                ExportFormat.HTML ->
+                    HtmlExporter.writeMultipleHeader(
+                        context = context,
+                        chatHistories = chatHistories,
+                        totalMessageCount = totalMessageCount,
+                        writer = writer,
+                    )
+
+                ExportFormat.TXT ->
+                    TextExporter.writeMultipleHeader(
+                        context = context,
+                        chatHistories = chatHistories,
+                        totalMessageCount = totalMessageCount,
+                        writer = writer,
+                    )
+
+                ExportFormat.JSON, ExportFormat.MARKDOWN, ExportFormat.CSV -> check(false)
+            }
+
+            chatHistories.forEachIndexed { index, chatHistoryBasic ->
+                when (format) {
+                    ExportFormat.HTML -> HtmlExporter.writeConversationSeparator(writer, index)
+                    ExportFormat.TXT -> TextExporter.writeConversationSeparator(writer, index)
+                    ExportFormat.JSON, ExportFormat.MARKDOWN, ExportFormat.CSV -> check(false)
+                }
+
+                val completeHistory = loadDisplayHistory(chatHistoryBasic)
+                val onContentCharactersWritten: (Long) -> Unit = { characterCount ->
+                    processedCharacters += characterCount
+                    reportProgress()
+                }
+                when (format) {
+                    ExportFormat.HTML ->
+                        HtmlExporter.writeConversationToWriter(
+                            context = context,
+                            writer = writer,
+                            chatHistory = completeHistory,
+                            onContentCharactersWritten = onContentCharactersWritten,
+                        )
+
+                    ExportFormat.TXT ->
+                        TextExporter.writeSingleToWriter(
+                            context = context,
+                            chatHistory = completeHistory,
+                            writer = writer,
+                            onContentCharactersWritten = onContentCharactersWritten,
+                        )
+
+                    ExportFormat.JSON, ExportFormat.MARKDOWN, ExportFormat.CSV -> check(false)
+                }
+                writer.flush()
+                reportProgress(force = true)
+                yield()
+            }
+
+            when (format) {
+                ExportFormat.HTML -> HtmlExporter.writeMultipleFooter(context, writer)
+                ExportFormat.TXT -> TextExporter.writeMultipleFooter(context, writer)
+                ExportFormat.JSON, ExportFormat.MARKDOWN, ExportFormat.CSV -> check(false)
+            }
+        }
+
+        processedCharacters = totalTextCharacters
+        reportProgress(force = true)
+    }
 
     /**
      * 从指定URI导入聊天记录（指定格式）

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/components/BackupManagementCards.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/components/BackupManagementCards.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,6 +39,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.ai.assistance.operit.R
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -134,6 +136,10 @@ fun DataManagementCard(
     totalChatCount: Int,
     operationState: ChatHistoryOperation,
     operationMessage: String,
+    isLongTextExport: Boolean,
+    longTextExportProgress: Float,
+    longTextExportProcessedCharacters: Long,
+    longTextExportTotalCharacters: Long,
     onExport: () -> Unit,
     onImport: () -> Unit,
     onDelete: () -> Unit
@@ -187,7 +193,15 @@ fun DataManagementCard(
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     when (operationState) {
                         ChatHistoryOperation.EXPORTING ->
-                            OperationProgressView(message = stringResource(R.string.backup_exporting, chatTitle))
+                            if (isLongTextExport) {
+                                TextExportProgressView(
+                                    progress = longTextExportProgress,
+                                    processedCharacters = longTextExportProcessedCharacters,
+                                    totalCharacters = longTextExportTotalCharacters,
+                                )
+                            } else {
+                                OperationProgressView(message = stringResource(R.string.backup_exporting, chatTitle))
+                            }
 
                         ChatHistoryOperation.IMPORTING ->
                             OperationProgressView(message = stringResource(R.string.backup_importing, chatTitle))
@@ -489,6 +503,35 @@ fun OperationProgressView(message: String) {
         Spacer(modifier = Modifier.width(16.dp))
         Text(
             text = message,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@Composable
+private fun TextExportProgressView(
+    progress: Float,
+    processedCharacters: Long,
+    totalCharacters: Long,
+) {
+    val percentage = (progress.coerceIn(0f, 1f) * 100).roundToInt()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        LinearProgressIndicator(
+            progress = { progress.coerceIn(0f, 1f) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            text = stringResource(
+                R.string.backup_text_export_progress,
+                percentage,
+                processedCharacters,
+                totalCharacters,
+            ),
             style = MaterialTheme.typography.bodyLarge,
         )
     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/ChatBackupSettingsScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/ChatBackupSettingsScreen.kt
@@ -157,6 +157,10 @@ fun ChatBackupSettingsScreen() {
     var totalModelConfigCount by remember { mutableStateOf(0) }
     var operationState by remember { mutableStateOf(ChatHistoryOperation.IDLE) }
     var operationMessage by remember { mutableStateOf("") }
+    var isLongTextExport by remember { mutableStateOf(false) }
+    var longTextExportProgress by remember { mutableStateOf(0f) }
+    var longTextExportProcessedCharacters by remember { mutableStateOf(0L) }
+    var longTextExportTotalCharacters by remember { mutableStateOf(0L) }
     var characterCardOperationState by remember { mutableStateOf(CharacterCardOperation.IDLE) }
     var characterCardOperationMessage by remember { mutableStateOf("") }
     var memoryOperationState by remember { mutableStateOf(MemoryOperation.IDLE) }
@@ -543,6 +547,10 @@ fun ChatBackupSettingsScreen() {
                 totalChatCount = totalChatCount,
                 operationState = operationState,
                 operationMessage = operationMessage,
+                isLongTextExport = isLongTextExport,
+                longTextExportProgress = longTextExportProgress,
+                longTextExportProcessedCharacters = longTextExportProcessedCharacters,
+                longTextExportTotalCharacters = longTextExportTotalCharacters,
                 onExport = {
                     // 显示格式选择对话框
                     showExportFormatDialog = true
@@ -1228,8 +1236,20 @@ fun ChatBackupSettingsScreen() {
                 showExportFormatDialog = false
                 scope.launch {
                     operationState = ChatHistoryOperation.EXPORTING
+                    isLongTextExport = false
+                    longTextExportProgress = 0f
+                    longTextExportProcessedCharacters = 0L
+                    longTextExportTotalCharacters = 0L
                     try {
-                        val filePath = chatHistoryManager.exportChatHistoriesToDownloads(selectedExportFormat)
+                        val filePath = chatHistoryManager.exportChatHistoriesToDownloads(
+                            format = selectedExportFormat,
+                            onProgress = { progress ->
+                                isLongTextExport = progress.isLongText
+                                longTextExportProgress = progress.progress
+                                longTextExportProcessedCharacters = progress.processedCharacters
+                                longTextExportTotalCharacters = progress.totalCharacters
+                            },
+                        )
                         if (filePath != null) {
                             operationState = ChatHistoryOperation.EXPORTED
                             val chatCount = chatHistoryManager.chatHistoriesFlow.first().size
@@ -1600,4 +1620,3 @@ private suspend fun importMemoriesFromUri(
 
     memoryRepository.importMemoriesFromJson(jsonString, strategy)
 }
-

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -5226,6 +5226,7 @@
     <string name="backup_model_config_current_count">Currently %1$d model configuration(s).</string>
     
     <string name="backup_exporting">Exporting %1$s...</string>
+    <string name="backup_text_export_progress">Exporting long text: %1$d%% (%2$d / %3$d characters processed)</string>
     <string name="backup_importing">Importing %1$s...</string>
     <string name="backup_deleting">Clearing chat history...</string>
     <string name="backup_export_success">Export Successful</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4975,6 +4975,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="backup_model_config_subtitle">Copia de seguridad y restauración de todas las configuraciones del modelo, incluyendo claves API y parámetros.</string>
     <string name="backup_model_config_current_count">Actualmente hay %1$d configuraciones de modelo.</string>
     <string name="backup_exporting">Exportando %1$s...</string>
+    <string name="backup_text_export_progress">Exportando texto largo: %1$d%% (%2$d / %3$d caracteres procesados)</string>
     <string name="backup_importing">Importando %1$s...</string>
     <string name="backup_deleting">Limpiando el historial de chat...</string>
     <string name="backup_export_success">Exportación exitosa</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -4819,6 +4819,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="backup_model_config_subtitle">Cadangkan dan pulihkan semua pengaturan model, termasuk kunci API dan parameter</string>
     <string name="backup_model_config_current_count">Saat ini ada %1$d konfigurasi model.</string>
     <string name="backup_exporting">Sedang mengekspor %1$s...</string>
+    <string name="backup_text_export_progress">Mengekspor teks panjang: %1$d%% (%2$d / %3$d karakter telah diproses)</string>
     <string name="backup_importing">Sedang mengimpor %1$s...</string>
     <string name="backup_deleting">Sedang menghapus riwayat obrolan...</string>
     <string name="backup_export_success">Ekspor Berhasil</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -4932,6 +4932,7 @@
     <string name="backup_model_config_subtitle">API 키 및 매개변수를 포함한 모든 모델 설정 백업 및 복원</string>
     <string name="backup_model_config_current_count">현재 모델 구성 %1$d개입니다.</string>
     <string name="backup_exporting">%1$s 내보내기 중...</string>
+    <string name="backup_text_export_progress">긴 텍스트 내보내기: %1$d%% (처리됨 %2$d / %3$d자)</string>
     <string name="backup_importing">%1$s 가져오는 중...</string>
     <string name="backup_deleting">채팅 기록을 지우는 중...</string>
     <string name="backup_export_success">내보내기 성공</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -4822,6 +4822,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
 
     <string name="backup_model_config_current_count">Kini terdapat %1$d konfigurasi model.</string>
     <string name="backup_exporting">Sedang mengeksport %1$s...</string>
+    <string name="backup_text_export_progress">Mengeksport teks panjang: %1$d%% (%2$d / %3$d aksara diproses)</string>
     <string name="backup_importing">Sedang mengimport %1$s...</string>
     <string name="backup_deleting">Sedang membersihkan rekod sembang...</string>
     <string name="backup_export_success">Eksport berjaya</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -4519,6 +4519,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="backup_model_config_subtitle">Faça backup e restaure todas as configurações do modelo, incluindo chaves e parâmetros de API</string>
     <string name="backup_model_config_current_count">Atualmente existem %1$d configurações de modelo.</string>
     <string name="backup_exporting">Exportando %1$s...</string>
+    <string name="backup_text_export_progress">Exportando texto longo: %1$d%% (%2$d / %3$d caracteres processados)</string>
     <string name="backup_importing">Importando %1$s...</string>
     <string name="backup_deleting">Limpando histórico de bate-papo...</string>
     <string name="backup_export_success">Exportação bem-sucedida</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -5633,6 +5633,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="backup_model_config_current_count">În prezent, există în total %1$d Configurația modelului.</string>
 
     <string name="backup_exporting">Se exportă%1$s...</string>
+    <string name="backup_text_export_progress">Se exportă textul lung: %1$d%% (%2$d / %3$d caractere procesate)</string>
     <string name="backup_importing">Se importă%1$s...</string>
     <string name="backup_deleting">Se șterg istoricul conversațiilor...</string>
     <string name="backup_export_success">Exportul s-a realizat cu succes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5669,6 +5669,7 @@
     <string name="backup_model_config_current_count">当前共有 %1$d 个模型配置。</string>
     
     <string name="backup_exporting">正在导出%1$s...</string>
+    <string name="backup_text_export_progress">正在导出超长文本：%1$d%%（已处理 %2$d / %3$d 个字符）</string>
     <string name="backup_importing">正在导入%1$s...</string>
     <string name="backup_deleting">正在清除聊天记录...</string>
     <string name="backup_export_success">导出成功</string>


### PR DESCRIPTION

  ## 变更说明 / Description

  修复超长聊天记录导出 HTML/TXT 时可能触发 OOM。

  长文本现在会按字符数检测并使用流式 Writer 导出，同时在设置页显示导出进度。

  ### 背景与动机 / Context and motivation

  原实现会将全部聊天记录拼接为单个大字符串，超长记录会造成大量临时字符串和内存峰值。

  HTML 导出还会在每行分别查找 `\n` 和 `\r`，在单一换行符的长文本上退化为 O(n²)，导致导出长时间无进度反馈。

  ### 改动范围 / Changes

  - 增加超长文本字符数检测，阈值为 4,000,000 个正文字符。（其实改到20mb就行 但是我喜欢进度条！我不能接受没有进度条的等待 除非是秒好awa）
  - HTML/TXT 超长导出改用有界缓冲的 Writer 流式写入。
  - HTML 换行扫描改为线性处理，避免 O(n²)。
  - HTML 转义改为分块写入，减少临时字符串。
  - 设置页增加线性进度条及已处理字符数显示。
  - 新增并更新多语言 `strings.xml` 文本。
  - 保留原有导出 API 和普通长度导出行为。

  不包含 JSON、Markdown、CSV 导出逻辑变更，也不包含本地未追踪目录、生成文件或其他实验内容。

  ### 兼容性与风险 / Compatibility and risks

  - 不涉及数据库结构迁移。
  - 不改变 HTML/TXT 文件格式和文件命名。
  - 保留现有 `exportChatHistoriesToDownloads(format)` 调用方式。
  - 超长导出的内存峰值和响应性得到改善。
  - 进度总量基于当前选中消息版本的正文字符数。
  - JSON、Markdown、CSV 及导入流程不受影响。

  ## 关联 Issue / Related issue

  Fixes #887

  ## 验证方式 / Verification

  检查或命令：
  `/gradlew assembleDebugClone`
  `adb -s T1AIOC656445Y8V install -r app/build/outputs/apk/clone/app-clone.apk`
  `adb -s T1AIOC656445Y8V shell dumpsys package com.ai.assistance.operit.clone`

  环境与变体：
  设备：ASUSAI2501
  ADB serial：T1AIOC656445Y8V
  构建变体：clone/debug



  ## 证据 / Evidence

  >原版报错：
<img width="341" height="757" alt="图片" src="https://github.com/user-attachments/assets/591cfaa2-2d64-43ea-aee6-efeaeb4153b3" />

  >修复后：
<img width="341" height="757" alt="图片" src="https://github.com/user-attachments/assets/80c7fef2-908f-4eb5-b8a0-c914ba9af761" />

  已验证html可检视显示 已验证txt格式与原版相同

  ## 检查清单 / Checklist

  - [x] 我已记录可复现验证和未运行项原因
  - [x] Candidate checks 覆盖了当前 Kotlin/Android 编译范围
  - [x] 最终 diff 无无关、临时、生成、二进制或敏感内容
  - [x] 已提供对应的回归、UI、文档/字符串或兼容性证据