### PR TITLE
fix: sidebar_opencode stuck at 0% loading after failed server startup

### DIFF
--- a/examples/sidebar_opencode/src/main.ts
+++ b/examples/sidebar_opencode/src/main.ts
@@ -9,7 +9,7 @@ export function registerToolPkg(): boolean {
     runtime: "compose_dsl",
     screen: opencodeDashboardScreen,
     params: {},
-    keepAlive: true,
+    keepAlive: false,
     title: {
       zh: "OpenCode",
       en: "OpenCode",

--- a/examples/sidebar_opencode/src/ui/opencode_dashboard/index.ui.ts
+++ b/examples/sidebar_opencode/src/ui/opencode_dashboard/index.ui.ts
@@ -235,7 +235,7 @@ export default function Screen(ctx: ComposeDslContext): ComposeNode {
     {
       fillMaxSize: true,
       onLoad: async () => {
-        if (!initialized) {
+        if (!initialized || !serverUrl) {
           setInitialized(true);
           await ensureServer();
         }


### PR DESCRIPTION
## Bug: Sidebar OpenCode panel permanently stuck at 0% after failed startup

### Problem

The  plugin has two issues that cause the OpenCode sidebar panel to become permanently stuck at 0% loading:

1. ** in ** — When the sidebar UI is first opened and the OpenCode Web server fails to start (e.g., when OpenCode is not yet installed, or network is unavailable to reach npm registry via ), the UI state variables (, , etc.) are cached in memory. Because  preserves the composable state, navigating away and back to the sidebar does NOT re-trigger , so the failed state persists indefinitely.


### Reproduction

1. Open the OpenCode sidebar before installing OpenCode CLI
2. The panel shows a loading spinner that gets stuck (pnpm dlx fails because opencode-ai package can't be downloaded)
3. Install OpenCode CLI and restart the app
4. Open the sidebar again — it's still stuck at 0% because  preserved the old failed state

### Fix

**Two changes:**

1. ****: Set  so the sidebar UI gets a fresh state every time it's opened.


### Testing

Tested manually on Operit (Android, proot Ubuntu 24.04 aarch64):
- Before fix: sidebar stuck at 0% after failed first attempt, requires full app restart with pre-started server to recover
- After fix: sidebar correctly retries server startup on every open, and immediately succeeds when the server is already running (health check passes on first try)
