### PR TITLE
fix(composedsl): use supported size modifier

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslScreen.kt
@@ -59,7 +59,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -79,7 +78,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
@@ -1929,7 +1927,7 @@ private fun renderAdaptiveSidePanelNode(
                     Box(
                         modifier =
                             Modifier
-                                .matchParentSize()
+                                .fillMaxSize()
                                 .background(Color.Black.copy(alpha = 0.18f))
                                 .clickable { onAction(onOpenChangedActionId, false) }
                     )


### PR DESCRIPTION
## 变更说明\n\n修复 ToolPkg Compose DSL 屏蔽层使用不适用布局修饰符导致的 Kotlin 编译错误。将 matchParentSize() 替换为公开的 illMaxSize()，并移除对应无用导入。\n\n## 验证\n\n未运行本地构建或测试；仅提交目标文件。