### PR TITLE
fix(market): preserve assets after registration failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -397,8 +397,8 @@ android {
         applicationId = "com.ai.assistance.operit"
         minSdk = 26
         targetSdk = 34
-        versionCode = 45
-        versionName = "1.12.0+9"
+        versionCode = 46
+        versionName = "1.12.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/GitHubForgePublishService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/GitHubForgePublishService.kt
@@ -259,15 +259,6 @@ class GitHubForgePublishService(
                     existingEntryId = request.publishContext?.entryId,
                     includeEntryPatch = request.publishContext?.canEditEntry ?: true
                 ).getOrElse { error ->
-                    resolvedAsset.releaseWasCreated?.let { releaseWasCreated ->
-                        rollbackFailedMarketRegistration(
-                            owner = resolvedAsset.owner,
-                            repo = resolvedAsset.repository,
-                            release = resolvedAsset.release,
-                            releaseWasCreated = releaseWasCreated,
-                            uploadedAsset = resolvedAsset.asset
-                        )
-                    }
                     return@withContext Result.success(
                         PublishAttemptResult.RegistrationFailed(
                             errorMessage = error.message ?: "Failed to register market entry"
@@ -407,20 +398,6 @@ class GitHubForgePublishService(
                 draft = false,
                 prerelease = false
             ).map { release -> EnsuredRelease(release = release, created = false) }
-        }
-    }
-
-    private suspend fun rollbackFailedMarketRegistration(
-        owner: String,
-        repo: String,
-        release: GitHubRelease,
-        releaseWasCreated: Boolean,
-        uploadedAsset: GitHubReleaseAsset
-    ) {
-        if (releaseWasCreated) {
-            githubApiService.deleteRelease(owner, repo, release.id)
-        } else {
-            githubApiService.deleteReleaseAsset(owner, repo, uploadedAsset.id)
         }
     }
 


### PR DESCRIPTION
### 变更说明 / Description

修复插件市场登记失败后客户端删除 GitHub Release 或资产，导致已登记版本下载地址变成 404 的问题。

### 背景与动机 / Context and motivation

市场登记请求与 GitHub 资产操作不是同一事务。登记返回失败时，服务端可能已经完成写入；客户端继续回滚远端 Release/资产会破坏有效下载地址。

### 改动范围 / Changes

- 删除登记失败分支中的 GitHub Release/资产自动回滚。
- 保留现有版本预校验、后端版本冲突校验和上传流程。
- 纳入工作区已有的应用版本变更：versionCode 46、versionName 1.12.1。

### 兼容性与风险 / Compatibility and risks

市场登记失败时会保留远端 Release/资产，便于重试，可能留下需要人工处理的孤立资源；不改变市场 API、资产格式或已成功发布资源的下载路径。

### 关联 Issue / Related issue

N/A：修复已确认的客户端发布回滚问题。

### 验证方式 / Verification

```text
检查或命令：git diff --cached --check
环境与变体：未构建
结果：通过静态差异检查；按要求未运行编译、构建或测试
```

### 证据 / Evidence

已确认的事故链路为登记返回 version_conflict 后客户端删除同名 Release 资产；本 PR 删除该删除路径。

### 检查清单 / Checklist

- [x] 已记录可复现验证和未运行项原因
- [x] 已确认 Candidate checks 覆盖改动范围
- [x] 最终 diff 无临时、生成、二进制或敏感内容
- [x] 已提供发布流程回归说明