### PR TITLE
fix(markdown): make links inside table cells clickable

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/CanvasMarkdownNodeRenderer.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/CanvasMarkdownNodeRenderer.kt
@@ -614,7 +614,8 @@ private fun renderNodeContent(
             EnhancedTableBlock(
                 tableContent = content,
                 textColor = textColor,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                onLinkClick = onLinkClick,
             )
         }
         

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/EnhancedTableBlock.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/EnhancedTableBlock.kt
@@ -2,13 +2,16 @@ package com.ai.assistance.operit.ui.common.markdown
 
 import android.graphics.Typeface
 import android.os.SystemClock
+import android.text.Spanned
 import android.text.StaticLayout
 import android.text.TextPaint
+import android.text.style.URLSpan
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -29,6 +32,7 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFontFamilyResolver
@@ -88,7 +92,8 @@ private data class TableRenderLayout(
 fun EnhancedTableBlock(
     tableContent: String,
     modifier: Modifier = Modifier,
-    textColor: Color = MaterialTheme.colorScheme.onSurface
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
+    onLinkClick: ((String) -> Unit)? = null,
 ) {
     val density = LocalDensity.current
     val typography = MaterialTheme.typography
@@ -246,6 +251,72 @@ fun EnhancedTableBlock(
                                 }
                             lastDragEventTimeMs = nowMs
                             scrollOffsetPx = (scrollOffsetPx - dragAmount).coerceIn(0f, maxScrollPx)
+                        }
+                    }
+                    .pointerInput(renderLayout, onLinkClick, scrollOffsetPx) {
+                        if (onLinkClick == null) return@pointerInput
+                        awaitEachGesture {
+                            val down = awaitPointerEvent(PointerEventPass.Initial).changes.first()
+                            val downTime = System.currentTimeMillis()
+                            val downPosition = down.position
+
+                            val up = awaitPointerEvent(PointerEventPass.Initial).changes.first()
+                            val upTime = System.currentTimeMillis()
+                            val upPosition = up.position
+
+                            val isTap =
+                                (upTime - downTime) < 500 &&
+                                    (upPosition - downPosition).getDistance() < 10f
+
+                            if (!isTap) return@awaitEachGesture
+
+                            var clickedLink = false
+                            outer@ for (rowIndex in renderLayout.cells.indices) {
+                                var cellY = 0f
+                                for (r in 0 until rowIndex) {
+                                    cellY += renderLayout.rowHeightsPx[r]
+                                }
+                                for (colIndex in renderLayout.cells[rowIndex].indices) {
+                                    var cellX = 0f
+                                    for (c in 0 until colIndex) {
+                                        cellX += renderLayout.columnWidthsPx[c]
+                                    }
+                                    val screenX = cellX - scrollOffsetPx
+                                    val cellWidth = renderLayout.columnWidthsPx[colIndex].toFloat()
+                                    val cellHeight = renderLayout.rowHeightsPx[rowIndex].toFloat()
+                                    if (
+                                        upPosition.x >= screenX &&
+                                        upPosition.x <= screenX + cellWidth &&
+                                        upPosition.y >= cellY &&
+                                        upPosition.y <= cellY + cellHeight
+                                    ) {
+                                        val cell = renderLayout.cells[rowIndex][colIndex]
+                                        val text = cell.layout.text
+                                        if (text is Spanned) {
+                                            val relativeX =
+                                                upPosition.x - screenX - cellHorizontalPaddingPx
+                                            val relativeY =
+                                                upPosition.y - cellY - cellVerticalPaddingPx
+                                            if (relativeX >= 0f && relativeY >= 0f) {
+                                                val line =
+                                                    cell.layout.getLineForVertical(relativeY.toInt())
+                                                val offset =
+                                                    cell.layout.getOffsetForHorizontal(line, relativeX)
+                                                val spans =
+                                                    text.getSpans(offset, offset, URLSpan::class.java)
+                                                spans.firstOrNull()?.let { span ->
+                                                    onLinkClick?.invoke(span.url)
+                                                    clickedLink = true
+                                                }
+                                            }
+                                        }
+                                        break@outer
+                                    }
+                                }
+                            }
+                            if (clickedLink) {
+                                up.consume()
+                            }
                         }
                     }
         ) {


### PR DESCRIPTION
fix(markdown): make links inside table cells clickable

## 背景与动机

Fixes #932

Markdown 表格中的链接无法点击打开。表格由 EnhancedTableBlock 用 Canvas + StaticLayout 自绘，单元格内的链接虽然以 URLSpan 存在于 Spannable 中（由 buildMarkdownInlineSpannableFromText 生成），但 Canvas 只注册了横向拖拽手势，没有任何点击命中检测，导致链接永远无法被点击。

## 改动范围

- EnhancedTableBlock.kt：新增 onLinkClick 参数；在 Canvas 上追加 tap 检测（awaitEachGesture，参考 UnifiedCanvasRenderer 已有的链接点击实现），将点击位置映射到「单元格 → 行/字符偏移 → URLSpan」，命中时触发 onLinkClick。
- CanvasMarkdownNodeRenderer.kt：将 onLinkClick 透传给表格组件（之前只有表格没接这个回调）。

## 兼容性

- 纯前端交互增强，无数据 / 配置 / API 变更，向后兼容。
- 未命中链接的点击不消费事件，行为不变。
- 表格横向滚动、fling 等手势不受影响。

## 验证

- 命中检测坐标与绘制逻辑一致（translate(-scrollOffsetPx) 后的单元格屏幕位置）。
- 遵循仓库 AGENTS.md 约定，未在本地执行编译/构建/测试；未改动构建输入，由 CI 的 PR Check 执行完整检查。

## 检查清单

- [x] 分支名符合规范（fix/ 前缀）
- [x] 仅包含本次修复相关改动，无无关格式化
- [x] 无兜底 / 回退逻辑