### PR TITLE
fix(mnn): pin native dependency to stable release

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -55,6 +55,8 @@ PR workflow 只有 `contents: read` 权限，不读取仓库 secret，也不上�
 
 ## Android dependencies
 
+MNN 使用官方 `3.6.1` 发布提交 `d407447ed56c4121a11ccbd266dc184ca1ead0c2`，不跟随 `master`；其余原生源码依赖仍由各模块通过 `cmake/operit_git_source.cmake` 下载固定 GitHub archive。
+
 JVM lane 只下载 `libs.zip`，完整 Android lane 下载 `libs.zip`、`subpack.zip` 和 `jniLibs.zip` 三个固定归档。`download_android_dependencies.sh` 使用固定 Google Drive file ID；`prepare_android_dependencies.py` 限制成员数量、解压大小、压缩比和文件类型，重建固定输出根目录，只验证本次实际解出的文件，并拒绝越界路径、重复成员及符号链接。DragonBones 等原生源码依赖由各模块通过 `cmake/operit_git_source.cmake` 下载固定 GitHub archive。`arsc.jar` 已无消费者，`smart-exception` 改由 Maven Central 提供，`android-gif-drawable` 的重复 native 库也不会从归档写入构建目录。应用打包前，Gradle 会检查外部构建的 `liboperit_ripgrep.so`，以及本地 FFmpegKit AAR 中 10 个 arm64 native 库；缺失或零长度文件会使打包失败。默认本地 STT 模型不再来自 Drive 归档，由 Gradle 按 `app/config/stt-model-assets.properties` 获取到生成 assets 目录并校验 SHA-256。
 
 这些 Drive 归档目前还没有内容 hash。归档内容寻址与许可证清单继续由[外部制品清单计划](../docs/TODO/refactor_building_sys/3_ExternalArtifactManifest.md)跟踪，在取得并审计真实归档前不记录推测值。STT 模型资产已有逐文件来源和 hash，但 Sherpa NCNN 模型上游元数据尚未声明许可证，发布前仍需完成许可证审计。

--- a/docs/TODO/mnn_stable_dependency_20260814/index.md
+++ b/docs/TODO/mnn_stable_dependency_20260814/index.md
@@ -1,0 +1,35 @@
+---
+title: 固定 MNN 稳定依赖
+For_Agent: 记录 MNN 原生依赖固定与 PR 合并过程
+fork_repository: "git@github.com:Nyashiiro/Operit-follow-up.git"
+---
+
+# 固定 MNN 稳定依赖
+
+## 旧实现
+
+- `llm/mnn/CMakeLists.txt` 使用 MNN `master`
+- CMake 配置阶段按远端分支当前指向解析提交，导致不同时间的构建输入不同
+- 2026-08-13 解析到的提交 `d68305cf2476a7dc319643ba7c62f44e2bc5246b` 在 `:mnn:buildCMakeDebug[arm64-v8a]` 链接阶段缺少 `qwenVideoProcess`
+
+## 修改意图
+
+- 使用官方最新稳定版 MNN `3.6.1`
+- 使用发布标签背后的不可变提交 `d407447ed56c4121a11ccbd266dc184ca1ead0c2`
+- 将已存在的 `master` 和已知故障提交缓存迁移到稳定提交，避免 Android Studio 复用旧解析结果
+- 强制同步 `OPERIT_MNN_GIT_REF` 缓存，避免旧的 `master` 配置继续生效；后续升级只通过审查后的源码提交完成
+
+## 作用域
+
+- `llm/mnn/CMakeLists.txt`
+- `ci/README.md`
+- `docs/TODO/native_dependency_fetchcontent/index.md`
+
+## 验收
+
+- 默认 CMake 输入不再包含 `master`
+- MNN 版本头为 `3.6.1`
+- 稳定提交记录在 CI 依赖说明和 TODO 中
+- 未执行编译、构建或测试命令
+
+[DONE]

--- a/docs/TODO/native_dependency_fetchcontent/index.md
+++ b/docs/TODO/native_dependency_fetchcontent/index.md
@@ -13,7 +13,7 @@ For_Agent: native dependency FetchContent migration notes
 ## 本次意图
 
 - 将这些原生依赖改成 CMake `FetchContent`
-- 默认跟随各自上游主分支
+- 默认使用各依赖声明的稳定版本或不可变提交；MNN 固定为官方 3.6.1 发布提交 `d407447ed56c4121a11ccbd266dc184ca1ead0c2`
 - 每次配置先解析远端 ref 的 commit，再下载对应 GitHub archive
 - 保留 `OPERIT_*_GIT_REF` 参数，便于 CI 或发布构建指定 ref
 - FetchContent 源码和构建目录落在各模块 `.cxx/operit_deps`，降低 Windows native build 路径长度

--- a/llm/mnn/CMakeLists.txt
+++ b/llm/mnn/CMakeLists.txt
@@ -4,12 +4,19 @@ project("mnn_jni")
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/operit_git_source.cmake")
 
+# Pin MNN to the commit behind the latest stable 3.6.1 release. Using the
+# release commit keeps every native configure reproducible across machines.
+set(OPERIT_MNN_STABLE_COMMIT "d407447ed56c4121a11ccbd266dc184ca1ead0c2")
+# Migrate every existing cache value, including configurations created from
+# master, so Android Studio cannot reuse a different MNN snapshot.
+set(OPERIT_MNN_GIT_REF "${OPERIT_MNN_STABLE_COMMIT}" CACHE STRING "Git ref used to fetch mnn" FORCE)
+
 operit_prepare_git_source(
     MNN_SOURCE_DIR
     OPERIT_MNN_BINARY_DIR
     mnn
     "https://github.com/alibaba/MNN.git"
-    "master"
+    "${OPERIT_MNN_GIT_REF}"
 )
 
 operit_prepare_git_source(


### PR DESCRIPTION
## 变更说明 / Description

将 MNN 原生依赖从浮动的 `master` 固定到官方稳定版 3.6.1 的不可变提交，修复不同时间构建输入不一致以及已知上游链接失败问题。

### 背景与动机 / Context and motivation

此前 `llm/mnn/CMakeLists.txt` 使用 `master`，CMake 每次配置都会解析远端分支当前提交。2026-08-13 解析到 `d68305cf2476a7dc319643ba7c62f44e2bc5246b` 时，`:mnn:buildCMakeDebug[arm64-v8a]` 在链接阶段缺少 `qwenVideoProcess`。

### 改动范围 / Changes

- 固定 MNN 到 `3.6.1` 发布提交 `d407447ed56c4121a11ccbd266dc184ca1ead0c2`
- 强制迁移旧 CMake 缓存，避免 Android Studio 复用 `master` 快照
- 同步 CI 依赖说明和 TODO 记录
- 不修改 JNI、模型配置或用户可见接口

### 兼容性与风险 / Compatibility and risks

保持现有 MNN LLM/JNI 接口；改变仅限构建时第三方源码版本。后续 MNN 升级需要审查并修改固定提交。

## 关联 Issue / Related issue

N/A：构建可复现性与 MNN 原生链接修复。

## 验证方式 / Verification

```text
检查或命令：git diff --check；远端 Git tag/commit、MNN 3.6.1 版本头及现有 JNI 头文件接口核对
环境与变体：Windows；Android arm64-v8a 配置日志静态分析
结果：通过；按用户要求未运行编译、构建或测试命令
```

## 证据 / Evidence

失败日志中的原始错误为 `undefined symbol: MNN::Transformer::Omni::qwenVideoProcess(...)`；固定提交对应 MNN 版本头 `3.6.1`。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因
- [x] 我已确认 Candidate checks 覆盖改动范围
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容
- [x] 已提供构建修复和兼容性证据