### PR TITLE
fix(markdown): don't dispatch document-relative links as view intents

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/common/displays/MarkdownTextComposable.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/displays/MarkdownTextComposable.kt
@@ -12,8 +12,13 @@ import com.ai.assistance.operit.util.stream.stream
 import androidx.compose.material3.LocalContentColor
 import com.ai.assistance.operit.ui.common.markdown.StreamMarkdownRenderer
 import androidx.compose.ui.platform.LocalContext
+import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
+import com.ai.assistance.operit.R
+import com.ai.assistance.operit.util.AppLogger
 
 /** 新一代流式Markdown+LaTeX渲染器，完全替换原有实现。 兼容原有API，支持所有Markdown和LaTeX混排。 */
 @Composable
@@ -35,9 +40,38 @@ fun MarkdownTextComposable(
                 textColor = textColor,
                 fontSize = fontSize,
                 enableDialogs = enableDialogs,
-                onLinkClick = { url ->
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                    context.startActivity(intent)
-                }
+                onLinkClick = { url -> openMarkdownLink(context, url) }
         )
+}
+
+private const val MARKDOWN_LINK_TAG = "MarkdownLink"
+
+// A markdown link target is not necessarily something the system can open. Market package
+// descriptions are rendered straight from a repository README, so they carry references that are
+// relative to that document, such as the "English" link of a bilingual README pointing at
+// README.md, or an in-document anchor pointing at #usage. Those have no URI scheme, no activity
+// can ever match them, and handing one to ACTION_VIEW makes startActivity throw
+// ActivityNotFoundException and take the app down. Dispatch absolute URIs only, and tell the user
+// why a document-relative reference goes nowhere.
+//
+// An absolute URI is not a guarantee either: startActivity documents that it throws when nothing
+// on the device declares a matching intent filter (mailto: with no mail client, an app scheme
+// whose app is not installed) and it can also fail with SecurityException when the matching
+// activity is not exported to us. Both leave the user exactly where a relative reference does, so
+// they report the same way instead of taking the process down.
+private fun openMarkdownLink(context: Context, url: String) {
+    val uri = Uri.parse(url)
+    if (uri.scheme.isNullOrEmpty()) {
+        Toast.makeText(context, R.string.markdown_link_not_openable, Toast.LENGTH_SHORT).show()
+        return
+    }
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, uri))
+    } catch (e: ActivityNotFoundException) {
+        AppLogger.w(MARKDOWN_LINK_TAG, "no activity can open markdown link: $url", e)
+        Toast.makeText(context, R.string.markdown_link_not_openable, Toast.LENGTH_SHORT).show()
+    } catch (e: SecurityException) {
+        AppLogger.w(MARKDOWN_LINK_TAG, "not allowed to open markdown link: $url", e)
+        Toast.makeText(context, R.string.markdown_link_not_openable, Toast.LENGTH_SHORT).show()
+    }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8253,5 +8253,6 @@
     <string name="token_stats_detail_tokens">Token breakdown</string>
     <string name="token_stats_detail_close">Close</string>
     <string name="token_stats_detail_open">Tap to view details</string>
+    <string name="markdown_link_not_openable">This link points to a reference inside the document and cannot be opened</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7477,4 +7477,5 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="artifact_publish_load_github_releases">Cargar Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>
     <string name="artifact_publish_github_release_asset">Activo de Release</string>
+    <string name="markdown_link_not_openable">Este enlace apunta a una referencia dentro del documento y no se puede abrir</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7409,4 +7409,5 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="artifact_publish_load_github_releases">Muat Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>
     <string name="artifact_publish_github_release_asset">Aset Release</string>
+    <string name="markdown_link_not_openable">Tautan ini menunjuk ke referensi di dalam dokumen dan tidak dapat dibuka</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7256,4 +7256,5 @@
     <string name="artifact_publish_load_github_releases">Release 로드</string>
     <string name="artifact_publish_github_release">GitHub Release</string>
     <string name="artifact_publish_github_release_asset">Release 자산</string>
+    <string name="markdown_link_not_openable">이 링크는 문서 내부의 참조를 가리켜서 열 수 없습니다</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7406,4 +7406,5 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="artifact_publish_load_github_releases">Muat Siaran</string>
     <string name="artifact_publish_github_release">Siaran GitHub</string>
     <string name="artifact_publish_github_release_asset">Aset Siaran</string>
+    <string name="markdown_link_not_openable">Pautan ini menghala ke rujukan dalam dokumen dan tidak boleh dibuka</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7247,4 +7247,5 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="artifact_publish_load_github_releases">Carregar Releases</string>
     <string name="artifact_publish_github_release">GitHub Release</string>
     <string name="artifact_publish_github_release_asset">Ativo do Release</string>
+    <string name="markdown_link_not_openable">Este link aponta para uma referência dentro do documento e não pode ser aberto</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -8003,5 +8003,6 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="notification_kind_review_rejected">Nu a fost aprobat</string>
     <string name="notification_kind_review_changes">Trebuie modificat</string>
     <string name="notification_kind_entry_curated">Selectat în selecția de top</string>
+    <string name="markdown_link_not_openable">Acest link indică o referință din interiorul documentului și nu poate fi deschis</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8244,5 +8244,6 @@
     <string name="token_stats_detail_tokens">Token 明细</string>
     <string name="token_stats_detail_close">关闭</string>
     <string name="token_stats_detail_open">点击查看详细数据</string>
+    <string name="markdown_link_not_openable">该链接指向文档内部的引用，无法打开</string>
 
 </resources>


### PR DESCRIPTION
## 变更说明 / Description

应用市场的包简介直接渲染仓库 README，README 里的相对引用（例如双语 README 的 `[English](README.md)`、章节锚点 `[用法](#usage)`）会被当成外部链接交给 `Intent.ACTION_VIEW`，点击即闪退。这个 PR 让 Markdown 链接只把绝对 URI 交给系统。

The market renders a package description straight from its repository README. Document-relative references inside that README were handed to `Intent.ACTION_VIEW` as if they were external links, which crashes the app on tap.

### 背景与动机 / Context and motivation

`MarkdownTextComposable` 把 `onLinkClick` 收到的 href 原样塞进 `Intent(Intent.ACTION_VIEW, Uri.parse(url))` 并直接 `startActivity`。

`MarkdownInlineSpannable` 构造 `URLSpan` 时用的是 Markdown 里的原始 href，不做任何归一化，所以 `README.md`、`#usage` 这类目标会原样传下来。它们没有 URI scheme，系统里不存在能响应的 Activity，`startActivity` 抛出 `ActivityNotFoundException`：

```text
android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat= xflg=0x4 }
    at com.ai.assistance.operit.ui.common.displays.MarkdownTextComposableKt.MarkdownTextComposable_Pe9_g_s$lambda$0$0(MarkdownTextComposable.kt:40)
```

Issue #984 里点击的“English”正是 `多 Agent 协作调度器` 简介开头 `English | 简体中文` 这一行的相对链接。同一段简介里的“项目仓库”是 `https://` 绝对链接，所以不受影响 —— 触发条件就是 href 没有 scheme。

### 改动范围 / Changes

- `MarkdownTextComposable`：链接点击改走新增的 `openMarkdownLink`，只有带 scheme 的绝对 URI 才发 `ACTION_VIEW`；文档内相对引用弹 Toast 说明打不开，而不是把异常丢给框架，也不是静默无反应。
- 绝对 URI 这一路同时接住 `startActivity` 文档中声明的两种失败：`ActivityNotFoundException`（设备上没有任何组件声明匹配的 intent-filter，例如没装邮件客户端时的 `mailto:`、未安装应用的自定义 scheme）和 `SecurityException`（匹配到的 Activity 未对外导出）。两种都写一条 `AppLogger.w` 并复用同一个 Toast，不再让进程直接死掉。
- 新增字符串 `markdown_link_not_openable`，补齐全部 8 个 locale（zh/en/es/id/ko/ms/pt-rBR/ro）。
- 不在范围内：Markdown 相对链接的解析（把 `README.md` 拼回仓库地址）不做，包简介里拿不到可靠的文档基址；`MarkdownTextComposable` 里那个从未被使用的 `onLinkClicked` 参数保持原样，属于另一个问题。

### 兼容性与风险 / Compatibility and risks

能被系统处理的绝对链接（`https:`、装了客户端的 `mailto:` 等）行为不变，仍然直接跳转。行为变化只有一处：原先会让 app 崩溃的两类链接现在都是同一次 Toast 提示 —— 没有 scheme 的文档内引用（issue #984 的实际触发路径），以及有 scheme 但设备上没有可处理 Activity、或该 Activity 未导出的绝对 URI。没有数据格式、配置或 API 改动。

刻意没有用 `resolveActivity` 做前置判定：Android 11 起的软件包可见性会让 `mailto:`、`tel:` 这类非浏览器 scheme 在未声明 `<queries>` 时返回 null，那样会把本来能打开的链接误判成打不开。所以判定拆成两段 —— 能静态判定的（没有 scheme）在发 intent 前拦掉，只有真正取决于设备装了什么的那部分交给 `startActivity` 抛出的既定异常。

## 关联 Issue / Related issue

Fixes #984

## 验证方式 / Verification

```text
检查或命令：
  python3 -B ci/script/check_repo_hygiene.py   --base <merge-base> --candidate HEAD  -> errors=0 warnings=0
  python3 -B ci/script/check_markdown_links.py --base <merge-base> --candidate HEAD  -> errors=0 warnings=0
  python3 -B ci/script/check_localizations.py  --base <merge-base> --candidate HEAD  -> errors=0 warnings=0
环境与变体：Windows 本地仓库，未执行 Gradle 构建
结果：三项快速检查通过；Android build 与 JVM tests 依赖 NDK/CMake 与手工二进制依赖，本地无法复现，留给 PR Check 执行
```

崩溃路径由 issue 中的堆栈直接定位到 `MarkdownTextComposable.kt:40` 的 `startActivity`，触发条件（href 无 scheme）可由 `MarkdownInlineSpannable` 不做归一化的 `URLSpan(linkUrl)` 推出，改动本身是这一行的前置判定。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)
