### PR TITLE
fix(chat): prevent copy preview sheet rebound

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
@@ -62,7 +62,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -72,6 +76,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ai.assistance.operit.R
@@ -1138,6 +1143,37 @@ private fun MessageCopyPreviewBottomSheet(
     val clipboardManager = LocalClipboardManager.current
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val textScrollState = rememberScrollState()
+    val copyPreviewNestedScrollConnection =
+        remember(textScrollState) {
+            object : NestedScrollConnection {
+                override fun onPostScroll(
+                    consumed: Offset,
+                    available: Offset,
+                    source: NestedScrollSource,
+                ): Offset {
+                    return if (
+                        source == NestedScrollSource.UserInput &&
+                            textScrollState.value == 0 &&
+                            available.y > 0f
+                    ) {
+                        Offset(x = 0f, y = available.y)
+                    } else {
+                        Offset.Zero
+                    }
+                }
+
+                override suspend fun onPostFling(
+                    consumed: Velocity,
+                    available: Velocity,
+                ): Velocity {
+                    return if (textScrollState.value == 0 && available.y > 0f) {
+                        Velocity(x = 0f, y = available.y)
+                    } else {
+                        Velocity.Zero
+                    }
+                }
+            }
+        }
     var showPlainText by remember(text) { mutableStateOf(true) }
     var plainText by remember(text) { mutableStateOf<String?>(null) }
     LaunchedEffect(text, context) {
@@ -1201,6 +1237,8 @@ private fun MessageCopyPreviewBottomSheet(
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(max = 520.dp)
+                        // Keep top pulls in the preview so the sheet does not start a second rebound.
+                        .nestedScroll(copyPreviewNestedScrollConnection)
                         .verticalScroll(textScrollState)
                         .padding(bottom = 12.dp)
                 ) {


### PR DESCRIPTION
## 变更说明 / Description

修复复制消息预览中，文本滚动到顶部后强力下拉会反复触发底部弹层回弹的问题。

### 背景与动机 / Context and motivation

复制预览同时使用可滚动的 `SelectionContainer` 和可拖动的 `ModalBottomSheet`。文本到达顶部后，未消费的向下位移和 fling 会继续传给 Material3 弹层，使同一次手势同时驱动文本 overscroll 与弹层锚点动画，表现为弹层反复回弹。

此前针对复制页面滚动的修复替换了文本选择组件，但没有隔离这条 nested-scroll 手势链路。

### 改动范围 / Changes

- 在复制预览文本区域增加局部 `NestedScrollConnection`。
- 文本位于顶部时，消费向下的剩余滚动和 fling，避免继续驱动底部弹层。
- 保留文本正常滚动、选择复制，以及弹层非文本区域和其他关闭方式的原有行为。
- 不包含 Compose 依赖升级、复制文本转换逻辑或其他聊天滚动行为调整。

### 兼容性与风险 / Compatibility and risks

- 用户行为：复制预览文本区域在顶部向下拖动时不再带动整个底部弹层；其他弹层关闭方式不变。
- API、数据格式、配置、性能与安全：N/A。
- 风险局限于复制预览中的纵向 nested-scroll 手势分发。

## 关联 Issue / Related issue

Fixes #901

## 验证方式 / Verification

```text
检查或命令：git diff --check upstream/main...HEAD
环境与变体：Windows 工作树；Kotlin/Java 路径将由 PR Candidate checks 执行 JVM 单测
结果：差异检查通过；按仓库执行规则未运行本地 Android 构建、自动化测试或真机验证，真机动画回归待确认
```

## 证据 / Evidence

- 修复前复现录屏见 #901。
- 最终 diff 仅修改 `ChatArea.kt`，在文本滚动与 `ModalBottomSheet` 之间隔离顶部向下的剩余位移和速度。
- 修复后真机录屏尚未提供。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [ ] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided