### PR TITLE
feat(tools): expose character card and group ids in ChatInfo

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/tools/ToolResultDataClasses.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/ToolResultDataClasses.kt
@@ -2021,7 +2021,9 @@ data class ChatListResultData(
         val isCurrent: Boolean,
         val inputTokens: Long,
         val outputTokens: Long,
-        val characterCardName: String? = null
+        val characterCardName: String? = null,
+        val characterCardId: String? = null,
+        val characterGroupId: String? = null
     )
     
     override fun toString(): String {
@@ -2042,6 +2044,12 @@ data class ChatListResultData(
                 sb.appendLine("Message Count: ${chat.messageCount}")
                 if (!chat.characterCardName.isNullOrBlank()) {
                     sb.appendLine("Character Card: ${chat.characterCardName}")
+                }
+                if (!chat.characterCardId.isNullOrBlank()) {
+                    sb.appendLine("Character Card ID: ${chat.characterCardId}")
+                }
+                if (!chat.characterGroupId.isNullOrBlank()) {
+                    sb.appendLine("Character Group ID: ${chat.characterGroupId}")
                 }
                 sb.appendLine("Token Statistics: Input ${chat.inputTokens} / Output ${chat.outputTokens}")
                 sb.appendLine("Created: ${chat.createdAt}")

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardChatManagerTool.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardChatManagerTool.kt
@@ -139,10 +139,22 @@ class StandardChatManagerTool(private val context: Context) {
         }
     }
 
+    /** 角色卡名到角色卡ID的映射，同名时取第一张，与 findCharacterCardByName 的选取一致 */
+    private suspend fun buildCharacterCardIdsByName(chats: List<ChatHistory>): Map<String, String> {
+        if (chats.none { !it.characterCardName.isNullOrBlank() }) {
+            return emptyMap()
+        }
+        return CharacterCardManager.getInstance(appContext)
+            .getAllCharacterCards()
+            .groupBy { it.name }
+            .mapValues { (_, cards) -> cards.first().id }
+    }
+
     private fun buildChatInfo(
         chat: ChatHistory,
         messageCounts: Map<String, Int>,
-        currentChatId: String?
+        currentChatId: String?,
+        characterCardIdsByName: Map<String, String>
     ): ChatListResultData.ChatInfo {
         return ChatListResultData.ChatInfo(
             id = chat.id,
@@ -153,7 +165,11 @@ class StandardChatManagerTool(private val context: Context) {
             isCurrent = currentChatId != null && chat.id == currentChatId,
             inputTokens = chat.inputTokens,
             outputTokens = chat.outputTokens,
-            characterCardName = chat.characterCardName
+            characterCardName = chat.characterCardName,
+            characterCardId = chat.characterCardName
+                ?.takeIf { it.isNotBlank() }
+                ?.let { characterCardIdsByName[it] },
+            characterGroupId = chat.characterGroupId
         )
     }
 
@@ -554,7 +570,13 @@ class StandardChatManagerTool(private val context: Context) {
                 )
             }
 
-            val chatInfo = buildChatInfo(matched[targetIndex], messageCounts, currentChatId)
+            val selectedChat = matched[targetIndex]
+            val chatInfo = buildChatInfo(
+                selectedChat,
+                messageCounts,
+                currentChatId,
+                buildCharacterCardIdsByName(listOf(selectedChat))
+            )
             ToolResult(
                 toolName = tool.name,
                 success = true,
@@ -1202,8 +1224,10 @@ class StandardChatManagerTool(private val context: Context) {
                     if (sortOrder == "asc") av.compareTo(bv) else bv.compareTo(av)
                 }
 
-            val chatInfoList = matched.take(limit).map { chat ->
-                buildChatInfo(chat, messageCounts, currentChatId)
+            val visibleChats = matched.take(limit)
+            val characterCardIdsByName = buildCharacterCardIdsByName(visibleChats)
+            val chatInfoList = visibleChats.map { chat ->
+                buildChatInfo(chat, messageCounts, currentChatId, characterCardIdsByName)
             }
 
             ToolResult(

--- a/examples/types/results.d.ts
+++ b/examples/types/results.d.ts
@@ -1553,6 +1553,10 @@ export interface ChatInfo {
     outputTokens: number;
     /** Bound character card name (if any) */
     characterCardName?: string | null;
+    /** ID of the character card bound to this chat, resolved from characterCardName */
+    characterCardId?: string | null;
+    /** Bound character group ID, set only for group chats */
+    characterGroupId?: string | null;
 }
 
 /**


### PR DESCRIPTION
## 变更说明 / Description

`find_chat` 与 `list_chats` 返回的 `ChatInfo` 只有 `characterCardName`，插件拿不到角色卡 ID，也认不出群组会话。本 PR 给 `ChatInfo` 补上 `characterCardId` 与 `characterGroupId`。

### 背景与动机 / Context and motivation

Issue #864 指出两个缺口：

- 复制角色卡是常见操作，同名角色卡在插件侧无法区分，按人格隔离的插件只能报歧义让用户手动指定
- 群组会话的 `characterCardName` 为空，插件看到的结果和「未绑卡」完全一样，无法识别群组会话

宿主自己是能分辨的：`MessageCoordinationDelegate.resolveBoundRoleCardId` 读 `ChatHistory.characterGroupId` 判断群组，再用 `findCharacterCardByName` 拿到实际发送时使用的角色卡 ID。这两个信息此前没有透出到 ToolPkg 结果里。

### 改动范围 / Changes

- `ChatListResultData.ChatInfo` 新增 `characterCardId` 与 `characterGroupId`，两者都是带默认值的可空字段
- `StandardChatManagerTool.buildChatInfo` 补映射：`characterGroupId` 直接取自 `ChatHistory`；`characterCardId` 由绑定的角色卡名解析，同名时取角色卡列表中的第一张，与 `findCharacterCardByName` 的选取一致，因此插件拿到的 ID 就是宿主发送消息时实际使用的那张卡
- 新增 `buildCharacterCardIdsByName`，`list_chats` 每次调用只读一次角色卡列表；没有任何会话绑定角色卡时不读取
- `ChatListResultData.toString()` 在存在时输出 `Character Card ID` 与 `Character Group ID`，让模型在读取列表时也能识别群组会话
- `examples/types/results.d.ts` 的 `ChatInfo` 同步声明这两个字段

明确不包含：不改动聊天与角色卡的持久化绑定方式。Issue 正文假设 `characterCardId` 已经存在于 `ChatHistory`，实际上它在 docs/TODO/character_card_uuid_binding_rollback_20260805 中被整体回退过，理由是按 UUID 绑定破坏了既有聊天绑定。所以这里选择在读取时解析，不重新引入持久化字段和数据库迁移。

需要说明的是，这也意味着同名角色卡的歧义并没有在数据层被消除：`characterCardId` 给出的是宿主会选中的那张卡，插件与宿主的行为从此一致，但如果用户真的保留了两张同名卡，宿主本身也只认第一张。Issue 里提到的「禁止重名」是另一个话题，不在本 PR 范围内。

### 兼容性与风险 / Compatibility and risks

- 纯新增可空字段。`toJson()` 沿用 `encodeDefaults = false`，两个字段为空时不会出现在 JSON 里，非空时作为新键追加，按键读取的旧插件不受影响
- 无数据库、无持久化格式、无工具参数变更，不需要迁移
- 性能：`list_chats` 每次调用最多额外读取一次角色卡列表；当前没有任何会话绑定角色卡时跳过。`find_chat` 的这一次读取与宿主发送消息时 `resolveBoundRoleCardId` 的开销相同
- 安全：N/A

## 关联 Issue / Related issue

Closes #864

## 验证方式 / Verification

```text
检查或命令：
  python3 -B ci/script/check_repo_hygiene.py --base "$(git merge-base upstream/main HEAD)" --candidate HEAD
  python3 -B ci/script/check_markdown_links.py --base "$(git merge-base upstream/main HEAD)" --candidate HEAD
  python3 -B ci/script/check_localizations.py --base "$(git merge-base upstream/main HEAD)" --candidate HEAD
  python3 -B -m unittest discover -s ci/test -p 'test_*.py'
  node --experimental-strip-types 解析 examples/types/results.d.ts

环境与变体：Windows 11 + Git Bash，Python 3.14，Node.js 24.14.0；未执行 Gradle 构建

结果：
  repo hygiene：errors=0 warnings=0（检查 3 个改动文件）
  markdown links：errors=0 warnings=0
  localizations：errors=0 warnings=0（本 PR 不新增字符串资源）
  ci/test：46 项中 44 项通过，2 项失败为 Windows 符号链接权限限制
    （test_existing_symlink_in_destination_is_rejected、test_runtime_symlink_cannot_escape_package，
     均在创建符号链接夹具时抛 OSError WinError 1314，与本改动无关，本 PR 不含 Python 改动）
  results.d.ts：类型剥离解析通过
```

未运行 `./gradlew :app:testDebugUnitTest` 与 `assembleDebug`：本机缺少 Android SDK、NDK 与 CMake，无法完成完整构建，交由 CI 的 `Android build` 与 `Android JVM tests` job 覆盖。

## 证据 / Evidence

没有设备端运行记录，本机无法完成 Android 构建，因此不提供截图或真机日志。

对 `ChatListResultData.toString()` 的改动可以在 diff 中直接核对：在已有的 `Character Card` 行之后，分别在 `characterCardId` 与 `characterGroupId` 非空时追加 `Character Card ID` 与 `Character Group ID` 两行。此前群组会话在这段文本输出里只有标题和消息数，与未绑定角色卡的普通会话没有任何区别。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
