### PR TITLE
feat(settings): 一键让全部功能模型跟随当前对话模型

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/FunctionalConfigManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/FunctionalConfigManager.kt
@@ -151,6 +151,13 @@ class FunctionalConfigManager(private val context: Context) {
         setConfigForFunction(functionType, DEFAULT_CONFIG_ID)
     }
 
+    // 让全部功能跟随当前对话功能的配置，包含多模型索引
+    suspend fun followChatConfigForAllFunctions() {
+        val chatMapping = getConfigMappingForFunction(FunctionType.CHAT)
+        val mapping = FunctionType.values().associateWith { chatMapping }
+        saveFunctionConfigMappingWithIndex(mapping)
+    }
+
     // 重置所有功能配置为默认
     suspend fun resetAllFunctionConfigs() {
         val defaultMapping = FunctionType.values().associateWith { FunctionConfigMapping(DEFAULT_CONFIG_ID, 0) }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/FunctionalConfigScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/FunctionalConfigScreen.kt
@@ -191,6 +191,31 @@ fun FunctionalConfigScreen(
                 }
 
                 item {
+                    // 跟随当前对话模型按钮
+                    OutlinedButton(
+                            onClick = {
+                                scope.launch {
+                                    functionalConfigManager.followChatConfigForAllFunctions()
+                                    // 刷新所有服务实例
+                                    EnhancedAIService.refreshAllServices(context)
+                                    showSaveSuccess = true
+                                }
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(8.dp),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline)
+                    ) {
+                        Icon(
+                                imageVector = Icons.Default.Sync,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(stringResource(id = R.string.follow_chat_model_for_all_functions))
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
                     // 重置按钮
                     OutlinedButton(
                             onClick = {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2862,6 +2862,7 @@
     <string name="functional_model_config_desc">Set separate model configurations for different functions, allowing each function to use the most suitable API settings.</string>
     <string name="manage_all_model_configs">Manage All Model Configurations</string>
     <string name="manage_model_configs_desc">Manage Model Configurations</string>
+    <string name="follow_chat_model_for_all_functions">Sync All Functions to Current Chat Model</string>
     <string name="reset_all_functions_to_default">Reset All Functions to Default Configuration</string>
     <string name="current_config_label">Current Configuration: %1$s</string>
     <string name="default_config">Default Configuration</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -933,6 +933,7 @@
     <string name="functional_model_config_desc">Establecer configuraciones de modelo separadas para diferentes funciones, permitiendo que cada función use la configuración de API más adecuada.</string>
     <string name="manage_all_model_configs">Gestionar Todas las Configuraciones de Modelo</string>
     <string name="manage_model_configs_desc">Gestionar Configuraciones de Modelo</string>
+    <string name="follow_chat_model_for_all_functions">Sincronizar Todas las Funciones con el Modelo de Chat Actual</string>
     <string name="reset_all_functions_to_default">Restablecer Todas las Funciones a la Configuración Predeterminada</string>
     <string name="current_config_label">Configuración Actual: %1$s</string>
     <string name="default_config">Configuración Predeterminada</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -2622,6 +2622,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="functional_model_config_desc">Atur konfigurasi model terpisah untuk fungsi yang berbeda, sehingga setiap fungsi dapat menggunakan pengaturan API yang paling sesuai.</string>
     <string name="manage_all_model_configs">Kelola semua konfigurasi model</string>
     <string name="manage_model_configs_desc">Kelola konfigurasi model</string>
+    <string name="follow_chat_model_for_all_functions">Samakan semua fungsi dengan model obrolan saat ini</string>
     <string name="reset_all_functions_to_default">Setel ulang semua fungsi ke konfigurasi default</string>
 
     <string name="speech_services_openai_models_fetch_failed">Gagal mengambil daftar model: %1$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2607,6 +2607,7 @@
     <string name="functional_model_config_desc">각 기능에 대해 별도의 모델 구성을 설정하여 각 기능이 가장 적합한 API 설정을 사용할 수 있도록 합니다.</string>
     <string name="manage_all_model_configs">모든 모델 구성 관리</string>
     <string name="manage_model_configs_desc">모델 구성 관리</string>
+    <string name="follow_chat_model_for_all_functions">모든 기능을 현재 대화 모델에 맞추기</string>
     <string name="reset_all_functions_to_default">모든 기능을 기본 구성으로 재설정</string>
     <string name="current_config_label">현재 구성: %1$s</string>
     <string name="default_config">기본 구성</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -2698,6 +2698,7 @@
     <string name="functional_model_config_desc">Tetapkan konfigurasi model berasingan untuk fungsi yang berbeza, membolehkan setiap fungsi menggunakan tetapan API yang paling sesuai.</string>
     <string name="manage_all_model_configs">Urus semua konfigurasi model</string>
     <string name="manage_model_configs_desc">Urus konfigurasi model</string>
+    <string name="follow_chat_model_for_all_functions">Samakan semua fungsi dengan model sembang semasa</string>
     <string name="reset_all_functions_to_default">Tetapkan semula semua fungsi kepada konfigurasi lalai</string>
     <string name="current_config_label">Konfigurasi semasa: %1$s</string>
     <string name="default_config">Konfigurasi lalai</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -2510,6 +2510,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="functional_model_config_desc">Defina configurações de modelo separadas para funções diferentes para que cada função possa usar as configurações de API mais apropriadas.</string>
     <string name="manage_all_model_configs">Gerencie todas as configurações do modelo</string>
     <string name="manage_model_configs_desc">Gerenciar configuração do modelo</string>
+    <string name="follow_chat_model_for_all_functions">Sincronizar todas as funções com o modelo de conversa atual</string>
     <string name="reset_all_functions_to_default">Redefinir todas as funções para a configuração padrão</string>
     <string name="current_config_label">Configuração atual: %1$s</string>
     <string name="default_config">Configuração padrão</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -2905,6 +2905,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="functional_model_config_desc">Configurarea unor setări separate pentru fiecare funcție, astfel încât fiecare funcție să poată utiliza cea mai potrivităAPISetări.</string>
     <string name="manage_all_model_configs">Gestionarea tuturor configurațiilor modelelor</string>
     <string name="manage_model_configs_desc">Configurarea modelului de gestionare</string>
+    <string name="follow_chat_model_for_all_functions">Sincronizarea tuturor funcțiilor cu modelul de conversație curent</string>
     <string name="reset_all_functions_to_default">Resetarea tuturor funcțiilor la setările implicite</string>
     <string name="current_config_label">Configurația actuală: %1$s</string>
     <string name="default_config">Configurația implicită</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2943,6 +2943,7 @@
     <string name="functional_model_config_desc">为不同功能设置单独的模型配置，使每个功能都能使用最适合的API设置。</string>
     <string name="manage_all_model_configs">管理所有模型配置</string>
     <string name="manage_model_configs_desc">管理模型配置</string>
+    <string name="follow_chat_model_for_all_functions">全部跟随当前对话模型</string>
     <string name="reset_all_functions_to_default">重置所有功能至默认配置</string>
     <string name="current_config_label">当前配置: %1$s</string>
     <string name="default_config">默认配置</string>


### PR DESCRIPTION
## 变更说明 / Description

在「功能模型配置设置」中新增“全部跟随当前对话模型”按钮，一键把当前 `FunctionType.CHAT` 的完整绑定（`configId` + `modelIndex`）原子地复制给全部 `FunctionType`，省去逐项选择配置和模型索引。

Adds a one-tap action to the functional model config screen that copies the current `FunctionType.CHAT` binding (`configId` + `modelIndex`) to every `FunctionType` in a single write.

### 背景与动机 / Context and motivation

见 #985。功能模型目前必须逐项设置，配置数量多、又用了多模型索引时操作成本很高。以 CHAT 当前绑定为唯一来源，而不是取全局默认配置，因此兼容对话正在使用的自定义配置和多模型选择。

### 改动范围 / Changes

- `FunctionalConfigManager` 新增 `followChatConfigForAllFunctions()`：读取 CHAT 的 `FunctionConfigMapping`，用同一个映射覆盖全部 `FunctionType`，通过已有的 `saveFunctionConfigMappingWithIndex()` 一次性写入 DataStore。
- `FunctionalConfigScreen` 在「重置所有功能至默认配置」按钮之前加入同样式的按钮，点击后调用上述方法并执行现有的 `EnhancedAIService.refreshAllServices(context)`，让缓存的服务实例立刻使用新映射。
- 新增字符串 `follow_chat_model_for_all_functions`，并补齐 zh / en / es / id / ko / ms / pt-rBR / ro 全部 8 个语言资源。
- 不在范围内：模型配置本身、API Key、角色卡绑定、模型参数，以及持久化格式，均未改动。

### 兼容性与风险 / Compatibility and risks

沿用现有的 `FunctionConfigMapping` 持久化格式，没有新增字段或迁移逻辑。该操作会覆盖用户此前为各功能单独设置的绑定，属于按钮的预期语义，和已有的「重置所有功能至默认配置」一致，同样不带二次确认。

## 关联 Issue / Related issue

Closes #985

## 验证方式 / Verification

```text
检查或命令：
  python3 -B ci/script/check_localizations.py --base <merge-base> --candidate HEAD
  python3 -B ci/script/check_repo_hygiene.py --base <merge-base> --candidate HEAD
环境与变体：Windows 11 + Git Bash，仅静态检查；本机缺少 NDK/CMake 和手动二进制依赖，未跑 Gradle 构建
结果：
  Localization: errors=0 warnings=0
  Repository hygiene: errors=0 warnings=0
```

新增代码只使用仓库内已有的 API：`getConfigMappingForFunction()`、`saveFunctionConfigMappingWithIndex()`、`EnhancedAIService.refreshAllServices()`，图标 `Icons.Default.Sync` 已在 `UserPreferencesSettingsScreen` 中使用。设备端验证建议按 issue 中的步骤：把 CHAT 绑定到含多个模型的配置并选非 0 索引，点击新按钮后重开该页面，确认每个功能卡显示相同配置与同一模型索引。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)
