### PR TITLE
fix(market): allow withdrawn entry updates

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/UnifiedMarketManageScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/UnifiedMarketManageScreen.kt
@@ -379,11 +379,12 @@ private fun ManagedEntryCard(
     val canSubmitRevision = review.state == MarketReviewState.CHANGES_REQUESTED
     // A pending listing has no public detail shard, so public-detail actions cannot be opened yet.
     val canOpenPublicEntry = entry.isOpen() && entry.listingState != "pending_listing"
+    val canPublishNewVersion = canOpenPublicEntry || (canManageEntry && entry.isWithdrawn())
     MarketManageItemCard(
         title = entry.title,
         description = entry.manageSummaryText(),
         isOpen = canOpenPublicEntry,
-        showActions = canManageEntry || canOpenPublicEntry || canSubmitRevision,
+        showActions = canPublishNewVersion || canSubmitRevision || (canManageEntry && entry.isOpen()),
         onClick = {
             if (canOpenPublicEntry) {
                 viewModel.openEntryDetail(entry, onNavigateToDetail)
@@ -436,12 +437,12 @@ private fun ManagedEntryCard(
                     }
                 )
             }
-            if (canOpenPublicEntry) {
+            if (canPublishNewVersion) {
                 MarketManageSecondaryActionButton(
                     label = stringResource(R.string.market_publish_new_version),
                     icon = Icons.Default.NewReleases,
                     onClick = {
-                        viewModel.openEntryDetail(entry) { fullEntry ->
+                        val openNewVersionScreen = { fullEntry: MarketV2Entry ->
                             when (val type = fullEntry.marketStatsType()) {
                                 MarketStatsType.SCRIPT,
                                 MarketStatsType.PACKAGE -> onNavigateToPublishArtifactVersion(fullEntry, canManageEntry)
@@ -449,6 +450,11 @@ private fun ManagedEntryCard(
                                 MarketStatsType.MCP -> onNavigateToPublishRepoVersion(type, fullEntry, canManageEntry)
                                 null -> Unit
                             }
+                        }
+                        if (canOpenPublicEntry) {
+                            viewModel.openEntryDetail(entry, openNewVersionScreen)
+                        } else {
+                            viewModel.openOwnedEntryDetail(entry, openNewVersionScreen)
                         }
                     }
                 )
@@ -580,6 +586,10 @@ private fun MarketManageRelationBadge(relation: String) {
 
 private fun MarketV2PublisherEntrySummary.isOpen(): Boolean {
     return stateCode.equals("approved", ignoreCase = true) || stateCode.equals("open", ignoreCase = true)
+}
+
+private fun MarketV2PublisherEntrySummary.isWithdrawn(): Boolean {
+    return stateCode.equals("withdrawn", ignoreCase = true)
 }
 
 private fun MarketV2PublisherEntrySummary.isOwnerRelation(): Boolean {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/market/viewmodel/UnifiedMarketManageViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/market/viewmodel/UnifiedMarketManageViewModel.kt
@@ -177,6 +177,13 @@ class UnifiedMarketManageViewModel(
             return
         }
         AppLogger.i(TAG, "revision_gate decision=allowed entryId=${entry.id} next=getMyEntryDetail")
+        openOwnedEntryDetail(entry, onLoaded)
+    }
+
+    fun openOwnedEntryDetail(
+        entry: MarketV2PublisherEntrySummary,
+        onLoaded: (MarketV2Entry) -> Unit
+    ) {
         viewModelScope.launch {
             if (!githubAuth.isLoggedIn()) {
                 _errorMessage.value = context.getString(R.string.skillmarket_github_login_required)
@@ -197,7 +204,7 @@ class UnifiedMarketManageViewModel(
                 onLoaded(fullEntry)
             } catch (e: Exception) {
                 _errorMessage.value = e.message ?: context.getString(R.string.market_error_load_failed)
-                AppLogger.e(TAG, "Failed to load revision detail for managed market entry ${entry.id}", e)
+                AppLogger.e(TAG, "Failed to load owner detail for managed market entry ${entry.id}", e)
             } finally {
                 _isLoading.value = false
             }

--- a/docs/TODO/withdrawn_entry_republish_20260811/01_owner_republish_flow.md
+++ b/docs/TODO/withdrawn_entry_republish_20260811/01_owner_republish_flow.md
@@ -1,0 +1,34 @@
+# Owner Republish Flow
+
+## Previous behavior
+
+Withdrawing an entry changes its state to `withdrawn`. The management page
+only exposes the new-version action for public entries, leaving the owner
+without a path to submit a reviewed update.
+
+## Intended behavior
+
+The owner of a withdrawn entry can open the existing new-version flow. The
+screen loads the owner's private entry detail and submits the version against
+the original entry ID. When that version passes review, the existing Worker
+approval mutation sets the entry state to `approved`, allowing the market
+projections to list it again.
+
+## Scope
+
+- `UnifiedMarketManageScreen`
+- `UnifiedMarketManageViewModel`
+- Market Worker review-approval handler verification
+
+## Verification
+
+- Statically verify the withdrawn owner action uses `getMyEntryDetail`
+- Statically verify the existing entry ID reaches `publishNewVersion`
+- Verify the Worker routes withdrawn-entry approval through `reviewApproveEntry`
+- Verify `reviewApproveEntry` writes `approved` to both the entry and version
+
+[DONE] The Android management page now exposes the existing new-version flow to
+the owner of a withdrawn entry and loads its private entry detail before
+navigation. The Worker already routes approval of a withdrawn entry through
+`reviewApproveEntry`, which restores the entry and approved version to
+`approved` before rebuilding the relevant projections.

--- a/docs/TODO/withdrawn_entry_republish_20260811/index.md
+++ b/docs/TODO/withdrawn_entry_republish_20260811/index.md
@@ -1,0 +1,23 @@
+---
+Fork: local workspace
+Status: complete
+---
+
+# Withdrawn Entry Republish
+
+## Intent
+
+Authors must be able to submit a new version for an entry they previously
+withdrew. Approval of that version returns the existing entry to the public
+market.
+
+## Scope
+
+- Market-management actions for withdrawn owner entries
+- Loading the owner's non-public entry detail before publishing a new version
+- Verification of the Market Worker review-approval transition
+
+## Non-goals
+
+- Creating a second market entry for the same project
+- Adding an immediate restore action without review


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

下架条目的作者在市场管理页无法再提交新版本，尽管市场 Worker 已支持原作者的新版本审核通过后恢复上架。

### 改动范围 / Changes

- 为下架条目的作者显示现有的发布新版本操作
- 通过作者私有详情加载同一市场条目后进入原有发布流程
- 记录并静态核对 Worker 的恢复上架状态转换

### 兼容性与风险 / Compatibility and risks

不修改 API、数据格式或配置。下架条目仍需新版本审核通过才恢复公开；非作者不能通过该路径恢复条目。

## 关联 Issue / Related issue

N/A - 修复市场管理页缺失的既有状态流入口。

## 验证方式 / Verification

```text
检查或命令：git diff --check；发布路径和 Worker 审核状态转换的静态核对
环境与变体：未运行 Android 构建或测试
结果：静态检查通过；构建与测试遵循仓库默认约束未运行
```

## 证据 / Evidence

Worker 对 withdrawn 条目只允许原作者提交版本；审核批准走完整 entry approval mutation，将条目和版本设为 approved 后重建投影。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided