### PR TITLE
feat(chat): 支持多选消息复制为纯文本

### DIFF
--- a/app/src/androidTest/java/com/ai/assistance/operit/ui/common/markdown/MarkdownPlainTextRendererAndroidTest.kt
+++ b/app/src/androidTest/java/com/ai/assistance/operit/ui/common/markdown/MarkdownPlainTextRendererAndroidTest.kt
@@ -16,6 +16,11 @@ class MarkdownPlainTextRendererAndroidTest {
         latexToPlainText: (List<String>) -> List<String> = { it },
     ): String = runBlocking { markdownToPlainTextForCopy(markdown, latexToPlainText) }
 
+    @Test fun markdownToPlainTextForCopy_preservesSingleLineUserText() {
+        assertEquals("3", render("3"))
+        assertEquals("plain user message", render("plain user message"))
+    }
+
     @Test fun markdownToPlainTextForCopy_removesFormattingMarkers() {
         val content =
             """

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/MarkdownPlainTextRenderer.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/MarkdownPlainTextRenderer.kt
@@ -12,7 +12,9 @@ internal suspend fun markdownToPlainTextForCopy(
     markdown: String,
     latexToPlainText: (List<String>) -> List<String> = { it },
 ): String {
-    val nodes = parseMarkdownToNodes(markdown).map { it.toStableNode() }
+    // A complete document needs an explicit line ending to flush native streaming parser lookahead.
+    val completeMarkdown = if (markdown.endsWith('\n')) markdown else "$markdown\n"
+    val nodes = parseMarkdownToNodes(completeMarkdown).map { it.toStableNode() }
     val latexSegments = mutableListOf<String>()
     val rendered = joinBlocks(nodes, latexSegments)
     // 折叠"空白行"：2 个以上换行（中间可能夹着空格/全角空格等水平空白，例如模型输出里

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
@@ -147,6 +147,24 @@ internal fun cleanMessageContentForCopy(content: String): String {
         .trim()
 }
 
+internal suspend fun buildSelectedMessagesPlainText(
+    chatHistory: List<ChatMessage>,
+    selectedMessageIndices: Set<Int>,
+    markdownToPlainText: suspend (String) -> String,
+): String {
+    return selectedMessageIndices
+        .sorted()
+        .mapNotNull(chatHistory::getOrNull)
+        .filter { message -> message.sender == "user" || message.sender == "ai" }
+        .filterNot(::isHiddenUserPlaceholder)
+        .mapNotNull { message ->
+            markdownToPlainText(cleanMessageContentForCopy(message.content))
+                .trim()
+                .takeIf(String::isNotEmpty)
+        }
+        .joinToString("\n\n")
+}
+
 private fun isHiddenUserPlaceholder(message: ChatMessage): Boolean {
     return message.sender == "user" &&
         message.displayMode == ChatMessageDisplayMode.HIDDEN_PLACEHOLDER

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
@@ -148,13 +148,10 @@ internal fun cleanMessageContentForCopy(content: String): String {
 }
 
 internal suspend fun buildSelectedMessagesPlainText(
-    chatHistory: List<ChatMessage>,
-    selectedMessageIndices: Set<Int>,
+    messages: List<ChatMessage>,
     markdownToPlainText: suspend (String) -> String,
 ): String {
-    return selectedMessageIndices
-        .sorted()
-        .mapNotNull(chatHistory::getOrNull)
+    return messages
         .filter { message -> message.sender == "user" || message.sender == "ai" }
         .filterNot(::isHiddenUserPlaceholder)
         .mapNotNull { message ->

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import com.ai.assistance.operit.util.AppLogger
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -19,7 +20,9 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -32,7 +35,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -52,6 +58,7 @@ import kotlinx.coroutines.launch
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
@@ -71,9 +78,13 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.ui.res.stringResource
 import com.ai.assistance.operit.R
+import com.ai.assistance.operit.ui.common.markdown.markdownToPlainTextForCopy
 import com.ai.assistance.operit.ui.features.chat.components.MessageEditor
 import com.ai.assistance.operit.ui.main.screens.GestureStateHolder
+import com.ai.assistance.operit.util.LatexMathMlConverter
 import kotlin.math.roundToInt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -160,6 +171,7 @@ fun ChatScreenContent(
 
     // Export state
     val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
     var showExportPlatformDialog by remember { mutableStateOf(false) }
     var showAndroidExportDialog by remember { mutableStateOf(false) }
     var showWindowsExportDialog by remember { mutableStateOf(false) }
@@ -459,6 +471,7 @@ fun ChatScreenContent(
                 ) {
                     // 显示选中数量
                     Row(
+                        modifier = Modifier.weight(1f),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
@@ -486,11 +499,17 @@ fun ChatScreenContent(
                             },
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurface,
-                            fontWeight = androidx.compose.ui.text.font.FontWeight.Medium
+                            fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
                         )
                     }
 
                     Row(
+                        modifier = Modifier
+                            .weight(2f)
+                            .horizontalScroll(rememberScrollState()),
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -544,6 +563,57 @@ fun ChatScreenContent(
                             Icon(
                                 imageVector = Icons.Default.CheckCircle,
                                 contentDescription = stringResource(R.string.add_selected_to_memory),
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+
+                        FilledIconButton(
+                            onClick = {
+                                if (selectedMessageIndices.isNotEmpty()) {
+                                    val indicesToCopy = selectedMessageIndices
+                                    coroutineScope.launch {
+                                        val copiedText =
+                                            withContext(Dispatchers.Default) {
+                                                buildSelectedMessagesPlainText(
+                                                    chatHistory = chatHistory,
+                                                    selectedMessageIndices = indicesToCopy,
+                                                ) { markdown ->
+                                                    markdownToPlainTextForCopy(markdown) { formulas ->
+                                                        LatexMathMlConverter.convertAll(context, formulas)
+                                                    }
+                                                }
+                                            }
+                                        if (copiedText.isNotEmpty()) {
+                                            clipboardManager.setText(AnnotatedString(copiedText))
+                                            Toast.makeText(
+                                                context,
+                                                context.getString(R.string.message_copied_to_clipboard),
+                                                Toast.LENGTH_SHORT,
+                                            ).show()
+                                            isMultiSelectMode = false
+                                            selectedMessageIndices = emptySet()
+                                        } else {
+                                            Toast.makeText(
+                                                context,
+                                                context.getString(R.string.no_text_to_copy),
+                                                Toast.LENGTH_SHORT,
+                                            ).show()
+                                        }
+                                    }
+                                }
+                            },
+                            enabled = selectedMessageIndices.isNotEmpty(),
+                            modifier = Modifier.size(32.dp),
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                            )
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.ContentCopy,
+                                contentDescription = stringResource(R.string.copy_text),
                                 modifier = Modifier.size(16.dp)
                             )
                         }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -595,7 +595,10 @@ fun ChatScreenContent(
                         FilledIconButton(
                             onClick = {
                                 if (selectedMessageIndices.isNotEmpty() && !isCopyingSelectedMessages) {
-                                    val indicesToCopy = selectedMessageIndices
+                                    val messagesToCopy =
+                                        selectedMessageIndices
+                                            .sorted()
+                                            .mapNotNull(chatHistory::getOrNull)
                                     isCopyingSelectedMessages = true
                                     selectedMessagesCopyJob = selectedMessagesCopyScope.launch {
                                         val currentCopyJob = coroutineContext[Job]
@@ -603,8 +606,7 @@ fun ChatScreenContent(
                                             val copiedText =
                                                 withContext(Dispatchers.Default) {
                                                     buildSelectedMessagesPlainText(
-                                                        chatHistory = chatHistory,
-                                                        selectedMessageIndices = indicesToCopy,
+                                                        messages = messagesToCopy,
                                                     ) { markdown ->
                                                         markdownToPlainTextForCopy(markdown) { formulas ->
                                                             LatexMathMlConverter.convertAll(context, formulas)

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -53,7 +53,9 @@ import com.ai.assistance.operit.ui.features.chat.viewmodel.ChatHistoryDisplayMod
 import com.ai.assistance.operit.ui.features.chat.components.style.bubble.BubbleImageStyleConfig
 import com.ai.assistance.operit.ui.features.chat.webview.workspace.WorkspaceBackupManager
 import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
@@ -155,6 +157,9 @@ fun ChatScreenContent(
     // Multi-select mode state
     var isMultiSelectMode by remember { mutableStateOf(false) }
     var selectedMessageIndices by remember { mutableStateOf(setOf<Int>()) }
+    var isCopyingSelectedMessages by remember { mutableStateOf(false) }
+    var selectedMessagesCopyJob by remember { mutableStateOf<Job?>(null) }
+    val messageOrder = chatHistory.map(ChatMessage::timestamp)
     val selectableMessageIndices = remember(chatHistory) {
         chatHistory.mapIndexedNotNull { index, message ->
             if (message.sender == "user" || message.sender == "ai") index else null
@@ -172,12 +177,23 @@ fun ChatScreenContent(
     // Export state
     val context = LocalContext.current
     val clipboardManager = LocalClipboardManager.current
+    val selectedMessagesCopyScope = rememberCoroutineScope()
     var showExportPlatformDialog by remember { mutableStateOf(false) }
     var showAndroidExportDialog by remember { mutableStateOf(false) }
     var showWindowsExportDialog by remember { mutableStateOf(false) }
     var showExportProgressDialog by remember { mutableStateOf(false) }
     var showExportCompleteDialog by remember { mutableStateOf(false) }
     var exportProgress by remember { mutableStateOf(0f) }
+
+    LaunchedEffect(currentChatId, messageOrder) {
+        selectedMessagesCopyJob?.cancel()
+        selectedMessagesCopyJob = null
+        isCopyingSelectedMessages = false
+        if (isMultiSelectMode) {
+            isMultiSelectMode = false
+            selectedMessageIndices = emptySet()
+        }
+    }
     var exportStatus by remember { mutableStateOf("") }
     var exportSuccess by remember { mutableStateOf(false) }
     var exportFilePath by remember { mutableStateOf<String?>(null) }
@@ -303,6 +319,9 @@ fun ChatScreenContent(
                         onToggleMultiSelectMode = { initialIndex ->
                             isMultiSelectMode = !isMultiSelectMode
                             if (!isMultiSelectMode) {
+                                selectedMessagesCopyJob?.cancel()
+                                selectedMessagesCopyJob = null
+                                isCopyingSelectedMessages = false
                                 selectedMessageIndices = emptySet()
                             } else if (initialIndex != null) {
                                 // 进入多选模式时，自动选中触发的消息
@@ -420,6 +439,9 @@ fun ChatScreenContent(
                         onToggleMultiSelectMode = { initialIndex ->
                             isMultiSelectMode = !isMultiSelectMode
                             if (!isMultiSelectMode) {
+                                selectedMessagesCopyJob?.cancel()
+                                selectedMessagesCopyJob = null
+                                isCopyingSelectedMessages = false
                                 selectedMessageIndices = emptySet()
                             } else if (initialIndex != null) {
                                 // 进入多选模式时，自动选中触发的消息
@@ -478,6 +500,9 @@ fun ChatScreenContent(
                         // 取消按钮移到左侧
                         IconButton(
                             onClick = {
+                                selectedMessagesCopyJob?.cancel()
+                                selectedMessagesCopyJob = null
+                                isCopyingSelectedMessages = false
                                 isMultiSelectMode = false
                                 selectedMessageIndices = emptySet()
                             },
@@ -569,40 +594,66 @@ fun ChatScreenContent(
 
                         FilledIconButton(
                             onClick = {
-                                if (selectedMessageIndices.isNotEmpty()) {
+                                if (selectedMessageIndices.isNotEmpty() && !isCopyingSelectedMessages) {
                                     val indicesToCopy = selectedMessageIndices
-                                    coroutineScope.launch {
-                                        val copiedText =
-                                            withContext(Dispatchers.Default) {
-                                                buildSelectedMessagesPlainText(
-                                                    chatHistory = chatHistory,
-                                                    selectedMessageIndices = indicesToCopy,
-                                                ) { markdown ->
-                                                    markdownToPlainTextForCopy(markdown) { formulas ->
-                                                        LatexMathMlConverter.convertAll(context, formulas)
+                                    isCopyingSelectedMessages = true
+                                    selectedMessagesCopyJob = selectedMessagesCopyScope.launch {
+                                        val currentCopyJob = coroutineContext[Job]
+                                        try {
+                                            val copiedText =
+                                                withContext(Dispatchers.Default) {
+                                                    buildSelectedMessagesPlainText(
+                                                        chatHistory = chatHistory,
+                                                        selectedMessageIndices = indicesToCopy,
+                                                    ) { markdown ->
+                                                        markdownToPlainTextForCopy(markdown) { formulas ->
+                                                            LatexMathMlConverter.convertAll(context, formulas)
+                                                        }
                                                     }
                                                 }
+                                            if (copiedText.isNotEmpty()) {
+                                                clipboardManager.setText(AnnotatedString(copiedText))
+                                                Toast.makeText(
+                                                    context,
+                                                    context.getString(R.string.message_copied_to_clipboard),
+                                                    Toast.LENGTH_SHORT,
+                                                ).show()
+                                                isMultiSelectMode = false
+                                                selectedMessageIndices = emptySet()
+                                            } else {
+                                                Toast.makeText(
+                                                    context,
+                                                    context.getString(R.string.no_text_to_copy),
+                                                    Toast.LENGTH_SHORT,
+                                                ).show()
                                             }
-                                        if (copiedText.isNotEmpty()) {
-                                            clipboardManager.setText(AnnotatedString(copiedText))
+                                        } catch (cancellation: CancellationException) {
+                                            throw cancellation
+                                        } catch (error: Exception) {
+                                            AppLogger.e(
+                                                "ChatScreenContent",
+                                                "Failed to copy selected messages",
+                                                error,
+                                            )
                                             Toast.makeText(
                                                 context,
-                                                context.getString(R.string.message_copied_to_clipboard),
+                                                context.getString(
+                                                    R.string.dialog_copy_failed,
+                                                    error.localizedMessage
+                                                        ?: error.javaClass.simpleName,
+                                                ),
                                                 Toast.LENGTH_SHORT,
                                             ).show()
-                                            isMultiSelectMode = false
-                                            selectedMessageIndices = emptySet()
-                                        } else {
-                                            Toast.makeText(
-                                                context,
-                                                context.getString(R.string.no_text_to_copy),
-                                                Toast.LENGTH_SHORT,
-                                            ).show()
+                                        } finally {
+                                            if (selectedMessagesCopyJob === currentCopyJob) {
+                                                selectedMessagesCopyJob = null
+                                                isCopyingSelectedMessages = false
+                                            }
                                         }
                                     }
                                 }
                             },
-                            enabled = selectedMessageIndices.isNotEmpty(),
+                            enabled = selectedMessageIndices.isNotEmpty() && !isCopyingSelectedMessages,
                             modifier = Modifier.size(32.dp),
                             colors = IconButtonDefaults.filledIconButtonColors(
                                 containerColor = MaterialTheme.colorScheme.secondaryContainer,

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
@@ -40,7 +40,7 @@ class MessageCopyTextTest {
         assertEquals("<meta charset=\"utf-8\">visibleanswer", cleanMessageContentForCopy(content))
     }
 
-    @Test fun buildSelectedMessagesPlainText_usesChatIndexOrderAndPlainTextConversion() = runTest {
+    @Test fun buildSelectedMessagesPlainText_usesMessageOrderAndPlainTextConversion() = runTest {
         val chatHistory =
             listOf(
                 ChatMessage(sender = "user", content = "**first**", timestamp = 30L),
@@ -49,7 +49,7 @@ class MessageCopyTextTest {
             )
 
         val result =
-            buildSelectedMessagesPlainText(chatHistory, setOf(2, 0, 1)) { markdown ->
+            buildSelectedMessagesPlainText(chatHistory) { markdown ->
                 markdown.replace("**", "")
             }
 
@@ -76,7 +76,7 @@ class MessageCopyTextTest {
             )
 
         val result =
-            buildSelectedMessagesPlainText(chatHistory, setOf(0, 1, 2, 3, 4, 99)) { content -> content }
+            buildSelectedMessagesPlainText(chatHistory) { content -> content }
 
         assertEquals("answer\n\nreply", result)
     }
@@ -91,7 +91,7 @@ class MessageCopyTextTest {
         var conversionCount = 0
 
         val result =
-            buildSelectedMessagesPlainText(chatHistory, chatHistory.indices.reversed().toSet()) { content ->
+            buildSelectedMessagesPlainText(chatHistory) { content ->
                 conversionCount += 1
                 content
             }

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
@@ -80,4 +80,23 @@ class MessageCopyTextTest {
 
         assertEquals("answer\n\nreply", result)
     }
+
+    @Test fun buildSelectedMessagesPlainText_convertsEachMessageOnceForLargeSelection() = runTest {
+        val messageCount = 100
+        val messageContent = "x".repeat(4_096)
+        val chatHistory =
+            List(messageCount) { index ->
+                ChatMessage(sender = if (index % 2 == 0) "user" else "ai", content = messageContent)
+            }
+        var conversionCount = 0
+
+        val result =
+            buildSelectedMessagesPlainText(chatHistory, chatHistory.indices.reversed().toSet()) { content ->
+                conversionCount += 1
+                content
+            }
+
+        assertEquals(messageCount, conversionCount)
+        assertEquals(messageCount * messageContent.length + (messageCount - 1) * 2, result.length)
+    }
 }

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
@@ -1,5 +1,8 @@
 package com.ai.assistance.operit.ui.features.chat.components
 
+import com.ai.assistance.operit.data.model.ChatMessage
+import com.ai.assistance.operit.data.model.ChatMessageDisplayMode
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -35,5 +38,46 @@ class MessageCopyTextTest {
                 "<meta provider=\"openai:responses_reasoning\">payload</meta>answer"
 
         assertEquals("<meta charset=\"utf-8\">visibleanswer", cleanMessageContentForCopy(content))
+    }
+
+    @Test fun buildSelectedMessagesPlainText_usesChatIndexOrderAndPlainTextConversion() = runTest {
+        val chatHistory =
+            listOf(
+                ChatMessage(sender = "user", content = "**first**", timestamp = 30L),
+                ChatMessage(sender = "ai", content = "second", timestamp = 10L),
+                ChatMessage(sender = "user", content = "third", timestamp = 20L),
+            )
+
+        val result =
+            buildSelectedMessagesPlainText(chatHistory, setOf(2, 0, 1)) { markdown ->
+                markdown.replace("**", "")
+            }
+
+        assertEquals("first\n\nsecond\n\nthird", result)
+    }
+
+    @Test fun buildSelectedMessagesPlainText_cleansMetadataAndKeepsOnlyUserAndAi() = runTest {
+        val chatHistory =
+            listOf(
+                ChatMessage(
+                    sender = "user",
+                    content = "answer<meta provider=\"gemini:thought_signature\">signature</meta>",
+                    timestamp = 1L,
+                ),
+                ChatMessage(sender = "system", content = "hidden", timestamp = 2L),
+                ChatMessage(
+                    sender = "user",
+                    content = "hidden placeholder",
+                    timestamp = 3L,
+                    displayMode = ChatMessageDisplayMode.HIDDEN_PLACEHOLDER,
+                ),
+                ChatMessage(sender = "ai", content = "<think>empty</think>", timestamp = 4L),
+                ChatMessage(sender = "ai", content = "reply", timestamp = 5L),
+            )
+
+        val result =
+            buildSelectedMessagesPlainText(chatHistory, setOf(0, 1, 2, 3, 4, 99)) { content -> content }
+
+        assertEquals("answer\n\nreply", result)
     }
 }


### PR DESCRIPTION
## 变更说明 / Description

为聊天多选模式增加“复制文本”操作，使用户可以一次复制连续或不连续的多条消息。

### 背景与动机 / Context and motivation

当前聊天多选工具栏支持加入记忆、分享和删除，但无法复制选中的消息文本。用户只能退出多选模式后逐条复制。

### 改动范围 / Changes

- 在多选消息工具栏增加复制按钮。
- 按消息在聊天记录中的索引顺序合并内容，不受选择先后顺序影响。
- 复用现有消息清理、Markdown 纯文本转换和 LaTeX 转换逻辑。
- 过滤隐藏占位消息、无效索引以及清理后为空的消息。
- 使用空行分隔消息，并将结果写入系统剪贴板。
- 复制成功后显示提示并退出多选模式。
- 调整多选工具栏的窄屏布局。
- 在点击复制时固定消息快照，避免异步转换期间聊天记录变化导致错位。
- 修复无结尾换行的单行用户消息在流式 Markdown 解析器中未刷新的问题。
- 补充消息顺序、文本转换、过滤行为和单行用户消息的测试。

本次仅实现纯文本复制，不包含 Markdown 源码复制、发送者标签和格式配置选项。

### 兼容性与风险 / Compatibility and risks

不修改数据格式、公开 API 或配置。主要风险集中在 Compose 工具栏布局、异步复制状态和不同 Markdown 内容的复制结果。复制转换在后台调度器执行，并且只在点击时读取一次选中消息快照。

## 关联 Issue / Related issue

Closes #895

## 验证方式 / Verification

```text
检查：git diff --check
结果：通过

检查：仓库 hygiene、Markdown links、localizations
结果：通过，0 errors / 0 warnings

测试：MessageCopyTextTest（Debug JVM）
结果：通过，7 tests / 0 failures

构建：.\gradlew.bat :app:assembleDebug --stacktrace --no-daemon
说明：未排除 native 任务，包含 app 与 mnn 的 CMake 配置和构建
结果：BUILD SUCCESSFUL，240 tasks

测试：MarkdownPlainTextRendererAndroidTest
设备：HONOR Magic7 Pro（PTP-AN10），Android 16 / API 36，arm64-v8a
结果：通过，7 tests / 0 failures

测试：仓库 Python 快速测试（WSL）
结果：通过，45 tests / 0 failures

检查：npm.cmd --prefix web-chat run typecheck
结果：通过

测试：真机手动回归
设备：HONOR Magic7 Pro（PTP-AN10），Android 16 / API 36
结果：通过。已验证仅复制用户单行消息、同时复制用户与 AI 消息、连续/非连续选择，以及顺序/逆序/乱序选择；粘贴结果均包含预期消息并保持聊天原始顺序。
```

### 上游基线说明 / Upstream baseline note

完整 `:app:testDebugUnitTest` 在本分支运行 1029 项，其中 1027 项通过，2 项失败：

- `MemoryAnalysisProtocolTest.parseAnalysisResult_acceptsObjectProtocolWithoutMainEvent`
- `MemoryAnalysisProtocolTest.parseAnalysisResult_rejectsMissingRequiredOperationField`

这两项可在完全未包含本 PR 修改的 `upstream/main` 独立工作树中复现，并与已合并 #941 的 Candidate checks 结果一致（`1026 tests completed, 2 failed`）。本 PR 未修改 memory 实现或对应测试，因此属于 base branch 已有失败，不是 #937 引入的回归。

## 证据 / Evidence

- 本 PR 定向 JVM 回归：7/7 通过。
- Android 仪器回归：7/7 通过。
- 完整 native Debug APK：构建成功。
- Python 仓库测试：45/45 通过。
- WebChat TypeScript：typecheck 通过。
- 真机手动回归：用户消息与 AI 消息均可多选复制，结果保持聊天原始顺序。
- 上游基线问题：2 项 memory JVM 失败已在未修改的 `upstream/main` 和 #941 CI 中交叉复现。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和上游基线失败
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理本 PR 引入的技术失败项
- [x] 最终源码 diff 无无关、临时、生成、二进制或敏感内容
- [x] 已提供对应的回归、UI 和兼容性证据