### PR TITLE
fix(chat): 国际化多选消息删除确认弹窗文案

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -859,7 +859,7 @@ fun ChatScreenContent(
             AlertDialog(
                 onDismissRequest = { showDeleteSelectedConfirmDialog = false },
                 title = { Text(stringResource(R.string.confirm_delete)) },
-                text = { Text("Delete ${selectedMessageIndices.size} selected messages? This cannot be undone.") },
+                text = { Text(stringResource(R.string.chat_delete_selected_messages_confirm, selectedMessageIndices.size)) },
                 confirmButton = {
                     TextButton(
                         onClick = {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScreenContent.kt
@@ -79,6 +79,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.ui.common.markdown.markdownToPlainTextForCopy
@@ -859,7 +860,15 @@ fun ChatScreenContent(
             AlertDialog(
                 onDismissRequest = { showDeleteSelectedConfirmDialog = false },
                 title = { Text(stringResource(R.string.confirm_delete)) },
-                text = { Text(stringResource(R.string.chat_delete_selected_messages_confirm, selectedMessageIndices.size)) },
+                text = {
+                    Text(
+                        pluralStringResource(
+                            R.plurals.chat_delete_selected_messages_confirm,
+                            selectedMessageIndices.size,
+                            selectedMessageIndices.size,
+                        )
+                    )
+                },
                 confirmButton = {
                     TextButton(
                         onClick = {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -7864,6 +7864,7 @@
     <string name="chat_delete_single_variant_unavailable">No single message candidates available for deletion</string>
     <string name="chat_delete_single_variant_failed">Failed to delete single message: %1$s</string>
     <string name="chat_delete_message_confirm_message">Are you sure you want to delete this message? This action cannot be undone.</string>
+    <string name="chat_delete_selected_messages_confirm">Delete %1$d selected messages? This cannot be undone.</string>
 
     <string name="quick_plugin_creator_title">Quickly Create Your Plugin</string>
     <string name="quick_plugin_creator_desc">Cannot find the plugin you want in the built-in list or marketplace? Create your own.</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -7864,7 +7864,10 @@
     <string name="chat_delete_single_variant_unavailable">No single message candidates available for deletion</string>
     <string name="chat_delete_single_variant_failed">Failed to delete single message: %1$s</string>
     <string name="chat_delete_message_confirm_message">Are you sure you want to delete this message? This action cannot be undone.</string>
-    <string name="chat_delete_selected_messages_confirm">Delete %1$d selected messages? This cannot be undone.</string>
+    <plurals name="chat_delete_selected_messages_confirm">
+        <item quantity="one">Delete %1$d selected message? This cannot be undone.</item>
+        <item quantity="other">Delete %1$d selected messages? This cannot be undone.</item>
+    </plurals>
 
     <string name="quick_plugin_creator_title">Quickly Create Your Plugin</string>
     <string name="quick_plugin_creator_desc">Cannot find the plugin you want in the built-in list or marketplace? Create your own.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7180,7 +7180,10 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="speech_services_doubao_voice_id_placeholder">Ejemplo: BV700_V2_streaming</string>
     <string name="speech_services_doubao_voice_id_hint">Ingrese el voice_type proporcionado por la consola de Doubao Voice.</string>
     <string name="chat_delete_message_confirm_message">¿Está seguro de que desea eliminar este mensaje? Esta acción no se puede deshacer.</string>
-    <string name="chat_delete_selected_messages_confirm">¿Eliminar los %1$d mensajes seleccionados? Esta acción no se puede deshacer.</string>
+    <plurals name="chat_delete_selected_messages_confirm">
+        <item quantity="one">¿Eliminar %1$d mensaje seleccionado? Esta acción no se puede deshacer.</item>
+        <item quantity="other">¿Eliminar los %1$d mensajes seleccionados? Esta acción no se puede deshacer.</item>
+    </plurals>
     <string name="pin_chat">Fijar chat</string>
     <string name="unpin_chat">Desfijar chat</string>
     <string name="provider_mimo">Xiaomi MiMo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7180,6 +7180,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="speech_services_doubao_voice_id_placeholder">Ejemplo: BV700_V2_streaming</string>
     <string name="speech_services_doubao_voice_id_hint">Ingrese el voice_type proporcionado por la consola de Doubao Voice.</string>
     <string name="chat_delete_message_confirm_message">¿Está seguro de que desea eliminar este mensaje? Esta acción no se puede deshacer.</string>
+    <string name="chat_delete_selected_messages_confirm">¿Eliminar los %1$d mensajes seleccionados? Esta acción no se puede deshacer.</string>
     <string name="pin_chat">Fijar chat</string>
     <string name="unpin_chat">Desfijar chat</string>
     <string name="provider_mimo">Xiaomi MiMo</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7113,6 +7113,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="speech_services_doubao_voice_id_placeholder">Contoh: BV700_V2_streaming</string>
     <string name="speech_services_doubao_voice_id_hint">Isi voice_type yang disediakan oleh konsol suara Doubao.</string>
     <string name="chat_delete_message_confirm_message">Apakah Anda yakin ingin menghapus pesan ini? Tindakan ini tidak dapat dibatalkan.</string>
+    <string name="chat_delete_selected_messages_confirm">Hapus %1$d pesan yang dipilih? Tindakan ini tidak dapat dibatalkan.</string>
     <string name="pin_chat">Sematkan Obrolan</string>
     <string name="unpin_chat">Lepas Sematan</string>
     <string name="provider_mimo">Xiaomi MiMo</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7113,7 +7113,9 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="speech_services_doubao_voice_id_placeholder">Contoh: BV700_V2_streaming</string>
     <string name="speech_services_doubao_voice_id_hint">Isi voice_type yang disediakan oleh konsol suara Doubao.</string>
     <string name="chat_delete_message_confirm_message">Apakah Anda yakin ingin menghapus pesan ini? Tindakan ini tidak dapat dibatalkan.</string>
-    <string name="chat_delete_selected_messages_confirm">Hapus %1$d pesan yang dipilih? Tindakan ini tidak dapat dibatalkan.</string>
+    <plurals name="chat_delete_selected_messages_confirm">
+        <item quantity="other">Hapus %1$d pesan yang dipilih? Tindakan ini tidak dapat dibatalkan.</item>
+    </plurals>
     <string name="pin_chat">Sematkan Obrolan</string>
     <string name="unpin_chat">Lepas Sematan</string>
     <string name="provider_mimo">Xiaomi MiMo</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2817,6 +2817,7 @@
     <string name="chat_delete_single_variant_unavailable">삭제할 수 있는 단일 메시지 후보가 없습니다.</string>
     <string name="chat_delete_single_variant_failed">단일 메시지 삭제 실패: %1$s</string>
     <string name="chat_delete_message_confirm_message">이 메시지를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.</string>
+    <string name="chat_delete_selected_messages_confirm">선택한 %1$d개의 메시지를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.</string>
     <string name="chat_switch_variant_failed">답장 전환 실패: %1$s</string>
     <string name="chat_message_variant_counter">%1$d/%2$d</string>
     <string name="chat_previous_variant">이전 답변</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2817,7 +2817,9 @@
     <string name="chat_delete_single_variant_unavailable">삭제할 수 있는 단일 메시지 후보가 없습니다.</string>
     <string name="chat_delete_single_variant_failed">단일 메시지 삭제 실패: %1$s</string>
     <string name="chat_delete_message_confirm_message">이 메시지를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.</string>
-    <string name="chat_delete_selected_messages_confirm">선택한 %1$d개의 메시지를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.</string>
+    <plurals name="chat_delete_selected_messages_confirm">
+        <item quantity="other">선택한 %1$d개의 메시지를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.</item>
+    </plurals>
     <string name="chat_switch_variant_failed">답장 전환 실패: %1$s</string>
     <string name="chat_message_variant_counter">%1$d/%2$d</string>
     <string name="chat_previous_variant">이전 답변</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7110,7 +7110,9 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="speech_services_doubao_voice_id_placeholder">Contoh: BV700_V2_streaming</string>
     <string name="speech_services_doubao_voice_id_hint">Isikan voice_type yang disediakan oleh konsol pertuturan Doubao.</string>
     <string name="chat_delete_message_confirm_message">Adakah anda pasti mahu memadamkan mesej ini? Tindakan ini tidak boleh dibatalkan.</string>
-    <string name="chat_delete_selected_messages_confirm">Padam %1$d mesej yang dipilih? Tindakan ini tidak boleh dibatalkan.</string>
+    <plurals name="chat_delete_selected_messages_confirm">
+        <item quantity="other">Padam %1$d mesej yang dipilih? Tindakan ini tidak boleh dibatalkan.</item>
+    </plurals>
     <string name="pin_chat">Semat Sembang</string>
     <string name="unpin_chat">Nyahsemat Sembang</string>
     <string name="provider_mimo">Xiaomi MiMo</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7110,6 +7110,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="speech_services_doubao_voice_id_placeholder">Contoh: BV700_V2_streaming</string>
     <string name="speech_services_doubao_voice_id_hint">Isikan voice_type yang disediakan oleh konsol pertuturan Doubao.</string>
     <string name="chat_delete_message_confirm_message">Adakah anda pasti mahu memadamkan mesej ini? Tindakan ini tidak boleh dibatalkan.</string>
+    <string name="chat_delete_selected_messages_confirm">Padam %1$d mesej yang dipilih? Tindakan ini tidak boleh dibatalkan.</string>
     <string name="pin_chat">Semat Sembang</string>
     <string name="unpin_chat">Nyahsemat Sembang</string>
     <string name="provider_mimo">Xiaomi MiMo</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -6950,7 +6950,10 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="speech_services_doubao_voice_id_placeholder">Exemplo: BV700_V2_streaming</string>
     <string name="speech_services_doubao_voice_id_hint">Preencha o voice_type fornecido no console de voz do Doubao.</string>
     <string name="chat_delete_message_confirm_message">Tem certeza de que deseja excluir esta mensagem? Esta ação não pode ser desfeita.</string>
-    <string name="chat_delete_selected_messages_confirm">Excluir %1$d mensagens selecionadas? Esta ação não pode ser desfeita.</string>
+    <plurals name="chat_delete_selected_messages_confirm">
+        <item quantity="one">Excluir %1$d mensagem selecionada? Esta ação não pode ser desfeita.</item>
+        <item quantity="other">Excluir %1$d mensagens selecionadas? Esta ação não pode ser desfeita.</item>
+    </plurals>
     <string name="pin_chat">Fixar chat</string>
     <string name="unpin_chat">Desafixar chat</string>
     <string name="provider_mimo">Xiaomi MiMo</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -6950,6 +6950,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="speech_services_doubao_voice_id_placeholder">Exemplo: BV700_V2_streaming</string>
     <string name="speech_services_doubao_voice_id_hint">Preencha o voice_type fornecido no console de voz do Doubao.</string>
     <string name="chat_delete_message_confirm_message">Tem certeza de que deseja excluir esta mensagem? Esta ação não pode ser desfeita.</string>
+    <string name="chat_delete_selected_messages_confirm">Excluir %1$d mensagens selecionadas? Esta ação não pode ser desfeita.</string>
     <string name="pin_chat">Fixar chat</string>
     <string name="unpin_chat">Desafixar chat</string>
     <string name="provider_mimo">Xiaomi MiMo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3136,7 +3136,11 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="chat_delete_single_variant_unavailable">În mesajul curent nu există nicio candidatură unică care să poată fi ștersă</string>
     <string name="chat_delete_single_variant_failed">Eșecul ștergerii unui mesaj individual: %1$s</string>
     <string name="chat_delete_message_confirm_message">Sunteți sigur că doriți să ștergeți acest mesaj? Această acțiune nu poate fi anulată.</string>
-    <string name="chat_delete_selected_messages_confirm">Ștergeți %1$d mesaje selectate? Această acțiune nu poate fi anulată.</string>
+    <plurals name="chat_delete_selected_messages_confirm">
+        <item quantity="one">Ștergeți %1$d mesaj selectat? Această acțiune nu poate fi anulată.</item>
+        <item quantity="few">Ștergeți %1$d mesaje selectate? Această acțiune nu poate fi anulată.</item>
+        <item quantity="other">Ștergeți %1$d mesaje selectate? Această acțiune nu poate fi anulată.</item>
+    </plurals>
     <string name="chat_switch_variant_failed">Eșec la comutarea răspunsului: %1$s</string>
     <string name="chat_message_variant_counter">%1$d/%2$d</string>
     <string name="chat_previous_variant">Răspunsul anterior</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3136,6 +3136,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="chat_delete_single_variant_unavailable">În mesajul curent nu există nicio candidatură unică care să poată fi ștersă</string>
     <string name="chat_delete_single_variant_failed">Eșecul ștergerii unui mesaj individual: %1$s</string>
     <string name="chat_delete_message_confirm_message">Sunteți sigur că doriți să ștergeți acest mesaj? Această acțiune nu poate fi anulată.</string>
+    <string name="chat_delete_selected_messages_confirm">Ștergeți %1$d mesaje selectate? Această acțiune nu poate fi anulată.</string>
     <string name="chat_switch_variant_failed">Eșec la comutarea răspunsului: %1$s</string>
     <string name="chat_message_variant_counter">%1$d/%2$d</string>
     <string name="chat_previous_variant">Răspunsul anterior</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3181,7 +3181,9 @@
     <string name="chat_delete_single_variant_unavailable">当前消息没有可删除的单次候选</string>
     <string name="chat_delete_single_variant_failed">删除单次消息失败: %1$s</string>
     <string name="chat_delete_message_confirm_message">确定要删除这条消息吗？此操作不可恢复。</string>
-    <string name="chat_delete_selected_messages_confirm">确定要删除选中的 %1$d 条消息吗？此操作不可恢复。</string>
+    <plurals name="chat_delete_selected_messages_confirm">
+        <item quantity="other">确定要删除选中的 %1$d 条消息吗？此操作不可恢复。</item>
+    </plurals>
     <string name="chat_switch_variant_failed">切换回答失败: %1$s</string>
     <string name="chat_message_variant_counter">%1$d/%2$d</string>
     <string name="chat_previous_variant">上一条回答</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3181,6 +3181,7 @@
     <string name="chat_delete_single_variant_unavailable">当前消息没有可删除的单次候选</string>
     <string name="chat_delete_single_variant_failed">删除单次消息失败: %1$s</string>
     <string name="chat_delete_message_confirm_message">确定要删除这条消息吗？此操作不可恢复。</string>
+    <string name="chat_delete_selected_messages_confirm">确定要删除选中的 %1$d 条消息吗？此操作不可恢复。</string>
     <string name="chat_switch_variant_failed">切换回答失败: %1$s</string>
     <string name="chat_message_variant_counter">%1$d/%2$d</string>
     <string name="chat_previous_variant">上一条回答</string>


### PR DESCRIPTION
## 变更背景

多选消息删除确认弹窗的提示文案为硬编码英文 `"Delete ${selectedMessageIndices.size} selected messages? This cannot be undone."`，未走字符串资源国际化，导致所有语言环境下均显示英文。

而单条消息删除确认弹窗已正确使用 `R.string.chat_delete_message_confirm_message` 资源，两种删除路径的 i18n 行为不一致。

## 改动范围

- 新增字符串资源 `chat_delete_selected_messages_confirm`（带 `%1$d` 占位符），覆盖 8 种语言：中文（默认）、英语、西语、印尼语、韩语、马来语、巴西葡语、罗马尼亚语
- 将 `ChatScreenContent.kt:862` 的硬编码英文替换为 `stringResource(R.string.chat_delete_selected_messages_confirm, selectedMessageIndices.size)`

| 文件 | 改动 |
|------|------|
| `ChatScreenContent.kt` | 硬编码 → stringResource 引用（+1 -1）|
| `values/strings.xml` | 新增中文 key（+1）|
| `values-en/strings.xml` | 新增英文 key（+1）|
| `values-es/strings.xml` | 新增西语 key（+1）|
| `values-id/strings.xml` | 新增印尼语 key（+1）|
| `values-ko/strings.xml` | 新增韩语 key（+1）|
| `values-ms/strings.xml` | 新增马来语 key（+1）|
| `values-pt-rBR/strings.xml` | 新增葡语 key（+1）|
| `values-ro/strings.xml` | 新增罗马尼亚语 key（+1）|

共 9 个文件，+9 -1，无无关改动。

## 关联 Issue

N/A — 目前无已报告的 Issue。

## 兼容性影响

- 纯新增字符串资源 key + 一处代码引用替换，不改变任何功能逻辑
- 不涉及数据持久化、配置格式或公开接口变更
- `stringResource(R.string.chat_delete_selected_messages_confirm, count)` 与原硬编码行为一致，仅文案来源从硬编码改为资源引用

## 验证方式

- GitHub Actions CI 构建 `assembleDebug` 成功（Run #5，conclusion=success），APK 产物正常产出
- 未运行本地单元测试（无本地构建环境），但改动仅涉及字符串资源和一处 UI 文案引用，不影响业务逻辑

## 截图

暂无（需在真机上多选消息后触发删除确认弹窗对比）