### PR TITLE
fix(settings): persist the tapped value on background sliders

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ThemeSettingsBackgroundSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ThemeSettingsBackgroundSection.kt
@@ -61,7 +61,6 @@ import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout
 import com.google.android.exoplayer2.ui.StyledPlayerView
 import kotlinx.coroutines.flow.collect
-import kotlin.math.abs
 
 private fun calculateLuminance(color: Color): Float {
     return 0.299f * color.red + 0.587f * color.green + 0.114f * color.blue
@@ -419,7 +418,6 @@ internal fun ThemeSettingsBackgroundSection(
                     modifier = Modifier.padding(bottom = 8.dp),
                 )
 
-                var lastSavedOpacity by remember { mutableStateOf(backgroundImageOpacityInput) }
                 var isDragging by remember { mutableStateOf(false) }
                 val interactionSource = remember { MutableInteractionSource() }
 
@@ -440,20 +438,25 @@ internal fun ThemeSettingsBackgroundSection(
                     }
                 }
 
-                val latestOpacity by rememberUpdatedState(backgroundImageOpacityInput)
+                // A tap makes the slider emit onValueChange and onValueChangeFinished within
+                // the same frame, so the hoisted state cannot have been recomposed yet when
+                // the value is persisted. Keep the value the slider itself just emitted.
+                var pendingOpacity by remember { mutableStateOf<Float?>(null) }
                 val latestOpacityChange by rememberUpdatedState(onBackgroundImageOpacityInputChange)
 
                 val updateOpacity = remember {
-                    { value: Float -> latestOpacityChange(value) }
+                    { value: Float ->
+                        pendingOpacity = value
+                        latestOpacityChange(value)
+                    }
                 }
 
                 val onValueChangeFinished = remember {
                     {
-                        val newOpacity = latestOpacity
-                        if (abs(lastSavedOpacity - newOpacity) > 0.01f) {
-                            editorSession.setFloat("background_image_opacity", newOpacity)
-                            lastSavedOpacity = newOpacity
+                        pendingOpacity?.let {
+                            editorSession.setFloat("background_image_opacity", it)
                         }
+                        pendingOpacity = null
                     }
                 }
 
@@ -512,25 +515,24 @@ internal fun ThemeSettingsBackgroundSection(
                         modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
                     )
 
-                    var lastSavedBlurRadius by remember {
-                        mutableStateOf(backgroundBlurRadiusInput)
-                    }
                     val blurInteractionSource = remember { MutableInteractionSource() }
-                    val latestBlurRadius by rememberUpdatedState(backgroundBlurRadiusInput)
+                    var pendingBlurRadius by remember { mutableStateOf<Float?>(null) }
                     val latestBlurRadiusChange by
                         rememberUpdatedState(onBackgroundBlurRadiusInputChange)
 
                     val onBlurValueChange = remember {
-                        { value: Float -> latestBlurRadiusChange(value) }
+                        { value: Float ->
+                            pendingBlurRadius = value
+                            latestBlurRadiusChange(value)
+                        }
                     }
 
                     val onBlurValueChangeFinished = remember {
                         {
-                            val newBlurRadius = latestBlurRadius
-                            if (abs(lastSavedBlurRadius - newBlurRadius) > 0.1f) {
-                                editorSession.setFloat("background_blur_radius", newBlurRadius)
-                                lastSavedBlurRadius = newBlurRadius
+                            pendingBlurRadius?.let {
+                                editorSession.setFloat("background_blur_radius", it)
                             }
+                            pendingBlurRadius = null
                         }
                     }
 


### PR DESCRIPTION
## 变更说明 / Description

修复背景设置里透明度 / 模糊两个进度条「点击（非拖动）时状态错位」的问题：第一次点击不生效、第二次点击保存的却是上一次点击的值并让滑块闪回。

### 背景与动机 / Context and motivation

Material3 的 `Slider` 在**点击**（而不是拖动）时，会在同一帧内先后触发 `onValueChange` 和 `onValueChangeFinished`（`sliderTapModifier` 里 `onPress` → `dispatchRawDelta(0f)` → `gestureEndAction()`）。

`ThemeSettingsBackgroundSection` 里的 `onValueChangeFinished` 通过 `rememberUpdatedState(backgroundImageOpacityInput)` 把提升到父级的状态读回来。该状态要等下一次重组才会刷新，所以在同一帧里读到的仍然是**点击前**的值：

1. 第一次点击 A —— 滑块移动到 A，但持久化时读到的是初始值，`abs(lastSaved - 初始值) == 0`，什么都没写入，保存按钮不亮；
2. 第二次点击 B —— 此时读回来的是 A，于是写入 A。保存按钮亮起，`ThemeEditorSession` 回流让 `backgroundImageOpacityInput` 变回 A，滑块闪回 A。

拖动之所以正常，是因为期间经过了多帧重组，状态早已追上。

### 改动范围 / Changes

- 两个进度条改为记住 `onValueChange` **刚刚发出**的值（`pendingOpacity` / `pendingBlurRadius`），`onValueChangeFinished` 持久化这个值，不再回读父级状态；手势结束后清空，因此「点在滑块当前位置、没有产生值变化」的点击不会写入任何东西。
- 顺带移除随之失效的 `lastSavedOpacity` / `lastSavedBlurRadius` 阈值判断：`ThemeEditorSession.update` 本身在值没变化时就直接 return，脏状态也是拿 `currentValues` 与 baseline 做真实 diff，重复写入本来就是空操作。这个旧判断还有个副作用——外部重置主题后 `lastSaved*` 会过期，把滑回原值这一次合法保存也挡掉。
- 不在范围内：其它页面的滑块（全仓库只有这个文件用了这种回读写法）、拖动逻辑、`isDragging` 相关代码。

### 兼容性与风险 / Compatibility and risks

无数据格式、API 或配置变更。行为变化仅限于「点击进度条现在会立即生效并正确置脏」。移除阈值判断后，小于 0.01（不透明度）/ 0.1（模糊半径）的改动也会被写入——这本来就是用户明确操作的结果，且 editor session 对无变化写入是空操作。

## 关联 Issue / Related issue

Fixes #981

## 验证方式 / Verification

```text
检查或命令：
  1. 逐行推演 Material3 Slider 点击路径（sliderTapModifier: onPress → dispatchRawDelta(0f) → gestureEndAction），
     确认 onValueChange / onValueChangeFinished 同帧触发，与 issue 描述的两次点击现象完全吻合。
  2. 把改动后的语言构造（remember 住的 lambda 捕获局部委托属性、nullable Float 的 ?.let）抽成等价最小样例，
     用 kotlinc 完整编译并运行，验证时序语义。
  3. 对改动前后的文件各跑一次 kotlinc 解析检查，比对报错集合：差异只有
     abs / math / rememberUpdatedState 引用数的变化，无新增语法或类型问题。
环境与变体：Windows 本机；未跑完整 Gradle 构建（本机缺 NDK/CMake 与 ffmpeg 等原生依赖，无法完成 assemble）。
结果：
  最小样例输出——点击 0.8 → 持久化 0.8；紧接着点击 0.3 → 持久化 0.3；无值变化的收尾回调 → 不写入。
  即改前「首次不保存、二次保存上一次的值」的时序问题已消除。
```

需要真机回归的话，麻烦在设置 → 主题 → 背景里点击（不要拖动）透明度和模糊进度条：每次点击都应立刻亮起保存按钮，且滑块停在点击位置不回弹。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
