### PR TITLE
fix(editor): step fling on the main thread to fix no-looper crash on HONOR (#798)

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/editor/CanvasCodeEditorView.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/editor/CanvasCodeEditorView.kt
@@ -276,6 +276,21 @@ class CanvasCodeEditorView @JvmOverloads constructor(
             }
         )
 
+    // Steps the fling on the main thread, one Choreographer frame at a time. OverScroller is a
+    // UI-thread helper: it is not thread-safe, and some OEM frameworks (e.g. HONOR) call
+    // Choreographer.getInstance() inside computeScrollOffset(), which throws
+    // "The current thread must have a looper!" when it runs on the render thread (#798).
+    // The render thread only draws whatever scroll offsets this runnable publishes.
+    private val flingRunnable = object : Runnable {
+        override fun run() {
+            if (!scroller.computeScrollOffset()) {
+                return
+            }
+            setScrollOffsets(scroller.currX.toFloat(), scroller.currY.toFloat())
+            postOnAnimation(this)
+        }
+    }
+
     init {
         setZOrderOnTop(false)
         setZOrderMediaOverlay(false)
@@ -295,6 +310,7 @@ class CanvasCodeEditorView @JvmOverloads constructor(
             return
         }
         isReleased = true
+        removeCallbacks(flingRunnable)
         stopRenderThread()
         actionMode?.finish()
         actionMode = null
@@ -816,7 +832,10 @@ class CanvasCodeEditorView @JvmOverloads constructor(
             0,
             maxScrollY().roundToInt()
         )
-        requestRender()
+        // A MOVE that stopped the previous fling and the UP that starts this one can land in
+        // the same frame, leaving the previous step still posted; drop it so only one runs.
+        removeCallbacks(flingRunnable)
+        postOnAnimation(flingRunnable)
     }
 
     private fun setScrollOffsets(x: Float, y: Float, request: Boolean = true) {
@@ -1881,16 +1900,7 @@ class CanvasCodeEditorView @JvmOverloads constructor(
 
         override fun run() {
             while (running) {
-                var needsDraw = false
-                if (scroller.computeScrollOffset()) {
-                    scrollOffsetX = scroller.currX.toFloat()
-                    scrollOffsetY = scroller.currY.toFloat()
-                    needsDraw = true
-                } else if (isDirty) {
-                    needsDraw = true
-                }
-
-                if (!needsDraw) {
+                if (!isDirty) {
                     synchronized(renderSignal) {
                         if (!running && !isDirty) {
                             return
@@ -1925,23 +1935,15 @@ class CanvasCodeEditorView @JvmOverloads constructor(
                     }.getOrNull()
 
                 if (canvas != null) {
+                    // Clear the flag before drawing: fling steps now arrive from the main thread
+                    // while a frame may be in flight, and a request that lands mid-draw must
+                    // survive to trigger the next frame instead of being wiped after the draw.
+                    isDirty = false
                     try {
                         drawEditor(canvas)
-                        isDirty = false
                     } finally {
                         runCatching {
                             holder.unlockCanvasAndPost(canvas)
-                        }
-                    }
-                }
-
-                if (scroller.computeScrollOffset()) {
-                    isDirty = true
-                    try {
-                        sleep(16L)
-                    } catch (_: InterruptedException) {
-                        if (!running) {
-                            return
                         }
                     }
                 }


### PR DESCRIPTION
## 变更说明 / Description

工作区代码编辑器在部分厂商 ROM（Issue 报告为 HONOR LGE-AN00 / Android 14）上，打开较长文件后手指快速滑动（fling）会直接崩溃：`IllegalStateException: The current thread must have a looper!`。本 PR 把惯性滚动的步进从渲染线程移回主线程，修掉这个崩溃。

### 背景与动机 / Context and motivation

`CanvasCodeEditorView` 是一个 `SurfaceView`，用自己的 `RenderThread` 绘制。它把 `OverScroller.computeScrollOffset()` 放在渲染线程里驱动惯性滚动，而 `fling()` / `forceFinished()` 在主线程调用。

`OverScroller` 是 UI 线程的动画辅助类，本身没有任何同步。AOSP 的 `computeScrollOffset()` 只做时间插值，所以在原生系统上"碰巧能跑"；HONOR 的框架在 `SplineOverScroller.update()` 里经由 `HnPromotionAnimationManager.getFrameIntervalNanos()` 调用了 `Choreographer.getInstance()`，而 `Choreographer` 要求当前线程持有 Looper。渲染线程没有 Looper，于是第一次 fling 就抛异常，与 Issue 中的栈完全吻合：

```
java.lang.IllegalStateException: The current thread must have a looper!
    at android.view.Choreographer.getInstance(Choreographer.java:504)
    at android.view.HnPromotionAnimationManager.getFrameIntervalNanos(...)
    at android.widget.OverScroller$SplineOverScroller.update(OverScroller.java:1325)
    at android.widget.OverScroller.computeScrollOffset(OverScroller.java:483)
    at ...CanvasCodeEditorView$RenderThread.run(CanvasCodeEditorView.kt:1938)
```

根因是 `OverScroller` 被跨线程使用，而不是"渲染线程缺一个 Looper"。所以没有采用 Issue 评论里"在渲染线程 `Looper.prepare()`"的方案：那会在一个不跑 `Looper.loop()` 的线程上创建 `Choreographer` 和 vsync 接收器，只是掩盖问题。项目里 `SqlTableView` 已经是主线程 `computeScroll()` 驱动 `OverScroller` 的标准写法，本 PR 与之保持一致。

### 改动范围 / Changes

只改 `app/src/main/java/com/ai/assistance/operit/ui/features/chat/webview/workspace/editor/CanvasCodeEditorView.kt`（+25 / −23）：

- 新增主线程的 `flingRunnable`：每一帧用 `View.postOnAnimation` 调 `scroller.computeScrollOffset()`，把 `currX/currY` 通过既有的 `setScrollOffsets()` 发布并 `requestRender()`，直到 scroller 结束。`startFling()` 改为投递这个 runnable；投递前先 `removeCallbacks`，避免同一帧内 MOVE 结束上一次 fling、UP 又开始新 fling 时重复投递。
- `RenderThread.run()` 不再触碰 `scroller`：去掉两处 `computeScrollOffset()` 调用和 fling 期间的 `sleep(16)` 循环，渲染线程只按 `isDirty` 绘制。
- `isDirty` 改为绘制前清除而不是绘制后：fling 步进现在来自另一个线程，可能在一帧绘制过程中到达，如果绘制后再清会吞掉这次请求。绘制路径（`drawEditor` 及其 helper）里没有任何 `requestRender()` 调用，不会形成重绘循环。
- `release()` 时 `removeCallbacks(flingRunnable)`。

不包含：滚动手感/物理参数的调整、渲染线程等待策略（`wait(24L)`）的改动、其他文件。

### 兼容性与风险 / Compatibility and risks

无用户可见接口、数据、配置或字符串变化。惯性滚动的位置计算仍由 `OverScroller` 完成，只是步进时机从渲染线程固定 `sleep(16)` 改为跟随 Choreographer 帧（在高刷屏上会更顺）。`OverScroller` 现在只在主线程被访问，也顺带消除了原来 `fling()`（主线程）与 `computeScrollOffset()`（渲染线程）之间的数据竞争。

## 关联 Issue / Related issue

Fixes #798

## 验证方式 / Verification

```text
检查或命令：
  kotlinc 直接类型检查 editor 包（含 CanvasCodeEditorView.kt 及其同包依赖，classpath = android-36.1 android.jar +
    compose ui-graphics/ui-unit）→ 0 errors / 0 warnings，新的 flingRunnable 匿名类正常生成
  本机未能跑 ./gradlew :app:compileDebugKotlin：Windows 上缺 NDK/CMake、terminal 子模块与 jniLibs/ffmpeg-kit 手动依赖，
    AGP 在配置阶段就要为 :mnn/:llama 等 native 模块装 NDK；完整 Kotlin 编译交给 CI 的 Android JVM tests job
  python3 -B ci/script/check_repo_hygiene.py --base upstream/main --candidate HEAD  → errors=0 warnings=0
  python3 -B ci/script/check_markdown_links.py --base upstream/main --candidate HEAD → errors=0 warnings=0
  python3 -B ci/script/check_localizations.py --base upstream/main --candidate HEAD  → errors=0 warnings=0
  python3 -B -m unittest discover -s ci/test -p 'test_*.py' → 44/46 通过；2 个失败是 Windows 上无符号链接权限
    (WinError 1314) 导致的环境问题，与本改动无关，CI 的 Ubuntu runner 不受影响
环境与变体：
  Windows 11，JDK 21，Kotlin 编译器 2.0.21（项目为 2.2.21，本文件无版本相关语法）；debug 变体
结果：
  改动文件编译通过；仓库快速检查全部通过；崩溃调用点（渲染线程内的 OverScroller.computeScrollOffset）已不存在
未运行项：
  没有 HONOR 设备，未能在真机上复现并验证崩溃消失；从栈上看崩溃点已经不存在（渲染线程不再调用
  OverScroller）。如果方便的话，希望 Issue 作者 @yazerst-live 能在合并后的 nightly 上验证一下。
  web-chat typecheck 未运行：改动不涉及 web-chat/。
```

## 证据 / Evidence

Issue 中的崩溃栈见上文；改动为纯逻辑修复，无 UI 变化，无截图。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
