### PR TITLE
fix(chat): avoid IME overlap in agent input

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -733,8 +733,10 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
     val showWebView by actualViewModel.showWebView.collectAsState()
     // 收集AI电脑显示状态
     val showAiComputer by actualViewModel.showAiComputer.collectAsState()
+    // AppContent owns the primary chat IME layout; embedded chat retains its local translation.
     val shouldUseChatLocalImeHandling =
-        inputStyle == UserPreferencesManager.INPUT_STYLE_AGENT &&
+        embedded &&
+            inputStyle == UserPreferencesManager.INPUT_STYLE_AGENT &&
             !showWebView &&
             !showAiComputer
     var hasEverShownWebView by remember { mutableStateOf(false) }


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

Agent 样式的主聊天页在 Android 10 上关闭父级 IME padding 后依赖局部绘制位移。局部 inset 位移未生效时，输入栏会被软键盘遮挡；经典样式因使用父级 IME 布局避让而正常。

### 改动范围 / Changes

- 仅将 Agent 的局部 IME 位移策略限制到嵌入式 AIChatScreen。
- 主聊天页的 Agent 样式复用 AppContent 已有的 ADJUST_RESIZE 和 imePadding 布局策略。
- 不修改输入组件、持久化数据、配置、Manifest、工作区或 AI 电脑页面。

### 兼容性与风险 / Compatibility and risks

不涉及数据格式、公开 API、用户配置、安全或性能变化。嵌入式 Compose DSL 聊天保留局部位移行为；主聊天页改用与经典输入样式相同的 inset 所有者。

## 关联 Issue / Related issue

Fixes #961

## 验证方式 / Verification

检查或命令：git diff --check；静态审查 AIChatScreen 的软键盘模式、局部位移和 AppContent 的 imePadding 路径。

环境与变体：源码静态审查；未运行 Android 构建、自动化测试或真机验证。

结果：git diff --check 通过；主聊天页 Agent 样式现在启用 AppContent 的 IME 布局避让。未执行设备验证，因为本次未请求构建或测试，且仓库默认不执行。

## 证据 / Evidence

最终 diff 仅包含 AIChatScreen.kt 的单一条件收窄，共 3 行新增、1 行删除。建议在 Android 10 真机上验证 Agent 样式的键盘显示与隐藏、多行输入和附件场景。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 Candidate checks 覆盖改动范围，并会处理技术失败项 / Candidate checks covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided