### PR TITLE
fix(build): unblock nightly packaging

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7399,11 +7399,6 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="title_activity_data_recovery">Recuperación de datos</string>
     <string name="shortcut_data_recovery">Recuperación de datos</string>
     <string name="memory_space_select">Seleccionar espacio de memoria</string>
-    <string name="memory_space_create">Crear espacio de memoria</string>
-    <string name="memory_space_rename">Renombrar espacio de memoria</string>
-    <string name="memory_space_delete">Eliminar espacio de memoria</string>
-    <string name="memory_space_name">Nombre del espacio de memoria</string>
-    <string name="memory_space_delete_warning">¿Está seguro de que desea eliminar "%1$s" y todos sus recuerdos? Esta acción no se puede deshacer.</string>
     <string name="settings_privacy_data_cleanup">Privacidad y limpieza de datos</string>
     <string name="settings_clear_cookies">Borrar cookies</string>
     <string name="settings_clear_cookies_subtitle">Borrar cookies guardadas por la herramienta de búsqueda, el paquete Browser y el navegador integrado</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7332,11 +7332,6 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="title_activity_data_recovery">Pemulihan Data</string>
     <string name="shortcut_data_recovery">Pemulihan Data</string>
     <string name="memory_space_select">Pilih Ruang Memori</string>
-    <string name="memory_space_create">Buat Ruang Memori Baru</string>
-    <string name="memory_space_rename">Ubah Nama Ruang Memori</string>
-    <string name="memory_space_delete">Hapus Ruang Memori</string>
-    <string name="memory_space_name">Nama Ruang Memori</string>
-    <string name="memory_space_delete_warning">Yakin ingin menghapus "%1$s" beserta semua memori di dalamnya? Tindakan ini tidak dapat dibatalkan.</string>
     <string name="settings_privacy_data_cleanup">Privasi &amp; Pembersihan Data</string>
     <string name="settings_clear_cookies">Hapus Cookie</string>
     <string name="settings_clear_cookies_subtitle">Hapus cookie yang disimpan oleh alat pencarian, paket Browser, dan browser bawaan</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7179,11 +7179,6 @@
     <string name="title_activity_data_recovery">데이터 복구</string>
     <string name="shortcut_data_recovery">데이터 복구</string>
     <string name="memory_space_select">메모리 공간 선택</string>
-    <string name="memory_space_create">새 메모리 공간 만들기</string>
-    <string name="memory_space_rename">메모리 공간 이름 바꾸기</string>
-    <string name="memory_space_delete">메모리 공간 삭제</string>
-    <string name="memory_space_name">메모리 공간 이름</string>
-    <string name="memory_space_delete_warning">"%1$s" 및 그 안의 모든 기억을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
     <string name="settings_privacy_data_cleanup">개인정보 및 데이터 정리</string>
     <string name="settings_clear_cookies">쿠키 삭제</string>
     <string name="settings_clear_cookies_subtitle">검색 도구, Browser 패키지 및 내장 브라우저에 저장된 쿠키 삭제</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7329,11 +7329,6 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="title_activity_data_recovery">Pemulihan Data</string>
     <string name="shortcut_data_recovery">Pemulihan Data</string>
     <string name="memory_space_select">Pilih Ruang Memori</string>
-    <string name="memory_space_create">Cipta Ruang Memori Baharu</string>
-    <string name="memory_space_rename">Namakan Semula Ruang Memori</string>
-    <string name="memory_space_delete">Padam Ruang Memori</string>
-    <string name="memory_space_name">Nama Ruang Memori</string>
-    <string name="memory_space_delete_warning">Adakah anda pasti mahu memadam "%1$s" dan semua memori di dalamnya? Tindakan ini tidak boleh dibatalkan.</string>
     <string name="settings_privacy_data_cleanup">Privasi &amp; Pembersihan Data</string>
     <string name="settings_clear_cookies">Kosongkan Kuki</string>
     <string name="settings_clear_cookies_subtitle">Kosongkan kuki yang disimpan oleh alat carian, pakej Pelayar dan pelayar terbina dalam</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7169,11 +7169,6 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="title_activity_data_recovery">Recuperação de dados</string>
     <string name="shortcut_data_recovery">Recuperação de dados</string>
     <string name="memory_space_select">Selecionar espaço de memória</string>
-    <string name="memory_space_create">Criar espaço de memória</string>
-    <string name="memory_space_rename">Renomear espaço de memória</string>
-    <string name="memory_space_delete">Excluir espaço de memória</string>
-    <string name="memory_space_name">Nome do espaço de memória</string>
-    <string name="memory_space_delete_warning">Tem certeza de que deseja excluir "%1$s" e todas as memórias contidas nele? Esta ação não pode ser desfeita.</string>
     <string name="settings_privacy_data_cleanup">Privacidade e limpeza de dados</string>
     <string name="settings_clear_cookies">Limpar cookies</string>
     <string name="settings_clear_cookies_subtitle">Limpar cookies salvos pela ferramenta de busca, pacotes Browser e navegador integrado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3102,11 +3102,6 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="memory">Amintiri</string>
     <string name="memory_desc">Selectarea unui spațiu de memorie independent pentru dialogul curent</string>
     <string name="memory_space_select">Selectați spațiul de stocare</string>
-    <string name="memory_space_create">Crearea unui spațiu de memorie nou</string>
-    <string name="memory_space_rename">Redenumirea spațiului de memorie</string>
-    <string name="memory_space_delete">Ștergerea spațiului de memorie</string>
-    <string name="memory_space_name">Denumirea spațiului de memorie</string>
-    <string name="memory_space_delete_warning">Confirmați ștergerea „%1$s”și toate amintirile conținute în acesta? Această operațiune nu poate fi anulată.</string>
     <string name="memory_auto_update">Salvarea automată a datelor</string>
     <string name="memory_auto_update_desc">După activare, la finalul rundei curente, conținutul propus va fi mai întâi adăugat în coada de memorie pe termen lung, iar pe durata de funcționare a aplicației va fi organizat periodic în fundal și înregistrat în baza de date.</string>
     <string name="memory_auto_update_runtime_status">Numărul de amintiri care urmează să fie extrase%1$d, până la următoarea salvare%2$dminute</string>

--- a/llm/mnn/CMakeLists.txt
+++ b/llm/mnn/CMakeLists.txt
@@ -145,6 +145,9 @@ set(MNN_BUILD_FOR_ANDROID_COMMAND ON CACHE BOOL "Build from command" FORCE)
 
 # 启用 LLM 支持及相关优化
 set(MNN_BUILD_LLM ON CACHE BOOL "Build LLM support" FORCE)
+# The Android app links the LLM library but does not ship MNN command-line demos.
+# Upstream's Qwen3 TTS demo has extra audio sources that are not part of this build.
+set(MNN_LLM_BUILD_DEMO OFF CACHE BOOL "Build LLM demos" FORCE)
 set(MNN_LOW_MEMORY ON CACHE BOOL "Use low memory mode" FORCE)
 set(MNN_SUPPORT_TRANSFORMER_FUSE ON CACHE BOOL "Support transformer fuse" FORCE)
 set(MNN_CPU_WEIGHT_DEQUANT_GEMM ON CACHE BOOL "CPU weight dequant gemm" FORCE)


### PR DESCRIPTION
## Summary
- disable MNN LLM command-line demos from the Android native build
- remove translations whose default memory_space_* resources no longer exist

## Issue
N/A - fixes local Nightly packaging blockers.

## Compatibility and data
- No application runtime API, data schema, or user-visible behavior changes.
- The MNN command-line demos are not packaged by the app.

## Validation
- :app:assembleNightly succeeded locally.
- Nightly APK V2/V3 signatures verified.
- XML resource parsing and git diff --check passed.