### PR TITLE
ci: prepare native ripgrep for JVM checks

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -265,8 +265,11 @@ jobs:
           if [[ "$JVM_REQUIRED" == "true" || "$FULL_REQUIRED" == "true" ]]; then
             packages+=("platform-tools" "platforms;android-34" "platforms;android-36")
           fi
+          if [[ "$JVM_REQUIRED" == "true" || "$FULL_REQUIRED" == "true" ]]; then
+            packages+=("ndk;$ANDROID_NDK_VERSION")
+          fi
           if [[ "$FULL_REQUIRED" == "true" ]]; then
-            packages+=("ndk;$ANDROID_NDK_VERSION" "cmake;$ANDROID_CMAKE_VERSION")
+            packages+=("cmake;$ANDROID_CMAKE_VERSION")
           fi
           sdkmanager --install "${packages[@]}"
 
@@ -345,7 +348,7 @@ jobs:
             --repository "$GITHUB_WORKSPACE"
 
       - name: Restore native ripgrep cache
-        if: steps.plan.outputs.android_full == 'true'
+        if: steps.plan.outputs.android_jvm == 'true' || steps.plan.outputs.android_full == 'true'
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
@@ -355,7 +358,7 @@ jobs:
           key: native-ripgrep-arm64-${{ runner.os }}-${{ hashFiles('tools/native_ripgrep/Cargo.lock') }}
 
       - name: Build native ripgrep
-        if: steps.plan.outputs.android_full == 'true'
+        if: steps.plan.outputs.android_jvm == 'true' || steps.plan.outputs.android_full == 'true'
         shell: bash
         run: |
           set -euo pipefail

--- a/docs/TODO/native_ripgrep_pr_check_20260809/1_PrepareNativeRipgrep.md
+++ b/docs/TODO/native_ripgrep_pr_check_20260809/1_PrepareNativeRipgrep.md
@@ -1,0 +1,22 @@
+# Prepare Native Ripgrep
+
+## Existing behavior
+
+`pr-check.yml` runs `:app:testDebugUnitTest` when `android_jvm` is enabled.
+Gradle requires `liboperit_ripgrep.so` before its pre-build phase. The workflow
+installs the NDK and builds that library only when `android_full` is enabled,
+so test-only Android pull requests fail before their test suite executes.
+
+## Intended correction
+
+Install the NDK and build native ripgrep for either `android_jvm` or
+`android_full`. Keep CMake, full dependency preparation, and all resource-only
+paths scoped to the full lane.
+
+## Verification
+
+Validate the workflow diff statically, then use the PR Check run as the build
+verification. No local build or test command is run because repository guidance
+requires explicit user authorization.
+
+[DONE]

--- a/docs/TODO/native_ripgrep_pr_check_20260809/index.md
+++ b/docs/TODO/native_ripgrep_pr_check_20260809/index.md
@@ -1,0 +1,23 @@
+---
+fork: https://github.com/tuxKOH/Operit
+branch: ci/prepare-native-ripgrep-for-jvm-checks
+---
+
+# Native Ripgrep PR Check Repair
+
+The PR Check workflow runs Android JVM tests for test-only Android changes. Those
+tests invoke the Gradle native-library verification task, but the workflow builds
+the required native ripgrep library only for the full Android lane.
+
+The workflow must prepare the Android NDK and native ripgrep library whenever it
+runs the Android JVM or full Android lane. The resource-only lane remains unchanged.
+
+Expected outcome:
+
+- Android JVM checks receive a non-empty `liboperit_ripgrep.so`
+- full Android checks retain their existing native preparation
+- resource-only checks do not install the NDK or build the native library
+
+Steps:
+
+- [Prepare native ripgrep for JVM checks](1_PrepareNativeRipgrep.md)


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

The Candidate checks run for #902 failed before unit tests started because Gradle requires liboperit_ripgrep.so, while the PR workflow only builds it in the full Android lane. Test-only Android changes select the JVM lane instead.

### 改动范围 / Changes

- Install the Android NDK for Android JVM and full lanes.
- Restore and build native ripgrep for Android JVM and full lanes.
- Keep CMake, full dependencies, and STT assets scoped to the full Android lane.

### 兼容性与风险 / Compatibility and risks

No application behavior changes. Android JVM PR checks now perform the native preparation required by Gradle before running unit tests; this adds required CI work only to Android JVM checks.

## 关联 Issue / Related issue

N/A. This repairs the pre-test CI failure reported by Candidate checks on #902 and earlier PR checks.

## 验证方式 / Verification

`	ext
检查或命令：git diff --check; cloud Candidate checks
环境与变体：GitHub Actions Android JVM lane
结果：Static diff check passed. Cloud verification is pending for this PR. No local build or test command was run because repository guidance requires explicit user authorization.
`

## 证据 / Evidence

The prior failure was Missing or empty externally built native library: liboperit_ripgrep.so from :app:verifyExternallyBuiltNativeLibraries.

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 Candidate checks 覆盖改动范围，并会处理技术失败项 / Candidate checks covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided