### PR TITLE
feat: add MiniMax as built-in LLM provider

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIServiceFactory.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIServiceFactory.kt
@@ -469,6 +469,7 @@ object AIServiceFactory {
             ApiProviderType.ALIPAY_BAILING,
             ApiProviderType.PPINFRA,
             ApiProviderType.NOVITA,
+            ApiProviderType.MINIMAX,
             ApiProviderType.OTHER ->
                 OpenAIProvider(
                     apiEndpoint = config.apiEndpoint,

--- a/app/src/main/java/com/ai/assistance/operit/data/collects/ApiProviderConfigCollect.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/collects/ApiProviderConfigCollect.kt
@@ -241,6 +241,21 @@ object ApiProviderConfigs {
             )
         ),
         ProviderApiConfig(
+            providerType = ApiProviderType.MINIMAX,
+            defaultModelName = "MiniMax-M2.7",
+            defaultApiEndpoint = "https://api.minimaxi.com/v1/chat/completions",
+            endpointOptions = listOf(
+                ProviderEndpointOption(
+                    endpoint = "https://api.minimaxi.com/v1/chat/completions",
+                    label = "China (minimaxi.com)"
+                ),
+                ProviderEndpointOption(
+                    endpoint = "https://api.minimax.io/v1/chat/completions",
+                    label = "International (minimax.io)"
+                )
+            )
+        ),
+        ProviderApiConfig(
             providerType = ApiProviderType.OTHER,
             defaultModelName = "",
             defaultApiEndpoint = ""

--- a/app/src/main/java/com/ai/assistance/operit/data/collects/ModelPricingDefaultsCollect.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/collects/ModelPricingDefaultsCollect.kt
@@ -35,7 +35,8 @@ object DefaultModelPricingCollect {
         "DOUBAO",
         "PPINFRA",
         "OPENAI_LOCAL",
-        "MIMO"
+        "MIMO",
+        "MINIMAX"
     )
 
     private fun defaultPricePerRequest(currency: PricingCurrency): Double {
@@ -184,7 +185,8 @@ object DefaultModelPricingCollect {
         "MNN" to zeroPricing(PricingCurrency.CNY),
         "LLAMA_CPP" to zeroPricing(PricingCurrency.CNY),
         "MIMO" to zeroPricing(PricingCurrency.CNY),
-        "NOVITA" to zeroPricing(PricingCurrency.USD)
+        "NOVITA" to zeroPricing(PricingCurrency.USD),
+        "MINIMAX" to zeroPricing(PricingCurrency.CNY)
     )
 
     private fun splitProviderModel(providerModel: String): Pair<String, String> {

--- a/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
@@ -38,6 +38,7 @@ enum class ApiProviderType {
         LLAMA_CPP, // llama.cpp 本地推理引擎
         PPINFRA, // 派欧云
         NOVITA, // Novita AI
+        MINIMAX, // MiniMax
         OTHER; // 其他提供商（自定义端点）
 
         companion object {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
@@ -1085,6 +1085,7 @@ private fun getBuiltInProviderDisplayName(provider: ApiProviderType, context: an
         ApiProviderType.LLAMA_CPP -> context.getString(R.string.provider_llama_cpp)
         ApiProviderType.PPINFRA -> context.getString(R.string.provider_ppinfra)
         ApiProviderType.NOVITA -> context.getString(R.string.provider_novita)
+        ApiProviderType.MINIMAX -> context.getString(R.string.provider_minimax)
         ApiProviderType.OTHER -> context.getString(R.string.provider_other)
     }
 }
@@ -1741,6 +1742,7 @@ private fun getProviderColor(providerTypeId: String): androidx.compose.ui.graphi
         ApiProviderType.LLAMA_CPP -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.9f)
         ApiProviderType.PPINFRA -> MaterialTheme.colorScheme.primaryContainer
         ApiProviderType.NOVITA -> MaterialTheme.colorScheme.tertiary.copy(alpha = 0.75f)
+        ApiProviderType.MINIMAX -> MaterialTheme.colorScheme.primary.copy(alpha = 0.78f)
         ApiProviderType.OTHER -> MaterialTheme.colorScheme.surfaceVariant
     }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -4075,6 +4075,7 @@
     <string name="provider_openai_local">OpenAI-Compatible (Local Model)</string>
     <string name="provider_ppinfra">PPInfra Cloud</string>
     <string name="provider_novita">Novita AI</string>
+    <string name="provider_minimax">MiniMax</string>
     <string name="provider_openai_generic">OpenAI (Generic)</string>
     <string name="provider_other">Other Providers</string>
     <string name="provider_doubao">Doubao</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1246,6 +1246,7 @@
     <string name="provider_ollama">Ollama (modelo local)</string>
     <string name="provider_openai_local">OpenAI compatible (modelo local)</string>
     <string name="provider_novita">Novita AI</string>
+    <string name="provider_minimax">MiniMax</string>
     <string name="provider_other">Otros proveedores</string>
     <string name="select_api_provider_title">Seleccionar Proveedor API</string>
     <string name="search_providers">Buscar proveedores</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -3290,6 +3290,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="provider_llama_cpp">Inferensi Lokal llama.cpp</string>
     <string name="provider_ppinfra">Paiouyun</string>
     <string name="provider_novita">Novita AI</string>
+    <string name="provider_minimax">MiniMax</string>
     <string name="provider_openai_generic">OpenAI Umum</string>
     <string name="provider_other">Penyedia Lainnya</string>
     <string name="select_api_provider_title">Pilih Penyedia API</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -3522,6 +3522,7 @@
     <string name="provider_llama_cpp">llama.cpp 로컬 추론</string>
     <string name="provider_ppinfra">PPInfra 클라우드</string>
     <string name="provider_novita">노비타 AI</string>
+    <string name="provider_minimax">MiniMax</string>
     <string name="provider_openai_generic">OpenAI(일반)</string>
     <string name="provider_other">기타 제공자</string>
     <string name="select_api_provider_title">API 제공업체 선택</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -3538,6 +3538,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="provider_llama_cpp">Inferens Tempatan llama.cpp</string>
     <string name="provider_ppinfra">Pai Ou Yun</string>
     <string name="provider_novita">Novita AI</string>
+    <string name="provider_minimax">MiniMax</string>
     <string name="provider_openai_generic">OpenAI Generik</string>
     <string name="provider_other">Pembekal Lain</string>
     <string name="select_api_provider_title">Pilih Pembekal API</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -3380,6 +3380,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="provider_llama_cpp">inferência local llama.cpp</string>
     <string name="provider_ppinfra">Pai Ouyun</string>
     <string name="provider_novita">Novita AI</string>
+    <string name="provider_minimax">MiniMax</string>
     <string name="provider_openai_generic">OpenAI Geral</string>
     <string name="provider_other">Outros fornecedores</string>
     <string name="select_api_provider_title">Escolha o provedor de API</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3897,6 +3897,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="provider_llama_cpp">llama.cpp Raționament local</string>
     <string name="provider_ppinfra">Paiou Cloud</string>
     <string name="provider_novita">Novita AI</string>
+    <string name="provider_minimax">MiniMax</string>
     <string name="provider_openai_generic">OpenAIGeneralități</string>
     <string name="provider_other">Alți furnizori</string>
     <string name="select_api_provider_title">AlegereAPIFurnizor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4033,6 +4033,7 @@
     <string name="provider_llama_cpp">llama.cpp 本地推理</string>
     <string name="provider_ppinfra">派欧云</string>
     <string name="provider_novita">Novita AI</string>
+    <string name="provider_minimax">MiniMax</string>
     <string name="provider_openai_generic">OpenAI通用</string>
     <string name="provider_other">其他供应商</string>
     <string name="select_api_provider_title">选择API提供商</string>


### PR DESCRIPTION
## Summary
- add MiniMax as a built-in LLM provider
- preset China and international OpenAI-compatible endpoints
- route MiniMax through the existing OpenAI-compatible provider implementation
- add provider UI/localization and pricing fallback

## Verification
- [x] Android assembleDebug
- [x] provider selection/configuration wiring checked
- [ ] Live MiniMax API/tool-call test (requires API key)

Closes #986