### PR TITLE
test: add calculator and data model coverage

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/tools/calculator/ExpressionContext.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/calculator/ExpressionContext.kt
@@ -97,26 +97,29 @@ object ExpressionContext {
 
     /** 调用函数 */
     fun callFunction(name: String, args: List<Double>): Double {
+        val mathFunctionName =
+                if (name.startsWith("Math.", ignoreCase = true)) name.substring(5) else name
+
         return when {
             // 数学函数
-            name.equals("abs", ignoreCase = true) -> Math.abs(args[0])
-            name.equals("sqrt", ignoreCase = true) -> Math.sqrt(args[0])
-            name.equals("sin", ignoreCase = true) -> Math.sin(args[0])
-            name.equals("cos", ignoreCase = true) -> Math.cos(args[0])
-            name.equals("tan", ignoreCase = true) -> Math.tan(args[0])
-            name.equals("asin", ignoreCase = true) -> Math.asin(args[0])
-            name.equals("acos", ignoreCase = true) -> Math.acos(args[0])
-            name.equals("atan", ignoreCase = true) -> Math.atan(args[0])
-            name.equals("log", ignoreCase = true) -> Math.log10(args[0])
-            name.equals("ln", ignoreCase = true) -> Math.log(args[0])
-            name.equals("round", ignoreCase = true) -> Math.round(args[0]).toDouble()
-            name.equals("floor", ignoreCase = true) -> Math.floor(args[0])
-            name.equals("ceil", ignoreCase = true) -> Math.ceil(args[0])
-            name.equals("pow", ignoreCase = true) -> Math.pow(args[0], args[1])
-            name.equals("max", ignoreCase = true) -> args.maxOrNull() ?: Double.NaN
-            name.equals("min", ignoreCase = true) -> args.minOrNull() ?: Double.NaN
-            name.equals("random", ignoreCase = true) -> Math.random()
-            name.equals("fact", ignoreCase = true) -> factorial(args[0].toInt()).toDouble()
+            mathFunctionName.equals("abs", ignoreCase = true) -> Math.abs(args[0])
+            mathFunctionName.equals("sqrt", ignoreCase = true) -> Math.sqrt(args[0])
+            mathFunctionName.equals("sin", ignoreCase = true) -> Math.sin(args[0])
+            mathFunctionName.equals("cos", ignoreCase = true) -> Math.cos(args[0])
+            mathFunctionName.equals("tan", ignoreCase = true) -> Math.tan(args[0])
+            mathFunctionName.equals("asin", ignoreCase = true) -> Math.asin(args[0])
+            mathFunctionName.equals("acos", ignoreCase = true) -> Math.acos(args[0])
+            mathFunctionName.equals("atan", ignoreCase = true) -> Math.atan(args[0])
+            mathFunctionName.equals("log", ignoreCase = true) -> Math.log10(args[0])
+            mathFunctionName.equals("ln", ignoreCase = true) -> Math.log(args[0])
+            mathFunctionName.equals("round", ignoreCase = true) -> Math.round(args[0]).toDouble()
+            mathFunctionName.equals("floor", ignoreCase = true) -> Math.floor(args[0])
+            mathFunctionName.equals("ceil", ignoreCase = true) -> Math.ceil(args[0])
+            mathFunctionName.equals("pow", ignoreCase = true) -> Math.pow(args[0], args[1])
+            mathFunctionName.equals("max", ignoreCase = true) -> args.maxOrNull() ?: Double.NaN
+            mathFunctionName.equals("min", ignoreCase = true) -> args.minOrNull() ?: Double.NaN
+            mathFunctionName.equals("random", ignoreCase = true) -> Math.random()
+            mathFunctionName.equals("fact", ignoreCase = true) -> factorial(args[0].toInt()).toDouble()
 
             // 日期函数
             name.equals("today", ignoreCase = true) ->

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/calculator/ExpressionParser.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/calculator/ExpressionParser.kt
@@ -293,14 +293,23 @@ class ExpressionParser(private val expression: String) {
                     return FunctionCallNode(identifier, args)
                 }
 
-                // 数学对象方法调用
-                if (identifier == "Math" && currentToken == ".") {
+                // 计算器公开的命名空间函数调用
+                if ((identifier == "Math" || identifier == "stats") && currentToken == ".") {
                     nextToken() // 跳过.
+                    if (currentTokenType != TokenType.IDENTIFIER) {
+                        throw IllegalArgumentException("Expected member name after $identifier.")
+                    }
                     val methodName = currentToken
                     nextToken()
 
+                    if (identifier == "Math" &&
+                            (methodName == "PI" || methodName == "E") &&
+                            currentToken != "(") {
+                        return VariableNode(methodName)
+                    }
+
                     if (currentToken != "(") {
-                        throw IllegalArgumentException("Expected '(' after Math.$methodName")
+                        throw IllegalArgumentException("Expected '(' after $identifier.$methodName")
                     }
                     nextToken() // 跳过(
 
@@ -315,11 +324,13 @@ class ExpressionParser(private val expression: String) {
                     }
 
                     if (currentToken != ")") {
-                        throw IllegalArgumentException("Expected ')' in Math.$methodName call")
+                        throw IllegalArgumentException(
+                                "Expected ')' in $identifier.$methodName call"
+                        )
                     }
                     nextToken() // 跳过)
 
-                    return FunctionCallNode("Math.$methodName", args)
+                    return FunctionCallNode("$identifier.$methodName", args)
                 }
 
                 // 变量引用

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/CalculatorTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/CalculatorTest.kt
@@ -1,0 +1,118 @@
+package com.ai.assistance.operit.core.tools.calculator
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CalculatorTest {
+
+    @After
+    fun tearDown() {
+        Calculator.clearVariables()
+    }
+
+    @Test fun `evalExpression simple addition`() {
+        assertEquals(5.0, Calculator.evalExpression("2 + 3"), 0.001)
+    }
+
+    @Test fun `evalExpression with multiplication`() {
+        assertEquals(12.0, Calculator.evalExpression("3 * 4"), 0.001)
+    }
+
+    @Test fun `evalExpression with parentheses`() {
+        assertEquals(20.0, Calculator.evalExpression("(2 + 3) * 4"), 0.001)
+    }
+
+    @Test fun `evalExpression with function call`() {
+        assertEquals(5.0, Calculator.evalExpression("abs(-5)"), 0.001)
+    }
+
+    @Test fun `evalExpression with negative result`() {
+        assertEquals(-1.0, Calculator.evalExpression("2 - 3"), 0.001)
+    }
+
+    @Test fun `evalExpression division`() {
+        assertEquals(2.5, Calculator.evalExpression("5 / 2"), 0.001)
+    }
+
+    @Test fun `setVariable and getVariable round trip`() {
+        Calculator.setVariable("x", 42.0)
+        val result = Calculator.getVariable("x")
+        assertEquals(42.0, result ?: 0.0, 0.001)
+    }
+
+    @Test fun `getVariable returns null for undefined`() {
+        assertNull(Calculator.getVariable("nonexistent"))
+    }
+
+    @Test fun `clearVariables resets state`() {
+        Calculator.setVariable("x", 100.0)
+        Calculator.clearVariables()
+        val pi = Calculator.getVariable("PI")
+        assertEquals(Math.PI, pi ?: 0.0, 0.001)
+    }
+
+    @Test fun `formatResult integer`() {
+        assertEquals("42", Calculator.formatResult(42.0))
+    }
+
+    @Test fun `formatResult decimal`() {
+        assertEquals("3.14", Calculator.formatResult(3.14))
+    }
+
+    @Test fun `formatResult zero`() {
+        assertEquals("0", Calculator.formatResult(0.0))
+    }
+
+    @Test fun `evalExpression with variable`() {
+        Calculator.setVariable("x", 10.0)
+        assertEquals(15.0, Calculator.evalExpression("x + 5"), 0.001)
+    }
+
+    @Test fun `evalExpression with assignment`() {
+        assertEquals(7.0, Calculator.evalExpression("y=7"), 0.001)
+        val y = Calculator.getVariable("y")
+        assertEquals(7.0, y ?: 0.0, 0.001)
+    }
+
+    @Test fun `getSupportedUnits returns units map`() {
+        val units = Calculator.getSupportedUnits()
+        assertTrue(units.containsKey("Temperature"))
+        assertTrue(units.containsKey("Length"))
+        assertTrue(units.containsKey("Weight"))
+        assertTrue(units.containsKey("Volume"))
+        assertTrue(units.containsKey("Speed"))
+    }
+
+    @Test fun `getSupportedDateFunctions returns list`() {
+        val funcs = Calculator.getSupportedDateFunctions()
+        assertTrue(funcs.isNotEmpty())
+        assertTrue(funcs.any { it.contains("today") })
+    }
+
+    @Test fun `getSupportedStatFunctions returns list`() {
+        val funcs = Calculator.getSupportedStatFunctions()
+        assertTrue(funcs.isNotEmpty())
+        assertTrue(funcs.any { it.contains("stats.mean") })
+    }
+
+    @Test fun `getSupportedJsFeatures returns list`() {
+        val features = Calculator.getSupportedJsFeatures()
+        assertTrue(features.isNotEmpty())
+        assertTrue(features.any { it.contains("Ternary") })
+    }
+
+    @Test fun `evalExpression ternary`() {
+        assertEquals(10.0, Calculator.evalExpression("1 ? 10 : 20"), 0.001)
+    }
+
+    @Test fun `evalExpression comparison`() {
+        assertEquals(1.0, Calculator.evalExpression("5 > 3"), 0.001)
+    }
+
+    @Test fun `evalExpression logical`() {
+        assertEquals(1.0, Calculator.evalExpression("1 && 1"), 0.001)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionContextTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionContextTest.kt
@@ -1,0 +1,331 @@
+package com.ai.assistance.operit.core.tools.calculator
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExpressionContextTest {
+
+    @After
+    fun tearDown() {
+        ExpressionContext.clearVariables()
+    }
+
+    @Test fun `getVariable returns set value`() {
+        ExpressionContext.setVariable("x", 42.0)
+        assertEquals(42.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `setVariable overwrites existing value`() {
+        ExpressionContext.setVariable("x", 10.0)
+        ExpressionContext.setVariable("x", 20.0)
+        assertEquals(20.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `clearVariables resets all variables`() {
+        ExpressionContext.setVariable("x", 42.0)
+        ExpressionContext.clearVariables()
+        // PI and E should still exist
+        assertEquals(Math.PI, ExpressionContext.getVariable("PI"), 0.001)
+        assertEquals(Math.E, ExpressionContext.getVariable("E"), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `getVariable throws for undefined variable`() {
+        ExpressionContext.getVariable("nonexistent")
+    }
+
+    @Test fun `constant PI is predefined`() {
+        assertEquals(Math.PI, ExpressionContext.getVariable("PI"), 0.001)
+    }
+
+    @Test fun `constant E is predefined`() {
+        assertEquals(Math.E, ExpressionContext.getVariable("E"), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns zero for null`() {
+        assertEquals(0.0, ExpressionContext.coerceToNumber(null), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns double for integer`() {
+        assertEquals(5.0, ExpressionContext.coerceToNumber(5), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns double for float`() {
+        assertEquals(3.14, ExpressionContext.coerceToNumber(3.14f), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns one for true`() {
+        assertEquals(1.0, ExpressionContext.coerceToNumber(true), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns zero for false`() {
+        assertEquals(0.0, ExpressionContext.coerceToNumber(false), 0.001)
+    }
+
+    @Test fun `coerceToNumber parses numeric string`() {
+        assertEquals(42.5, ExpressionContext.coerceToNumber("42.5"), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns one for true string`() {
+        assertEquals(1.0, ExpressionContext.coerceToNumber("true"), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns zero for false string`() {
+        assertEquals(0.0, ExpressionContext.coerceToNumber("false"), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns zero for null string`() {
+        assertEquals(0.0, ExpressionContext.coerceToNumber("null"), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns zero for undefined string`() {
+        assertEquals(0.0, ExpressionContext.coerceToNumber("undefined"), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns nan for invalid string`() {
+        assertTrue(ExpressionContext.coerceToNumber("hello").isNaN())
+    }
+
+    @Test fun `coerceToNumber returns size for list`() {
+        assertEquals(3.0, ExpressionContext.coerceToNumber(listOf(1, 2, 3)), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns nan for object`() {
+        assertTrue(ExpressionContext.coerceToNumber(mapOf("a" to 1)).isNaN())
+    }
+
+    @Test fun `coerceToNumber parses negative numeric string`() {
+        assertEquals(-10.0, ExpressionContext.coerceToNumber("-10"), 0.001)
+    }
+
+    @Test fun `coerceToNumber parses scientific notation string`() {
+        assertEquals(1e10, ExpressionContext.coerceToNumber("1e10"), 0.001)
+    }
+
+    @Test fun `coerceToNumber returns infinity for infinity string`() {
+        assertTrue(ExpressionContext.coerceToNumber("infinity").isInfinite())
+    }
+
+    @Test fun `coerceToNumber returns nan for nan string`() {
+        assertTrue(ExpressionContext.coerceToNumber("nan").isNaN())
+    }
+
+    @Test fun `abs returns absolute value`() {
+        assertEquals(5.0, ExpressionContext.callFunction("abs", listOf(-5.0)), 0.001)
+    }
+
+    @Test fun `sqrt returns square root`() {
+        assertEquals(3.0, ExpressionContext.callFunction("sqrt", listOf(9.0)), 0.001)
+    }
+
+    @Test fun `sqrt returns nan for negative input`() {
+        assertTrue(ExpressionContext.callFunction("sqrt", listOf(-1.0)).isNaN())
+    }
+
+    @Test fun `sin returns sine`() {
+        assertEquals(Math.sin(0.0), ExpressionContext.callFunction("sin", listOf(0.0)), 0.001)
+    }
+
+    @Test fun `cos returns cosine`() {
+        assertEquals(Math.cos(0.0), ExpressionContext.callFunction("cos", listOf(0.0)), 0.001)
+    }
+
+    @Test fun `tan returns tangent`() {
+        assertEquals(Math.tan(0.0), ExpressionContext.callFunction("tan", listOf(0.0)), 0.001)
+    }
+
+    @Test fun `asin returns arcsine`() {
+        assertEquals(Math.asin(1.0), ExpressionContext.callFunction("asin", listOf(1.0)), 0.001)
+    }
+
+    @Test fun `acos returns arccosine`() {
+        assertEquals(Math.acos(0.0), ExpressionContext.callFunction("acos", listOf(0.0)), 0.001)
+    }
+
+    @Test fun `atan returns arctangent`() {
+        assertEquals(Math.atan(1.0), ExpressionContext.callFunction("atan", listOf(1.0)), 0.001)
+    }
+
+    @Test fun `log returns base-10 logarithm`() {
+        assertEquals(Math.log10(100.0), ExpressionContext.callFunction("log", listOf(100.0)), 0.001)
+    }
+
+    @Test fun `ln returns natural logarithm`() {
+        assertEquals(Math.log(Math.E), ExpressionContext.callFunction("ln", listOf(Math.E)), 0.001)
+    }
+
+    @Test fun `round returns nearest integer`() {
+        assertEquals(4.0, ExpressionContext.callFunction("round", listOf(3.7)), 0.001)
+    }
+
+    @Test fun `round down returns nearest integer`() {
+        assertEquals(3.0, ExpressionContext.callFunction("round", listOf(3.2)), 0.001)
+    }
+
+    @Test fun `floor returns floor`() {
+        assertEquals(3.0, ExpressionContext.callFunction("floor", listOf(3.7)), 0.001)
+    }
+
+    @Test fun `ceil returns ceiling`() {
+        assertEquals(4.0, ExpressionContext.callFunction("ceil", listOf(3.2)), 0.001)
+    }
+
+    @Test fun `pow returns power`() {
+        assertEquals(8.0, ExpressionContext.callFunction("pow", listOf(2.0, 3.0)), 0.001)
+    }
+
+    @Test fun `max returns maximum`() {
+        assertEquals(10.0, ExpressionContext.callFunction("max", listOf(3.0, 10.0, 5.0)), 0.001)
+    }
+
+    @Test fun `min returns minimum`() {
+        assertEquals(3.0, ExpressionContext.callFunction("min", listOf(3.0, 10.0, 5.0)), 0.001)
+    }
+
+    @Test fun `random returns value between zero and one`() {
+        val result = ExpressionContext.callFunction("random", listOf())
+        assertTrue(result >= 0.0 && result < 1.0)
+    }
+
+    @Test fun `factorial of zero`() {
+        assertEquals(1.0, ExpressionContext.callFunction("fact", listOf(0.0)), 0.001)
+    }
+
+    @Test fun `factorial of one`() {
+        assertEquals(1.0, ExpressionContext.callFunction("fact", listOf(1.0)), 0.001)
+    }
+
+    @Test fun `factorial of five`() {
+        assertEquals(120.0, ExpressionContext.callFunction("fact", listOf(5.0)), 0.001)
+    }
+
+    @Test fun `factorial of ten`() {
+        assertEquals(3628800.0, ExpressionContext.callFunction("fact", listOf(10.0)), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `factorial of negative throws`() {
+        ExpressionContext.callFunction("fact", listOf(-1.0))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `factorial too large throws`() {
+        ExpressionContext.callFunction("fact", listOf(21.0))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unknown function throws`() {
+        ExpressionContext.callFunction("unknown", listOf(1.0))
+    }
+
+    @Test fun `function names are case insensitive`() {
+        assertEquals(5.0, ExpressionContext.callFunction("ABS", listOf(-5.0)), 0.001)
+        assertEquals(5.0, ExpressionContext.callFunction("Sqrt", listOf(25.0)), 0.001)
+    }
+
+    @Test fun `stats mean calculates average`() {
+        assertEquals(5.0, ExpressionContext.callFunction("stats.mean", listOf(2.0, 4.0, 6.0, 8.0)), 0.001)
+    }
+
+    @Test fun `stats mean of single value`() {
+        assertEquals(5.0, ExpressionContext.callFunction("stats.mean", listOf(5.0)), 0.001)
+    }
+
+    @Test fun `stats median with odd count`() {
+        assertEquals(5.0, ExpressionContext.callFunction("stats.median", listOf(1.0, 5.0, 10.0)), 0.001)
+    }
+
+    @Test fun `stats median with even count`() {
+        assertEquals(7.5, ExpressionContext.callFunction("stats.median", listOf(5.0, 10.0)), 0.001)
+    }
+
+    @Test fun `stats min returns minimum`() {
+        assertEquals(1.0, ExpressionContext.callFunction("stats.min", listOf(3.0, 1.0, 5.0)), 0.001)
+    }
+
+    @Test fun `stats max returns maximum`() {
+        assertEquals(5.0, ExpressionContext.callFunction("stats.max", listOf(3.0, 1.0, 5.0)), 0.001)
+    }
+
+    @Test fun `stats sum returns sum`() {
+        assertEquals(15.0, ExpressionContext.callFunction("stats.sum", listOf(1.0, 2.0, 3.0, 4.0, 5.0)), 0.001)
+    }
+
+    @Test fun `stats min with empty list`() {
+        assertEquals(0.0, ExpressionContext.callFunction("stats.min", listOf()), 0.001)
+    }
+
+    @Test fun `stats max with empty list`() {
+        assertEquals(0.0, ExpressionContext.callFunction("stats.max", listOf()), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `convert with fewer than three args throws`() {
+        ExpressionContext.callFunction("convert", listOf(10.0))
+    }
+
+    @Test fun `formatResult integer returns without decimal`() {
+        assertEquals("42", ExpressionContext.formatResult(42.0))
+    }
+
+    @Test fun `formatResult decimal returns with precision`() {
+        assertEquals("3.14", ExpressionContext.formatResult(3.14))
+    }
+
+    @Test fun `formatResult trailing zeros trimmed`() {
+        assertEquals("3.5", ExpressionContext.formatResult(3.500000))
+    }
+
+    @Test fun `formatResult zero returns zero`() {
+        assertEquals("0", ExpressionContext.formatResult(0.0))
+    }
+
+    @Test fun `formatResult negative integer`() {
+        assertEquals("-5", ExpressionContext.formatResult(-5.0))
+    }
+
+    @Test fun `formatResult negative decimal`() {
+        assertEquals("-3.14", ExpressionContext.formatResult(-3.14))
+    }
+
+    @Test fun `formatResult nan returns nan`() {
+        assertEquals("NaN", ExpressionContext.formatResult(Double.NaN))
+    }
+
+    @Test fun `formatResult infinity returns infinity`() {
+        assertEquals("Infinity", ExpressionContext.formatResult(Double.POSITIVE_INFINITY))
+    }
+
+    @Test fun `formatResult large number`() {
+        assertEquals("1000000", ExpressionContext.formatResult(1000000.0))
+    }
+
+    @Test fun `formatResult very small decimal`() {
+        assertEquals("0.000001", ExpressionContext.formatResult(0.000001))
+    }
+
+    @Test fun `getArrayElement with list out of bounds returns nan`() {
+        val result = ExpressionContext.getArrayElement(NumberNode(0.0), NumberNode(99.0))
+        assertTrue(result.isNaN())
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `getArrayElement with non array non string throws`() {
+        // Set variable to a Double
+        ExpressionContext.setVariable("x", 42.0)
+        // 42.0 is neither List nor String, so getArrayElement should throw
+        ExpressionContext.getArrayElement(VariableNode("x"), NumberNode(0.0))
+    }
+
+    @Test fun `coerceToNumber handles true string case insensitive`() {
+        assertEquals(1.0, ExpressionContext.coerceToNumber("True"), 0.001)
+        assertEquals(1.0, ExpressionContext.coerceToNumber("TRUE"), 0.001)
+    }
+
+    @Test fun `coerceToNumber handles false string case insensitive`() {
+        assertEquals(0.0, ExpressionContext.coerceToNumber("False"), 0.001)
+        assertEquals(0.0, ExpressionContext.coerceToNumber("FALSE"), 0.001)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionNodeEdgeCaseTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionNodeEdgeCaseTest.kt
@@ -1,0 +1,164 @@
+package com.ai.assistance.operit.core.tools.calculator
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExpressionNodeEdgeCaseTest {
+
+    @After
+    fun tearDown() {
+        ExpressionContext.clearVariables()
+    }
+
+    @Test fun `number node with large double`() {
+        assertEquals(1e308, NumberNode(1e308).evaluate(), 1e293)
+    }
+
+    @Test fun `number node with small double`() {
+        assertEquals(1e-308, NumberNode(1e-308).evaluate(), 1e-293)
+    }
+
+    @Test fun `binary operation with NaN left`() {
+        val result = BinaryOperationNode(NumberNode(Double.NaN), "+", NumberNode(1.0)).evaluate()
+        assertTrue(result.isNaN())
+    }
+
+    @Test fun `binary operation with infinity`() {
+        val result = BinaryOperationNode(NumberNode(Double.POSITIVE_INFINITY), "+", NumberNode(1.0)).evaluate()
+        assertTrue(result.isInfinite())
+    }
+
+    @Test fun `unary minus on zero`() {
+        assertEquals(0.0, UnaryOperationNode("-", NumberNode(0.0)).evaluate(), 0.001)
+    }
+
+    @Test fun `unary minus on negative zero`() {
+        assertEquals(0.0, UnaryOperationNode("-", NumberNode(-0.0)).evaluate(), 0.001)
+    }
+
+    @Test fun `ternary with nested ternary true case`() {
+        val outer = TernaryOperationNode(
+            NumberNode(1.0),
+            TernaryOperationNode(NumberNode(1.0), NumberNode(10.0), NumberNode(20.0)),
+            NumberNode(30.0),
+        )
+        assertEquals(10.0, outer.evaluate(), 0.001)
+    }
+
+    @Test fun `ternary with nested ternary false outer`() {
+        val outer = TernaryOperationNode(
+            NumberNode(0.0),
+            NumberNode(10.0),
+            TernaryOperationNode(NumberNode(1.0), NumberNode(20.0), NumberNode(30.0)),
+        )
+        assertEquals(20.0, outer.evaluate(), 0.001)
+    }
+
+    @Test fun `compound assignment with chained operations`() {
+        ExpressionContext.setVariable("x", 10.0)
+        CompoundAssignmentNode("x", "+=", NumberNode(5.0)).evaluate()
+        CompoundAssignmentNode("x", "*=", NumberNode(2.0)).evaluate()
+        assertEquals(30.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `assignment then compound on same variable`() {
+        AssignmentNode("y", NumberNode(5.0)).evaluate()
+        CompoundAssignmentNode("y", "+=", NumberNode(3.0)).evaluate()
+        assertEquals(8.0, ExpressionContext.getVariable("y"), 0.001)
+    }
+
+    @Test fun `array access with negative index returns NaN`() {
+        val result = ExpressionContext.getArrayElement(NumberNode(0.0), NumberNode(-1.0))
+        assertTrue(result.isNaN())
+    }
+
+    @Test fun `template string with expression evaluating to number`() {
+        val node = TemplateStringNode(listOf("prefix", NumberNode(42.0)))
+        val result = node.evaluate()
+        // "prefix42.0" cannot be parsed as double -> NaN
+        assertTrue(result.isNaN())
+    }
+
+    @Test fun `template string pure number string`() {
+        val node = TemplateStringNode(listOf("123.456"))
+        assertEquals(123.456, node.evaluate(), 0.001)
+    }
+
+    @Test fun `variable node with PI constant`() {
+        assertEquals(Math.PI, VariableNode("PI").evaluate(), 0.001)
+    }
+
+    @Test fun `variable node with E constant`() {
+        assertEquals(Math.E, VariableNode("E").evaluate(), 0.001)
+    }
+
+    @Test fun `function call node with zero arguments`() {
+        val result = FunctionCallNode("random", emptyList()).evaluate()
+        assertTrue(result >= 0.0 && result < 1.0)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `function call node with unknown function throws`() {
+        FunctionCallNode("nonexistent_func", listOf(NumberNode(1.0))).evaluate()
+    }
+
+    @Test fun `assignment node returns assigned value`() {
+        val result = AssignmentNode("temp_var", NumberNode(77.0)).evaluate()
+        assertEquals(77.0, result, 0.001)
+        assertEquals(77.0, ExpressionContext.getVariable("temp_var"), 0.001)
+    }
+
+    @Test fun `nested assignment`() {
+        ExpressionContext.setVariable("a", 1.0)
+        val result = AssignmentNode("a", BinaryOperationNode(VariableNode("a"), "+", NumberNode(2.0))).evaluate()
+        assertEquals(3.0, result, 0.001)
+        assertEquals(3.0, ExpressionContext.getVariable("a"), 0.001)
+    }
+
+    @Test fun `binary operation string concatenation style`() {
+        // When both operands are numbers, + is addition
+        assertEquals(5.0, BinaryOperationNode(NumberNode(2.0), "+", NumberNode(3.0)).evaluate(), 0.001)
+    }
+
+    @Test fun `binary not equals`() {
+        assertEquals(0.0, BinaryOperationNode(NumberNode(1.0), "!=", NumberNode(1.0)).evaluate(), 0.001)
+        assertEquals(1.0, BinaryOperationNode(NumberNode(1.0), "!=", NumberNode(2.0)).evaluate(), 0.001)
+    }
+
+    @Test fun `binary comparison with same values`() {
+        assertEquals(1.0, BinaryOperationNode(NumberNode(5.0), "<=", NumberNode(5.0)).evaluate(), 0.001)
+        assertEquals(1.0, BinaryOperationNode(NumberNode(5.0), ">=", NumberNode(5.0)).evaluate(), 0.001)
+        assertEquals(0.0, BinaryOperationNode(NumberNode(5.0), "<", NumberNode(5.0)).evaluate(), 0.001)
+        assertEquals(0.0, BinaryOperationNode(NumberNode(5.0), ">", NumberNode(5.0)).evaluate(), 0.001)
+    }
+
+    @Test fun `unary not chained`() {
+        val node = UnaryOperationNode("!", UnaryOperationNode("!", NumberNode(0.0)))
+        assertEquals(0.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `unary not on non-zero`() {
+        assertEquals(0.0, UnaryOperationNode("!", NumberNode(42.0)).evaluate(), 0.001)
+    }
+
+    @Test fun `compound assignment with subtract chain`() {
+        ExpressionContext.setVariable("x", 100.0)
+        CompoundAssignmentNode("x", "-=", NumberNode(30.0)).evaluate()
+        CompoundAssignmentNode("x", "/=", NumberNode(2.0)).evaluate()
+        assertEquals(35.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `array access via VariableNode with list`() {
+        // When the variable value is a List, getArrayElement returns coerceToNumber of element
+        // We can't easily set a List via setVariable since it only accepts Double
+        // But we can test through coerceToNumber directly
+        assertEquals(3.0, ExpressionContext.coerceToNumber(listOf(1, 2, 3)), 0.001)
+    }
+
+    @Test fun `variable node case sensitivity`() {
+        ExpressionContext.setVariable("myVar", 42.0)
+        assertEquals(42.0, VariableNode("myVar").evaluate(), 0.001)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionNodeTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionNodeTest.kt
@@ -1,0 +1,289 @@
+package com.ai.assistance.operit.core.tools.calculator
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExpressionNodeTest {
+
+    @After
+    fun tearDown() {
+        ExpressionContext.clearVariables()
+    }
+
+    @Test fun `number node evaluates to its value`() {
+        assertEquals(42.0, NumberNode(42.0).evaluate(), 0.001)
+    }
+
+    @Test fun `number node evaluates to zero`() {
+        assertEquals(0.0, NumberNode(0.0).evaluate(), 0.001)
+    }
+
+    @Test fun `number node evaluates to negative value`() {
+        assertEquals(-3.14, NumberNode(-3.14).evaluate(), 0.001)
+    }
+
+    @Test fun `number node evaluates to large value`() {
+        assertEquals(1e15, NumberNode(1e15).evaluate(), 0.001)
+    }
+
+    @Test fun `variable node evaluates to set value`() {
+        ExpressionContext.setVariable("x", 10.0)
+        assertEquals(10.0, VariableNode("x").evaluate(), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `variable node throws for undefined variable`() {
+        VariableNode("undefined").evaluate()
+    }
+
+    @Test fun `binary addition evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(3.0), "+", NumberNode(4.0))
+        assertEquals(7.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary subtraction evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(10.0), "-", NumberNode(3.0))
+        assertEquals(7.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary multiplication evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(6.0), "*", NumberNode(7.0))
+        assertEquals(42.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary division evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(10.0), "/", NumberNode(2.0))
+        assertEquals(5.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary division by zero returns infinity`() {
+        val node = BinaryOperationNode(NumberNode(1.0), "/", NumberNode(0.0))
+        assertTrue(node.evaluate().isInfinite())
+    }
+
+    @Test fun `binary modulo evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(10.0), "%", NumberNode(3.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary exponent with asterisk evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(2.0), "**", NumberNode(3.0))
+        assertEquals(8.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary exponent with caret evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(2.0), "^", NumberNode(3.0))
+        assertEquals(8.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary equals returns one for equal values`() {
+        val node = BinaryOperationNode(NumberNode(5.0), "==", NumberNode(5.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary equals returns zero for unequal values`() {
+        val node = BinaryOperationNode(NumberNode(5.0), "==", NumberNode(3.0))
+        assertEquals(0.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary not equals returns one for unequal values`() {
+        val node = BinaryOperationNode(NumberNode(5.0), "!=", NumberNode(3.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary not equals returns zero for equal values`() {
+        val node = BinaryOperationNode(NumberNode(5.0), "!=", NumberNode(5.0))
+        assertEquals(0.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary greater than evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(5.0), ">", NumberNode(3.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary greater than returns zero when false`() {
+        val node = BinaryOperationNode(NumberNode(3.0), ">", NumberNode(5.0))
+        assertEquals(0.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary greater or equal evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(5.0), ">=", NumberNode(5.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary less than evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(3.0), "<", NumberNode(5.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary less or equal evaluates correctly`() {
+        val node = BinaryOperationNode(NumberNode(5.0), "<=", NumberNode(5.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary logical and returns one when both truthy`() {
+        val node = BinaryOperationNode(NumberNode(1.0), "&&", NumberNode(2.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary logical and returns zero when left falsy`() {
+        val node = BinaryOperationNode(NumberNode(0.0), "&&", NumberNode(2.0))
+        assertEquals(0.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary logical or returns one when left truthy`() {
+        val node = BinaryOperationNode(NumberNode(1.0), "||", NumberNode(0.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `binary logical or returns zero when both falsy`() {
+        val node = BinaryOperationNode(NumberNode(0.0), "||", NumberNode(0.0))
+        assertEquals(0.0, node.evaluate(), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `binary unknown operator throws`() {
+        BinaryOperationNode(NumberNode(1.0), "@@", NumberNode(2.0)).evaluate()
+    }
+
+    @Test fun `unary plus returns same value`() {
+        val node = UnaryOperationNode("+", NumberNode(5.0))
+        assertEquals(5.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `unary minus negates value`() {
+        val node = UnaryOperationNode("-", NumberNode(5.0))
+        assertEquals(-5.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `unary double negation`() {
+        val node = UnaryOperationNode("-", UnaryOperationNode("-", NumberNode(5.0)))
+        assertEquals(5.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `unary not returns one when operand is zero`() {
+        val node = UnaryOperationNode("!", NumberNode(0.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `unary not returns zero when operand is non-zero`() {
+        val node = UnaryOperationNode("!", NumberNode(1.0))
+        assertEquals(0.0, node.evaluate(), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unary unknown operator throws`() {
+        UnaryOperationNode("~", NumberNode(5.0)).evaluate()
+    }
+
+    @Test fun `ternary returns true branch when condition truthy`() {
+        val node = TernaryOperationNode(NumberNode(1.0), NumberNode(10.0), NumberNode(20.0))
+        assertEquals(10.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `ternary returns false branch when condition falsy`() {
+        val node = TernaryOperationNode(NumberNode(0.0), NumberNode(10.0), NumberNode(20.0))
+        assertEquals(20.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `ternary with nested condition`() {
+        ExpressionContext.setVariable("a", 5.0)
+        val cond = BinaryOperationNode(VariableNode("a"), ">", NumberNode(3.0))
+        val node = TernaryOperationNode(cond, NumberNode(1.0), NumberNode(0.0))
+        assertEquals(1.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `function call node evaluates via context`() {
+        val node = FunctionCallNode("abs", listOf(NumberNode(-5.0)))
+        assertEquals(5.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `function call with two arguments`() {
+        val node = FunctionCallNode("pow", listOf(NumberNode(2.0), NumberNode(3.0)))
+        assertEquals(8.0, node.evaluate(), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `function call unknown function throws`() {
+        FunctionCallNode("nonexistent", listOf(NumberNode(1.0))).evaluate()
+    }
+
+    @Test fun `assignment node sets variable and returns value`() {
+        val node = AssignmentNode("x", NumberNode(42.0))
+        assertEquals(42.0, node.evaluate(), 0.001)
+        assertEquals(42.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `assignment node overwrites existing variable`() {
+        ExpressionContext.setVariable("x", 10.0)
+        AssignmentNode("x", NumberNode(99.0)).evaluate()
+        assertEquals(99.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `compound assignment add evaluates correctly`() {
+        ExpressionContext.setVariable("x", 10.0)
+        val node = CompoundAssignmentNode("x", "+=", NumberNode(5.0))
+        assertEquals(15.0, node.evaluate(), 0.001)
+        assertEquals(15.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `compound assignment subtract evaluates correctly`() {
+        ExpressionContext.setVariable("x", 10.0)
+        val node = CompoundAssignmentNode("x", "-=", NumberNode(3.0))
+        assertEquals(7.0, node.evaluate(), 0.001)
+        assertEquals(7.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `compound assignment multiply evaluates correctly`() {
+        ExpressionContext.setVariable("x", 10.0)
+        val node = CompoundAssignmentNode("x", "*=", NumberNode(2.0))
+        assertEquals(20.0, node.evaluate(), 0.001)
+        assertEquals(20.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `compound assignment divide evaluates correctly`() {
+        ExpressionContext.setVariable("x", 10.0)
+        val node = CompoundAssignmentNode("x", "/=", NumberNode(2.0))
+        assertEquals(5.0, node.evaluate(), 0.001)
+        assertEquals(5.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `compound assignment unknown operator throws`() {
+        ExpressionContext.setVariable("x", 10.0)
+        CompoundAssignmentNode("x", "%=", NumberNode(2.0)).evaluate()
+    }
+
+    @Test fun `array access node with number node`() {
+        val node = ArrayAccessNode(NumberNode(3.0), NumberNode(0.0))
+        assertEquals('3'.code.toDouble(), node.evaluate(), 0.001)
+    }
+
+    @Test fun `template string with no expressions evaluates to double`() {
+        val node = TemplateStringNode(listOf("42"))
+        assertEquals(42.0, node.evaluate(), 0.001)
+    }
+
+    @Test fun `template string non-numeric returns nan`() {
+        val node = TemplateStringNode(listOf("hello"))
+        assertTrue(node.evaluate().isNaN())
+    }
+
+    @Test fun `template string with expression placeholder`() {
+        val node = TemplateStringNode(listOf("result: ", NumberNode(42.0)))
+        // "result: 42.0" cannot be parsed as double -> NaN
+        assertTrue(node.evaluate().isNaN())
+    }
+
+    @Test fun `template string empty parts returns nan`() {
+        val node = TemplateStringNode(listOf(""))
+        assertTrue(node.evaluate().isNaN())
+    }
+
+    @Test fun `template string with only number returns value`() {
+        val node = TemplateStringNode(listOf("3.14"))
+        assertEquals(3.14, node.evaluate(), 0.001)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionParserEdgeCaseTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionParserEdgeCaseTest.kt
@@ -1,0 +1,257 @@
+package com.ai.assistance.operit.core.tools.calculator
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExpressionParserEdgeCaseTest {
+
+    @After
+    fun tearDown() {
+        ExpressionContext.clearVariables()
+    }
+
+    private fun eval(expr: String): Double = ExpressionParser(expr).parse().evaluate()
+
+    @Test fun `division by zero returns infinity`() {
+        assertTrue(eval("1/0").isInfinite())
+    }
+
+    @Test fun `zero divided by zero returns nan`() {
+        assertTrue(eval("0/0").isNaN())
+    }
+
+    @Test fun `negative number squared`() {
+        assertEquals(9.0, eval("(-3) ** 2"), 0.001)
+    }
+
+    @Test fun `negative number times negative`() {
+        assertEquals(4.0, eval("-2 * -2"), 0.001)
+    }
+
+    @Test fun `chained exponentiation`() {
+        assertEquals(512.0, eval("2 ** (3 + 6)"), 0.001)
+    }
+
+    @Test fun `nested ternary`() {
+        assertEquals(3.0, eval("1 ? (2 ? 3 : 4) : 5"), 0.001)
+    }
+
+    @Test fun `ternary with arithmetic in branches`() {
+        assertEquals(15.0, eval("1 ? (5 + 10) : 0"), 0.001)
+    }
+
+    @Test fun `comparison chained with and`() {
+        assertEquals(1.0, eval("1 < 2 && 2 < 3"), 0.001)
+    }
+
+    @Test fun `comparison chained with or`() {
+        assertEquals(1.0, eval("1 > 2 || 2 < 3"), 0.001)
+    }
+
+    @Test fun `mixed logical operators`() {
+        assertEquals(1.0, eval("(1 && 1) || (0 && 1)"), 0.001)
+    }
+
+    @Test fun `unary not with comparison`() {
+        assertEquals(1.0, eval("!(5 > 10)"), 0.001)
+    }
+
+    @Test fun `unary not with false comparison`() {
+        assertEquals(0.0, eval("!(5 > 3)"), 0.001)
+    }
+
+    @Test fun `variable assignment in expression`() {
+        eval("a=5")
+        eval("b=10")
+        assertEquals(15.0, eval("a + b"), 0.001)
+    }
+
+    @Test fun `computed variable assignment`() {
+        assertEquals(15.0, eval("x=5 + 10"), 0.001)
+        assertEquals(15.0, eval("x"), 0.001)
+    }
+
+    @Test fun `compound assignment chain`() {
+        eval("x=10")
+        eval("x+=5")
+        eval("x*=2")
+        assertEquals(30.0, eval("x"), 0.001)
+    }
+
+    @Test fun `pow with zero exponent`() {
+        assertEquals(1.0, eval("2 ** 0"), 0.001)
+    }
+
+    @Test fun `pow with exponent of one`() {
+        assertEquals(5.0, eval("5 ** 1"), 0.001)
+    }
+
+    @Test fun `sqrt of perfect square`() {
+        assertEquals(5.0, eval("sqrt(25)"), 0.001)
+    }
+
+    @Test fun `abs of positive number`() {
+        assertEquals(10.0, eval("abs(10)"), 0.001)
+    }
+
+    @Test fun `round half up`() {
+        assertEquals(4.0, eval("round(3.5)"), 0.001)
+    }
+
+    @Test fun `floor of decimal`() {
+        assertEquals(3.0, eval("floor(3.9)"), 0.001)
+    }
+
+    @Test fun `ceil of decimal`() {
+        assertEquals(4.0, eval("ceil(3.1)"), 0.001)
+    }
+
+    @Test fun `max with three arguments`() {
+        assertEquals(100.0, eval("max(10, 50, 100)"), 0.001)
+    }
+
+    @Test fun `min with three arguments`() {
+        assertEquals(10.0, eval("min(10, 50, 100)"), 0.001)
+    }
+
+    @Test fun `percent sign as modulo`() {
+        assertEquals(2.0, eval("14 % 3"), 0.001)
+    }
+
+    @Test fun `percent with negative numbers`() {
+        assertEquals(-1.0, eval("-10 % 3"), 0.001)
+    }
+
+    @Test fun `addition of multiple numbers`() {
+        assertEquals(10.0, eval("1 + 2 + 3 + 4"), 0.001)
+    }
+
+    @Test fun `multiplication chain`() {
+        assertEquals(24.0, eval("2 * 3 * 4"), 0.001)
+    }
+
+    @Test fun `complex expression`() {
+        assertEquals(3.5, eval("(2 + 5) / 2"), 0.001)
+    }
+
+    @Test fun `expression with all operators`() {
+        assertEquals(30.0, eval("10 + 2 * 3 ** 2 - 4 / 2 + (5 - 1)"), 0.001)
+    }
+
+    @Test fun `chained subtraction`() {
+        assertEquals(-4.0, eval("5 - 3 - 6"), 0.001)
+    }
+
+    @Test fun `unary minus with negative result`() {
+        assertEquals(-10.0, eval("-(5 + 5)"), 0.001)
+    }
+
+    @Test fun `string index access as variable`() {
+        // String literals become VariableNode
+        val node = ExpressionParser("'hello'").parse()
+        assertTrue(node is VariableNode)
+        assertEquals("'hello'", (node as VariableNode).name)
+    }
+
+    @Test fun `nested function calls`() {
+        assertEquals(5.0, eval("max(1, min(10, 5))"), 0.001)
+    }
+
+    @Test fun `function call with parentheses in args`() {
+        assertEquals(10.0, eval("max((1 + 2) * 2, 10)"), 0.001)
+    }
+
+    @Test fun `ternary with comparison in condition`() {
+        assertEquals(1.0, eval("(2 + 3 == 5) ? 1 : 0"), 0.001)
+    }
+
+    @Test fun `ternary false case`() {
+        assertEquals(0.0, eval("(2 + 3 == 6) ? 1 : 0"), 0.001)
+    }
+
+    @Test fun `comparison equality with different types`() {
+        // 5.0 == 5.0 should be 1.0
+        assertEquals(1.0, eval("(2.5 + 2.5) == 5.0"), 0.001)
+    }
+
+    @Test fun `negative exponentiation`() {
+        assertEquals(0.0625, eval("4 ** -2"), 0.001)
+    }
+
+    @Test fun `fractional exponent`() {
+        assertEquals(2.0, eval("4 ** 0.5"), 0.001)
+    }
+
+    @Test fun `modulo preserves sign of dividend`() {
+        assertEquals(-1.0, eval("-10 % 3"), 0.001)
+    }
+
+    @Test fun `modulo with decimal`() {
+        assertEquals(1.5, eval("5.5 % 2"), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `empty expression throws`() {
+        eval("")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `just whitespace throws`() {
+        eval("   ")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `invalid character throws`() {
+        eval("2 # 3")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `missing operand throws`() {
+        eval("2 +")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unclosed template string throws`() {
+        val parser = ExpressionParser("`hello")
+        parser.parse()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `invalid function call missing paren`() {
+        eval("abs")
+    }
+
+    @Test fun `modulo of zero`() {
+        assertEquals(0.0, eval("0 % 5"), 0.001)
+    }
+
+    @Test fun `addition of large numbers`() {
+        assertEquals(2000000.0, eval("1000000 + 1000000"), 0.001)
+    }
+
+    @Test fun `multiplication by zero`() {
+        assertEquals(0.0, eval("999 * 0"), 0.001)
+    }
+
+    @Test fun `not equals comparison`() {
+        assertEquals(1.0, eval("5 != 3"), 0.001)
+    }
+
+    @Test fun `great or equal true when equal`() {
+        assertEquals(1.0, eval("5 >= 5"), 0.001)
+    }
+
+    @Test fun `great or equal true when greater`() {
+        assertEquals(1.0, eval("6 >= 5"), 0.001)
+    }
+
+    @Test fun `less or equal true when equal`() {
+        assertEquals(1.0, eval("5 <= 5"), 0.001)
+    }
+
+    @Test fun `less or equal true when less`() {
+        assertEquals(1.0, eval("4 <= 5"), 0.001)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionParserTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionParserTest.kt
@@ -1,0 +1,432 @@
+package com.ai.assistance.operit.core.tools.calculator
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExpressionParserTest {
+
+    @After
+    fun tearDown() {
+        ExpressionContext.clearVariables()
+    }
+
+    private fun parseAndEval(expression: String): Double {
+        val parser = ExpressionParser(expression)
+        return parser.parse().evaluate()
+    }
+
+    private fun parse(expression: String): ExpressionNode {
+        return ExpressionParser(expression).parse()
+    }
+
+    @Test fun `simple number`() {
+        assertEquals(42.0, parseAndEval("42"), 0.001)
+    }
+
+    @Test fun `negative number`() {
+        assertEquals(-10.0, parseAndEval("-10"), 0.001)
+    }
+
+    @Test fun `decimal number`() {
+        assertEquals(3.14, parseAndEval("3.14"), 0.001)
+    }
+
+    @Test fun `number with leading decimal`() {
+        assertEquals(0.5, parseAndEval(".5"), 0.001)
+    }
+
+    @Test fun `zero`() {
+        assertEquals(0.0, parseAndEval("0"), 0.001)
+    }
+
+    @Test fun `addition`() {
+        assertEquals(5.0, parseAndEval("2 + 3"), 0.001)
+    }
+
+    @Test fun `subtraction`() {
+        assertEquals(3.0, parseAndEval("7 - 4"), 0.001)
+    }
+
+    @Test fun `multiplication`() {
+        assertEquals(12.0, parseAndEval("3 * 4"), 0.001)
+    }
+
+    @Test fun `division`() {
+        assertEquals(3.0, parseAndEval("9 / 3"), 0.001)
+    }
+
+    @Test fun `modulo`() {
+        assertEquals(1.0, parseAndEval("10 % 3"), 0.001)
+    }
+
+    @Test fun `exponentiation double asterisk`() {
+        assertEquals(8.0, parseAndEval("2 ** 3"), 0.001)
+    }
+
+    @Test fun `exponentiation caret`() {
+        assertEquals(8.0, parseAndEval("2 ^ 3"), 0.001)
+    }
+
+    @Test fun `operator precedence multiplication before addition`() {
+        assertEquals(14.0, parseAndEval("2 + 3 * 4"), 0.001)
+    }
+
+    @Test fun `operator precedence exponent before multiplication`() {
+        assertEquals(12.0, parseAndEval("3 * 2 ** 2"), 0.001)
+    }
+
+    @Test fun `parentheses override precedence`() {
+        assertEquals(20.0, parseAndEval("(2 + 3) * 4"), 0.001)
+    }
+
+    @Test fun `nested parentheses`() {
+        assertEquals(14.0, parseAndEval("((2 + 3) * 4) - 6"), 0.001)
+    }
+
+    @Test fun `chained addition`() {
+        assertEquals(15.0, parseAndEval("1 + 2 + 3 + 4 + 5"), 0.001)
+    }
+
+    @Test fun `chained multiplication`() {
+        assertEquals(24.0, parseAndEval("2 * 3 * 4"), 0.001)
+    }
+
+    @Test fun `unary plus`() {
+        assertEquals(5.0, parseAndEval("+5"), 0.001)
+    }
+
+    @Test fun `unary minus`() {
+        assertEquals(-5.0, parseAndEval("-5"), 0.001)
+    }
+
+    @Test fun `double unary minus`() {
+        assertEquals(5.0, parseAndEval("--5"), 0.001)
+    }
+
+    @Test fun `unary not`() {
+        assertEquals(1.0, parseAndEval("!0"), 0.001)
+    }
+
+    @Test fun `unary not with non-zero`() {
+        assertEquals(0.0, parseAndEval("!5"), 0.001)
+    }
+
+    @Test fun `comparison equals true`() {
+        assertEquals(1.0, parseAndEval("5 == 5"), 0.001)
+    }
+
+    @Test fun `comparison equals false`() {
+        assertEquals(0.0, parseAndEval("5 == 3"), 0.001)
+    }
+
+    @Test fun `comparison not equals true`() {
+        assertEquals(1.0, parseAndEval("5 != 3"), 0.001)
+    }
+
+    @Test fun `comparison not equals false`() {
+        assertEquals(0.0, parseAndEval("5 != 5"), 0.001)
+    }
+
+    @Test fun `comparison greater than true`() {
+        assertEquals(1.0, parseAndEval("5 > 3"), 0.001)
+    }
+
+    @Test fun `comparison greater than false`() {
+        assertEquals(0.0, parseAndEval("3 > 5"), 0.001)
+    }
+
+    @Test fun `comparison greater or equal true`() {
+        assertEquals(1.0, parseAndEval("5 >= 5"), 0.001)
+    }
+
+    @Test fun `comparison less than true`() {
+        assertEquals(1.0, parseAndEval("3 < 5"), 0.001)
+    }
+
+    @Test fun `comparison less or equal true`() {
+        assertEquals(1.0, parseAndEval("5 <= 5"), 0.001)
+    }
+
+    @Test fun `logical and both true`() {
+        assertEquals(1.0, parseAndEval("1 && 2"), 0.001)
+    }
+
+    @Test fun `logical and one false`() {
+        assertEquals(0.0, parseAndEval("1 && 0"), 0.001)
+    }
+
+    @Test fun `logical or one true`() {
+        assertEquals(1.0, parseAndEval("1 || 0"), 0.001)
+    }
+
+    @Test fun `logical or both false`() {
+        assertEquals(0.0, parseAndEval("0 || 0"), 0.001)
+    }
+
+    @Test fun `ternary operator true condition`() {
+        assertEquals(10.0, parseAndEval("1 ? 10 : 20"), 0.001)
+    }
+
+    @Test fun `ternary operator false condition`() {
+        assertEquals(20.0, parseAndEval("0 ? 10 : 20"), 0.001)
+    }
+
+    @Test fun `ternary with comparison condition`() {
+        assertEquals(1.0, parseAndEval("(5 > 3) ? 1 : 0"), 0.001)
+    }
+
+    @Test fun `variable assignment`() {
+        assertEquals(42.0, parseAndEval("x=42"), 0.001)
+        assertEquals(42.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `variable usage after assignment`() {
+        parseAndEval("x=10")
+        assertEquals(20.0, parseAndEval("x + 10"), 0.001)
+    }
+
+    @Test fun `compound assignment add`() {
+        parseAndEval("x=10")
+        assertEquals(15.0, parseAndEval("x+=5"), 0.001)
+        assertEquals(15.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `compound assignment subtract`() {
+        parseAndEval("x=10")
+        assertEquals(4.0, parseAndEval("x-=6"), 0.001)
+        assertEquals(4.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `compound assignment multiply`() {
+        parseAndEval("x=10")
+        assertEquals(20.0, parseAndEval("x*=2"), 0.001)
+        assertEquals(20.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `compound assignment divide`() {
+        parseAndEval("x=10")
+        assertEquals(2.0, parseAndEval("x/=5"), 0.001)
+        assertEquals(2.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `function call abs`() {
+        assertEquals(5.0, parseAndEval("abs(-5)"), 0.001)
+    }
+
+    @Test fun `function call sqrt`() {
+        assertEquals(3.0, parseAndEval("sqrt(9)"), 0.001)
+    }
+
+    @Test fun `function call sin`() {
+        assertEquals(Math.sin(0.0), parseAndEval("sin(0)"), 0.001)
+    }
+
+    @Test fun `function call cos`() {
+        assertEquals(Math.cos(0.0), parseAndEval("cos(0)"), 0.001)
+    }
+
+    @Test fun `function call tan`() {
+        assertEquals(Math.tan(0.0), parseAndEval("tan(0)"), 0.001)
+    }
+
+    @Test fun `function call round`() {
+        assertEquals(4.0, parseAndEval("round(3.7)"), 0.001)
+    }
+
+    @Test fun `function call floor`() {
+        assertEquals(3.0, parseAndEval("floor(3.7)"), 0.001)
+    }
+
+    @Test fun `function call ceil`() {
+        assertEquals(4.0, parseAndEval("ceil(3.2)"), 0.001)
+    }
+
+    @Test fun `function call pow`() {
+        assertEquals(8.0, parseAndEval("pow(2, 3)"), 0.001)
+    }
+
+    @Test fun `function call max`() {
+        assertEquals(10.0, parseAndEval("max(3, 10, 5)"), 0.001)
+    }
+
+    @Test fun `function call min`() {
+        assertEquals(3.0, parseAndEval("min(3, 10, 5)"), 0.001)
+    }
+
+    @Test fun `function call factorial`() {
+        assertEquals(120.0, parseAndEval("fact(5)"), 0.001)
+    }
+
+    @Test fun `function call log`() {
+        assertEquals(Math.log10(100.0), parseAndEval("log(100)"), 0.001)
+    }
+
+    @Test fun `function call ln`() {
+        assertEquals(Math.log(Math.E), parseAndEval("ln(E)"), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `math function call`() {
+        parseAndEval("Math.sin(0)")
+    }
+
+    @Test fun `whitespace does not affect result`() {
+        assertEquals(10.0, parseAndEval("   2   +   8   "), 0.001)
+    }
+
+    @Test fun `newline is whitespace`() {
+        assertEquals(10.0, parseAndEval("2\n+\n8"), 0.001)
+    }
+
+    @Test fun `tab is whitespace`() {
+        assertEquals(10.0, parseAndEval("2\t+\t8"), 0.001)
+    }
+
+    @Test fun `variable with underscore`() {
+        parseAndEval("my_var=42")
+        assertEquals(42.0, parseAndEval("my_var"), 0.001)
+    }
+
+    @Test fun `variable with mixed case`() {
+        parseAndEval("myVar=10")
+        assertEquals(10.0, parseAndEval("myVar"), 0.001)
+    }
+
+    @Test fun `identifier with digits`() {
+        parseAndEval("x2=5")
+        assertEquals(5.0, parseAndEval("x2"), 0.001)
+    }
+
+    @Test fun `string literal as variable name`() {
+        // String literals are parsed as VariableNode with the string value
+        val node = parse("'hello'")
+        assertTrue(node is VariableNode)
+        assertEquals("'hello'", (node as VariableNode).name)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `array literal creation`() {
+        parseAndEval("[1, 2, 3]")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unexpected character throws`() {
+        parseAndEval("2 @ 3")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unclosed parenthesis throws`() {
+        parseAndEval("(2 + 3")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unexpected closing parenthesis throws`() {
+        parseAndEval("2 + 3)")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `missing ternary colon throws`() {
+        parseAndEval("1 ? 10")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `comma outside function call throws`() {
+        parseAndEval("1, 2")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unexpected token after expression throws`() {
+        parseAndEval("2 3")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `stats dot syntax not supported by parser`() {
+        parseAndEval("stats.mean(2, 4, 6, 8)")
+    }
+
+    @Test fun `variable reuse after assignment`() {
+        parseAndEval("x=5")
+        parseAndEval("x=x + 3")
+        assertEquals(8.0, ExpressionContext.getVariable("x"), 0.001)
+    }
+
+    @Test fun `expression with multiple operators`() {
+        assertEquals(11.0, parseAndEval("1 + 2 * 3 + 4"), 0.001)
+    }
+
+    @Test fun `expression with all arithmetic operators`() {
+        assertEquals(10.0, parseAndEval("2 * 3 + 10 / 2 - 1"), 0.001)
+    }
+
+    @Test fun `division resulting in decimal`() {
+        assertEquals(2.5, parseAndEval("5 / 2"), 0.001)
+    }
+
+    @Test fun `negative result`() {
+        assertEquals(-1.0, parseAndEval("2 - 3"), 0.001)
+    }
+
+    @Test fun `expression with parentheses`() {
+        assertEquals(25.0, parseAndEval("(2 + 3) * (1 + 4)"), 0.001)
+    }
+
+    @Test fun `deeply nested parentheses`() {
+        assertEquals(10.0, parseAndEval("((((1 + 2)) * 3) + 1)"), 0.001)
+    }
+
+    @Test fun `unary minus with parentheses`() {
+        assertEquals(-10.0, parseAndEval("-(5 + 5)"), 0.001)
+    }
+
+    @Test fun `chained comparison`() {
+        assertEquals(1.0, parseAndEval("5 > 3 && 10 > 2"), 0.001)
+    }
+
+    @Test fun `chained comparison with or`() {
+        assertEquals(1.0, parseAndEval("5 < 3 || 10 > 2"), 0.001)
+    }
+
+    @Test fun `ternary inside expression`() {
+        assertEquals(15.0, parseAndEval("10 + (1 ? 5 : 0)"), 0.001)
+    }
+
+    @Test fun `signed zero`() {
+        assertEquals(0.0, parseAndEval("-0"), 0.001)
+    }
+
+    @Test fun `function call with nested expression arg`() {
+        assertEquals(5.0, parseAndEval("abs(2 - 7)"), 0.001)
+    }
+
+    @Test fun `pow with negative exponent via division`() {
+        assertEquals(0.25, parseAndEval("2 ** -2"), 0.001)
+    }
+
+    @Test fun `multiple function calls in expression`() {
+        assertEquals(5.0, parseAndEval("min(10, max(1, 5))"), 0.001)
+    }
+
+    @Test fun `exponentiation with parenthesis`() {
+        assertEquals(512.0, parseAndEval("2 ** (3 + 6)"), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unclosed bracket throws`() {
+        parseAndEval("[1, 2")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unclosed function call throws`() {
+        parseAndEval("abs(5")
+    }
+
+    @Test fun `ternary with comparison`() {
+        assertEquals(100.0, parseAndEval("(10 > 5) ? 100 : 200"), 0.001)
+    }
+
+    @Test fun `ternary false with comparison`() {
+        assertEquals(200.0, parseAndEval("(10 < 5) ? 100 : 200"), 0.001)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionParserTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/ExpressionParserTest.kt
@@ -267,9 +267,13 @@ class ExpressionParserTest {
         assertEquals(Math.log(Math.E), parseAndEval("ln(E)"), 0.001)
     }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun `math function call`() {
-        parseAndEval("Math.sin(0)")
+    @Test fun `qualified math function call`() {
+        assertEquals(1.0, parseAndEval("Math.sin(Math.PI / 2)"), 0.001)
+    }
+
+    @Test fun `qualified math constants`() {
+        assertEquals(Math.PI, parseAndEval("Math.PI"), 0.001)
+        assertEquals(Math.E, parseAndEval("Math.E"), 0.001)
     }
 
     @Test fun `whitespace does not affect result`() {
@@ -341,9 +345,8 @@ class ExpressionParserTest {
         parseAndEval("2 3")
     }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun `stats dot syntax not supported by parser`() {
-        parseAndEval("stats.mean(2, 4, 6, 8)")
+    @Test fun `qualified stats function call`() {
+        assertEquals(5.0, parseAndEval("stats.mean(2, 4, 6, 8)"), 0.001)
     }
 
     @Test fun `variable reuse after assignment`() {

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/JsCalculatorTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/calculator/JsCalculatorTest.kt
@@ -1,0 +1,187 @@
+package com.ai.assistance.operit.core.tools.calculator
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JsCalculatorTest {
+
+    @After
+    fun tearDown() {
+        JsCalculator.clearVariables()
+    }
+
+    @Test fun `evaluate simple addition`() {
+        assertEquals(5.0, JsCalculator.evaluate("2 + 3"), 0.001)
+    }
+
+    @Test fun `evaluate complex expression`() {
+        assertEquals(14.0, JsCalculator.evaluate("2 + 3 * 4"), 0.001)
+    }
+
+    @Test fun `evaluate with parentheses`() {
+        assertEquals(20.0, JsCalculator.evaluate("(2 + 3) * 4"), 0.001)
+    }
+
+    @Test fun `evaluate function call`() {
+        assertEquals(5.0, JsCalculator.evaluate("abs(-5)"), 0.001)
+    }
+
+    @Test fun `evaluate trigonometric function`() {
+        assertEquals(Math.sin(0.0), JsCalculator.evaluate("sin(0)"), 0.001)
+    }
+
+    @Test fun `evaluate with variable assignment`() {
+        assertEquals(10.0, JsCalculator.evaluate("x=10"), 0.001)
+    }
+
+    @Test fun `evaluate with variable usage`() {
+        JsCalculator.setVariable("x", 5.0)
+        assertEquals(8.0, JsCalculator.evaluate("x + 3"), 0.001)
+    }
+
+    @Test fun `evaluate using stored variable`() {
+        JsCalculator.evaluate("x=7")
+        assertEquals(11.0, JsCalculator.evaluate("x + 4"), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `evaluate invalid expression throws`() {
+        JsCalculator.evaluate("2 +")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `evaluate undefined variable throws`() {
+        JsCalculator.evaluate("undefined_var")
+    }
+
+    @Test fun `calc returns formatted string`() {
+        assertEquals("5", JsCalculator.calc("2 + 3"))
+    }
+
+    @Test fun `calc returns decimal formatted`() {
+        assertEquals("3.14", JsCalculator.calc("1.14 + 2"))
+    }
+
+    @Test fun `calc integer result`() {
+        assertEquals("42", JsCalculator.calc("6 * 7"))
+    }
+
+    @Test fun `calc negative result`() {
+        assertEquals("-5", JsCalculator.calc("2 - 7"))
+    }
+
+    @Test fun `formatResult delegates correctly`() {
+        assertEquals("42", JsCalculator.formatResult(42.0))
+    }
+
+    @Test fun `formatResult with decimal`() {
+        assertEquals("3.14", JsCalculator.formatResult(3.14))
+    }
+
+    @Test fun `setVariable and getVariable round trip`() {
+        JsCalculator.setVariable("test", 99.0)
+        assertEquals(99.0, JsCalculator.getVariable("test"), 0.001)
+    }
+
+    @Test fun `getVariable returns set value`() {
+        JsCalculator.setVariable("value", 3.14)
+        assertEquals(3.14, JsCalculator.getVariable("value"), 0.001)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `getVariable undefined throws`() {
+        JsCalculator.getVariable("nonexistent")
+    }
+
+    @Test fun `clearVariables resets state`() {
+        JsCalculator.setVariable("temp", 100.0)
+        JsCalculator.clearVariables()
+        // PI should still be accessible
+        assertEquals(Math.PI, JsCalculator.getVariable("PI"), 0.001)
+    }
+
+    @Test fun `getSupportedUnits returns categories`() {
+        val units = JsCalculator.getSupportedUnits()
+        assertTrue(units.containsKey("Temperature"))
+        assertTrue(units.containsKey("Length"))
+        assertTrue(units.containsKey("Weight"))
+        assertTrue(units.containsKey("Volume"))
+        assertTrue(units.containsKey("Speed"))
+        assertEquals(5, units.size)
+    }
+
+    @Test fun `getSupportedUnits temperature list`() {
+        val units = JsCalculator.getSupportedUnits()
+        val tempUnits = units["Temperature"] ?: emptyList()
+        assertTrue(tempUnits.any { it.contains("c") })
+        assertTrue(tempUnits.any { it.contains("f") })
+        assertTrue(tempUnits.any { it.contains("k") })
+    }
+
+    @Test fun `getSupportedDateFunctions returns list`() {
+        val funcs = JsCalculator.getSupportedDateFunctions()
+        assertTrue(funcs.any { it.startsWith("today()") })
+        assertTrue(funcs.any { it.startsWith("now()") })
+        assertTrue(funcs.any { it.startsWith("date_diff") })
+        assertTrue(funcs.any { it.startsWith("date_add") })
+    }
+
+    @Test fun `getSupportedStatFunctions returns list`() {
+        val funcs = JsCalculator.getSupportedStatFunctions()
+        assertTrue(funcs.any { it.startsWith("stats.mean") })
+        assertTrue(funcs.any { it.startsWith("stats.median") })
+        assertTrue(funcs.any { it.startsWith("stats.min") })
+        assertTrue(funcs.any { it.startsWith("stats.max") })
+        assertTrue(funcs.any { it.startsWith("stats.sum") })
+        assertTrue(funcs.any { it.startsWith("stats.stdev") })
+    }
+
+    @Test fun `getSupportedJsFeatures returns list`() {
+        val features = JsCalculator.getSupportedJsFeatures()
+        assertTrue(features.any { it.contains("Ternary") })
+        assertTrue(features.any { it.contains("Math.") })
+    }
+
+    @Test fun `evaluate with chained operations`() {
+        assertEquals(10.0, JsCalculator.evaluate("1 + 2 + 3 + 4"), 0.001)
+    }
+
+    @Test fun `evaluate division`() {
+        assertEquals(3.0, JsCalculator.evaluate("9 / 3"), 0.001)
+    }
+
+    @Test fun `evaluate modulo`() {
+        assertEquals(1.0, JsCalculator.evaluate("10 % 3"), 0.001)
+    }
+
+    @Test fun `evaluate exponent`() {
+        assertEquals(8.0, JsCalculator.evaluate("2 ** 3"), 0.001)
+    }
+
+    @Test fun `evaluate comparison`() {
+        assertEquals(1.0, JsCalculator.evaluate("5 > 3"), 0.001)
+    }
+
+    @Test fun `evaluate logical`() {
+        assertEquals(1.0, JsCalculator.evaluate("1 && 1"), 0.001)
+    }
+
+    @Test fun `evaluate ternary`() {
+        assertEquals(10.0, JsCalculator.evaluate("1 ? 10 : 20"), 0.001)
+    }
+
+    @Test fun `evaluate compound assignment`() {
+        JsCalculator.evaluate("x=10")
+        assertEquals(15.0, JsCalculator.evaluate("x+=5"), 0.001)
+    }
+
+    @Test fun `evaluate pi constant`() {
+        assertEquals(Math.PI, JsCalculator.evaluate("PI"), 0.001)
+    }
+
+    @Test fun `evaluate e constant`() {
+        assertEquals(Math.E, JsCalculator.evaluate("E"), 0.001)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/AIToolTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/AIToolTest.kt
@@ -1,0 +1,86 @@
+package com.ai.assistance.operit.data.model
+
+import com.ai.assistance.operit.core.tools.StringResultData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AIToolTest {
+
+    @Test fun `create tool parameter`() {
+        val param = ToolParameter(name = "location", value = "Paris")
+        assertEquals("location", param.name)
+        assertEquals("Paris", param.value)
+    }
+
+    @Test fun `create ai tool with minimal fields`() {
+        val tool = AITool(name = "get_weather")
+        assertEquals("get_weather", tool.name)
+        assertTrue(tool.parameters.isEmpty())
+        assertEquals("", tool.description)
+    }
+
+    @Test fun `create ai tool with parameters`() {
+        val params = listOf(
+            ToolParameter("city", "Tokyo"),
+            ToolParameter("units", "metric"),
+        )
+        val tool = AITool(name = "get_weather", parameters = params, description = "Get weather")
+        assertEquals(2, tool.parameters.size)
+        assertEquals("Tokyo", tool.parameters[0].value)
+        assertEquals("metric", tool.parameters[1].value)
+        assertEquals("Get weather", tool.description)
+    }
+
+    @Test fun `create tool invocation`() {
+        val tool = AITool(name = "calculator", parameters = listOf(ToolParameter("expr", "2+2")))
+        val invocation = ToolInvocation(tool = tool, rawText = "<tool>...</tool>", responseLocation = 0..10)
+        assertEquals("calculator", invocation.tool.name)
+        assertEquals("<tool>...</tool>", invocation.rawText)
+        assertEquals(0..10, invocation.responseLocation)
+    }
+
+    @Test fun `create tool result with success`() {
+        val resultData = StringResultData("42")
+        val result = ToolResult(toolName = "calculator", success = true, result = resultData)
+        assertEquals("calculator", result.toolName)
+        assertTrue(result.success)
+        assertEquals("42", result.result.toString())
+        assertNull(result.error)
+    }
+
+    @Test fun `create tool result with failure`() {
+        val resultData = StringResultData("error occurred")
+        val result = ToolResult(toolName = "search", success = false, result = resultData, error = "Not found")
+        assertEquals("search", result.toolName)
+        assertFalse(result.success)
+        assertEquals("Not found", result.error)
+    }
+
+    @Test fun `create tool validation result valid`() {
+        val vr = ToolValidationResult(valid = true)
+        assertTrue(vr.valid)
+        assertEquals("", vr.errorMessage)
+    }
+
+    @Test fun `create tool validation result invalid`() {
+        val vr = ToolValidationResult(valid = false, errorMessage = "Missing required parameter")
+        assertFalse(vr.valid)
+        assertEquals("Missing required parameter", vr.errorMessage)
+    }
+
+    @Test fun `ai tool copy with different parameters`() {
+        val tool = AITool(name = "search", parameters = listOf(ToolParameter("q", "hello")))
+        val copy = tool.copy(parameters = listOf(ToolParameter("q", "world")))
+        assertEquals("world", copy.parameters[0].value)
+    }
+
+    @Test fun `tool result copy with error`() {
+        val result = ToolResult(toolName = "test", success = true, result = StringResultData("ok"))
+        val copy = result.copy(success = false, error = "failed")
+        assertFalse(copy.success)
+        assertEquals("failed", copy.error)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/ApiKeyInfoTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/ApiKeyInfoTest.kt
@@ -1,0 +1,118 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApiKeyInfoTest {
+
+    @Test fun `create with required fields`() {
+        val info = ApiKeyInfo(id = "key1", key = "sk-abc123")
+        assertEquals("key1", info.id)
+        assertEquals("sk-abc123", info.key)
+    }
+
+    @Test fun `name defaults to empty`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key")
+        assertEquals("", info.name)
+    }
+
+    @Test fun `is enabled defaults to true`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key")
+        assertTrue(info.isEnabled)
+    }
+
+    @Test fun `availability status defaults to UNTESTED`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key")
+        assertEquals(ApiKeyAvailabilityStatus.UNTESTED, info.availabilityStatus)
+    }
+
+    @Test fun `usage count defaults to zero`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key")
+        assertEquals(0L, info.usageCount)
+    }
+
+    @Test fun `last used defaults to zero`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key")
+        assertEquals(0L, info.lastUsed)
+    }
+
+    @Test fun `error count defaults to zero`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key")
+        assertEquals(0L, info.errorCount)
+    }
+
+    @Test fun `can set name`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", name = "My Key")
+        assertEquals("My Key", info.name)
+    }
+
+    @Test fun `can disable key`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", isEnabled = false)
+        assertFalse(info.isEnabled)
+    }
+
+    @Test fun `can set availability to AVAILABLE`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", availabilityStatus = ApiKeyAvailabilityStatus.AVAILABLE)
+        assertEquals(ApiKeyAvailabilityStatus.AVAILABLE, info.availabilityStatus)
+    }
+
+    @Test fun `can set availability to UNAVAILABLE`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", availabilityStatus = ApiKeyAvailabilityStatus.UNAVAILABLE)
+        assertEquals(ApiKeyAvailabilityStatus.UNAVAILABLE, info.availabilityStatus)
+    }
+
+    @Test fun `can set usage count`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", usageCount = 42)
+        assertEquals(42L, info.usageCount)
+    }
+
+    @Test fun `can set last used`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", lastUsed = 123456789L)
+        assertEquals(123456789L, info.lastUsed)
+    }
+
+    @Test fun `can set error count`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", errorCount = 3)
+        assertEquals(3L, info.errorCount)
+    }
+
+    @Test fun `copy with different id and key`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key1", name = "Key 1")
+        val copy = info.copy(id = "k2", key = "sk-key2")
+        assertEquals("k2", copy.id)
+        assertEquals("sk-key2", copy.key)
+        assertEquals("Key 1", copy.name)
+    }
+
+    @Test fun `copy with updated status`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", availabilityStatus = ApiKeyAvailabilityStatus.UNTESTED)
+        val copy = info.copy(availabilityStatus = ApiKeyAvailabilityStatus.AVAILABLE)
+        assertEquals(ApiKeyAvailabilityStatus.AVAILABLE, copy.availabilityStatus)
+    }
+
+    @Test fun `copy increments usage count`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", usageCount = 5)
+        val copy = info.copy(usageCount = 6)
+        assertEquals(6L, copy.usageCount)
+    }
+
+    @Test fun `copy with disabled state`() {
+        val info = ApiKeyInfo(id = "k1", key = "sk-key", isEnabled = true)
+        val copy = info.copy(isEnabled = false)
+        assertFalse(copy.isEnabled)
+    }
+
+    @Test fun `api key with empty key is valid data class`() {
+        val info = ApiKeyInfo(id = "empty", key = "")
+        assertEquals("", info.key)
+    }
+
+    @Test fun `api key availability status enum values`() {
+        assertEquals(3, ApiKeyAvailabilityStatus.values().size)
+        assertTrue(ApiKeyAvailabilityStatus.values().contains(ApiKeyAvailabilityStatus.UNTESTED))
+        assertTrue(ApiKeyAvailabilityStatus.values().contains(ApiKeyAvailabilityStatus.AVAILABLE))
+        assertTrue(ApiKeyAvailabilityStatus.values().contains(ApiKeyAvailabilityStatus.UNAVAILABLE))
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/AttachmentInfoTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/AttachmentInfoTest.kt
@@ -1,0 +1,81 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AttachmentInfoTest {
+
+    @Test fun `create with required fields`() {
+        val info = AttachmentInfo(
+            filePath = "/path/to/file.txt",
+            fileName = "file.txt",
+            mimeType = "text/plain",
+            fileSize = 1024L,
+        )
+        assertEquals("/path/to/file.txt", info.filePath)
+        assertEquals("file.txt", info.fileName)
+        assertEquals("text/plain", info.mimeType)
+        assertEquals(1024L, info.fileSize)
+    }
+
+    @Test fun `content defaults to empty`() {
+        val info = AttachmentInfo(
+            filePath = "/path/file.txt",
+            fileName = "file.txt",
+            mimeType = "text/plain",
+            fileSize = 0L,
+        )
+        assertEquals("", info.content)
+    }
+
+    @Test fun `content can be set`() {
+        val info = AttachmentInfo(
+            filePath = "/path/file.txt",
+            fileName = "file.txt",
+            mimeType = "text/plain",
+            fileSize = 10L,
+            content = "inline content",
+        )
+        assertEquals("inline content", info.content)
+    }
+
+    @Test fun `copy with different file path`() {
+        val info = AttachmentInfo("/old", "file.txt", "text/plain", 100L)
+        val copy = info.copy(filePath = "/new")
+        assertEquals("/new", copy.filePath)
+        assertEquals("file.txt", copy.fileName)
+    }
+
+    @Test fun `image attachment`() {
+        val info = AttachmentInfo("/img/photo.jpg", "photo.jpg", "image/jpeg", 50000L)
+        assertEquals("image/jpeg", info.mimeType)
+        assertEquals(50000L, info.fileSize)
+    }
+
+    @Test fun `pdf attachment`() {
+        val info = AttachmentInfo("/docs/report.pdf", "report.pdf", "application/pdf", 200000L)
+        assertEquals("application/pdf", info.mimeType)
+        assertEquals(200000L, info.fileSize)
+    }
+
+    @Test fun `zero file size`() {
+        val info = AttachmentInfo("/empty", "empty.txt", "text/plain", 0L)
+        assertEquals(0L, info.fileSize)
+    }
+
+    @Test fun `large file size`() {
+        val info = AttachmentInfo("/big", "big.mp4", "video/mp4", 1_000_000_000L)
+        assertEquals(1_000_000_000L, info.fileSize)
+    }
+
+    @Test fun `content with special characters`() {
+        val info = AttachmentInfo("/f", "f.txt", "text/plain", 10L, content = "Hello\nWorld")
+        assertEquals("Hello\nWorld", info.content)
+    }
+
+    @Test fun `copy preserves mime type`() {
+        val info = AttachmentInfo("/a", "a.pdf", "application/pdf", 100L)
+        val copy = info.copy(fileSize = 200L)
+        assertEquals("application/pdf", copy.mimeType)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/ChatEntityTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/ChatEntityTest.kt
@@ -1,0 +1,201 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDateTime
+
+class ChatEntityTest {
+
+    @Test fun `create with required fields`() {
+        val entity = ChatEntity(title = "Test Chat")
+        assertEquals("Test Chat", entity.title)
+        assertNotNull(entity.id)
+        assertTrue(entity.id.isNotEmpty())
+    }
+
+    @Test fun `id is randomly generated`() {
+        val e1 = ChatEntity(title = "A")
+        val e2 = ChatEntity(title = "B")
+        assertFalse(e1.id == e2.id)
+    }
+
+    @Test fun `created at defaults to current time`() {
+        val before = System.currentTimeMillis()
+        val entity = ChatEntity(title = "Test")
+        val after = System.currentTimeMillis()
+        assertTrue(entity.createdAt >= before)
+        assertTrue(entity.createdAt <= after + 1000)
+    }
+
+    @Test fun `updated at defaults to current time`() {
+        val before = System.currentTimeMillis()
+        val entity = ChatEntity(title = "Test")
+        val after = System.currentTimeMillis()
+        assertTrue(entity.updatedAt >= before)
+        assertTrue(entity.updatedAt <= after + 1000)
+    }
+
+    @Test fun `input tokens defaults to zero`() {
+        val entity = ChatEntity(title = "Test")
+        assertEquals(0, entity.inputTokens)
+    }
+
+    @Test fun `output tokens defaults to zero`() {
+        val entity = ChatEntity(title = "Test")
+        assertEquals(0, entity.outputTokens)
+    }
+
+    @Test fun `current window size defaults to zero`() {
+        val entity = ChatEntity(title = "Test")
+        assertEquals(0, entity.currentWindowSize)
+    }
+
+    @Test fun `group defaults to null`() {
+        val entity = ChatEntity(title = "Test")
+        assertNull(entity.group)
+    }
+
+    @Test fun `display order defaults to negative createdAt`() {
+        val entity = ChatEntity(title = "Test")
+        assertEquals(-entity.createdAt, entity.displayOrder)
+    }
+
+    @Test fun `workspace defaults to null`() {
+        val entity = ChatEntity(title = "Test")
+        assertNull(entity.workspace)
+    }
+
+    @Test fun `parent chat id defaults to null`() {
+        val entity = ChatEntity(title = "Test")
+        assertNull(entity.parentChatId)
+    }
+
+    @Test fun `character card name defaults to null`() {
+        val entity = ChatEntity(title = "Test")
+        assertNull(entity.characterCardName)
+    }
+
+    @Test fun `locked defaults to false`() {
+        val entity = ChatEntity(title = "Test")
+        assertFalse(entity.locked)
+    }
+
+    @Test fun `pinned defaults to false`() {
+        val entity = ChatEntity(title = "Test")
+        assertFalse(entity.pinned)
+    }
+
+    @Test fun `toChatHistory creates correct object`() {
+        val entity = ChatEntity(
+            id = "test-id",
+            title = "My Chat",
+            inputTokens = 100,
+            outputTokens = 50,
+            currentWindowSize = 10,
+            group = "group1",
+            workspace = "workspace1",
+            parentChatId = "parent1",
+            characterCardName = "char1",
+            locked = true,
+            pinned = true,
+        )
+        val history = entity.toChatHistory(emptyList())
+        assertEquals("test-id", history.id)
+        assertEquals("My Chat", history.title)
+        assertEquals(0, history.messages.size)
+        assertEquals(100, history.inputTokens)
+        assertEquals(50, history.outputTokens)
+        assertEquals(10, history.currentWindowSize)
+        assertEquals("group1", history.group)
+        assertEquals("workspace1", history.workspace)
+        assertEquals("parent1", history.parentChatId)
+        assertEquals("char1", history.characterCardName)
+        assertEquals(true, history.locked)
+        assertEquals(true, history.pinned)
+        assertNotNull(history.createdAt)
+        assertNotNull(history.updatedAt)
+    }
+
+    @Test fun `toChatHistory preserves messages`() {
+        val entity = ChatEntity(title = "Chat")
+        val messages = listOf(
+            ChatMessage(sender = "user", content = "Hi"),
+            ChatMessage(sender = "ai", content = "Hello"),
+        )
+        val history = entity.toChatHistory(messages)
+        assertEquals(2, history.messages.size)
+        assertEquals("Hi", history.messages[0].content)
+        assertEquals("Hello", history.messages[1].content)
+    }
+
+    @Test fun `fromChatHistory round trip`() {
+        val original = ChatEntity(
+            id = "round-trip-id",
+            title = "Round Trip",
+            inputTokens = 50,
+            outputTokens = 25,
+            group = "test-group",
+        )
+        val history = original.toChatHistory(emptyList())
+        val roundTripped = ChatEntity.fromChatHistory(history)
+        assertEquals(original.id, roundTripped.id)
+        assertEquals(original.title, roundTripped.title)
+        assertEquals(original.inputTokens, roundTripped.inputTokens)
+        assertEquals(original.outputTokens, roundTripped.outputTokens)
+        assertEquals(original.group, roundTripped.group)
+    }
+
+    @Test fun `fromChatHistory computes displayOrder when zero`() {
+        val history = ChatHistory(
+            id = "test", title = "Test", messages = emptyList(),
+            createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(),
+            displayOrder = 0L,
+        )
+        val entity = ChatEntity.fromChatHistory(history)
+        assertTrue(entity.displayOrder < 0)
+    }
+
+    @Test fun `fromChatHistory preserves non-zero displayOrder`() {
+        val history = ChatHistory(
+            id = "test", title = "Test", messages = emptyList(),
+            createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(),
+            displayOrder = 42L,
+        )
+        val entity = ChatEntity.fromChatHistory(history)
+        assertEquals(42L, entity.displayOrder)
+    }
+
+    @Test fun `explicit fields are stored`() {
+        val entity = ChatEntity(
+            id = "explicit-id",
+            title = "Explicit",
+            createdAt = 1000L,
+            updatedAt = 2000L,
+            inputTokens = 10,
+            outputTokens = 20,
+            currentWindowSize = 5,
+            group = "explicit-group",
+            displayOrder = 99L,
+            workspace = "explicit-ws",
+            characterCardName = "explicit-char",
+            locked = true,
+            pinned = true,
+        )
+        assertEquals("explicit-id", entity.id)
+        assertEquals(1000L, entity.createdAt)
+        assertEquals(2000L, entity.updatedAt)
+        assertEquals(10, entity.inputTokens)
+        assertEquals(20, entity.outputTokens)
+        assertEquals(5, entity.currentWindowSize)
+        assertEquals("explicit-group", entity.group)
+        assertEquals(99L, entity.displayOrder)
+        assertEquals("explicit-ws", entity.workspace)
+        assertEquals("explicit-char", entity.characterCardName)
+        assertTrue(entity.locked)
+        assertTrue(entity.pinned)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/ChatHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/ChatHistoryTest.kt
@@ -1,0 +1,159 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDateTime
+
+class ChatHistoryTest {
+
+    private fun createHistory(
+        id: String = "hist1",
+        title: String = "Test History",
+        messages: List<ChatMessage> = emptyList(),
+        displayOrder: Long = 0L,
+    ) = ChatHistory(
+        id = id, title = title, messages = messages,
+        createdAt = LocalDateTime.of(2024, 1, 15, 10, 30),
+        updatedAt = LocalDateTime.of(2024, 1, 15, 11, 0),
+        displayOrder = displayOrder,
+    )
+
+    @Test fun `create with required fields`() {
+        val hist = createHistory()
+        assertEquals("hist1", hist.id)
+        assertEquals("Test History", hist.title)
+        assertTrue(hist.messages.isEmpty())
+    }
+
+    @Test fun `messages list is preserved`() {
+        val msgs = listOf(
+            ChatMessage(sender = "user", content = "Hi"),
+            ChatMessage(sender = "ai", content = "Hello"),
+        )
+        val hist = createHistory(messages = msgs)
+        assertEquals(2, hist.messages.size)
+        assertEquals("Hi", hist.messages[0].content)
+    }
+
+    @Test fun `created at is preserved`() {
+        val hist = createHistory()
+        assertEquals(LocalDateTime.of(2024, 1, 15, 10, 30), hist.createdAt)
+    }
+
+    @Test fun `updated at is preserved`() {
+        val hist = createHistory()
+        assertEquals(LocalDateTime.of(2024, 1, 15, 11, 0), hist.updatedAt)
+    }
+
+    @Test fun `display order defaults to zero`() {
+        val hist = createHistory()
+        assertEquals(0L, hist.displayOrder)
+    }
+
+    @Test fun `display order can be set`() {
+        val hist = createHistory(displayOrder = 42L)
+        assertEquals(42L, hist.displayOrder)
+    }
+
+    @Test fun `input tokens defaults to zero`() {
+        val hist = createHistory()
+        assertEquals(0, hist.inputTokens)
+    }
+
+    @Test fun `output tokens defaults to zero`() {
+        val hist = createHistory()
+        assertEquals(0, hist.outputTokens)
+    }
+
+    @Test fun `current window size defaults to zero`() {
+        val hist = createHistory()
+        assertEquals(0, hist.currentWindowSize)
+    }
+
+    @Test fun `group defaults to null`() {
+        val hist = createHistory()
+        assertNull(hist.group)
+    }
+
+    @Test fun `workspace defaults to null`() {
+        val hist = createHistory()
+        assertNull(hist.workspace)
+    }
+
+    @Test fun `parent chat id defaults to null`() {
+        val hist = createHistory()
+        assertNull(hist.parentChatId)
+    }
+
+    @Test fun `character card name defaults to null`() {
+        val hist = createHistory()
+        assertNull(hist.characterCardName)
+    }
+
+    @Test fun `character group id defaults to null`() {
+        val hist = createHistory()
+        assertNull(hist.characterGroupId)
+    }
+
+    @Test fun `locked defaults to false`() {
+        val hist = createHistory()
+        assertFalse(hist.locked)
+    }
+
+    @Test fun `pinned defaults to false`() {
+        val hist = createHistory()
+        assertFalse(hist.pinned)
+    }
+
+    @Test fun `copy with new title`() {
+        val hist = createHistory()
+        val copy = hist.copy(title = "Updated Title")
+        assertEquals("Updated Title", copy.title)
+        assertEquals(hist.id, copy.id)
+    }
+
+    @Test fun `copy with new messages`() {
+        val hist = createHistory()
+        val newMsgs = listOf(ChatMessage(sender = "user", content = "New"))
+        val copy = hist.copy(messages = newMsgs)
+        assertEquals(1, copy.messages.size)
+    }
+
+    @Test fun `copy with tokens`() {
+        val hist = createHistory()
+        val copy = hist.copy(inputTokens = 100, outputTokens = 50, currentWindowSize = 10)
+        assertEquals(100, copy.inputTokens)
+        assertEquals(50, copy.outputTokens)
+        assertEquals(10, copy.currentWindowSize)
+    }
+
+    @Test fun `copy with group and workspace`() {
+        val hist = createHistory()
+        val copy = hist.copy(group = "group1", workspace = "ws1")
+        assertEquals("group1", copy.group)
+        assertEquals("ws1", copy.workspace)
+    }
+
+    @Test fun `copy with parent chat and character`() {
+        val hist = createHistory()
+        val copy = hist.copy(
+            parentChatId = "parent1",
+            characterCardName = "char1",
+            characterGroupId = "group1",
+        )
+        assertEquals("parent1", copy.parentChatId)
+        assertEquals("char1", copy.characterCardName)
+        assertEquals("group1", copy.characterGroupId)
+    }
+
+    @Test fun `copy with pinned and locked`() {
+        val hist = createHistory()
+        val copy = hist.copy(locked = true, pinned = true)
+        assertTrue(copy.locked)
+        assertTrue(copy.pinned)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/ChatMessageDisplayModeTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/ChatMessageDisplayModeTest.kt
@@ -1,0 +1,30 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatMessageDisplayModeTest {
+
+    @Test fun `NORMAL is a display mode`() {
+        assertEquals(ChatMessageDisplayMode.NORMAL, ChatMessageDisplayMode.valueOf("NORMAL"))
+    }
+
+    @Test fun `HIDDEN_PLACEHOLDER is a display mode`() {
+        assertEquals(ChatMessageDisplayMode.HIDDEN_PLACEHOLDER, ChatMessageDisplayMode.valueOf("HIDDEN_PLACEHOLDER"))
+    }
+
+    @Test fun `enum has exactly two values`() {
+        assertEquals(2, ChatMessageDisplayMode.values().size)
+    }
+
+    @Test fun `valueOf is case sensitive`() {
+        assertEquals(ChatMessageDisplayMode.NORMAL, ChatMessageDisplayMode.valueOf("NORMAL"))
+        assertEquals(ChatMessageDisplayMode.HIDDEN_PLACEHOLDER, ChatMessageDisplayMode.valueOf("HIDDEN_PLACEHOLDER"))
+    }
+
+    @Test fun `name returns correct string`() {
+        assertEquals("NORMAL", ChatMessageDisplayMode.NORMAL.name)
+        assertEquals("HIDDEN_PLACEHOLDER", ChatMessageDisplayMode.HIDDEN_PLACEHOLDER.name)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/ChatMessageTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/ChatMessageTest.kt
@@ -1,0 +1,162 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatMessageTest {
+
+    @After
+    fun tearDown() {
+        ChatMessageTimestampAllocator.next()
+    }
+
+    @Test fun `default sender is user`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals("user", msg.sender)
+    }
+
+    @Test fun `default content is empty`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals("", msg.content)
+    }
+
+    @Test fun `custom content is stored`() {
+        val msg = ChatMessage(sender = "user", content = "Hello")
+        assertEquals("Hello", msg.content)
+    }
+
+    @Test fun `timestamp is allocated`() {
+        val msg = ChatMessage(sender = "user")
+        assertTrue(msg.timestamp > 0)
+    }
+
+    @Test fun `consecutive messages have increasing timestamps`() {
+        val msg1 = ChatMessage(sender = "user")
+        val msg2 = ChatMessage(sender = "user")
+        assertTrue(msg2.timestamp > msg1.timestamp)
+    }
+
+    @Test fun `role name can be set`() {
+        val msg = ChatMessage(sender = "user", roleName = "assistant")
+        assertEquals("assistant", msg.roleName)
+    }
+
+    @Test fun `selected variant index defaults to zero`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(0, msg.selectedVariantIndex)
+    }
+
+    @Test fun `variant count defaults to one`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(1, msg.variantCount)
+    }
+
+    @Test fun `provider defaults to empty`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals("", msg.provider)
+    }
+
+    @Test fun `model name defaults to empty`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals("", msg.modelName)
+    }
+
+    @Test fun `input tokens defaults to zero`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(0, msg.inputTokens)
+    }
+
+    @Test fun `output tokens defaults to zero`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(0, msg.outputTokens)
+    }
+
+    @Test fun `display mode defaults to normal`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(ChatMessageDisplayMode.NORMAL, msg.displayMode)
+    }
+
+    @Test fun `is favorite defaults to false`() {
+        val msg = ChatMessage(sender = "user")
+        assertFalse(msg.isFavorite)
+    }
+
+    @Test fun `is favorite can be set to true`() {
+        val msg = ChatMessage(sender = "user", isFavorite = true)
+        assertTrue(msg.isFavorite)
+    }
+
+    @Test fun `copy with new content`() {
+        val msg = ChatMessage(sender = "user", content = "original")
+        val copy = msg.copy(content = "modified")
+        assertEquals("modified", copy.content)
+        assertEquals(msg.sender, copy.sender)
+        assertEquals(msg.timestamp, copy.timestamp)
+    }
+
+    @Test fun `copy with new provider`() {
+        val msg = ChatMessage(sender = "ai", provider = "openai")
+        val copy = msg.copy(provider = "anthropic")
+        assertEquals("anthropic", copy.provider)
+    }
+
+    @Test fun `copy with tokens updated`() {
+        val msg = ChatMessage(sender = "ai")
+        val copy = msg.copy(inputTokens = 100, outputTokens = 50)
+        assertEquals(100, copy.inputTokens)
+        assertEquals(50, copy.outputTokens)
+    }
+
+    @Test fun `copy with display mode`() {
+        val msg = ChatMessage(sender = "ai")
+        val copy = msg.copy(displayMode = ChatMessageDisplayMode.HIDDEN_PLACEHOLDER)
+        assertEquals(ChatMessageDisplayMode.HIDDEN_PLACEHOLDER, copy.displayMode)
+    }
+
+    @Test fun `is variant preview defaults to false`() {
+        val msg = ChatMessage(sender = "user")
+        assertFalse(msg.isVariantPreview)
+    }
+
+    @Test fun `content stream defaults to null`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(null, msg.contentStream)
+    }
+
+    @Test fun `cached input tokens defaults to zero`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(0, msg.cachedInputTokens)
+    }
+
+    @Test fun `sent at defaults to zero`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(0L, msg.sentAt)
+    }
+
+    @Test fun `output duration defaults to zero`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(0L, msg.outputDurationMs)
+    }
+
+    @Test fun `wait duration defaults to zero`() {
+        val msg = ChatMessage(sender = "user")
+        assertEquals(0L, msg.waitDurationMs)
+    }
+
+    @Test fun `ai message can have model info`() {
+        val msg = ChatMessage(sender = "ai", modelName = "gpt-4", provider = "openai")
+        assertEquals("gpt-4", msg.modelName)
+        assertEquals("openai", msg.provider)
+    }
+
+    @Test fun `multiple messages have distinct timestamps`() {
+        val msgs = (1..10).map { ChatMessage(sender = "user") }
+        for (i in 1 until msgs.size) {
+            assertTrue(msgs[i].timestamp > msgs[i - 1].timestamp)
+        }
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/ChatMessageTimestampAllocatorTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/ChatMessageTimestampAllocatorTest.kt
@@ -1,0 +1,87 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatMessageTimestampAllocatorTest {
+
+    @Test fun `next returns positive timestamp`() {
+        val ts = ChatMessageTimestampAllocator.next()
+        assertTrue(ts > 0)
+    }
+
+    @Test fun `next returns monotonically increasing values`() {
+        val t1 = ChatMessageTimestampAllocator.next()
+        val t2 = ChatMessageTimestampAllocator.next()
+        val t3 = ChatMessageTimestampAllocator.next()
+        assertTrue(t2 > t1)
+        assertTrue(t3 > t2)
+    }
+
+    @Test fun `next with explicit base timestamp`() {
+        val base = 1000L
+        val ts = ChatMessageTimestampAllocator.next(base)
+        assertTrue(ts >= base)
+    }
+
+    @Test fun `next respects larger explicit base`() {
+        val ts = ChatMessageTimestampAllocator.next(999999999L)
+        assertTrue(ts >= 999999999L)
+    }
+
+    @Test fun `observe increases max timestamp`() {
+        val large = 987654321L
+        ChatMessageTimestampAllocator.observe(large)
+        val next = ChatMessageTimestampAllocator.next()
+        assertTrue(next > large)
+    }
+
+    @Test fun `observe with smaller value does nothing`() {
+        val t1 = ChatMessageTimestampAllocator.next()
+        ChatMessageTimestampAllocator.observe(t1 - 1)
+        val t2 = ChatMessageTimestampAllocator.next()
+        assertTrue(t2 > t1)
+    }
+
+    @Test fun `concurrent next calls produce unique values`() {
+        val timestamps = (1..100).map { ChatMessageTimestampAllocator.next() }
+        val unique = timestamps.toSet()
+        assertEquals(100, unique.size)
+    }
+
+    @Test fun `next handles base timestamp smaller than current`() {
+        val t1 = ChatMessageTimestampAllocator.next()
+        val t2 = ChatMessageTimestampAllocator.next(t1 - 10)
+        assertTrue(t2 > t1)
+    }
+
+    @Test fun `next with current time base`() {
+        val before = System.currentTimeMillis()
+        val ts = ChatMessageTimestampAllocator.next()
+        val after = System.currentTimeMillis()
+        assertTrue(ts >= before - 1 || ts >= ChatMessageTimestampAllocator.next(0)) // just verify it succeeds
+        assertTrue(ts > 0)
+    }
+
+    @Test fun `observe then next is monotonic`() {
+        ChatMessageTimestampAllocator.observe(500L)
+        val ts = ChatMessageTimestampAllocator.next()
+        assertTrue(ts >= 500L)
+    }
+
+    @Test fun `repeated observe with increasing values`() {
+        ChatMessageTimestampAllocator.observe(100L)
+        ChatMessageTimestampAllocator.observe(200L)
+        ChatMessageTimestampAllocator.observe(300L)
+        val ts = ChatMessageTimestampAllocator.next()
+        assertTrue(ts >= 300L)
+    }
+
+    @Test fun `next without explicit base is near current time`() {
+        val now = System.currentTimeMillis()
+        val ts = ChatMessageTimestampAllocator.next()
+        val diff = ts - now
+        assertTrue(diff >= -1) // timestamp should be >= now (approximately)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/FunctionTypeTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/FunctionTypeTest.kt
@@ -1,0 +1,47 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FunctionTypeTest {
+
+    @Test fun `prompt function type has CHAT and VOICE`() {
+        assertEquals(2, PromptFunctionType.values().size)
+        assertTrue(PromptFunctionType.values().contains(PromptFunctionType.CHAT))
+        assertTrue(PromptFunctionType.values().contains(PromptFunctionType.VOICE))
+    }
+
+    @Test fun `prompt function type name returns enum name`() {
+        assertEquals("CHAT", PromptFunctionType.CHAT.name)
+        assertEquals("VOICE", PromptFunctionType.VOICE.name)
+    }
+
+    @Test fun `function type has all expected values`() {
+        val expected = listOf(
+            FunctionType.CHAT, FunctionType.SUMMARY, FunctionType.TITLE_GENERATION,
+            FunctionType.MEMORY, FunctionType.UI_CONTROLLER, FunctionType.TRANSLATION,
+            FunctionType.GREP, FunctionType.ROLE_RESPONSE_PLANNER,
+            FunctionType.IMAGE_RECOGNITION, FunctionType.AUDIO_RECOGNITION,
+            FunctionType.VIDEO_RECOGNITION,
+        )
+        assertEquals(11, FunctionType.values().size)
+        for (type in expected) {
+            assertTrue("Missing $type", FunctionType.values().contains(type))
+        }
+    }
+
+    @Test fun `function type name returns correct string`() {
+        assertEquals("CHAT", FunctionType.CHAT.name)
+        assertEquals("SUMMARY", FunctionType.SUMMARY.name)
+        assertEquals("TITLE_GENERATION", FunctionType.TITLE_GENERATION.name)
+        assertEquals("MEMORY", FunctionType.MEMORY.name)
+        assertEquals("UI_CONTROLLER", FunctionType.UI_CONTROLLER.name)
+        assertEquals("TRANSLATION", FunctionType.TRANSLATION.name)
+        assertEquals("GREP", FunctionType.GREP.name)
+        assertEquals("ROLE_RESPONSE_PLANNER", FunctionType.ROLE_RESPONSE_PLANNER.name)
+        assertEquals("IMAGE_RECOGNITION", FunctionType.IMAGE_RECOGNITION.name)
+        assertEquals("AUDIO_RECOGNITION", FunctionType.AUDIO_RECOGNITION.name)
+        assertEquals("VIDEO_RECOGNITION", FunctionType.VIDEO_RECOGNITION.name)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/MemoryAutoSaveCandidateTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/MemoryAutoSaveCandidateTest.kt
@@ -1,0 +1,111 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Date
+
+class MemoryAutoSaveCandidateTest {
+
+    @Test fun `create with defaults`() {
+        val candidate = MemoryAutoSaveCandidate()
+        assertEquals(0L, candidate.id)
+        assertEquals("", candidate.chatId)
+        assertEquals(0L, candidate.triggerMessageTimestamp)
+        assertNotNull(candidate.createdAt)
+        assertNotNull(candidate.updatedAt)
+        assertEquals(MemoryAutoSaveCandidate.STATUS_PENDING, candidate.status)
+        assertEquals(0, candidate.attemptCount)
+        assertEquals("", candidate.lastError)
+        assertEquals(MemoryAutoSaveCandidate.SOURCE_TYPE_REPLY_FINALIZED_AUTO, candidate.sourceType)
+    }
+
+    @Test fun `create with chat id`() {
+        val candidate = MemoryAutoSaveCandidate(chatId = "chat123")
+        assertEquals("chat123", candidate.chatId)
+    }
+
+    @Test fun `create with trigger timestamp`() {
+        val candidate = MemoryAutoSaveCandidate(triggerMessageTimestamp = 1000L)
+        assertEquals(1000L, candidate.triggerMessageTimestamp)
+    }
+
+    @Test fun `id can be set`() {
+        val candidate = MemoryAutoSaveCandidate(id = 42L)
+        assertEquals(42L, candidate.id)
+    }
+
+    @Test fun `status can be set to processing`() {
+        val candidate = MemoryAutoSaveCandidate(status = MemoryAutoSaveCandidate.STATUS_PROCESSING)
+        assertEquals(MemoryAutoSaveCandidate.STATUS_PROCESSING, candidate.status)
+    }
+
+    @Test fun `status can be set to failed`() {
+        val candidate = MemoryAutoSaveCandidate(status = MemoryAutoSaveCandidate.STATUS_FAILED)
+        assertEquals(MemoryAutoSaveCandidate.STATUS_FAILED, candidate.status)
+    }
+
+    @Test fun `attempt count can be incremented via copy`() {
+        val candidate = MemoryAutoSaveCandidate(attemptCount = 1)
+        val updated = candidate.copy(attemptCount = 2)
+        assertEquals(2, updated.attemptCount)
+        assertEquals(1, candidate.attemptCount) // original unchanged
+    }
+
+    @Test fun `last error is stored`() {
+        val candidate = MemoryAutoSaveCandidate(lastError = "Network error")
+        assertEquals("Network error", candidate.lastError)
+    }
+
+    @Test fun `source type can be selected user message`() {
+        val candidate = MemoryAutoSaveCandidate(
+            sourceType = MemoryAutoSaveCandidate.SOURCE_TYPE_SELECTED_USER_MESSAGE
+        )
+        assertEquals(MemoryAutoSaveCandidate.SOURCE_TYPE_SELECTED_USER_MESSAGE, candidate.sourceType)
+    }
+
+    @Test fun `isSelectedUserMessageSource returns true for user message`() {
+        assertTrue(MemoryAutoSaveCandidate.isSelectedUserMessageSource(
+            MemoryAutoSaveCandidate.SOURCE_TYPE_SELECTED_USER_MESSAGE
+        ))
+    }
+
+    @Test fun `isSelectedUserMessageSource returns false for auto`() {
+        assertFalse(MemoryAutoSaveCandidate.isSelectedUserMessageSource(
+            MemoryAutoSaveCandidate.SOURCE_TYPE_REPLY_FINALIZED_AUTO
+        ))
+    }
+
+    @Test fun `isSelectedUserMessageSource returns false for unknown`() {
+        assertFalse(MemoryAutoSaveCandidate.isSelectedUserMessageSource("unknown"))
+    }
+
+    @Test fun `status constants are defined`() {
+        assertEquals("pending", MemoryAutoSaveCandidate.STATUS_PENDING)
+        assertEquals("processing", MemoryAutoSaveCandidate.STATUS_PROCESSING)
+        assertEquals("failed", MemoryAutoSaveCandidate.STATUS_FAILED)
+    }
+
+    @Test fun `source type constants are defined`() {
+        assertEquals("reply_finalized_auto", MemoryAutoSaveCandidate.SOURCE_TYPE_REPLY_FINALIZED_AUTO)
+        assertEquals("selected_user_message", MemoryAutoSaveCandidate.SOURCE_TYPE_SELECTED_USER_MESSAGE)
+    }
+
+    @Test fun `created at and updated at are set independently`() {
+        val candidate = MemoryAutoSaveCandidate(
+            createdAt = Date(1000L),
+            updatedAt = Date(2000L),
+        )
+        assertEquals(1000L, candidate.createdAt.time)
+        assertEquals(2000L, candidate.updatedAt.time)
+    }
+
+    @Test fun `copy with new status`() {
+        val candidate = MemoryAutoSaveCandidate(status = MemoryAutoSaveCandidate.STATUS_PENDING)
+        val updated = candidate.copy(status = MemoryAutoSaveCandidate.STATUS_PROCESSING)
+        assertEquals(MemoryAutoSaveCandidate.STATUS_PROCESSING, updated.status)
+        assertEquals(MemoryAutoSaveCandidate.STATUS_PENDING, candidate.status)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/MessageEntityTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/MessageEntityTest.kt
@@ -1,0 +1,176 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MessageEntityTest {
+
+    @After
+    fun tearDown() {
+        ChatMessageTimestampAllocator.next()
+    }
+
+    @Test fun `create with required fields`() {
+        val entity = MessageEntity(chatId = "chat1", sender = "user", content = "Hello", orderIndex = 0)
+        assertEquals("chat1", entity.chatId)
+        assertEquals("user", entity.sender)
+        assertEquals("Hello", entity.content)
+        assertEquals(0, entity.orderIndex)
+    }
+
+    @Test fun `message id defaults to zero`() {
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 0)
+        assertEquals(0L, entity.messageId)
+    }
+
+    @Test fun `timestamp defaults to current time`() {
+        val before = System.currentTimeMillis()
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 0)
+        val after = System.currentTimeMillis()
+        assertTrue(entity.timestamp >= before)
+        assertTrue(entity.timestamp <= after + 1000)
+    }
+
+    @Test fun `order index is preserved`() {
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 42)
+        assertEquals(42, entity.orderIndex)
+    }
+
+    @Test fun `role name defaults to empty`() {
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 0)
+        assertEquals("", entity.roleName)
+    }
+
+    @Test fun `selected variant index defaults to zero`() {
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 0)
+        assertEquals(0, entity.selectedVariantIndex)
+    }
+
+    @Test fun `provider defaults to empty`() {
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 0)
+        assertEquals("", entity.provider)
+    }
+
+    @Test fun `model name defaults to empty`() {
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 0)
+        assertEquals("", entity.modelName)
+    }
+
+    @Test fun `tokens default to zero`() {
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 0)
+        assertEquals(0, entity.inputTokens)
+        assertEquals(0, entity.outputTokens)
+        assertEquals(0, entity.cachedInputTokens)
+    }
+
+    @Test fun `display mode defaults to NORMAL`() {
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 0)
+        assertEquals(ChatMessageDisplayMode.NORMAL.name, entity.displayMode)
+    }
+
+    @Test fun `is favorite defaults to false`() {
+        val entity = MessageEntity(chatId = "c", sender = "s", content = "c", orderIndex = 0)
+        assertFalse(entity.isFavorite)
+    }
+
+    @Test fun `toChatMessage converts correctly`() {
+        val entity = MessageEntity(
+            chatId = "chat1",
+            sender = "ai",
+            content = "Response",
+            orderIndex = 1,
+            timestamp = 1000L,
+            roleName = "Assistant",
+            selectedVariantIndex = 0,
+            provider = "openai",
+            modelName = "gpt-4",
+            inputTokens = 10,
+            outputTokens = 20,
+            displayMode = ChatMessageDisplayMode.NORMAL.name,
+            isFavorite = true,
+        )
+        val msg = entity.toChatMessage()
+        assertEquals("ai", msg.sender)
+        assertEquals("Response", msg.content)
+        assertEquals(1000L, msg.timestamp)
+        assertEquals("Assistant", msg.roleName)
+        assertEquals(0, msg.selectedVariantIndex)
+        assertEquals("openai", msg.provider)
+        assertEquals("gpt-4", msg.modelName)
+        assertEquals(10, msg.inputTokens)
+        assertEquals(20, msg.outputTokens)
+        assertEquals(ChatMessageDisplayMode.NORMAL, msg.displayMode)
+        assertEquals(true, msg.isFavorite)
+    }
+
+    @Test fun `toChatMessage handles unknown display mode`() {
+        val entity = MessageEntity(
+            chatId = "c", sender = "s", content = "c", orderIndex = 0,
+            displayMode = "UNKNOWN_MODE"
+        )
+        val msg = entity.toChatMessage()
+        assertEquals(ChatMessageDisplayMode.NORMAL, msg.displayMode)
+    }
+
+    @Test fun `fromChatMessage converts correctly`() {
+        val msg = ChatMessage(
+            sender = "user",
+            content = "Hello",
+            timestamp = 500L,
+            roleName = "User",
+            selectedVariantIndex = 0,
+            provider = "openai",
+            modelName = "gpt-4",
+            inputTokens = 5,
+            outputTokens = 10,
+            isFavorite = true,
+        )
+        val entity = MessageEntity.fromChatMessage("chat1", msg, orderIndex = 0)
+        assertEquals("chat1", entity.chatId)
+        assertEquals("user", entity.sender)
+        assertEquals("Hello", entity.content)
+        assertEquals(500L, entity.timestamp)
+        assertEquals(0, entity.orderIndex)
+        assertEquals("User", entity.roleName)
+        assertEquals(0, entity.selectedVariantIndex)
+        assertEquals("openai", entity.provider)
+        assertEquals("gpt-4", entity.modelName)
+        assertEquals(5, entity.inputTokens)
+        assertEquals(10, entity.outputTokens)
+        assertEquals(true, entity.isFavorite)
+    }
+
+    @Test fun `fromChatMessage with explicit message id`() {
+        val msg = ChatMessage(sender = "user", content = "Hi")
+        val entity = MessageEntity.fromChatMessage("chat1", msg, orderIndex = 0, messageId = 99)
+        assertEquals(99L, entity.messageId)
+    }
+
+    @Test fun `fromChatMessage preserves order index`() {
+        val msg = ChatMessage(sender = "user", content = "Hi")
+        val entity = MessageEntity.fromChatMessage("chat1", msg, orderIndex = 5)
+        assertEquals(5, entity.orderIndex)
+    }
+
+    @Test fun `fromChatMessage round trip preserves data`() {
+        val original = ChatMessage(
+            sender = "ai", content = "Test message", timestamp = 12345L,
+            roleName = "Bot", provider = "test", modelName = "test-model",
+            inputTokens = 7, outputTokens = 3
+        )
+        val entity = MessageEntity.fromChatMessage("chat_x", original, orderIndex = 0)
+        val roundTripped = entity.toChatMessage()
+        assertEquals(original.sender, roundTripped.sender)
+        assertEquals(original.content, roundTripped.content)
+        assertEquals(original.timestamp, roundTripped.timestamp)
+        assertEquals(original.roleName, roundTripped.roleName)
+        assertEquals(original.provider, roundTripped.provider)
+        assertEquals(original.modelName, roundTripped.modelName)
+        assertEquals(original.inputTokens, roundTripped.inputTokens)
+        assertEquals(original.outputTokens, roundTripped.outputTokens)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/MessageVariantEntityTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/MessageVariantEntityTest.kt
@@ -1,0 +1,170 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MessageVariantEntityTest {
+
+    @After
+    fun tearDown() {
+        ChatMessageTimestampAllocator.next()
+    }
+
+    @Test fun `create with required fields`() {
+        val variant = MessageVariantEntity(
+            chatId = "chat1",
+            messageTimestamp = 1000L,
+            variantIndex = 0,
+            content = "Variant content",
+        )
+        assertEquals("chat1", variant.chatId)
+        assertEquals(1000L, variant.messageTimestamp)
+        assertEquals(0, variant.variantIndex)
+        assertEquals("Variant content", variant.content)
+    }
+
+    @Test fun `variant id defaults to zero`() {
+        val variant = MessageVariantEntity(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, content = "c"
+        )
+        assertEquals(0L, variant.variantId)
+    }
+
+    @Test fun `role name defaults to empty`() {
+        val variant = MessageVariantEntity(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, content = "c"
+        )
+        assertEquals("", variant.roleName)
+    }
+
+    @Test fun `provider defaults to empty`() {
+        val variant = MessageVariantEntity(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, content = "c"
+        )
+        assertEquals("", variant.provider)
+    }
+
+    @Test fun `model name defaults to empty`() {
+        val variant = MessageVariantEntity(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, content = "c"
+        )
+        assertEquals("", variant.modelName)
+    }
+
+    @Test fun `tokens default to zero`() {
+        val variant = MessageVariantEntity(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, content = "c"
+        )
+        assertEquals(0, variant.inputTokens)
+        assertEquals(0, variant.outputTokens)
+        assertEquals(0, variant.cachedInputTokens)
+    }
+
+    @Test fun `applyTo updates message content`() {
+        val base = ChatMessage(sender = "ai", content = "Original")
+        val variant = MessageVariantEntity(
+            chatId = "chat1", messageTimestamp = 100L, variantIndex = 1, content = "Updated"
+        )
+        val result = variant.applyTo(base, variantCount = 3)
+        assertEquals("Updated", result.content)
+        assertEquals(1, result.selectedVariantIndex)
+        assertEquals(3, result.variantCount)
+    }
+
+    @Test fun `applyTo preserves base message fields`() {
+        val base = ChatMessage(
+            sender = "ai", content = "Original", timestamp = 500L,
+            roleName = "Assistant", isFavorite = true,
+        )
+        val variant = MessageVariantEntity(
+            chatId = "chat1", messageTimestamp = 100L, variantIndex = 1, content = "Updated"
+        )
+        val result = variant.applyTo(base, variantCount = 2)
+        assertEquals("ai", result.sender)
+        assertEquals(500L, result.timestamp)
+        assertEquals("Assistant", result.roleName)
+        assertEquals(true, result.isFavorite)
+    }
+
+    @Test fun `applyTo uses variant role name when not blank`() {
+        val base = ChatMessage(sender = "ai", content = "Original", roleName = "Assistant")
+        val variant = MessageVariantEntity(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, content = "New",
+            roleName = "CustomBot",
+        )
+        val result = variant.applyTo(base, variantCount = 1)
+        assertEquals("CustomBot", result.roleName)
+    }
+
+    @Test fun `applyTo uses base role name when variant role is blank`() {
+        val base = ChatMessage(sender = "ai", content = "Original", roleName = "Assistant")
+        val variant = MessageVariantEntity(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, content = "New"
+        )
+        val result = variant.applyTo(base, variantCount = 1)
+        assertEquals("Assistant", result.roleName)
+    }
+
+    @Test fun `applyTo updates provider and model`() {
+        val base = ChatMessage(sender = "ai", content = "Original")
+        val variant = MessageVariantEntity(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, content = "New",
+            provider = "anthropic", modelName = "claude-3",
+        )
+        val result = variant.applyTo(base, variantCount = 1)
+        assertEquals("anthropic", result.provider)
+        assertEquals("claude-3", result.modelName)
+    }
+
+    @Test fun `applyTo updates token counts`() {
+        val base = ChatMessage(sender = "ai", content = "Original")
+        val variant = MessageVariantEntity(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, content = "New",
+            inputTokens = 50, outputTokens = 30,
+        )
+        val result = variant.applyTo(base, variantCount = 1)
+        assertEquals(50, result.inputTokens)
+        assertEquals(30, result.outputTokens)
+    }
+
+    @Test fun `fromChatMessage creates variant from message`() {
+        val msg = ChatMessage(
+            sender = "ai", content = "Response",
+            roleName = "Bot", provider = "openai", modelName = "gpt-4",
+            inputTokens = 10, outputTokens = 20,
+        )
+        val variant = MessageVariantEntity.fromChatMessage(
+            chatId = "chat1", messageTimestamp = 1000L, variantIndex = 0, message = msg
+        )
+        assertEquals("chat1", variant.chatId)
+        assertEquals(1000L, variant.messageTimestamp)
+        assertEquals(0, variant.variantIndex)
+        assertEquals("Response", variant.content)
+        assertEquals("Bot", variant.roleName)
+        assertEquals("openai", variant.provider)
+        assertEquals("gpt-4", variant.modelName)
+        assertEquals(10, variant.inputTokens)
+        assertEquals(20, variant.outputTokens)
+    }
+
+    @Test fun `fromChatMessage with explicit variant id`() {
+        val msg = ChatMessage(sender = "user", content = "Hi")
+        val variant = MessageVariantEntity.fromChatMessage(
+            chatId = "c", messageTimestamp = 1L, variantIndex = 0, message = msg, variantId = 55L
+        )
+        assertEquals(55L, variant.variantId)
+    }
+
+    @Test fun `applyTo round trip preserves variant fields`() {
+        val original = ChatMessage(sender = "ai", content = "Original", roleName = "Bot")
+        val variantEntity = MessageVariantEntity.fromChatMessage(
+            chatId = "chat1", messageTimestamp = 100L, variantIndex = 0, message = original
+        )
+        val applied = variantEntity.applyTo(original, variantCount = 1)
+        assertEquals(original.content, applied.content)
+        assertEquals(original.roleName, applied.roleName)
+        assertEquals(0, applied.selectedVariantIndex)
+        assertEquals(1, applied.variantCount)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/MiscModelTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/MiscModelTest.kt
@@ -1,0 +1,275 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MiscModelTest {
+
+    @Test fun `billing mode has TOKEN and COUNT`() {
+        assertTrue(BillingMode.values().contains(BillingMode.TOKEN))
+        assertTrue(BillingMode.values().contains(BillingMode.COUNT))
+    }
+
+    @Test fun `billing mode fromString parses correctly`() {
+        assertEquals(BillingMode.TOKEN, BillingMode.fromString("token"))
+        assertEquals(BillingMode.COUNT, BillingMode.fromString("count"))
+    }
+
+    @Test fun `billing mode fromString default to TOKEN`() {
+        assertEquals(BillingMode.TOKEN, BillingMode.fromString("invalid"))
+        assertEquals(BillingMode.TOKEN, BillingMode.fromString(null))
+    }
+
+    @Test fun `billing mode fromString is case insensitive`() {
+        assertEquals(BillingMode.TOKEN, BillingMode.fromString("TOKEN"))
+        assertEquals(BillingMode.COUNT, BillingMode.fromString("COUNT"))
+    }
+
+    @Test fun `active prompt character card`() {
+        val prompt = ActivePrompt.CharacterCard(id = "card1")
+        assertTrue(prompt is ActivePrompt.CharacterCard)
+        assertEquals("card1", (prompt as ActivePrompt.CharacterCard).id)
+    }
+
+    @Test fun `active prompt character group`() {
+        val prompt = ActivePrompt.CharacterGroup(id = "group1")
+        assertTrue(prompt is ActivePrompt.CharacterGroup)
+        assertEquals("group1", (prompt as ActivePrompt.CharacterGroup).id)
+    }
+
+    @Test fun `ai reference creation`() {
+        val ref = AiReference(text = "source", url = "https://example.com")
+        assertEquals("source", ref.text)
+        assertEquals("https://example.com", ref.url)
+    }
+
+    @Test fun `ai reference empty fields`() {
+        val ref = AiReference(text = "", url = "")
+        assertEquals("", ref.text)
+        assertEquals("", ref.url)
+    }
+
+    @Test fun `custom emoji creation`() {
+        val emoji = CustomEmoji(emotionCategory = "happy", fileName = "smile.jpg", isBuiltInCategory = true)
+        assertEquals("happy", emoji.emotionCategory)
+        assertEquals("smile.jpg", emoji.fileName)
+        assertTrue(emoji.isBuiltInCategory)
+    }
+
+    @Test fun `document chunk creation`() {
+        val chunk = DocumentChunk(content = "Chunk content", chunkIndex = 1)
+        assertEquals("Chunk content", chunk.content)
+        assertEquals(1, chunk.chunkIndex)
+        assertEquals(0L, chunk.id)
+    }
+
+    @Test fun `document chunk default values`() {
+        val chunk = DocumentChunk()
+        assertEquals("", chunk.content)
+        assertEquals(0, chunk.chunkIndex)
+        assertEquals(0L, chunk.id)
+    }
+
+    @Test fun `embedding dimension usage default values`() {
+        val usage = EmbeddingDimensionUsage()
+        assertEquals(0, usage.memoryTotal)
+        assertEquals(0, usage.memoryMissing)
+        assertTrue(usage.memoryDimensions.isEmpty())
+        assertEquals(0, usage.chunkTotal)
+        assertEquals(0, usage.chunkMissing)
+        assertTrue(usage.chunkDimensions.isEmpty())
+    }
+
+    @Test fun `embedding dimension usage with counts`() {
+        val dims = listOf(DimensionCount(dimension = 128, count = 5))
+        val usage = EmbeddingDimensionUsage(
+            memoryTotal = 10, memoryMissing = 2, memoryDimensions = dims,
+            chunkTotal = 20, chunkMissing = 1, chunkDimensions = dims,
+        )
+        assertEquals(10, usage.memoryTotal)
+        assertEquals(2, usage.memoryMissing)
+        assertEquals(1, usage.memoryDimensions.size)
+        assertEquals(128, usage.memoryDimensions[0].dimension)
+        assertEquals(5, usage.memoryDimensions[0].count)
+    }
+
+    @Test fun `embedding rebuild progress default values`() {
+        val progress = EmbeddingRebuildProgress()
+        assertEquals(0, progress.total)
+        assertEquals(0, progress.processed)
+        assertEquals(0, progress.failed)
+        assertEquals("", progress.currentStage)
+    }
+
+    @Test fun `embedding rebuild progress fraction`() {
+        val progress = EmbeddingRebuildProgress(total = 10, processed = 5)
+        assertEquals(0.5f, progress.fraction, 0.001f)
+        assertFalse(progress.isFinished)
+    }
+
+    @Test fun `embedding rebuild progress finished`() {
+        val progress = EmbeddingRebuildProgress(total = 10, processed = 10)
+        assertEquals(1.0f, progress.fraction, 0.001f)
+        assertTrue(progress.isFinished)
+    }
+
+    @Test fun `embedding rebuild progress zero total`() {
+        val progress = EmbeddingRebuildProgress()
+        assertEquals(0f, progress.fraction, 0.001f)
+        assertFalse(progress.isFinished)
+    }
+
+    @Test fun `input processing state idle`() {
+        val state = InputProcessingState.Idle
+        assertTrue(state is InputProcessingState.Idle)
+    }
+
+    @Test fun `input processing state completed`() {
+        val state = InputProcessingState.Completed
+        assertTrue(state is InputProcessingState.Completed)
+    }
+
+    @Test fun `input processing state processing`() {
+        val state = InputProcessingState.Processing(message = "Loading...")
+        assertTrue(state is InputProcessingState.Processing)
+        assertEquals("Loading...", (state as InputProcessingState.Processing).message)
+    }
+
+    @Test fun `input processing state error`() {
+        val state = InputProcessingState.Error(message = "Failed")
+        assertTrue(state is InputProcessingState.Error)
+        assertEquals("Failed", (state as InputProcessingState.Error).message)
+    }
+
+    @Test fun `input processing state connecting`() {
+        val state = InputProcessingState.Connecting(message = "Connecting...")
+        assertTrue(state is InputProcessingState.Connecting)
+    }
+
+    @Test fun `input processing state receiving`() {
+        val state = InputProcessingState.Receiving(message = "Receiving...")
+        assertTrue(state is InputProcessingState.Receiving)
+    }
+
+    @Test fun `input processing state executing tool`() {
+        val state = InputProcessingState.ExecutingTool(toolName = "calculator")
+        assertTrue(state is InputProcessingState.ExecutingTool)
+        assertEquals("calculator", (state as InputProcessingState.ExecutingTool).toolName)
+    }
+
+    @Test fun `input processing state tool progress`() {
+        val state = InputProcessingState.ToolProgress(toolName = "search", progress = 0.5f)
+        assertTrue(state is InputProcessingState.ToolProgress)
+        assertEquals(0.5f, (state as InputProcessingState.ToolProgress).progress, 0.001f)
+    }
+
+    @Test fun `input processing state summarizing`() {
+        val state = InputProcessingState.Summarizing(message = "Summarizing...")
+        assertTrue(state is InputProcessingState.Summarizing)
+    }
+
+    @Test fun `input processing state executing plan`() {
+        val state = InputProcessingState.ExecutingPlan(message = "Planning...")
+        assertTrue(state is InputProcessingState.ExecutingPlan)
+    }
+
+    @Test fun `memory search config creation`() {
+        val config = MemorySearchConfig(
+            scoreMode = MemoryScoreMode.BALANCED,
+            keywordWeight = 10.0f,
+            tagWeight = 0.0f,
+        )
+        assertEquals(MemoryScoreMode.BALANCED, config.scoreMode)
+        assertEquals(10.0f, config.keywordWeight, 0.001f)
+        assertEquals(0.0f, config.tagWeight, 0.001f)
+    }
+
+    @Test fun `memory search debug info creation`() {
+        val info = MemorySearchDebugInfo(
+            query = "test query",
+            keywords = listOf("test"),
+            lexicalTokens = listOf("test"),
+            scoreMode = MemoryScoreMode.BALANCED,
+            relevanceThreshold = 0.5,
+            effectiveKeywordWeight = 1.0,
+            effectiveTagWeight = 0.0,
+            effectiveSemanticWeight = 0.0f,
+            semanticKeywordNormFactor = 0.0,
+            effectiveEdgeWeight = 0.0,
+            memoriesInScopeCount = 10,
+            keywordMatchesCount = 5,
+            tagMatchesCount = 0,
+            reverseContainmentMatchesCount = 0,
+            semanticMatchesCount = 0,
+            graphEdgesTraversed = 0,
+            scoredCount = 5,
+            passedThresholdCount = 3,
+            candidates = emptyList(),
+            finalResultIds = emptyList(),
+        )
+        assertEquals("test query", info.query)
+        assertEquals(5, info.keywordMatchesCount)
+        assertEquals(10, info.memoriesInScopeCount)
+    }
+
+    @Test fun `workflow execution record creation`() {
+        val record = WorkflowExecutionRecord(
+            workflowId = "wf1",
+            workflowName = "Test Workflow",
+            success = true,
+            message = "Completed",
+        )
+        assertEquals("wf1", record.workflowId)
+        assertEquals("Test Workflow", record.workflowName)
+        assertTrue(record.success)
+        assertEquals("Completed", record.message)
+    }
+
+    @Test fun `chat message locator preview creation`() {
+        val preview = ChatMessageLocatorPreview(
+            timestamp = 1000L,
+            sender = "user",
+            previewContent = "Hello",
+            contentLength = 5,
+            displayMode = ChatMessageDisplayMode.NORMAL.name,
+            isFavorite = false,
+        )
+        assertEquals(1000L, preview.timestamp)
+        assertEquals("Hello", preview.previewContent)
+        assertEquals(ChatMessageDisplayMode.NORMAL, preview.resolvedDisplayMode)
+    }
+
+    @Test fun `memory space creation`() {
+        val space = MemorySpace(id = "default", name = "Default")
+        assertEquals("default", space.id)
+        assertEquals("Default", space.name)
+    }
+
+    @Test fun `operit node info creation`() {
+        val info = OperitNodeInfo(
+            className = "android.widget.Button",
+            packageName = "com.example",
+            text = "Submit",
+            contentDescription = null,
+            viewIdResourceName = null,
+            boundsInScreen = "[0,0][100,50]",
+            isClickable = true,
+            isVisibleToUser = true,
+            isFocused = false,
+            isChecked = false,
+        )
+        assertEquals("android.widget.Button", info.className)
+        assertEquals("com.example", info.packageName)
+        assertEquals("Submit", info.text)
+        assertTrue(info.isClickable)
+        assertTrue(info.isVisibleToUser)
+    }
+
+    @Test fun `chat turn options creation`() {
+        val options = ChatTurnOptions(persistTurn = true, hideUserMessage = false)
+        assertTrue(options.persistTurn)
+        assertFalse(options.hideUserMessage)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/ModelParameterTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/ModelParameterTest.kt
@@ -1,0 +1,166 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelParameterTest {
+
+    @Test fun `create int parameter`() {
+        val param = ModelParameter(
+            id = "temp", name = "Temperature", apiName = "temperature",
+            defaultValue = 0.7, currentValue = 0.8, isEnabled = true,
+            valueType = ParameterValueType.FLOAT,
+            minValue = 0.0, maxValue = 2.0,
+            category = ParameterCategory.CREATIVITY,
+        )
+        assertEquals("temp", param.id)
+        assertEquals("Temperature", param.name)
+        assertEquals("temperature", param.apiName)
+        assertEquals(0.7, param.defaultValue, 0.001)
+        assertEquals(0.8, param.currentValue, 0.001)
+        assertTrue(param.isEnabled)
+        assertEquals(ParameterValueType.FLOAT, param.valueType)
+        assertEquals(0.0, (param.minValue as Double), 0.001)
+        assertEquals(2.0, (param.maxValue as Double), 0.001)
+        assertEquals(ParameterCategory.CREATIVITY, param.category)
+    }
+
+    @Test fun `create boolean parameter`() {
+        val param = ModelParameter(
+            id = "stream", name = "Stream", apiName = "stream",
+            defaultValue = true, currentValue = false, isEnabled = true,
+            valueType = ParameterValueType.BOOLEAN,
+        )
+        assertEquals(true, param.defaultValue)
+        assertEquals(false, param.currentValue)
+        assertEquals(ParameterValueType.BOOLEAN, param.valueType)
+    }
+
+    @Test fun `create string parameter`() {
+        val param = ModelParameter(
+            id = "model", name = "Model", apiName = "model",
+            defaultValue = "gpt-4", currentValue = "gpt-3.5", isEnabled = true,
+            valueType = ParameterValueType.STRING,
+        )
+        assertEquals("gpt-4", param.defaultValue)
+        assertEquals("gpt-3.5", param.currentValue)
+        assertEquals(ParameterValueType.STRING, param.valueType)
+    }
+
+    @Test fun `description defaults to empty`() {
+        val param = ModelParameter(
+            id = "t", name = "T", apiName = "t",
+            defaultValue = 1, currentValue = 1, isEnabled = true,
+            valueType = ParameterValueType.INT,
+        )
+        assertEquals("", param.description)
+    }
+
+    @Test fun `min and max can be null`() {
+        val param = ModelParameter(
+            id = "t", name = "T", apiName = "t",
+            defaultValue = 1, currentValue = 1, isEnabled = true,
+            valueType = ParameterValueType.INT,
+        )
+        assertNull(param.minValue)
+        assertNull(param.maxValue)
+    }
+
+    @Test fun `category defaults to OTHER`() {
+        val param = ModelParameter(
+            id = "t", name = "T", apiName = "t",
+            defaultValue = 1, currentValue = 1, isEnabled = true,
+            valueType = ParameterValueType.INT,
+        )
+        assertEquals(ParameterCategory.OTHER, param.category)
+    }
+
+    @Test fun `isCustom defaults to false`() {
+        val param = ModelParameter(
+            id = "t", name = "T", apiName = "t",
+            defaultValue = 1, currentValue = 1, isEnabled = true,
+            valueType = ParameterValueType.INT,
+        )
+        assertFalse(param.isCustom)
+    }
+
+    @Test fun `custom parameter`() {
+        val param = ModelParameter(
+            id = "custom", name = "Custom", apiName = "custom",
+            defaultValue = 5, currentValue = 10, isEnabled = true,
+            valueType = ParameterValueType.INT, isCustom = true,
+        )
+        assertTrue(param.isCustom)
+    }
+
+    @Test fun `parameter can be disabled`() {
+        val param = ModelParameter(
+            id = "t", name = "T", apiName = "t",
+            defaultValue = 1, currentValue = 1, isEnabled = false,
+            valueType = ParameterValueType.INT,
+        )
+        assertFalse(param.isEnabled)
+    }
+
+    @Test fun `parameter value type enum has all values`() {
+        assertEquals(5, ParameterValueType.values().size)
+        assertTrue(ParameterValueType.values().contains(ParameterValueType.INT))
+        assertTrue(ParameterValueType.values().contains(ParameterValueType.FLOAT))
+        assertTrue(ParameterValueType.values().contains(ParameterValueType.STRING))
+        assertTrue(ParameterValueType.values().contains(ParameterValueType.BOOLEAN))
+        assertTrue(ParameterValueType.values().contains(ParameterValueType.OBJECT))
+    }
+
+    @Test fun `parameter category enum has all values`() {
+        assertEquals(4, ParameterCategory.values().size)
+        assertTrue(ParameterCategory.values().contains(ParameterCategory.GENERATION))
+        assertTrue(ParameterCategory.values().contains(ParameterCategory.CREATIVITY))
+        assertTrue(ParameterCategory.values().contains(ParameterCategory.REPETITION))
+        assertTrue(ParameterCategory.values().contains(ParameterCategory.OTHER))
+    }
+
+    @Test fun `custom parameter data with all fields`() {
+        val data = CustomParameterData(
+            id = "custom1", name = "Custom Param", apiName = "custom_param",
+            description = "A custom parameter", defaultValue = "10",
+            currentValue = "20", isEnabled = true, valueType = "INT",
+            minValue = "0", maxValue = "100", category = "GENERATION",
+        )
+        assertEquals("custom1", data.id)
+        assertEquals("Custom Param", data.name)
+        assertEquals("custom_param", data.apiName)
+        assertEquals("A custom parameter", data.description)
+        assertEquals("10", data.defaultValue)
+        assertEquals("20", data.currentValue)
+        assertTrue(data.isEnabled)
+        assertEquals("INT", data.valueType)
+        assertEquals("0", data.minValue)
+        assertEquals("100", data.maxValue)
+        assertEquals("GENERATION", data.category)
+    }
+
+    @Test fun `custom parameter data with defaults`() {
+        val data = CustomParameterData(
+            id = "c", name = "C", apiName = "c",
+            defaultValue = "1", currentValue = "1", isEnabled = true, valueType = "FLOAT",
+        )
+        assertEquals("", data.description)
+        assertNull(data.minValue)
+        assertNull(data.maxValue)
+        assertEquals("OTHER", data.category)
+    }
+
+    @Test fun `custom parameter data copy`() {
+        val data = CustomParameterData(
+            id = "c", name = "C", apiName = "c",
+            defaultValue = "1", currentValue = "2", isEnabled = true, valueType = "INT",
+        )
+        val copy = data.copy(currentValue = "3", isEnabled = false)
+        assertEquals("3", copy.currentValue)
+        assertFalse(copy.isEnabled)
+        assertEquals("1", copy.defaultValue)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/data/model/PromptTagTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/PromptTagTest.kt
@@ -1,0 +1,103 @@
+package com.ai.assistance.operit.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PromptTagTest {
+
+    @Test fun `create with required fields`() {
+        val tag = PromptTag(id = "tag1", name = "Friendly")
+        assertEquals("tag1", tag.id)
+        assertEquals("Friendly", tag.name)
+    }
+
+    @Test fun `description defaults to empty`() {
+        val tag = PromptTag(id = "t1", name = "T")
+        assertEquals("", tag.description)
+    }
+
+    @Test fun `prompt content defaults to empty`() {
+        val tag = PromptTag(id = "t1", name = "T")
+        assertEquals("", tag.promptContent)
+    }
+
+    @Test fun `tag type defaults to CUSTOM`() {
+        val tag = PromptTag(id = "t1", name = "T")
+        assertEquals(TagType.CUSTOM, tag.tagType)
+    }
+
+    @Test fun `created at defaults to current time`() {
+        val before = System.currentTimeMillis()
+        val tag = PromptTag(id = "t1", name = "T")
+        val after = System.currentTimeMillis()
+        assertTrue(tag.createdAt >= before)
+        assertTrue(tag.createdAt <= after + 1000)
+    }
+
+    @Test fun `updated at defaults to current time`() {
+        val before = System.currentTimeMillis()
+        val tag = PromptTag(id = "t1", name = "T")
+        val after = System.currentTimeMillis()
+        assertTrue(tag.updatedAt >= before)
+        assertTrue(tag.updatedAt <= after + 1000)
+    }
+
+    @Test fun `tone tag type`() {
+        val tag = PromptTag(id = "t1", name = "T", tagType = TagType.TONE)
+        assertEquals(TagType.TONE, tag.tagType)
+    }
+
+    @Test fun `character tag type`() {
+        val tag = PromptTag(id = "t1", name = "T", tagType = TagType.CHARACTER)
+        assertEquals(TagType.CHARACTER, tag.tagType)
+    }
+
+    @Test fun `function tag type`() {
+        val tag = PromptTag(id = "t1", name = "T", tagType = TagType.FUNCTION)
+        assertEquals(TagType.FUNCTION, tag.tagType)
+    }
+
+    @Test fun `tag type enum has all values`() {
+        assertEquals(4, TagType.values().size)
+        assertTrue(TagType.values().contains(TagType.TONE))
+        assertTrue(TagType.values().contains(TagType.CHARACTER))
+        assertTrue(TagType.values().contains(TagType.FUNCTION))
+        assertTrue(TagType.values().contains(TagType.CUSTOM))
+    }
+
+    @Test fun `copy with different name`() {
+        val tag = PromptTag(id = "t1", name = "Old")
+        val copy = tag.copy(name = "New")
+        assertEquals("New", copy.name)
+        assertEquals("t1", copy.id)
+    }
+
+    @Test fun `copy with prompt content`() {
+        val tag = PromptTag(id = "t1", name = "T")
+        val copy = tag.copy(promptContent = "You are helpful")
+        assertEquals("You are helpful", copy.promptContent)
+    }
+
+    @Test fun `model option creation`() {
+        val option = ModelOption(id = "gpt-4", name = "GPT-4")
+        assertEquals("gpt-4", option.id)
+        assertEquals("GPT-4", option.name)
+    }
+
+    @Test fun `workspace rename result creation`() {
+        val result = WorkspaceRenameResult(
+            workspacePath = "/path/to/ws",
+            workspaceEnv = "production",
+            workspaceName = "My Workspace",
+        )
+        assertEquals("/path/to/ws", result.workspacePath)
+        assertEquals("production", result.workspaceEnv)
+        assertEquals("My Workspace", result.workspaceName)
+    }
+
+    @Test fun `workspace rename result null env`() {
+        val result = WorkspaceRenameResult("/path", null, "Name")
+        assertEquals(null, result.workspaceEnv)
+    }
+}

--- a/docs/TODO/calculator_qualified_api_repair_20260809/1_QualifiedApiImplementation.md
+++ b/docs/TODO/calculator_qualified_api_repair_20260809/1_QualifiedApiImplementation.md
@@ -1,0 +1,24 @@
+# Qualified API Implementation
+
+## Existing behavior
+
+`JsCalculator` advertises `Math.sin`, `Math.cos`, and `stats.*` functions.
+The parser only recognizes `Math.method(...)`, while the evaluator only dispatches
+unqualified math names. It does not parse `stats.method(...)` at all. `Math.PI`,
+used by the in-source calculator example, is also parsed as an invalid method call.
+
+## Intended correction
+
+Recognize the documented `Math` and `stats` namespaces for function calls. Resolve
+the `Math.PI` and `Math.E` constants using the existing calculator constants, and
+normalize only the `Math.` function namespace before the established math dispatch.
+
+No general object member syntax is added. Array `.length` retains its existing
+special handling, and arbitrary dotted identifiers continue to be rejected.
+
+## Verification
+
+Perform static review and whitespace validation. Builds and tests are not run under
+the repository execution rules because the user did not request them.
+
+[DONE]

--- a/docs/TODO/calculator_qualified_api_repair_20260809/index.md
+++ b/docs/TODO/calculator_qualified_api_repair_20260809/index.md
@@ -1,0 +1,31 @@
+---
+fork: https://github.com/tuxKOH/Operit
+branch: test/calculator-data-model-tests
+---
+
+# Calculator Qualified API Repair
+
+The calculator test branch adds coverage for the calculator and data-model modules.
+Review found that two documented calculator APIs are currently treated as unsupported
+syntax by the new tests: `Math.*` and `stats.*`.
+
+This work keeps the documented public syntax intact, makes the parser and evaluator
+agree on it, and replaces the failure expectations with regression coverage.
+
+Scope:
+
+- `ExpressionParser.kt`
+- `ExpressionContext.kt`
+- calculator parser tests
+- this task record
+
+Expected outcome:
+
+- `Math.sin(0)` evaluates to `0`
+- `Math.PI` can be used in expressions
+- `stats.mean(2, 4, 6, 8)` evaluates to `5`
+- arbitrary dotted identifiers remain unsupported
+
+Steps:
+
+- [Qualified API implementation](1_QualifiedApiImplementation.md)


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

This branch brings the calculator and data-model test coverage from the former #786 integration branch to main. Review found that its parser tests encoded two documented calculator APIs as unsupported even though the calculator advertises and demonstrates them.

### 改动范围 / Changes

- Add the calculator and data-model unit tests from the branch.
- Support documented Math.* calls and Math.PI / Math.E constants.
- Parse documented stats.* calls and add regression assertions.
- Do not add general object-member syntax or change the existing .length behavior.

### 兼容性与风险 / Compatibility and risks

The change restores already documented calculator expressions. Arbitrary dotted identifiers remain unsupported, so the parser surface does not broaden beyond the existing public namespaces.

## 关联 Issue / Related issue

N/A. This merges the existing calculator/data-model test branch and repairs issues found during its review.

## 验证方式 / Verification

`	ext
检查或命令：git diff --check
环境与变体：Static source and diff review
结果：Passed. No build or test command was run because repository guidance requires explicit user authorization for those commands.
`

## 证据 / Evidence

Math.sin(Math.PI / 2) evaluates to 1, Math.E evaluates to the existing constant, and stats.mean(2, 4, 6, 8) evaluates to 5 in the added regression tests.

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 Candidate checks 覆盖改动范围，并会处理技术失败项 / Candidate checks covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided