### PR TITLE
fix(chat): correct Waifu typing queue pacing

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/util/WaifuMessageProcessor.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/WaifuMessageProcessor.kt
@@ -1,7 +1,6 @@
 package com.ai.assistance.operit.util
 
 import android.content.Context
-import android.os.SystemClock
 import com.ai.assistance.operit.data.preferences.ActivePromptManager
 import com.ai.assistance.operit.data.repository.CustomEmojiRepository
 import com.ai.assistance.operit.util.markdown.MarkdownProcessorType
@@ -24,6 +23,7 @@ object WaifuMessageProcessor {
     private const val URL_CHARS = "[A-Za-z0-9._~:/?#\\[\\]@!$&'()*+,;=%-]"
     private const val ENTITY_PLACEHOLDER_PREFIX = "{WAIFUENTITY:"
     private const val ENTITY_PLACEHOLDER_SUFFIX = "}"
+    private const val MAX_TYPING_DELAY_MS = 3000L
     private val FENCED_CODE_BLOCK_REGEX = Regex("```[^\\r\\n`]*[\\r\\n]?[\\s\\S]*?```")
     private val UNCLOSED_FENCED_CODE_BLOCK_REGEX = Regex("```[^\\r\\n`]*[\\r\\n]?[\\s\\S]*$")
     private val SENTENCE_SPLIT_REGEX =
@@ -140,6 +140,18 @@ object WaifuMessageProcessor {
         session.collectFinalSegments(renderableBuffer.toString()).forEach { emit(it) }
     }
 
+    internal fun calculateTypingDelayMs(
+        segmentLength: Int,
+        charDelayMs: Int,
+        isFirstSegment: Boolean,
+    ): Long {
+        if (isFirstSegment || segmentLength <= 0 || charDelayMs <= 0) {
+            return 0L
+        }
+
+        return (segmentLength.toLong() * charDelayMs.toLong()).coerceAtMost(MAX_TYPING_DELAY_MS)
+    }
+
     fun streamSegmentsWithTypingQueue(
         sourceStream: Stream<String>,
         removePunctuation: Boolean = false,
@@ -168,16 +180,20 @@ object WaifuMessageProcessor {
                 }
             }
 
-            var nextSendAtMs = 0L
+            var isFirstSegment = true
             for (segment in segmentQueue) {
-                val waitMs = nextSendAtMs - SystemClock.elapsedRealtime()
+                val waitMs =
+                    calculateTypingDelayMs(
+                        segmentLength = segment.length,
+                        charDelayMs = charDelayMs,
+                        isFirstSegment = isFirstSegment,
+                    )
                 if (waitMs > 0L) {
                     delay(waitMs)
                 }
 
                 emit(segment)
-                nextSendAtMs =
-                    SystemClock.elapsedRealtime() + segment.length.toLong() * charDelayMs.toLong()
+                isFirstSegment = false
             }
 
             producerJob.join()
@@ -977,4 +993,4 @@ object WaifuMessageProcessor {
             return null
         }
     }
-} 
+}

--- a/app/src/test/java/com/ai/assistance/operit/util/WaifuMessageProcessorTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/util/WaifuMessageProcessorTest.kt
@@ -1,0 +1,54 @@
+package com.ai.assistance.operit.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WaifuMessageProcessorTest {
+    @Test
+    fun calculateTypingDelayMs_firstSegmentIsImmediate() {
+        assertEquals(
+            0L,
+            WaifuMessageProcessor.calculateTypingDelayMs(
+                segmentLength = 80,
+                charDelayMs = 240,
+                isFirstSegment = true,
+            )
+        )
+    }
+
+    @Test
+    fun calculateTypingDelayMs_usesCurrentSegmentLengthForShortTail() {
+        assertEquals(
+            720L,
+            WaifuMessageProcessor.calculateTypingDelayMs(
+                segmentLength = 3,
+                charDelayMs = 240,
+                isFirstSegment = false,
+            )
+        )
+    }
+
+    @Test
+    fun calculateTypingDelayMs_capsLongSegmentDelay() {
+        assertEquals(
+            3000L,
+            WaifuMessageProcessor.calculateTypingDelayMs(
+                segmentLength = 80,
+                charDelayMs = 240,
+                isFirstSegment = false,
+            )
+        )
+    }
+
+    @Test
+    fun calculateTypingDelayMs_nonPositiveDelayIsImmediate() {
+        assertEquals(
+            0L,
+            WaifuMessageProcessor.calculateTypingDelayMs(
+                segmentLength = 10,
+                charDelayMs = 0,
+                isFirstSegment = false,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

修复 #999：Waifu mode 的 typing queue 会用**上一条已发送分句**的长度推迟下一条，导致长句后的短尾句也被卡很久。

本次保持现有 Waifu「逐句独立消息」语义：
- 首个稳定分句立即发送；
- 后续分句按**当前待发送分句**自身长度计算等待；
- 单个分句模拟打字等待最多 3000ms；
- 新增 `WaifuMessageProcessorTest` 回归测试。

### 背景与动机 / Context and motivation

Issue #999 中，开启 Waifu mode 后会出现「等一阵再蹦出一大段、最后几个字继续卡住」，关闭后流式正常。旧逻辑相当于：

`previousSegment.length × charDelayMs`

因此前一个长句会把延迟错误传给后面的短句。

### 兼容性与风险 / Compatibility and risks

不涉及数据库、配置格式或公开 API；不改变 Waifu 分句规则和 `waifuCharDelay` 语义。行为变化仅限分句发送节奏。

## 关联 Issue / Related issue

Fixes #999

## 验证方式 / Verification

```text
GitHub Actions / base: development
Fast checks: PASS
Android JVM tests: PASS
Candidate checks: PASS
Android build: SKIPPED by repository candidate-check gating
```

在 `240ms/character` 下：
- 3 字符尾句：720ms；
- 80 字符分句：最多 3000ms，而不是 19200ms。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
