### PR TITLE
fix(i18n): correct context_window mistranslation in zh/es/id/ms/pt-BR/ro

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2091,7 +2091,7 @@
     <string name="total_tokens">Total: %1$s</string>
     <string name="input_tokens">Entrada: %1$s</string>
     <string name="output_tokens">Salida: %1$s</string>
-    <string name="context_window">Solicitud: %1$s</string>
+    <string name="context_window">Contexto: %1$s</string>
     <string name="auto_approve">Aprobación automática:</string>
     <string name="auto_approve_desc">Controla la política global predeterminada para las llamadas a herramientas de IA: al activarlo, todas las llamadas a herramientas se ejecutan directamente sin confirmación; las excepciones configuradas para herramientas individuales en "Ajustes - Gestión de permisos de herramientas" siguen teniendo prioridad. Al desactivarlo, se solicita confirmación para todas las llamadas a herramientas.</string>
     <string name="enabled">Activado</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1370,7 +1370,7 @@
     <string name="total_tokens">Total: %1$s</string>
     <string name="input_tokens">Masuk kumulatif: %1$s</string>
     <string name="output_tokens">Keluar kumulatif: %1$s</string>
-    <string name="context_window">Permintaan: %1$s</string>
+    <string name="context_window">Konteks: %1$s</string>
     <string name="auto_approve">Persetujuan otomatis:</string>
     <string name="auto_approve_desc">Digunakan untuk mengontrol kebijakan default global saat pemanggilan alat AI: jika diaktifkan, semua pemanggilan alat akan dieksekusi langsung tanpa konfirmasi pop-up; aturan pengecualian yang Anda atur untuk alat individual di "Pengaturan - Manajemen Izin Alat" akan tetap berlaku lebih dulu. Jika dinonaktifkan, konfirmasi pop-up akan muncul untuk semua pemanggilan alat secara default.</string>
     <string name="enabled">Diaktifkan</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1369,7 +1369,7 @@
     <string name="input_tokens">Kumulatif Masuk: %1$s</string>
 
     <string name="output_tokens">Jumlah Keluaran: %1$s</string>
-    <string name="context_window">Permintaan: %1$s</string>
+    <string name="context_window">Konteks: %1$s</string>
     <string name="auto_approve">Kelulusan Automatik:</string>
     <string name="auto_approve_desc">Digunakan untuk mengawal strategi lalai global semasa panggilan alat AI: Apabila dihidupkan, semua panggilan alat akan dilaksanakan secara lalai tanpa pengesahan pop-up; peraturan pengecualian yang anda tetapkan untuk alat tunggal dalam "Tetapan - Pengurusan Kebenaran Alat" masih akan berkuat kuasa terlebih dahulu. Apabila dimatikan, pengesahan pop-up akan muncul secara lalai untuk semua panggilan alat.</string>
     <string name="enabled">Dihidupkan</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1226,7 +1226,7 @@
     <string name="total_tokens">Total: %1$s</string>
     <string name="input_tokens">Ganhos acumulados: %1$s</string>
     <string name="output_tokens">Pagamento total: %1$s</string>
-    <string name="context_window">Solicitação: %1$s</string>
+    <string name="context_window">Contexto: %1$s</string>
     <string name="auto_approve">Aprovação automática:</string>
     <string name="auto_approve_desc">Política padrão global usada para controlar chamadas de ferramentas de IA: Quando ativada, todas as chamadas de ferramentas serão executadas diretamente por padrão, sem confirmação pop-up; as regras de exceção definidas para uma única ferramenta em "Configurações - Gerenciamento de permissões de ferramentas" ainda terão prioridade. Após fechar, um pop-up de confirmação aparecerá para todas as chamadas de ferramenta por padrão.</string>
     <string name="enabled">Já ativado</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1405,7 +1405,7 @@
     <string name="total_tokens">Total: %1$s</string>
     <string name="input_tokens">Total intrări: %1$s</string>
     <string name="output_tokens">Totalul ieșirilor: %1$s</string>
-    <string name="context_window">Solicitare: %1$s</string>
+    <string name="context_window">Context: %1$s</string>
     <string name="auto_approve">Aprobare automată:</string>
     <string name="auto_approve_desc">utilizat pentru control AI Politica globală implicită pentru apelurile către instrumente: odată activată, toate apelurile către instrumente vor fi executate automat, fără a mai apărea o fereastră de confirmare; în „Setări - Regulile de excepție configurate pentru fiecare instrument în parte în secțiunea „Gestionarea permisiunilor pentru instrumente” vor avea în continuare prioritate. După dezactivare, se va afișa în mod implicit o fereastră de confirmare pentru toate apelurile către instrumente.</string>
     <string name="enabled">Este activat</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1432,7 +1432,7 @@
     <string name="total_tokens">总计: %1$s</string>
     <string name="input_tokens">累计入: %1$s</string>
     <string name="output_tokens">累计出: %1$s</string>
-    <string name="context_window">请求: %1$s</string>
+    <string name="context_window">上下文: %1$s</string>
     <string name="auto_approve">自动批准:</string>
     <string name="auto_approve_desc">用于控制 AI 工具调用时的全局默认策略：开启后，默认直接执行所有工具调用而不再弹出确认；你在“设置 - 工具权限管理”中为单个工具设置的例外规则仍然会优先生效。关闭后，默认对所有工具调用都弹出确认。</string>
     <string name="enabled">已开启</string>


### PR DESCRIPTION
Closes #977

## Problem

The `context_window` string is displayed in the chat header stats dropdown with the **estimated context window size in tokens** (`currentWindowSize`, from the token estimation flow), not a request count. However, 6 locale files translated it as "request" (请求 / Solicitud / Permintaan / Solicitação / Solicitare), which misleads users into thinking the number is an HTTP request count.

## Change

Translate `context_window` as "context" in all affected locales:

| Locale | Before | After |
|---|---|---|
| default (zh) | 请求: %1$s | 上下文: %1$s |
| es | Solicitud: %1$s | Contexto: %1$s |
| id | Permintaan: %1$s | Konteks: %1$s |
| ms | Permintaan: %1$s | Konteks: %1$s |
| pt-BR | Solicitação: %1$s | Contexto: %1$s |
| ro | Solicitare: %1$s | Context: %1$s |

en ("Context") and ko ("컨텍스트") were already correct and are left untouched.