### PR TITLE
feat(market): stage contributor content updates

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
@@ -437,10 +437,19 @@ data class MarketV2PublishRequest(
 
 @Serializable
 data class MarketV2NewVersionRequest(
-    val entry: MarketV2EntryUpdateRequest? = null,
+    val entry: MarketV2NewVersionEntryPatch? = null,
     val version: MarketV2PublishVersion,
     val repoVersion: MarketV2PublishRepoVersion? = null,
     val asset: MarketV2PublishAsset? = null
+)
+
+@Serializable
+data class MarketV2NewVersionEntryPatch(
+    val title: String? = null,
+    val description: String? = null,
+    val detail: String? = null,
+    val categoryId: String? = null,
+    val allowPublicUpdates: Boolean? = null
 )
 
 @Serializable
@@ -956,7 +965,7 @@ class MarketStatsApiService {
     suspend fun publishNewVersion(
         entryId: String,
         request: MarketV2PublishRequest,
-        includeEntryPatch: Boolean = false
+        entryPatch: MarketV2NewVersionEntryPatch? = null
     ): Result<MarketV2NewVersionResponse> =
         withContext(Dispatchers.IO) {
             runCatching {
@@ -967,18 +976,7 @@ class MarketStatsApiService {
                     body =
                         json.encodeToString(
                             MarketV2NewVersionRequest(
-                                entry =
-                                    if (includeEntryPatch) {
-                                        MarketV2EntryUpdateRequest(
-                                            title = request.title,
-                                            description = request.description,
-                                            detail = request.detail,
-                                            categoryId = request.categoryId,
-                                            allowPublicUpdates = request.allowPublicUpdates
-                                        )
-                                    } else {
-                                        null
-                                    },
+                                entry = entryPatch,
                                 version = request.version,
                                 repoVersion = request.repoVersion,
                                 asset = request.asset

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/ArtifactMarketModels.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/ArtifactMarketModels.kt
@@ -152,6 +152,8 @@ data class ArtifactPublishClusterContext(
     val lockedDisplayName: String,
     val projectDisplayName: String,
     val projectDescription: String,
+    val marketDescription: String,
+    val marketDetail: String,
     val categoryId: String = "",
     val canEditEntry: Boolean = false
 )
@@ -164,6 +166,7 @@ data class PublishArtifactDescriptor(
     val runtimePackageId: String,
     val displayName: String,
     val description: String,
+    val detail: String,
     val categoryId: String,
     val version: String,
     val allowPublicUpdates: Boolean = true,
@@ -198,6 +201,7 @@ data class MarketRegistrationPayload(
     val version: String,
     val displayName: String,
     val description: String,
+    val detail: String,
     val categoryId: String,
     val allowPublicUpdates: Boolean = true,
     val sourceFileName: String,
@@ -265,6 +269,8 @@ fun ArtifactMarketMetadata.toPublishClusterContext(entryId: String? = null): Art
         lockedDisplayName = displayName.trim().ifBlank { effectiveProjectDisplayName() },
         projectDisplayName = effectiveProjectDisplayName(),
         projectDescription = effectiveProjectDescription(),
+        marketDescription = description,
+        marketDetail = effectiveProjectDescription(),
         categoryId = categoryId
     )
 }
@@ -346,14 +352,17 @@ fun buildPublishArtifactDescriptor(
             .removePrefix("V")
             .ifBlank { "1.0.0" }
     val lockedDisplayName = publishContext?.lockedDisplayName?.trim().orEmpty()
+    val isContributorContinuation = publishContext?.canEditEntry == false
     if (publishContext != null) {
         require(lockedDisplayName.isNotBlank()) {
             "Continuation publish must keep source display name"
         }
     }
     val resolvedDisplayName =
-        lockedDisplayName.ifBlank {
-            displayName.trim().ifBlank { localArtifact.displayName }
+        if (isContributorContinuation) {
+            lockedDisplayName
+        } else {
+            displayName.trim().ifBlank { lockedDisplayName.ifBlank { localArtifact.displayName } }
         }
     val extension = localArtifact.sourceFile.extension.lowercase().ifBlank { "bin" }
     val projectId =
@@ -363,12 +372,18 @@ fun buildPublishArtifactDescriptor(
             ?.let(::normalizeMarketArtifactId)
             ?: normalizeMarketArtifactId(runtimePackageId)
     val projectDisplayName =
-        publishContext?.projectDisplayName
-            ?.trim()
-            ?.takeIf { it.isNotBlank() }
-            ?: displayName.trim().ifBlank { localArtifact.displayName }
+        if (isContributorContinuation) {
+            publishContext?.projectDisplayName?.trim().orEmpty().ifBlank { resolvedDisplayName }
+        } else {
+            resolvedDisplayName
+        }
     val projectDescription = detail.trim().ifBlank { description.trim().ifBlank { localArtifact.description } }
-    val resolvedCategoryId = publishContext?.categoryId?.trim().orEmpty().ifBlank { categoryId.trim() }
+    val resolvedCategoryId =
+        if (isContributorContinuation) {
+            publishContext?.categoryId?.trim().orEmpty()
+        } else {
+            categoryId.trim().ifBlank { publishContext?.categoryId?.trim().orEmpty() }
+        }
     val assetName = "$normalizedRuntimePackageId-v$cleanVersion.$extension"
     val normalizedProtection = protection?.trim()?.takeIf { it.isNotBlank() }
 
@@ -380,6 +395,7 @@ fun buildPublishArtifactDescriptor(
         runtimePackageId = runtimePackageId,
         displayName = resolvedDisplayName,
         description = description.trim().ifBlank { localArtifact.description },
+        detail = detail.trim(),
         categoryId = resolvedCategoryId,
         version = cleanVersion,
         allowPublicUpdates = allowPublicUpdates,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/GitHubForgePublishService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/GitHubForgePublishService.kt
@@ -6,6 +6,7 @@ import com.ai.assistance.operit.data.api.GitHubRelease
 import com.ai.assistance.operit.data.api.GitHubReleaseAsset
 import com.ai.assistance.operit.data.api.MarketStatsApiService
 import com.ai.assistance.operit.data.api.MarketV2Entry
+import com.ai.assistance.operit.data.api.MarketV2NewVersionEntryPatch
 import com.ai.assistance.operit.data.api.MarketV2PublishAsset
 import com.ai.assistance.operit.data.api.MarketV2PublishRequest
 import com.ai.assistance.operit.data.api.MarketV2PublishVersion
@@ -245,6 +246,7 @@ class GitHubForgePublishService(
                     version = descriptor.version,
                     displayName = descriptor.displayName,
                     description = descriptor.description,
+                    detail = descriptor.detail,
                     categoryId = descriptor.categoryId,
                     allowPublicUpdates = descriptor.allowPublicUpdates,
                     sourceFileName = sourceFile.name,
@@ -257,7 +259,7 @@ class GitHubForgePublishService(
                 registerMarketEntry(
                     payload = payload,
                     existingEntryId = request.publishContext?.entryId,
-                    includeEntryPatch = request.publishContext?.canEditEntry ?: true
+                    publishContext = request.publishContext
                 ).getOrElse { error ->
                     return@withContext Result.success(
                         PublishAttemptResult.RegistrationFailed(
@@ -429,7 +431,7 @@ class GitHubForgePublishService(
     private suspend fun registerMarketEntry(
         payload: MarketRegistrationPayload,
         existingEntryId: String?,
-        includeEntryPatch: Boolean
+        publishContext: ArtifactPublishClusterContext?
     ): Result<MarketV2Entry> {
         val request =
             MarketV2PublishRequest(
@@ -438,7 +440,7 @@ class GitHubForgePublishService(
                 description = payload.description,
                 categoryId = payload.categoryId,
                 allowPublicUpdates = payload.allowPublicUpdates,
-                detail = payload.projectDescription.ifBlank { payload.description },
+                detail = payload.detail.ifBlank { payload.description },
                 version = MarketV2PublishVersion(
                     version = payload.version,
                     formatVer = payload.type.marketFormatVersion(),
@@ -463,14 +465,14 @@ class GitHubForgePublishService(
         return marketStatsApiService.publishNewVersion(
             entryId = resolvedEntryId,
             request = request,
-            includeEntryPatch = includeEntryPatch
+            entryPatch = buildNewVersionEntryPatch(payload, publishContext)
         ).map { response ->
             MarketV2Entry(
                 type = payload.type.wireValue,
                 id = response.entryId,
                 title = payload.displayName,
                 description = payload.description,
-                detail = payload.projectDescription.ifBlank { payload.description },
+                detail = payload.detail.ifBlank { payload.description },
                 stateCode = "pending",
                 latestVersion = MarketV2Version(
                     id = response.versionId,
@@ -483,6 +485,34 @@ class GitHubForgePublishService(
                     runtimePackageId = payload.runtimePackageId
                 )
             )
+        }
+    }
+
+    private fun buildNewVersionEntryPatch(
+        payload: MarketRegistrationPayload,
+        publishContext: ArtifactPublishClusterContext?
+    ): MarketV2NewVersionEntryPatch? {
+        val context = publishContext ?: return null
+        val patch =
+            if (context.canEditEntry) {
+                MarketV2NewVersionEntryPatch(
+                    title = payload.displayName.takeIf { it != context.lockedDisplayName },
+                    description = payload.description.takeIf { it != context.marketDescription },
+                    detail = payload.detail.takeIf { it != context.marketDetail },
+                    categoryId = payload.categoryId.takeIf { it != context.categoryId }
+                )
+            } else {
+                MarketV2NewVersionEntryPatch(
+                    description = payload.description.takeIf { it != context.marketDescription },
+                    detail = payload.detail.takeIf { it != context.marketDetail }
+                )
+            }
+        return patch.takeIf {
+            it.title != null ||
+                it.description != null ||
+                it.detail != null ||
+                it.categoryId != null ||
+                it.allowPublicUpdates != null
         }
     }
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
@@ -112,6 +112,8 @@ fun com.ai.assistance.operit.data.api.MarketV2Entry.toArtifactPublishClusterCont
         lockedDisplayName = title,
         projectDisplayName = title,
         projectDescription = detail.ifBlank { description },
+        marketDescription = description,
+        marketDetail = detail,
         categoryId = categoryId,
         canEditEntry = canEditEntry
     )
@@ -154,6 +156,7 @@ fun ArtifactPublishScreen(
     val lockedDisplayName = activePublishContext?.lockedDisplayName?.trim().orEmpty()
     val canEditContinuationEntry = activePublishContext?.canEditEntry ?: true
     val isDisplayNameLocked = !isEditMode && lockedDisplayName.isNotBlank() && !canEditContinuationEntry
+    val isContinuationCategoryLocked = isContinuationMode && !canEditContinuationEntry
     val continuationDescription =
         stringResource(R.string.artifact_publish_continuation_description)
 
@@ -180,11 +183,11 @@ fun ArtifactPublishScreen(
             initialInfo?.title.orEmpty().ifBlank { lockedDisplayName }
         )
     }
-    var description by rememberSaveable(activePublishContext?.projectDescription) {
-        mutableStateOf(initialInfo?.description.orEmpty().ifBlank { activePublishContext?.projectDescription.orEmpty() })
+    var description by rememberSaveable(activePublishContext?.marketDescription) {
+        mutableStateOf(initialInfo?.description.orEmpty().ifBlank { activePublishContext?.marketDescription.orEmpty() })
     }
-    var detail by rememberSaveable(activePublishContext?.projectDescription) {
-        mutableStateOf(initialInfo?.detail.orEmpty().ifBlank { activePublishContext?.projectDescription.orEmpty() })
+    var detail by rememberSaveable(activePublishContext?.marketDetail) {
+        mutableStateOf(initialInfo?.detail.orEmpty().ifBlank { activePublishContext?.marketDetail.orEmpty() })
     }
     var categoryId by rememberSaveable(activePublishContext?.categoryId) {
         mutableStateOf(initialInfo?.categoryId.orEmpty().ifBlank { activePublishContext?.categoryId.orEmpty() })
@@ -725,7 +728,7 @@ fun ArtifactPublishScreen(
         ExposedDropdownMenuBox(
             expanded = categoryExpanded,
             onExpandedChange = {
-                if (categories.isNotEmpty()) {
+                if (categories.isNotEmpty() && !isContinuationCategoryLocked) {
                     categoryExpanded = !categoryExpanded
                 }
             }
@@ -743,7 +746,7 @@ fun ArtifactPublishScreen(
                     .fillMaxWidth()
                     .menuAnchor(),
                 readOnly = true,
-                enabled = categories.isNotEmpty(),
+                enabled = categories.isNotEmpty() && !isContinuationCategoryLocked,
                 trailingIcon = {
                     ExposedDropdownMenuDefaults.TrailingIcon(expanded = categoryExpanded)
                 },

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/RepoMarketPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/RepoMarketPublishScreen.kt
@@ -99,7 +99,7 @@ fun RepoMarketPublishScreen(
     var showConfirmationDialog by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var categories by remember { mutableStateOf<List<MarketV2ManifestCategory>>(emptyList()) }
-    val isEntryMetadataLocked = isVersionMode && !canEditEntry
+    val isOwnerOnlyEntryMetadataLocked = isVersionMode && !canEditEntry
 
     if (!isEditMode) {
         LaunchedEffect(title, description, detail, repositoryUrl, installConfig, category, allowPublicUpdates) {
@@ -141,7 +141,7 @@ fun RepoMarketPublishScreen(
             label = { Text(repoNameLabel(type)) },
             modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
             singleLine = true,
-            enabled = !isEntryMetadataLocked,
+            enabled = !isOwnerOnlyEntryMetadataLocked,
             isError = title.isBlank()
         )
 
@@ -152,7 +152,7 @@ fun RepoMarketPublishScreen(
             modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
             minLines = 3,
             maxLines = 6,
-            enabled = !isEntryMetadataLocked,
+            enabled = true,
             isError = description.isBlank()
         )
 
@@ -163,7 +163,7 @@ fun RepoMarketPublishScreen(
             modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
             minLines = 4,
             maxLines = 10,
-            enabled = !isEntryMetadataLocked
+            enabled = true
         )
 
         OutlinedTextField(
@@ -186,7 +186,7 @@ fun RepoMarketPublishScreen(
             selectedCategory = category,
             categories = categories,
             onCategorySelected = { category = it },
-            enabled = !isEntryMetadataLocked,
+            enabled = !isOwnerOnlyEntryMetadataLocked,
             modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
         )
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/artifact/viewmodel/ArtifactMarketViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/artifact/viewmodel/ArtifactMarketViewModel.kt
@@ -443,6 +443,7 @@ class ArtifactMarketViewModel(
             version = versionValue?.version.orEmpty().trim().removePrefix("v").removePrefix("V").ifBlank { "1.0.0" },
             displayName = trimmedDisplayName,
             description = trimmedDescription,
+            detail = trimmedDetail,
             categoryId = entry.categoryId,
             sourceFileName = assetName,
             minSupportedAppVersion = normalizeAppVersionOrNull(minSupportedAppVersion),

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/market/viewmodel/RepoMarketPublishViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/market/viewmodel/RepoMarketPublishViewModel.kt
@@ -11,6 +11,7 @@ import com.ai.assistance.operit.data.api.GitHubApiService
 import com.ai.assistance.operit.data.api.MarketStatsApiService
 import com.ai.assistance.operit.data.api.MarketV2EntryUpdateRequest
 import com.ai.assistance.operit.data.api.MarketV2Entry
+import com.ai.assistance.operit.data.api.MarketV2NewVersionEntryPatch
 import com.ai.assistance.operit.data.api.MarketV2PublishRepoVersion
 import com.ai.assistance.operit.data.api.MarketV2PublishRequest
 import com.ai.assistance.operit.data.api.MarketV2PublishSource
@@ -150,13 +151,23 @@ class RepoMarketPublishViewModel(
         canEditEntry: Boolean = false
     ): Result<Unit> {
         validateNewVersion(entry, version)
-        val hasEntryPatch = canEditEntry && (
-            title != entry.title ||
-                description != entry.description ||
-                detail != entry.detail ||
-                category != entry.categoryId ||
-                allowPublicUpdates != entry.allowPublicUpdates
-            )
+        val entryPatch =
+            (
+                if (canEditEntry) {
+                    MarketV2NewVersionEntryPatch(
+                        title = title.takeIf { it != entry.title },
+                        description = description.takeIf { it != entry.description },
+                        detail = detail.takeIf { it != entry.detail },
+                        categoryId = category.takeIf { it != entry.categoryId },
+                        allowPublicUpdates = allowPublicUpdates.takeIf { it != entry.allowPublicUpdates }
+                    )
+                } else {
+                    MarketV2NewVersionEntryPatch(
+                        description = description.takeIf { it != entry.description },
+                        detail = detail.takeIf { it != entry.detail }
+                    )
+                }
+            ).takeIf { it.hasChanges() }
         return submit(
             entryId = entry.id,
             title = title,
@@ -167,7 +178,7 @@ class RepoMarketPublishViewModel(
             installConfig = installConfig,
             category = category,
             allowPublicUpdates = allowPublicUpdates,
-            includeEntryPatch = hasEntryPatch
+            entryPatch = entryPatch
         )
     }
 
@@ -214,7 +225,7 @@ class RepoMarketPublishViewModel(
         installConfig: String,
         category: String,
         allowPublicUpdates: Boolean,
-        includeEntryPatch: Boolean = false
+        entryPatch: MarketV2NewVersionEntryPatch? = null
     ): Result<Unit> {
         if (!githubAuth.isLoggedIn()) {
             return Result.failure(IllegalStateException(loginRequiredMessage()))
@@ -239,7 +250,7 @@ class RepoMarketPublishViewModel(
                 if (entryId == null) {
                     marketStatsApiService.publish(request).map { Unit }
                 } else {
-                    marketStatsApiService.publishNewVersion(entryId = entryId, request = request, includeEntryPatch = includeEntryPatch).map { Unit }
+                    marketStatsApiService.publishNewVersion(entryId = entryId, request = request, entryPatch = entryPatch).map { Unit }
                 }
             result
         } catch (e: Exception) {
@@ -376,6 +387,13 @@ class RepoMarketPublishViewModel(
         val refType: String,
         val refName: String
     )
+
+    private fun MarketV2NewVersionEntryPatch.hasChanges(): Boolean =
+        title != null ||
+            description != null ||
+            detail != null ||
+            categoryId != null ||
+            allowPublicUpdates != null
 
     private fun validateNewVersion(entry: MarketV2Entry, version: String) {
         val requestedVersion = version.trim().removePrefix("v").removePrefix("V").ifBlank { "1.0.0" }

--- a/docs/TODO/third_party_market_content_updates_20260816/1_StagedContentUpdates.md
+++ b/docs/TODO/third_party_market_content_updates_20260816/1_StagedContentUpdates.md
@@ -1,0 +1,5 @@
+# Stage Content Updates With New Versions
+
+The market API accepts a partial version entry patch. For a contributor, it contains only a changed description or detail. The server stores it on the pending version and applies it to the public entry only after approval.
+
+[DONE]

--- a/docs/TODO/third_party_market_content_updates_20260816/index.md
+++ b/docs/TODO/third_party_market_content_updates_20260816/index.md
@@ -1,0 +1,25 @@
+---
+fork: https://github.com/AAswordman/Operit.git
+status: complete
+---
+
+# Third-Party Market Content Updates
+
+## Current State
+
+Contributors can publish a newer version of a public-update entry, but the Android client drops any edited market description and detail before submitting the version.
+
+## Intent
+
+Let a contributor submit only the short description and detail with a new version. Keep those changes pending until the market reviewer approves the specific version. Original-author-only fields remain protected.
+
+## Scope
+
+- Send a nullable, partial entry patch with version publication requests.
+- Enable contributor editing of description and detail in repo and artifact update flows.
+- Preserve the original-author restriction for title, category, and public-update policy.
+- Keep the public entry unchanged until version approval.
+
+## Expected Result
+
+A contributor can describe a meaningful update for review without gaining authority to alter the entry's identity or publication policy.


### PR DESCRIPTION
## 变更说明 / Description

允许公共更新条目的贡献者在提交新版本时一并更新简介和详情，并将修改保留在待审核版本中。

### 背景与动机 / Context and motivation

客户端此前会丢弃贡献者在新版本发布页输入的市场简介和详情，无法向审核者完整说明更新内容。

### 改动范围 / Changes

- 版本发布请求支持可空的局部条目更新
- 仓库和制品发布流程允许贡献者更新简介与详情
- 保持标题、分类和公开更新策略只允许原作者修改
- 增加对应的实施 TODO 文档

### 兼容性与风险 / Compatibility and risks

新增局部 API 请求字段，不变更既有请求格式或持久化数据。只有用户实际修改可编辑字段时才发送条目更新；服务端在版本审核通过前不会公开这些更新。

## 关联 Issue / Related issue

N/A。此变更修复已实现的第三方市场新版本发布流程中内容更新被客户端丢弃的问题。

## 验证方式 / Verification

```text
检查或命令：git diff --check origin/main..HEAD
环境与变体：Windows 工作区
结果：通过；未运行构建和测试，遵循 AGENTS.md 的默认约束
```

## 证据 / Evidence

实施范围和预期行为记录于 docs/TODO/third_party_market_content_updates_20260816/。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided