### PR TITLE
fix(chat): use selected character card when sending

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/integrations/http/WebChatHttpBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/integrations/http/WebChatHttpBridge.kt
@@ -1154,7 +1154,7 @@ class WebChatHttpBridge(
                         )
                     )
 
-                    core.sendUserMessage()
+                    core.sendUserMessage(preferActiveRoleCard = true)
 
                     val responseStream: SharedStream<String>? =
                         withTimeoutOrNull<SharedStream<String>>(STREAM_READY_TIMEOUT_MS) {

--- a/app/src/main/java/com/ai/assistance/operit/services/ChatServiceCore.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/ChatServiceCore.kt
@@ -257,11 +257,13 @@ class ChatServiceCore(
         proxySenderNameOverride: String? = null,
         chatModelConfigIdOverride: String? = null,
         chatModelIndexOverride: Int? = null,
-        turnOptions: ChatTurnOptions = ChatTurnOptions()
+        turnOptions: ChatTurnOptions = ChatTurnOptions(),
+        preferActiveRoleCard: Boolean = false,
     ) {
         messageCoordinationDelegate.sendUserMessage(
             promptFunctionType = promptFunctionType,
             roleCardIdOverride = roleCardIdOverride,
+            preferActiveRoleCard = preferActiveRoleCard,
             chatIdOverride = chatIdOverride,
             messageTextOverride = messageTextOverride,
             proxySenderNameOverride = proxySenderNameOverride,

--- a/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
@@ -215,10 +215,18 @@ class MessageCoordinationDelegate(
 
     private suspend fun resolveRoleCardId(
         chatId: String?,
-        roleCardId: String?
+        roleCardId: String?,
+        preferActiveRoleCard: Boolean = false,
     ): String {
-        return roleCardId
-            ?: resolveBoundRoleCardId(chatId)
+        if (roleCardId != null) {
+            return roleCardId
+        }
+
+        if (preferActiveRoleCard) {
+            return activePromptManager.resolveActiveCardIdForSend()
+        }
+
+        return resolveBoundRoleCardId(chatId)
             ?: activePromptManager.resolveActiveCardIdForSend()
     }
 
@@ -323,7 +331,8 @@ class MessageCoordinationDelegate(
         proxySenderNameOverride: String? = null,
         chatModelConfigIdOverride: String? = null,
         chatModelIndexOverride: Int? = null,
-        turnOptions: ChatTurnOptions = ChatTurnOptions()
+        turnOptions: ChatTurnOptions = ChatTurnOptions(),
+        preferActiveRoleCard: Boolean = false,
     ) {
         // 仅在没有指定 chatId 的情况下，才需要确保有当前对话
         if (chatIdOverride.isNullOrBlank() && chatHistoryDelegate.currentChatId.value == null) {
@@ -356,6 +365,7 @@ class MessageCoordinationDelegate(
                 sendMessageInternal(
                     promptFunctionType,
                     roleCardIdOverride = roleCardIdOverride,
+                    preferActiveRoleCard = preferActiveRoleCard,
                     chatIdOverride = chatIdOverride,
                     messageTextOverride = messageTextOverride,
                     proxySenderNameOverride = proxySenderNameOverride,
@@ -369,6 +379,7 @@ class MessageCoordinationDelegate(
             sendMessageInternal(
                 promptFunctionType,
                 roleCardIdOverride = roleCardIdOverride,
+                preferActiveRoleCard = preferActiveRoleCard,
                 chatIdOverride = chatIdOverride,
                 messageTextOverride = messageTextOverride,
                 proxySenderNameOverride = proxySenderNameOverride,
@@ -509,6 +520,7 @@ class MessageCoordinationDelegate(
         skipSummaryCheck: Boolean = false,
         isAutoContinuation: Boolean = false,
         roleCardIdOverride: String? = null,
+        preferActiveRoleCard: Boolean = false,
         chatIdOverride: String? = null,
         messageTextOverride: String? = null,
         proxySenderNameOverride: String? = null,
@@ -572,6 +584,7 @@ class MessageCoordinationDelegate(
                         skipSummaryCheck = skipSummaryCheck,
                         isAutoContinuation = isAutoContinuation,
                         roleCardIdOverride = roleCardIdOverride,
+                        preferActiveRoleCard = preferActiveRoleCard,
                         chatIdOverride = chatIdOverride,
                         messageTextOverride = messageTextOverride,
                         proxySenderNameOverride = proxySenderNameOverride,
@@ -598,8 +611,14 @@ class MessageCoordinationDelegate(
         // 获取当前附件列表
         val currentAttachments =
             if (shouldReadComposerState) attachmentDelegate.attachments.value else emptyList()
-        // 群组会解析为活动提示管理器指定的默认角色卡。
-        val roleCardId = runBlocking { resolveRoleCardId(chatId, roleCardIdOverride) }
+        // 手动发送必须与选择器一致；后台和定向消息仍由窗口绑定决定角色卡。
+        val roleCardId = runBlocking {
+            resolveRoleCardId(
+                chatId = chatId,
+                roleCardId = roleCardIdOverride,
+                preferActiveRoleCard = preferActiveRoleCard,
+            )
+        }
         val resolvedOverrides = try {
             if (promptFunctionType == PromptFunctionType.CHAT) {
                 val (resolvedChatModelConfigIdOverride, resolvedChatModelIndexOverride) =

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/ChatViewModel.kt
@@ -1459,13 +1459,17 @@ class ChatViewModel(private val context: Context) : ViewModel() {
 
     fun sendUserMessage(promptFunctionType: PromptFunctionType = PromptFunctionType.CHAT) {
         hideMentionSuggestionPanel()
-        messageCoordinationDelegate.sendUserMessage(promptFunctionType)
+        messageCoordinationDelegate.sendUserMessage(
+            promptFunctionType = promptFunctionType,
+            preferActiveRoleCard = true,
+        )
     }
 
     fun sendTextMessage(text: String, promptFunctionType: PromptFunctionType = PromptFunctionType.CHAT) {
         hideMentionSuggestionPanel()
         messageCoordinationDelegate.sendUserMessage(
             promptFunctionType = promptFunctionType,
+            preferActiveRoleCard = true,
             messageTextOverride = text
         )
     }


### PR DESCRIPTION
## 变更说明 / Description

修复在不切换聊天窗口时更换当前角色卡后，发送消息仍使用窗口绑定角色卡的问题。主聊天和 Web Chat 的交互式发送现在使用当前选中的角色卡。

### 背景与动机 / Context and motivation

角色选择器表达用户当前希望对话的角色，但发送层此前优先读取 `ChatHistory.characterCardName`。当“自动切换聊天”关闭时，选择状态与窗口绑定可以不同，导致提示词、角色绑定模型和记忆配置使用错误角色卡。

### 改动范围 / Changes

- 为发送协调层增加显式的交互式发送角色优先级
- 原生主聊天与 Web Chat 的手动发送启用该优先级
- 保持窗口角色绑定用于聊天记录归属和非交互式发送
- 不修改聊天记录绑定字段、队列/后台定向消息、重生成或群聊编排

### 兼容性与风险 / Compatibility and risks

不修改持久化数据或配置格式。聊天窗口仍保留原有绑定；只有用户交互式发送在已选单角色卡时改用该选择。显式角色覆盖、后台定向和队列消息保持原有行为。

## 关联 Issue / Related issue

N/A。此修复由用户直接报告，未提供现有 Issue 编号。

## 验证方式 / Verification

```text
检查或命令：
git diff --check origin/main...HEAD
git diff --name-status origin/main...HEAD

环境与变体：Windows 开发环境，代码静态检查
结果：通过；最终差异仅包含 4 个预期 Kotlin 文件。
未运行项：未运行 Gradle 构建、JVM 测试或 UI 测试，遵循仓库 AGENTS.md 的默认限制。
```

## 证据 / Evidence

发送协调层在交互式发送标记下优先解析当前活动角色卡；主聊天和 Web Chat 均传入该标记。`terminal` 子模块与最新 `main` 一致，未包含在本 PR 差异中。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided