### PR TITLE
fix(backup): accept Operit package variants

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/backup/RawSnapshotBackupManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/backup/RawSnapshotBackupManager.kt
@@ -30,6 +30,11 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
+private const val SNAPSHOT_PACKAGE_NAME_PREFIX = "com.ai.assistance.operit"
+
+internal fun isSupportedSnapshotPackageName(packageName: String): Boolean =
+    packageName.startsWith(SNAPSHOT_PACKAGE_NAME_PREFIX)
+
 object RawSnapshotBackupManager {
 
     private const val TAG = "RawSnapshotBackup"
@@ -288,7 +293,7 @@ object RawSnapshotBackupManager {
                 AppLogger.i(TAG, "restore closed databases (room + objectbox)")
 
                 withContext(Dispatchers.Main) { onProgress?.invoke(RestoreProgress.EXTRACTING) }
-                val manifest = extractZipToWorkDir(cacheZip, workDir, expectedPackageName = context.packageName)
+                val manifest = extractZipToWorkDir(cacheZip, workDir)
 
                 val payloadDir = File(workDir, "payload")
                 val externalFilesPayloadDir = File(payloadDir, "external_files")
@@ -343,7 +348,7 @@ object RawSnapshotBackupManager {
         }
     }
 
-    private fun extractZipToWorkDir(zipFile: File, workDir: File, expectedPackageName: String): Manifest {
+    private fun extractZipToWorkDir(zipFile: File, workDir: File): Manifest {
         val payloadRoot = File(workDir, "payload")
         payloadRoot.mkdirs()
 
@@ -407,7 +412,7 @@ object RawSnapshotBackupManager {
             throw IllegalArgumentException("Unsupported backup version: ${manifest.formatVersion}")
         }
 
-        if (manifest.packageName != expectedPackageName) {
+        if (!isSupportedSnapshotPackageName(manifest.packageName)) {
             throw IllegalArgumentException("Backup package mismatch: ${manifest.packageName}")
         }
 

--- a/app/src/test/java/com/ai/assistance/operit/data/backup/RawSnapshotBackupManagerTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/backup/RawSnapshotBackupManagerTest.kt
@@ -1,0 +1,21 @@
+package com.ai.assistance.operit.data.backup
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RawSnapshotBackupManagerTest {
+
+    @Test
+    fun snapshotPackageName_acceptsOperitPackagePrefix() {
+        assertTrue(isSupportedSnapshotPackageName("com.ai.assistance.operit"))
+        assertTrue(isSupportedSnapshotPackageName("com.ai.assistance.operit.debug"))
+        assertTrue(isSupportedSnapshotPackageName("com.ai.assistance.operit.clone"))
+    }
+
+    @Test
+    fun snapshotPackageName_rejectsDifferentPackagePrefix() {
+        assertFalse(isSupportedSnapshotPackageName("com.ai.assistance.other"))
+        assertFalse(isSupportedSnapshotPackageName("com.example.operit"))
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

文件快照导入会按备份清单中的包名与当前安装包名完全相等校验，导致正式包与 `com.ai.assistance.operit.debug` 等同一 Operit 命名空间的构建变体之间无法互相导入。

### 改动范围 / Changes

- 仅接受以 `com.ai.assistance.operit` 开头的快照清单包名
- 添加根包名、`.debug`、`.clone` 允许，以及非 Operit 前缀拒绝的 JVM 单元测试

### 兼容性与风险 / Compatibility and risks

快照格式没有变化。正式包和同一 Operit 命名空间的构建变体可以互相导入；其他包名仍会被拒绝。

## 关联 Issue / Related issue

N/A - 修复已报告的文件快照导入包名校验问题。

## 验证方式 / Verification

```text
检查或命令：git diff --check
环境与变体：Windows，源代码静态检查
结果：通过；未运行 Gradle 测试/构建，遵循仓库 AGENTS.md 的默认约束
```

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided