### PR TITLE
更新思考模式的功能说明

### DIFF
--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -3454,7 +3454,7 @@
     <string name="chat_ai_computer_closed_due_to_workspace">AI computer closed (workspace opened)</string>
     <string name="ai_planning_desc">Will perform task decomposition and trigger multiple sub-agents to collect information, then summarize. Sub-agents have the same tool-calling capabilities as the chat agent. This can be very time-consuming, only recommended when collecting information.</string>
     <string name="thinking_mode">Thinking Mode</string>
-    <string name="thinking_mode_desc">Currently supports Gemini, Qwen3, Claude, Doubao, NVIDIA, SiliconFlow and MNN local models, enabling built-in thinking.</string>
+    <string name="thinking_mode_desc">Controls the model's built-in thinking and thinking intensity. Actual behavior depends on the current model and provider; some models may only support the on/off control.</string>
     <string name="model_selection">Model Selection</string>
     <string name="prompt_selection">Prompt Selection</string>
     <string name="memory_selection">Memory Selection</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -3454,7 +3454,7 @@
     <string name="chat_ai_computer_closed_due_to_workspace">AI computer closed (workspace opened)</string>
     <string name="ai_planning_desc">Will perform task decomposition and trigger multiple sub-agents to collect information, then summarize. Sub-agents have the same tool-calling capabilities as the chat agent. This can be very time-consuming, only recommended when collecting information.</string>
     <string name="thinking_mode">Thinking Mode</string>
-    <string name="thinking_mode_desc">Controls the model's built-in thinking and thinking intensity. Actual behavior depends on the current model and provider; some models may only support the on/off control.</string>
+    <string name="thinking_mode_desc">Controls built-in model thinking and thinking intensity. Actual behavior depends on the current model and provider; some models may only support the on/off control.</string>
     <string name="model_selection">Model Selection</string>
     <string name="prompt_selection">Prompt Selection</string>
     <string name="memory_selection">Memory Selection</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3547,7 +3547,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="chat_start_ai_computer_failed">Error al iniciar la computadora AI: %1$s</string>
     <string name="chat_ai_computer_closed_due_to_workspace">Computadora AI cerrada (debido a la apertura del espacio de trabajo)</string>
     <string name="thinking_mode">Modo de pensamiento</string>
-    <string name="thinking_mode_desc">Actualmente compatible con Gemini, Qwen3, Claude, Doubao, NVIDIA, SiliconFlow y modelos locales MNN, que pueden habilitar el pensamiento integrado.</string>
+    <string name="thinking_mode_desc">Controla el razonamiento integrado del modelo y su intensidad. El comportamiento real depende del modelo y del proveedor actuales; algunos modelos solo admiten activarlo o desactivarlo.</string>
     <string name="details">Detalles</string>
     <string name="model_selection">Selección de modelo</string>
     <string name="prompt_selection">Selección de prompt</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -3011,7 +3011,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="chat_start_ai_computer_failed">Gagal memulai komputer AI: %1$s</string>
     <string name="chat_ai_computer_closed_due_to_workspace">Komputer AI telah ditutup (karena membuka ruang kerja)</string>
     <string name="thinking_mode">Mode berpikir</string>
-    <string name="thinking_mode_desc">Saat ini mendukung model Gemini, Qwen3, Claude, Doubao, NVIDIA, Silicon Flow, dan MNN lokal, dapat mengaktifkan pemikiran bawaan.</string>
+    <string name="thinking_mode_desc">Mengontrol pemikiran bawaan model dan tingkat intensitasnya. Perilaku sebenarnya bergantung pada model dan penyedia saat ini; beberapa model mungkin hanya mendukung pengaktifan atau penonaktifan.</string>
     <string name="details">Detail</string>
     <string name="model_selection">Pemilihan model</string>
     <string name="prompt_selection">Pemilihan prompt</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2999,7 +2999,7 @@
     <string name="chat_start_ai_computer_failed">AI 컴퓨터 시작 실패: %1$s</string>
     <string name="chat_ai_computer_closed_due_to_workspace">AI 컴퓨터 닫힘(작업 공간 열림)</string>
     <string name="thinking_mode">사고 모드</string>
-    <string name="thinking_mode_desc">현재 Gemini, Qwen3, Claude, Doubao, NVIDIA, SiliconFlow 및 MNN 로컬 모델을 지원하며, 내장 사고 기능을 활성화합니다.</string>
+    <string name="thinking_mode_desc">모델의 내장 사고 사용 여부와 사고 강도를 조절합니다. 실제 동작은 현재 모델과 서비스 제공업체에 따라 다르며, 일부 모델은 켜기/끄기만 지원할 수 있습니다.</string>
     <string name="details">세부정보</string>
     <string name="model_selection">모델 선택</string>
     <string name="prompt_selection">프롬프트 선택</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -2761,7 +2761,7 @@
     <string name="chat_start_ai_computer_failed">Gagal memulakan komputer AI: %1$s</string>
     <string name="chat_ai_computer_closed_due_to_workspace">Komputer AI telah ditutup (kerana membuka ruang kerja)</string>
     <string name="thinking_mode">Mod berfikir</string>
-    <string name="thinking_mode_desc">Kini menyokong model tempatan Gemini, Qwen3, Claude, Doubao, NVIDIA, Silicon Flow dan MNN, mampu mengaktifkan pemikiran terbina dalam.</string>
+    <string name="thinking_mode_desc">Mengawal pemikiran terbina dalam model dan tahap keamatannya. Tingkah laku sebenar bergantung pada model dan penyedia semasa; sesetengah model mungkin hanya menyokong kawalan hidup atau mati.</string>
     <string name="details">Butiran</string>
     <string name="model_selection">Pemilihan model</string>
     <string name="prompt_selection">Pemilihan petunjuk</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -2877,7 +2877,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="chat_start_ai_computer_failed">Falha ao iniciar o computador AI: %1$s</string>
     <string name="chat_ai_computer_closed_due_to_workspace">O computador AI está fechado (devido ao espaço de trabalho aberto)</string>
     <string name="thinking_mode">Modelo de pensamento</string>
-    <string name="thinking_mode_desc">Atualmente suporta Gemini, Qwen3, Claude, Doubao, NVIDIA, fluxo baseado em silício e modelos locais MNN, permitindo pensamento integrado.</string>
+    <string name="thinking_mode_desc">Controla o raciocínio integrado do modelo e sua intensidade. O comportamento real depende do modelo e do provedor atuais; alguns modelos podem oferecer apenas a opção de ativar ou desativar.</string>
     <string name="details">Detalhes</string>
     <string name="model_selection">Seleção de modelo</string>
     <string name="prompt_selection">Seleção imediata de palavras</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3334,7 +3334,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="chat_start_ai_computer_failed">PornireAIEroare la computer: %1$s</string>
     <string name="chat_ai_computer_closed_due_to_workspace">AIComputerul a fost oprit (din cauza deschiderii spațiului de lucru)</string>
     <string name="thinking_mode">Modul de gândire</string>
-    <string name="thinking_mode_desc">În prezent, se acceptăGemini,Qwen3,Claude, chifle cu fasole,NVIDIA, curgerea pe bază de siliciu șiMNNModel local, capabil să activeze gândirea integrată.</string>
+    <string name="thinking_mode_desc">Controlează raționamentul integrat al modelului și intensitatea acestuia. Comportamentul efectiv depinde de modelul și furnizorul curent; unele modele pot permite doar activarea sau dezactivarea.</string>
     <string name="details">Detalii</string>
     <string name="model_selection">Alegerea modelului</string>
     <string name="prompt_selection">Alegerea cuvintelor-cheie</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3363,7 +3363,7 @@
     <string name="chat_start_ai_computer_failed">启动AI电脑失败: %1$s</string>
     <string name="chat_ai_computer_closed_due_to_workspace">AI电脑已关闭（由于打开工作区）</string>
     <string name="thinking_mode">思考模式</string>
-    <string name="thinking_mode_desc">目前支持Gemini、Qwen3、Claude、豆包、NVIDIA、硅基流动和MNN本地模型，能够启用内置的思考。</string>
+    <string name="thinking_mode_desc">控制模型的内置思考开关与思考程度。实际效果取决于当前模型和服务提供商，部分模型可能仅支持开关。</string>
     <string name="details">详情</string>
     <string name="model_selection">模型选择</string>
     <string name="prompt_selection">提示词选择</string>


### PR DESCRIPTION
## 变更说明

更新思考模式的说明文案，移除容易过时的具体模型与服务商列表，改为描述该选项的实际行为和能力差异。

### 改动内容

- 说明该选项用于控制模型的内置思考开关与思考程度。
- 说明实际效果取决于当前模型和服务提供商。
- 说明部分模型可能仅支持思考开关。
- 同步更新现有 8 个语言版本，避免其他语言继续显示过时的支持列表。
- 未修改任何 Provider、请求参数映射或交互逻辑。

### 验证

- `git diff --check` 通过。
- 最终差异仅包含 `thinking_mode_desc` 字符串资源。
- 基于最新 `upstream/main` 创建独立分支。
- 按仓库约束未在本地运行 Gradle/Android 构建，交由 PR CI 验证。