### PR TITLE
fix(ui): preserve window configuration during rotation

### DIFF
--- a/app/src/androidTest/java/com/ai/assistance/operit/util/LocaleUtilsConfigurationAndroidTest.kt
+++ b/app/src/androidTest/java/com/ai/assistance/operit/util/LocaleUtilsConfigurationAndroidTest.kt
@@ -1,0 +1,44 @@
+package com.ai.assistance.operit.util
+
+import android.content.res.Configuration
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocaleUtilsConfigurationAndroidTest {
+
+    @Test fun localeOverride_onlyDefinesLocaleFields() {
+        val override = LocaleUtils.createLocaleOverrideConfiguration(Locale.US)
+
+        assertEquals(Locale.US, override.locales[0])
+        assertEquals(Configuration.ORIENTATION_UNDEFINED, override.orientation)
+        assertEquals(Configuration.SCREEN_WIDTH_DP_UNDEFINED, override.screenWidthDp)
+        assertEquals(Configuration.SCREEN_HEIGHT_DP_UNDEFINED, override.screenHeightDp)
+        assertEquals(
+            Configuration.SMALLEST_SCREEN_WIDTH_DP_UNDEFINED,
+            override.smallestScreenWidthDp
+        )
+    }
+
+    @Test fun localizedContext_inheritsBaseWindowDimensions() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val baseConfiguration = context.resources.configuration
+        val localizedContext =
+            context.createConfigurationContext(
+                LocaleUtils.createLocaleOverrideConfiguration(Locale.US)
+            )
+        val localizedConfiguration = localizedContext.resources.configuration
+
+        assertEquals(baseConfiguration.orientation, localizedConfiguration.orientation)
+        assertEquals(baseConfiguration.screenWidthDp, localizedConfiguration.screenWidthDp)
+        assertEquals(baseConfiguration.screenHeightDp, localizedConfiguration.screenHeightDp)
+        assertEquals(
+            baseConfiguration.smallestScreenWidthDp,
+            localizedConfiguration.smallestScreenWidthDp
+        )
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/core/application/OperitApplication.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/application/OperitApplication.kt
@@ -573,15 +573,13 @@ class OperitApplication : Application(), ImageLoaderFactory, WorkConfiguration.P
         try {
             val code = LocaleUtils.getCurrentLanguage(base)
             val locale = LocaleUtils.getLocaleForLanguageCode(code, base)
-            val config = Configuration(base.resources.configuration)
+            val config = LocaleUtils.createLocaleOverrideConfiguration(locale)
 
             // 设置语言配置
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 val localeList = LocaleList(locale)
                 LocaleList.setDefault(localeList)
-                config.setLocales(localeList)
             } else {
-                config.locale = locale
                 Locale.setDefault(locale)
             }
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/main/MainActivity.kt
@@ -159,16 +159,14 @@ class MainActivity : ComponentActivity() {
         // 获取当前设置的语言
         val code = LocaleUtils.getCurrentLanguage(newBase)
         val locale = LocaleUtils.getLocaleForLanguageCode(code, newBase)
-        val config = Configuration(newBase.resources.configuration)
+        val config = LocaleUtils.createLocaleOverrideConfiguration(locale)
 
         // 设置语言配置
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             val localeList = LocaleList(locale)
             LocaleList.setDefault(localeList)
-            config.setLocales(localeList)
         } else {
             @Suppress("DEPRECATION")
-            config.locale = locale
             Locale.setDefault(locale)
         }
 

--- a/app/src/main/java/com/ai/assistance/operit/util/LocaleUtils.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/LocaleUtils.kt
@@ -77,6 +77,18 @@ object LocaleUtils {
                 ?: Locale(resolvedCode)
     }
 
+    fun createLocaleOverrideConfiguration(locale: Locale): Configuration {
+        // Keep this override sparse so window size and orientation continue to update.
+        return Configuration().apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                setLocales(LocaleList(locale))
+            } else {
+                @Suppress("DEPRECATION")
+                setLocale(locale)
+            }
+        }
+    }
+
     /**
      * 获取包含当前应用语言设置的上下文。
      * 对于使用applicationContext的单例或服务，这非常有用，
@@ -88,19 +100,7 @@ object LocaleUtils {
     fun getLocalizedContext(context: Context): Context {
         val lang = getCurrentLanguage(context)
         val locale = getLocaleForLanguageCode(lang, context)
-
-        val configuration = Configuration(context.resources.configuration)
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            configuration.setLocale(locale)
-            val localeList = LocaleList(locale)
-            configuration.setLocales(localeList)
-        } else {
-            @Suppress("DEPRECATION")
-            configuration.setLocale(locale)
-        }
-
-        return context.createConfigurationContext(configuration)
+        return context.createConfigurationContext(createLocaleOverrideConfiguration(locale))
     }
 
     /**

--- a/docs/TODO/phone_orientation_layout_860/1_SparseLocaleOverride.md
+++ b/docs/TODO/phone_orientation_layout_860/1_SparseLocaleOverride.md
@@ -1,0 +1,21 @@
+# Sparse Locale Override
+
+## Previous Implementation
+
+Each locale-aware context copied the complete base `Configuration` before changing its locale. `createConfigurationContext` interprets every defined field in that object as an override, including dimensions and orientation.
+
+## Change
+
+Create locale overrides from an empty `Configuration`, then set only the locale fields. Reuse that operation from the application, activity, and localized utility context paths. Add an Android test that verifies the override leaves the window-related fields undefined and inherits the base window dimensions.
+
+## Expected Result
+
+A phone that is launched while rotating can recompose with the current window width after the rotation settles. The existing responsive 600dp layout rule remains intact.
+
+## Completion
+
+- Added `LocaleUtils.createLocaleOverrideConfiguration` and used it for every localized Context path
+- Added Android instrumentation coverage for sparse override fields and inherited dimensions
+- Did not run Gradle tasks because no build or test command was requested
+
+[DONE]

--- a/docs/TODO/phone_orientation_layout_860/index.md
+++ b/docs/TODO/phone_orientation_layout_860/index.md
@@ -1,0 +1,39 @@
+---
+fork_repository: https://github.com/luojiaping/Operit.git
+upstream: https://github.com/AAswordman/Operit.git
+base: f83e69cba8e28ac78a35cffc4f1dae4acb118911
+issue: https://github.com/AAswordman/Operit/issues/860
+status: completed
+---
+
+# Phone Orientation Layout
+
+## Original State
+
+`MainActivity` creates its localized base context from a full copy of the startup `Configuration`. The copy becomes a persistent context override, so it can retain the startup window width and orientation after the activity handles a configuration change.
+
+## Intent
+
+Use a sparse locale-only configuration override. Window size, orientation, density, and other runtime configuration fields must continue to come from Android's current activity configuration.
+
+## Scope
+
+- `LocaleUtils`, `OperitApplication`, and `MainActivity` locale context creation
+- Android instrumentation coverage for sparse locale overrides
+- This TODO directory
+
+## Preserved Behavior
+
+The existing 600dp responsive navigation rule remains unchanged. Wide windows, including split-screen and foldable states, continue to select the permanent sidebar when their current width meets that threshold.
+
+## Steps
+
+1. [Sparse Locale Override](./1_SparseLocaleOverride.md)
+
+## Completion
+
+- Replaced complete locale context copies with a shared sparse override
+- Added Android instrumentation coverage for inherited orientation and window dimensions
+- Did not run Gradle tasks because no build or test command was requested
+
+[DONE]


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

手机在高频旋转中启动时，本地化 Context 会把启动瞬间的完整 Configuration 作为持久覆盖，导致最终窗口仍可能读取横屏宽度并进入永久侧栏布局。

### 改动范围 / Changes

- 创建只包含 locale 字段的稀疏 Configuration override。
- 在 MainActivity、OperitApplication 和 LocaleUtils 中统一使用该 override。
- 新增 Android instrumentation test，覆盖方向和窗口尺寸继承。
- 不改变现有 600dp 响应式导航规则。

### 兼容性与风险 / Compatibility and risks

保留已发布的宽窗口、分屏和折叠屏响应式行为；无数据、API 或配置迁移。修复后窗口尺寸和方向会继续跟随当前 Activity 配置。

## 关联 Issue / Related issue

Fixes #860

## 验证方式 / Verification

检查或命令：git diff --check
环境与变体：Windows 工作树；未连接 Android 设备。
结果：静态差异检查通过。未运行 Gradle 构建或测试，因为仓库默认要求仅在明确请求时执行。

## 证据 / Evidence

- 新增 LocaleUtilsConfigurationAndroidTest，验证 locale override 保持方向和窗口尺寸继承。
- 复核上游基线后的 PR 差异仅包含本问题修复、测试和协作记录。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 Candidate checks 覆盖改动范围，并会处理技术失败项 / Candidate checks covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided