### PR TITLE
refactor(chat): consolidate multi-select actions

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -20,9 +20,7 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -59,7 +57,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -78,6 +75,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.window.Dialog
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.ui.res.stringResource
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.ui.common.markdown.markdownToPlainTextForCopy
@@ -157,6 +155,7 @@ fun ChatScreenContent(
     // Multi-select mode state
     var isMultiSelectMode by remember { mutableStateOf(false) }
     var selectedMessageIndices by remember { mutableStateOf(setOf<Int>()) }
+    var showMultiSelectActionsMenu by remember { mutableStateOf(false) }
     var isCopyingSelectedMessages by remember { mutableStateOf(false) }
     var selectedMessagesCopyJob by remember { mutableStateOf<Job?>(null) }
     val messageOrder = chatHistory.map(ChatMessage::timestamp)
@@ -193,6 +192,7 @@ fun ChatScreenContent(
             isMultiSelectMode = false
             selectedMessageIndices = emptySet()
         }
+        showMultiSelectActionsMenu = false
     }
     var exportStatus by remember { mutableStateOf("") }
     var exportSuccess by remember { mutableStateOf(false) }
@@ -323,6 +323,7 @@ fun ChatScreenContent(
                                 selectedMessagesCopyJob = null
                                 isCopyingSelectedMessages = false
                                 selectedMessageIndices = emptySet()
+                                showMultiSelectActionsMenu = false
                             } else if (initialIndex != null) {
                                 // 进入多选模式时，自动选中触发的消息
                                 selectedMessageIndices = setOf(initialIndex)
@@ -443,6 +444,7 @@ fun ChatScreenContent(
                                 selectedMessagesCopyJob = null
                                 isCopyingSelectedMessages = false
                                 selectedMessageIndices = emptySet()
+                                showMultiSelectActionsMenu = false
                             } else if (initialIndex != null) {
                                 // 进入多选模式时，自动选中触发的消息
                                 selectedMessageIndices = setOf(initialIndex)
@@ -497,24 +499,16 @@ fun ChatScreenContent(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        // 取消按钮移到左侧
-                        IconButton(
+                        TextButton(
                             onClick = {
                                 selectedMessagesCopyJob?.cancel()
                                 selectedMessagesCopyJob = null
                                 isCopyingSelectedMessages = false
                                 isMultiSelectMode = false
                                 selectedMessageIndices = emptySet()
-                            },
-                            modifier = Modifier.size(32.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Close,
-                                contentDescription = stringResource(R.string.exit_multi_select),
-                                tint = MaterialTheme.colorScheme.onSurface,
-                                modifier = Modifier.size(18.dp)
-                            )
-                        }
+                                showMultiSelectActionsMenu = false
+                            }
+                        ) { Text(stringResource(R.string.common_cancel)) }
                         
                         Text(
                             text = if (selectedMessageIndices.isEmpty()) {
@@ -532,9 +526,7 @@ fun ChatScreenContent(
                     }
 
                     Row(
-                        modifier = Modifier
-                            .weight(2f)
-                            .horizontalScroll(rememberScrollState()),
+                        modifier = Modifier.weight(1f),
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -557,170 +549,112 @@ fun ChatScreenContent(
                             Icon(
                                 imageVector = Icons.Default.SelectAll,
                                 contentDescription = stringResource(
-                                        if (allSelectableSelected) R.string.clear_selection else R.string.select_all_messages
+                                    if (allSelectableSelected) R.string.clear_selection else R.string.select_all_messages
                                 ),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.size(16.dp)
                             )
-                        }
-
-                        FilledIconButton(
-                            onClick = {
-                                if (selectedMessageIndices.isNotEmpty()) {
-                                    val selectedMessages =
-                                        selectedMessageIndices
-                                            .mapNotNull { index -> chatHistory.getOrNull(index) }
-                                            .sortedBy { it.timestamp }
-                                    actualViewModel.enqueueSelectedMessagesForMemoryAutoSave(
-                                        selectedMessages
-                                    )
-                                }
-                            },
-                            enabled = selectedMessageIndices.isNotEmpty(),
-                            modifier = Modifier.size(32.dp),
-                            colors = IconButtonDefaults.filledIconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-                                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
-                            )
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.CheckCircle,
-                                contentDescription = stringResource(R.string.add_selected_to_memory),
-                                modifier = Modifier.size(16.dp)
+                            Text(
+                                text = stringResource(R.string.select_all_messages)
                             )
                         }
 
-                        FilledIconButton(
-                            onClick = {
-                                if (selectedMessageIndices.isNotEmpty() && !isCopyingSelectedMessages) {
-                                    val messagesToCopy =
-                                        selectedMessageIndices
+                        Box {
+                            TextButton(
+                                onClick = { showMultiSelectActionsMenu = true },
+                                enabled = selectedMessageIndices.isNotEmpty(),
+                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.MoreVert,
+                                    contentDescription = stringResource(R.string.multi_select_actions),
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Text(stringResource(R.string.multi_select_actions))
+                            }
+
+                            DropdownMenu(
+                                expanded = showMultiSelectActionsMenu,
+                                onDismissRequest = { showMultiSelectActionsMenu = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.copy_text)) },
+                                    leadingIcon = { Icon(Icons.Default.ContentCopy, contentDescription = null) },
+                                    enabled = !isCopyingSelectedMessages,
+                                    onClick = {
+                                        showMultiSelectActionsMenu = false
+                                        val messagesToCopy = selectedMessageIndices
                                             .sorted()
                                             .mapNotNull(chatHistory::getOrNull)
-                                    isCopyingSelectedMessages = true
-                                    selectedMessagesCopyJob = selectedMessagesCopyScope.launch {
-                                        val currentCopyJob = coroutineContext[Job]
-                                        try {
-                                            val copiedText =
-                                                withContext(Dispatchers.Default) {
-                                                    buildSelectedMessagesPlainText(
-                                                        messages = messagesToCopy,
-                                                    ) { markdown ->
+                                        isCopyingSelectedMessages = true
+                                        selectedMessagesCopyJob = selectedMessagesCopyScope.launch {
+                                            val currentCopyJob = coroutineContext[Job]
+                                            try {
+                                                val copiedText = withContext(Dispatchers.Default) {
+                                                    buildSelectedMessagesPlainText(messages = messagesToCopy) { markdown ->
                                                         markdownToPlainTextForCopy(markdown) { formulas ->
                                                             LatexMathMlConverter.convertAll(context, formulas)
                                                         }
                                                     }
                                                 }
-                                            if (copiedText.isNotEmpty()) {
-                                                clipboardManager.setText(AnnotatedString(copiedText))
-                                                Toast.makeText(
-                                                    context,
-                                                    context.getString(R.string.message_copied_to_clipboard),
-                                                    Toast.LENGTH_SHORT,
-                                                ).show()
-                                                isMultiSelectMode = false
-                                                selectedMessageIndices = emptySet()
-                                            } else {
-                                                Toast.makeText(
-                                                    context,
-                                                    context.getString(R.string.no_text_to_copy),
-                                                    Toast.LENGTH_SHORT,
-                                                ).show()
-                                            }
-                                        } catch (cancellation: CancellationException) {
-                                            throw cancellation
-                                        } catch (error: Exception) {
-                                            AppLogger.e(
-                                                "ChatScreenContent",
-                                                "Failed to copy selected messages",
-                                                error,
-                                            )
-                                            Toast.makeText(
-                                                context,
-                                                context.getString(
-                                                    R.string.dialog_copy_failed,
-                                                    error.localizedMessage
-                                                        ?: error.javaClass.simpleName,
-                                                ),
-                                                Toast.LENGTH_SHORT,
-                                            ).show()
-                                        } finally {
-                                            if (selectedMessagesCopyJob === currentCopyJob) {
-                                                selectedMessagesCopyJob = null
-                                                isCopyingSelectedMessages = false
+                                                if (copiedText.isNotEmpty()) {
+                                                    clipboardManager.setText(AnnotatedString(copiedText))
+                                                    Toast.makeText(context, context.getString(R.string.message_copied_to_clipboard), Toast.LENGTH_SHORT).show()
+                                                    isMultiSelectMode = false
+                                                    selectedMessageIndices = emptySet()
+                                                } else {
+                                                    Toast.makeText(context, context.getString(R.string.no_text_to_copy), Toast.LENGTH_SHORT).show()
+                                                }
+                                            } catch (cancellation: CancellationException) {
+                                                throw cancellation
+                                            } catch (error: Exception) {
+                                                AppLogger.e("ChatScreenContent", "Failed to copy selected messages", error)
+                                                Toast.makeText(context, context.getString(R.string.dialog_copy_failed, error.localizedMessage ?: error.javaClass.simpleName), Toast.LENGTH_SHORT).show()
+                                            } finally {
+                                                if (selectedMessagesCopyJob === currentCopyJob) {
+                                                    selectedMessagesCopyJob = null
+                                                    isCopyingSelectedMessages = false
+                                                }
                                             }
                                         }
                                     }
-                                }
-                            },
-                            enabled = selectedMessageIndices.isNotEmpty() && !isCopyingSelectedMessages,
-                            modifier = Modifier.size(32.dp),
-                            colors = IconButtonDefaults.filledIconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
-                            )
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.ContentCopy,
-                                contentDescription = stringResource(R.string.copy_text),
-                                modifier = Modifier.size(16.dp)
-                            )
-                        }
-
-                        // 分享按钮
-                        FilledIconButton(
-                            onClick = {
-                                if (selectedMessageIndices.isNotEmpty() && !isGeneratingImage) {
-                                    // 预览参数仅对本次截图生效，不污染正常聊天展示状态
-                                    sharePreviewUri = null
-                                    sharePreviewThinkingExpanded = false
-                                    sharePreviewExpandThinkToolsGroups = false
-                                    sharePreviewIncludeBackground = hasBackgroundImage
-                                    sharePreviewBorderWidth = 1.5f
-                                    showSharePreviewDialog = true
-                                }
-                            },
-                            enabled = selectedMessageIndices.isNotEmpty() && !isGeneratingImage,
-                            modifier = Modifier.size(32.dp),
-                            colors = IconButtonDefaults.filledIconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
-                            )
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Share,
-                                contentDescription = stringResource(R.string.share_selected),
-                                modifier = Modifier.size(16.dp)
-                            )
-                        }
-
-                        // 删除按钮
-                        FilledIconButton(
-                            onClick = {
-                                if (selectedMessageIndices.isNotEmpty()) {
-                                    showDeleteSelectedConfirmDialog = true
-                                }
-                            },
-                            enabled = selectedMessageIndices.isNotEmpty(),
-                            modifier = Modifier.size(32.dp),
-                            colors = IconButtonDefaults.filledIconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.errorContainer,
-                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
-                            )
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Delete,
-                                contentDescription = stringResource(R.string.delete_selected),
-                                modifier = Modifier.size(16.dp)
-                            )
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.add_selected_to_memory)) },
+                                    leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) },
+                                    enabled = selectedMessageIndices.isNotEmpty(),
+                                    onClick = {
+                                        showMultiSelectActionsMenu = false
+                                        val selectedMessages = selectedMessageIndices
+                                            .mapNotNull { index -> chatHistory.getOrNull(index) }
+                                            .sortedBy { it.timestamp }
+                                        actualViewModel.enqueueSelectedMessagesForMemoryAutoSave(selectedMessages)
+                                    }
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.share_selected)) },
+                                    leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+                                    enabled = selectedMessageIndices.isNotEmpty() && !isGeneratingImage,
+                                    onClick = {
+                                        showMultiSelectActionsMenu = false
+                                        sharePreviewUri = null
+                                        sharePreviewThinkingExpanded = false
+                                        sharePreviewExpandThinkToolsGroups = false
+                                        sharePreviewIncludeBackground = hasBackgroundImage
+                                        sharePreviewBorderWidth = 1.5f
+                                        showSharePreviewDialog = true
+                                    }
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.delete_selected)) },
+                                    leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                                    enabled = selectedMessageIndices.isNotEmpty(),
+                                    onClick = {
+                                        showMultiSelectActionsMenu = false
+                                        showDeleteSelectedConfirmDialog = true
+                                    }
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -57,6 +57,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -499,7 +500,7 @@ fun ChatScreenContent(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        TextButton(
+                        IconButton(
                             onClick = {
                                 selectedMessagesCopyJob?.cancel()
                                 selectedMessagesCopyJob = null
@@ -508,7 +509,14 @@ fun ChatScreenContent(
                                 selectedMessageIndices = emptySet()
                                 showMultiSelectActionsMenu = false
                             }
-                        ) { Text(stringResource(R.string.common_cancel)) }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = stringResource(R.string.exit_multi_select),
+                                tint = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
                         
                         Text(
                             text = if (selectedMessageIndices.isEmpty()) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -492,7 +492,7 @@ fun ChatScreenContent(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 10.dp),
+                        .padding(horizontal = 16.dp, vertical = 6.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -510,7 +510,8 @@ fun ChatScreenContent(
                                 isMultiSelectMode = false
                                 selectedMessageIndices = emptySet()
                                 showMultiSelectActionsMenu = false
-                            }
+                            },
+                            modifier = Modifier.size(32.dp)
                         ) {
                             Icon(
                                 imageVector = Icons.Filled.Close,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -542,7 +542,7 @@ fun ChatScreenContent(
                             selectableMessageIndices.isNotEmpty() &&
                                     selectableMessageIndices.all { selectedMessageIndices.contains(it) }
 
-                        TextButton(
+                        IconButton(
                             onClick = {
                                 selectedMessageIndices =
                                         if (allSelectableSelected) {
@@ -552,7 +552,7 @@ fun ChatScreenContent(
                                         }
                             },
                             enabled = selectableMessageIndices.isNotEmpty(),
-                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
+                            modifier = Modifier.size(32.dp)
                         ) {
                             Icon(
                                 imageVector = Icons.Default.SelectAll,
@@ -562,23 +562,20 @@ fun ChatScreenContent(
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.size(16.dp)
                             )
-                            Text(
-                                text = stringResource(R.string.select_all_messages)
-                            )
                         }
 
                         Box {
-                            TextButton(
+                            IconButton(
                                 onClick = { showMultiSelectActionsMenu = true },
                                 enabled = selectedMessageIndices.isNotEmpty(),
-                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
+                                modifier = Modifier.size(32.dp)
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.MoreVert,
                                     contentDescription = stringResource(R.string.multi_select_actions),
-                                    modifier = Modifier.size(18.dp)
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
-                                Text(stringResource(R.string.multi_select_actions))
                             }
 
                             DropdownMenu(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.content.FileProvider
 import com.ai.assistance.operit.data.model.ChatHistory
 import com.ai.assistance.operit.data.model.ChatMessage
@@ -75,6 +76,7 @@ import androidx.compose.material3.InputChip
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.PopupProperties
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.ui.res.stringResource
@@ -534,7 +536,7 @@ fun ChatScreenContent(
                     }
 
                     Row(
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier.wrapContentWidth(),
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -580,12 +582,37 @@ fun ChatScreenContent(
 
                             DropdownMenu(
                                 expanded = showMultiSelectActionsMenu,
-                                onDismissRequest = { showMultiSelectActionsMenu = false }
+                                onDismissRequest = { showMultiSelectActionsMenu = false },
+                                modifier = Modifier
+                                    .width(180.dp)
+                                    .background(
+                                        MaterialTheme.colorScheme.surface,
+                                        shape = RoundedCornerShape(6.dp)
+                                    ),
+                                properties = PopupProperties(
+                                    focusable = true,
+                                    dismissOnBackPress = true,
+                                    dismissOnClickOutside = true
+                                )
                             ) {
                                 DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.copy_text)) },
-                                    leadingIcon = { Icon(Icons.Default.ContentCopy, contentDescription = null) },
+                                    text = {
+                                        Text(
+                                            stringResource(R.string.copy_text),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontSize = 13.sp
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            Icons.Default.ContentCopy,
+                                            contentDescription = stringResource(R.string.copy_text),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                    },
                                     enabled = !isCopyingSelectedMessages,
+                                    modifier = Modifier.height(36.dp),
                                     onClick = {
                                         showMultiSelectActionsMenu = false
                                         val messagesToCopy = selectedMessageIndices
@@ -625,9 +652,23 @@ fun ChatScreenContent(
                                     }
                                 )
                                 DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.add_selected_to_memory)) },
-                                    leadingIcon = { Icon(Icons.Default.CheckCircle, contentDescription = null) },
+                                    text = {
+                                        Text(
+                                            stringResource(R.string.add_selected_to_memory),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontSize = 13.sp
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            Icons.Default.CheckCircle,
+                                            contentDescription = stringResource(R.string.add_selected_to_memory),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                    },
                                     enabled = selectedMessageIndices.isNotEmpty(),
+                                    modifier = Modifier.height(36.dp),
                                     onClick = {
                                         showMultiSelectActionsMenu = false
                                         val selectedMessages = selectedMessageIndices
@@ -637,9 +678,23 @@ fun ChatScreenContent(
                                     }
                                 )
                                 DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.share_selected)) },
-                                    leadingIcon = { Icon(Icons.Default.Share, contentDescription = null) },
+                                    text = {
+                                        Text(
+                                            stringResource(R.string.share_selected),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontSize = 13.sp
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            Icons.Default.Share,
+                                            contentDescription = stringResource(R.string.share_selected),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                    },
                                     enabled = selectedMessageIndices.isNotEmpty() && !isGeneratingImage,
+                                    modifier = Modifier.height(36.dp),
                                     onClick = {
                                         showMultiSelectActionsMenu = false
                                         sharePreviewUri = null
@@ -651,9 +706,23 @@ fun ChatScreenContent(
                                     }
                                 )
                                 DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.delete_selected)) },
-                                    leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                                    text = {
+                                        Text(
+                                            stringResource(R.string.delete_selected),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontSize = 13.sp
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            Icons.Default.Delete,
+                                            contentDescription = stringResource(R.string.delete_selected),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                    },
                                     enabled = selectedMessageIndices.isNotEmpty(),
+                                    modifier = Modifier.height(36.dp),
                                     onClick = {
                                         showMultiSelectActionsMenu = false
                                         showDeleteSelectedConfirmDialog = true

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -781,6 +781,7 @@
     <string name="exit_multi_select">Exit Multi-select</string>
     <string name="select_all_messages">Select all</string>
     <string name="clear_selection">Cancel</string>
+    <string name="multi_select_actions">Actions</string>
     <string name="delete_selected">Delete Selected</string>
     <string name="share_selected">Share</string>
     <string name="add_selected_to_memory">Add to summary memory</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1695,6 +1695,7 @@
     <string name="exit_multi_select">退出多选</string>
     <string name="select_all_messages">全选</string>
     <string name="clear_selection">取消</string>
+    <string name="multi_select_actions">操作</string>
     <string name="delete_selected">删除选中</string>
     <string name="share_selected">分享</string>
     <string name="add_selected_to_memory">纳入总结记忆</string>


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

聊天消息多选工具栏原本并列展示多个动作，窄屏下操作入口拥挤且易被左侧选中数量挤压。

### 改动范围 / Changes

- 将复制文本、纳入总结记忆、分享、删除归入一个操作菜单
- 顶层工具栏保留关闭、全选和操作三个图标入口
- 让全选与操作固定在工具栏右侧
- 多选操作菜单复用普通消息长按菜单的尺寸、圆角、文字与图标规格
- 收紧多选工具栏高度
- 补充中英文“操作”资源

### 兼容性与风险 / Compatibility and risks

未发布功能的界面调整；不涉及数据格式、API、配置或持久化迁移。

## 关联 Issue / Related issue

N/A，基于多选交互审阅后的界面调整。

## 验证方式 / Verification

```text
检查或命令：git diff --check
环境与变体：本地静态差异检查
结果：通过
未运行 Android 构建或测试：遵循仓库 AGENTS.md 的默认约束，未收到显式构建/测试请求。
```

## 证据 / Evidence

普通消息长按菜单的现有规格已在实现中复用：180dp 宽、6dp 圆角、36dp 菜单项、13sp 文案、16dp 图标。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided