### PR TITLE
ci: optimize Android CI caching

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -57,6 +57,8 @@ env:
   NODE_VERSION: '22'
   ANDROID_NDK_VERSION: '25.1.8937393'
   ANDROID_CMAKE_VERSION: '3.22.1'
+  ANDROID_API_LEVEL: '26'
+  RUST_VERSION: '1.88.0'
   MANUAL_DEPS_DIR: manual-deps
 
 jobs:
@@ -92,6 +94,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
 
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
@@ -113,6 +116,13 @@ jobs:
             "build-tools;35.0.0" \
             "ndk;$ANDROID_NDK_VERSION" \
             "cmake;$ANDROID_CMAKE_VERSION"
+
+      - name: Restore Android CMake source cache
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            **/.cxx/operit_deps/*-src
+          key: android-cmake-sources-${{ runner.os }}-${{ runner.arch }}-arm64-v8a-ndk-${{ env.ANDROID_NDK_VERSION }}-cmake-${{ env.ANDROID_CMAKE_VERSION }}-${{ hashFiles('cmake/**', '**/CMakeLists.txt', '**/*.cmake', '**/build.gradle.kts', 'gradle.properties') }}
 
       - name: Restore Android dependency cache
         id: cache-manual-deps
@@ -145,17 +155,17 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             tools/native_ripgrep/target
-          key: native-ripgrep-arm64-${{ runner.os }}-${{ hashFiles('tools/native_ripgrep/Cargo.lock') }}
+          key: native-ripgrep-arm64-${{ runner.os }}-${{ runner.arch }}-ndk-${{ env.ANDROID_NDK_VERSION }}-api-${{ env.ANDROID_API_LEVEL }}-rust-${{ env.RUST_VERSION }}-${{ hashFiles('tools/native_ripgrep/Cargo.toml', 'tools/native_ripgrep/Cargo.lock', 'tools/native_ripgrep/**/*.rs', 'tools/native_ripgrep/build_native_ripgrep.ps1') }}
 
       - name: Build native ripgrep
         shell: bash
         run: |
           set -euo pipefail
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION"
-          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang"
-          rustup toolchain install 1.88.0 --profile minimal
-          rustup target add --toolchain 1.88.0 aarch64-linux-android
-          cargo +1.88.0 build \
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
+          rustup toolchain install "$RUST_VERSION" --profile minimal
+          rustup target add --toolchain "$RUST_VERSION" aarch64-linux-android
+          cargo "+$RUST_VERSION" build \
             --manifest-path tools/native_ripgrep/Cargo.toml \
             --release \
             --target aarch64-linux-android \
@@ -201,7 +211,7 @@ jobs:
             *) echo "Unsupported workflow event: $EVENT_NAME" >&2; exit 2 ;;
           esac
           chmod +x ./gradlew
-          ./gradlew "$gradle_task" --stacktrace --no-build-cache --no-daemon
+          ./gradlew "$gradle_task" --stacktrace --no-daemon
 
       - name: Upload Android reports
         if: always()

--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -46,6 +46,8 @@ env:
   JAVA_VERSION: '21'
   ANDROID_BUILD_TOOLS_VERSION: '35.0.0'
   ANDROID_NDK_VERSION: '25.1.8937393'
+  ANDROID_API_LEVEL: '26'
+  RUST_VERSION: '1.88.0'
   MANUAL_DEPS_DIR: manual-deps
 
 jobs:
@@ -81,6 +83,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
@@ -127,17 +130,17 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             tools/native_ripgrep/target
-          key: native-ripgrep-arm64-${{ runner.os }}-${{ hashFiles('tools/native_ripgrep/Cargo.lock') }}
+          key: native-ripgrep-arm64-${{ runner.os }}-${{ runner.arch }}-ndk-${{ env.ANDROID_NDK_VERSION }}-api-${{ env.ANDROID_API_LEVEL }}-rust-${{ env.RUST_VERSION }}-${{ hashFiles('tools/native_ripgrep/Cargo.toml', 'tools/native_ripgrep/Cargo.lock', 'tools/native_ripgrep/**/*.rs', 'tools/native_ripgrep/build_native_ripgrep.ps1') }}
 
       - name: Build native ripgrep
         shell: bash
         run: |
           set -euo pipefail
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION"
-          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang"
-          rustup toolchain install 1.88.0 --profile minimal
-          rustup target add --toolchain 1.88.0 aarch64-linux-android
-          cargo +1.88.0 build \
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
+          rustup toolchain install "$RUST_VERSION" --profile minimal
+          rustup target add --toolchain "$RUST_VERSION" aarch64-linux-android
+          cargo "+$RUST_VERSION" build \
             --manifest-path tools/native_ripgrep/Cargo.toml \
             --release \
             --target aarch64-linux-android \
@@ -154,7 +157,7 @@ jobs:
           echo "sdk.dir=$ANDROID_HOME" > local.properties
 
       - name: Run JVM unit tests
-        run: ./gradlew :app:testDebugUnitTest --stacktrace --no-build-cache --no-daemon
+        run: ./gradlew :app:testDebugUnitTest --stacktrace --no-daemon
 
       - name: Upload Android test reports
         if: always()

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,6 +19,8 @@ env:
   ANDROID_BUILD_TOOLS_VERSION: '35.0.0'
   ANDROID_NDK_VERSION: '25.1.8937393'
   ANDROID_CMAKE_VERSION: '3.22.1'
+  ANDROID_API_LEVEL: '26'
+  RUST_VERSION: '1.88.0'
   MANUAL_DEPS_DIR: manual-deps
 
 jobs:
@@ -299,6 +301,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
 
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
@@ -319,6 +322,13 @@ jobs:
             "build-tools;$ANDROID_BUILD_TOOLS_VERSION" \
             "ndk;$ANDROID_NDK_VERSION" \
             "cmake;$ANDROID_CMAKE_VERSION"
+
+      - name: Restore Android CMake source cache
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: |
+            **/.cxx/operit_deps/*-src
+          key: android-cmake-sources-${{ runner.os }}-${{ runner.arch }}-arm64-v8a-ndk-${{ env.ANDROID_NDK_VERSION }}-cmake-${{ env.ANDROID_CMAKE_VERSION }}-${{ hashFiles('cmake/**', '**/CMakeLists.txt', '**/*.cmake', '**/build.gradle.kts', 'gradle.properties') }}
 
       - name: Restore full Android dependency cache
         id: cache-full-deps
@@ -351,17 +361,17 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             tools/native_ripgrep/target
-          key: native-ripgrep-arm64-${{ runner.os }}-${{ hashFiles('tools/native_ripgrep/Cargo.lock') }}
+          key: native-ripgrep-arm64-${{ runner.os }}-${{ runner.arch }}-ndk-${{ env.ANDROID_NDK_VERSION }}-api-${{ env.ANDROID_API_LEVEL }}-rust-${{ env.RUST_VERSION }}-${{ hashFiles('tools/native_ripgrep/Cargo.toml', 'tools/native_ripgrep/Cargo.lock', 'tools/native_ripgrep/**/*.rs', 'tools/native_ripgrep/build_native_ripgrep.ps1') }}
 
       - name: Build native ripgrep
         shell: bash
         run: |
           set -euo pipefail
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION"
-          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang"
-          rustup toolchain install 1.88.0 --profile minimal
-          rustup target add --toolchain 1.88.0 aarch64-linux-android
-          cargo +1.88.0 build \
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
+          rustup toolchain install "$RUST_VERSION" --profile minimal
+          rustup target add --toolchain "$RUST_VERSION" aarch64-linux-android
+          cargo "+$RUST_VERSION" build \
             --manifest-path tools/native_ripgrep/Cargo.toml \
             --release \
             --target aarch64-linux-android \
@@ -399,7 +409,7 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x ./gradlew
-          ./gradlew assembleDebug --stacktrace --no-build-cache --no-daemon
+          ./gradlew assembleDebug --stacktrace --no-daemon
 
   android_tests:
     name: Android JVM tests
@@ -437,6 +447,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
+          cache: gradle
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
@@ -506,17 +517,17 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             tools/native_ripgrep/target
-          key: native-ripgrep-arm64-${{ runner.os }}-${{ hashFiles('tools/native_ripgrep/Cargo.lock') }}
+          key: native-ripgrep-arm64-${{ runner.os }}-${{ runner.arch }}-ndk-${{ env.ANDROID_NDK_VERSION }}-api-${{ env.ANDROID_API_LEVEL }}-rust-${{ env.RUST_VERSION }}-${{ hashFiles('tools/native_ripgrep/Cargo.toml', 'tools/native_ripgrep/Cargo.lock', 'tools/native_ripgrep/**/*.rs', 'tools/native_ripgrep/build_native_ripgrep.ps1') }}
 
       - name: Build native ripgrep
         shell: bash
         run: |
           set -euo pipefail
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION"
-          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang"
-          rustup toolchain install 1.88.0 --profile minimal
-          rustup target add --toolchain 1.88.0 aarch64-linux-android
-          cargo +1.88.0 build \
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
+          rustup toolchain install "$RUST_VERSION" --profile minimal
+          rustup target add --toolchain "$RUST_VERSION" aarch64-linux-android
+          cargo "+$RUST_VERSION" build \
             --manifest-path tools/native_ripgrep/Cargo.toml \
             --release \
             --target aarch64-linux-android \
@@ -543,7 +554,7 @@ jobs:
           if [[ "$INSTRUMENTATION_REQUIRED" == "true" ]]; then
             tasks+=(":app:compileDebugAndroidTestKotlin" ":app:compileDebugAndroidTestJavaWithJavac")
           fi
-          ./gradlew "${tasks[@]}" --stacktrace --no-build-cache --no-daemon
+          ./gradlew "${tasks[@]}" --stacktrace --no-daemon
 
   candidate:
     name: Candidate checks

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -406,9 +406,7 @@ android {
         }
         
         ndk {
-            // Explicitly specify the ABIs we package for the app process.
-            // terminal now also ships x86_64 runtime binaries for the Android Studio emulator,
-            // while the rest of the app remains primarily ARM-focused.
+            // Keep native compilation aligned with the app's only supported ABI.
             abiFilters.addAll(listOf("arm64-v8a"))
         }
 

--- a/avator/dragonbones/build.gradle.kts
+++ b/avator/dragonbones/build.gradle.kts
@@ -13,6 +13,10 @@ android {
     defaultConfig {
         minSdk = 26
 
+        ndk {
+            abiFilters.addAll(listOf("arm64-v8a"))
+        }
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
 

--- a/docs/TODO/android_ci_cache_optimization_20260815/index.md
+++ b/docs/TODO/android_ci_cache_optimization_20260815/index.md
@@ -1,0 +1,38 @@
+---
+title: Android CI 缓存与 ARM64 构建优化
+repo: https://github.com/luojiaping/Operit
+upstream: https://github.com/AAswordman/Operit
+status: in-progress
+---
+
+# Android CI 缓存与 ARM64 构建优化
+
+## 原本状况
+
+Android CI 显式使用 `--no-build-cache`，JDK setup 没有启用 Gradle 依赖和 Wrapper 缓存。CMake 依赖 source 位于各模块的 `.cxx/operit_deps`，每个 runner 都重新下载。native ripgrep 的缓存 key 只包含系统和 `Cargo.lock`，没有绑定 NDK、Rust、Android API 或 runner 架构。
+
+DragonBones native module 没有声明 ABI 过滤器，而应用和其他 native module 只支持 `arm64-v8a`。
+
+## 修改意图
+
+- 让 Gradle 复用依赖、Wrapper 和可复用的 build cache
+- 让 CMake 只复用带工具链和源码配置 key 的 source tree，不复用带绝对路径的 binary tree
+- 让 native ripgrep cache key 覆盖实际编译环境
+- 让 DragonBones 的 native 编译范围与应用支持的 `arm64-v8a` 一致
+
+## 作用域
+
+- `.github/workflows/android-build.yml`
+- `.github/workflows/android-tests.yml`
+- `.github/workflows/pr-check.yml`
+- `avator/dragonbones/build.gradle.kts`
+- `app/build.gradle.kts`
+- 本 TODO 目录
+
+## 验证
+
+- [ ] 通过 workflow YAML、仓库门禁和 diff 检查
+- [ ] 推送 `ci/android-cache-optimization` 到 fork
+- [ ] 在 fork PR 中验证 Android build 与 Android JVM tests
+- [ ] 连续运行确认 Gradle、CMake source 和 native ripgrep cache 命中
+- [ ] 确认 APK 只包含 `lib/arm64-v8a/`

--- a/docs/TODO/android_ci_cache_optimization_20260815/index.md
+++ b/docs/TODO/android_ci_cache_optimization_20260815/index.md
@@ -2,7 +2,7 @@
 title: Android CI 缓存与 ARM64 构建优化
 repo: https://github.com/luojiaping/Operit
 upstream: https://github.com/AAswordman/Operit
-status: in-progress
+status: verified
 ---
 
 # Android CI 缓存与 ARM64 构建优化
@@ -31,8 +31,17 @@ DragonBones native module 没有声明 ABI 过滤器，而应用和其他 native
 
 ## 验证
 
-- [ ] 通过 workflow YAML、仓库门禁和 diff 检查
-- [ ] 推送 `ci/android-cache-optimization` 到 fork
-- [ ] 在 fork PR 中验证 Android build 与 Android JVM tests
-- [ ] 连续运行确认 Gradle、CMake source 和 native ripgrep cache 命中
-- [ ] 确认 APK 只包含 `lib/arm64-v8a/`
+- [x] 通过 workflow YAML、仓库门禁和 diff 检查
+- [x] 推送 `ci/android-cache-optimization` 到 fork
+- [x] 在 fork PR [#16](https://github.com/luojiaping/Operit/pull/16) 中验证 Android build 与 Android JVM tests
+- [x] 连续运行确认 Gradle、CMake source 和 native ripgrep cache 命中
+- [x] 构建日志中的 native packaging 路径仅使用 `lib/arm64-v8a/`
+
+## 结果
+
+Fork run `31875454511` 的两次尝试均通过 `Fast checks`、`Android JVM tests`、`Android build` 和 `Candidate checks`。
+
+- 首次 Android build：Gradle `24m31s`，`329` 个 actionable tasks 中 `29` 个来自 cache；CMake source cache 首次 miss，完成后保存约 `337 MB`
+- 第二次 Android build：Gradle `15m46s`，job 总耗时约 `17m51s`，`329` 个 actionable tasks 中 `116` 个来自 cache
+- 第二次日志确认 Gradle wrapper/dependency、CMake source 和 native ripgrep cache 均命中
+- Android JVM tests 从首次约 `11m04s` 降至第二次约 `2m28s`


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

Android 仅支持 arm64-v8a。现有 CI 禁用了 Gradle build cache，未缓存 Gradle dependency/Wrapper，CMake 依赖 source 每个 runner 都重新下载，native ripgrep cache key 也没有绑定完整工具链环境。

### 改动范围 / Changes

- 启用 Android build/test jobs 的 Gradle dependency、Wrapper 和 build cache。
- 缓存带 OS、runner 架构、arm64-v8a、NDK、CMake 和源码配置 key 的 CMake source tree；不缓存带绝对路径的 binary tree。
- 扩展 native ripgrep cache key，绑定 NDK、Android API、Rust 版本、架构和源码。
- 为 DragonBones 增加 arm64-v8a ABI 过滤。
- Out of scope：不改变应用 API、用户数据、模型内容或非 ARM64 支持。

### 兼容性与风险 / Compatibility and risks

仅影响 CI 构建范围和缓存行为。应用本来只支持 arm64-v8a；CMake binary 目录不进入 cache，工具链和源码配置变化会使 source cache 失效。

## 关联 Issue / Related issue

N/A：CI 性能维护改动，基于 fork Android build 日志和缓存命中数据。

## 验证方式 / Verification

`	ext
检查或命令：GitHub Actions PR Check；fork PR #16 run 31875454511 两次尝试，以及文档提交后的 run 31877783919
环境与变体：ubuntu-24.04，Android assembleDebug，Android JVM tests，arm64-v8a
结果：Fast checks、Android build、Android JVM tests、Candidate checks 全部通过
` 

## 证据 / Evidence

- 首次 Android build：Gradle 24m31s，329 tasks 中 29 个来自 cache；CMake source cache 保存约 337 MB。
- 第二次 Android build：Gradle 15m46s，329 tasks 中 116 个来自 cache；Gradle、CMake source 和 native ripgrep cache 均命中。
- Android JVM tests 从约 11m04s 降至约 2m28s。

## 检查清单 / Checklist

- [x] 已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 已确认 Candidate checks 覆盖改动范围 / Candidate checks covers the change scope
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供性能和兼容性证据 / Relevant performance and compatibility evidence is provided