### PR TITLE
fix(sidebar): retry OpenCode startup without dropping keep-alive state

### DIFF
--- a/examples/sidebar_opencode/src/ui/opencode_dashboard/index.ui.ts
+++ b/examples/sidebar_opencode/src/ui/opencode_dashboard/index.ui.ts
@@ -184,6 +184,16 @@ export default function Screen(ctx: ComposeDslContext): ComposeNode {
             overflow: "ellipsis",
           })
         ),
+        errorText
+          ? UI.Button({
+              text: "重试",
+              enabled: !loading,
+              onClick: async () => {
+                await ensureServer();
+              },
+              contentPadding: { horizontal: 18, vertical: 10 },
+            })
+          : UI.Spacer({ width: 0, height: 0 }),
       ]
     )
   );


### PR DESCRIPTION
Supersedes the approach in #900. Keeps the existing keepAlive lifecycle and adds an explicit retry action after OpenCode server startup failure, avoiding WebView state loss on normal sidebar switches. Fork PR CI: https://github.com/yoruuuchan/Operit/pull/1