### PR TITLE
feat(package): add ToolPkg Logo support

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/PackageManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/PackageManager.kt
@@ -134,7 +134,16 @@ private constructor(private val context: Context, private val aiToolHandler: AIT
         val toolboxUiModules: List<ToolPkgToolboxUiModule>,
         val subpackages: List<ToolPkgSubpackageInfo>,
         val workflowTemplates: List<ToolPkgWorkflowTemplate>,
-        val workspaceTemplates: List<ToolPkgWorkspaceTemplate>
+        val workspaceTemplates: List<ToolPkgWorkspaceTemplate>,
+        val logoResourceKey: String? = null,
+        val logoMimeType: String? = null
+    )
+
+    data class ToolPkgLogoBytes(
+        val resourceKey: String,
+        val mimeType: String,
+        val fileName: String,
+        val bytes: ByteArray
     )
 
     data class ToolPkgWasmModule(
@@ -1395,6 +1404,20 @@ private constructor(private val context: Context, private val aiToolHandler: AIT
         resolveContext: Context? = null
     ): ToolPkgContainerDetails? {
         return toolPkgFacade.getToolPkgContainerDetails(packageName, resolveContext)
+    }
+
+    fun readToolPkgLogoBytes(packageName: String): ToolPkgLogoBytes? {
+        ensureInitialized()
+        val normalizedPackageName = normalizePackageName(packageName)
+        val runtime = toolPkgContainers[normalizedPackageName] ?: return null
+        val logoResource = runtime.logoResource ?: return null
+        val bytes = readToolPkgResourceBytes(runtime, logoResource.path) ?: return null
+        return ToolPkgLogoBytes(
+            resourceKey = logoResource.key,
+            mimeType = logoResource.mime,
+            fileName = logoResource.path.substringAfterLast('/'),
+            bytes = bytes
+        )
     }
 
     fun getToolPkgUiRoutes(

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/PackageManagerToolPkgFacade.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/PackageManagerToolPkgFacade.kt
@@ -310,6 +310,8 @@ internal class PackageManagerToolPkgFacade(
             description = container.description.resolve(localizationContext),
             version = container.version,
             author = container.author,
+            logoResourceKey = container.logoResource?.key,
+            logoMimeType = container.logoResource?.mime,
             resourceCount = container.resources.size,
             wasmModuleCount = wasmModules.size,
             workflowTemplateCount = workflowTemplates.size,

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgParser.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgParser.kt
@@ -13,6 +13,8 @@ import java.util.zip.ZipInputStream
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 import org.hjson.JsonValue
 
 private val TOOLPKG_DIRECTORY_RESOURCE_MIME_TYPES =
@@ -165,6 +167,7 @@ internal data class ToolPkgContainerRuntime(
     val promptEstimateFinalizeHooks: List<ToolPkgFunctionHookRuntime>,
     val summaryGenerateHooks: List<ToolPkgFunctionHookRuntime>,
     val aiProviders: List<ToolPkgAiProviderRuntime>,
+    val logoResource: ToolPkgResourceRuntime? = null,
     val marketOrigin: ToolPkgMarketOrigin? = null
 )
 
@@ -182,6 +185,7 @@ internal data class ToolPkgManifest(
     val main: String = "",
     @SerialName("display_name") val displayName: LocalizedText = LocalizedText.of(""),
     val description: LocalizedText = LocalizedText.of(""),
+    @SerialName("logo") val logoElement: JsonElement? = null,
     @Serializable(with = StringOrStringListSerializer::class)
     val author: List<String> = emptyList(),
     @SerialName("enabled_by_default") val enabledByDefault: Boolean = true,
@@ -193,7 +197,10 @@ internal data class ToolPkgManifest(
     val workflowTemplates: List<ToolPkgManifestWorkflowTemplate> = emptyList(),
     @SerialName("workspace_templates")
     val workspaceTemplates: List<ToolPkgManifestWorkspaceTemplate> = emptyList()
-)
+) {
+    val logo: String?
+        get() = (logoElement as? JsonPrimitive)?.takeIf { it.isString }?.content
+}
 
 @Serializable
 internal data class ToolPkgManifestSubpackage(
@@ -497,6 +504,8 @@ internal object ToolPkgArchiveParser {
                     mime = resource.mime
                 )
             }
+
+        val logoResource = resolveLogoResource(manifest.logo, resources)
 
         val wasmModuleIds = linkedSetOf<String>()
         val wasmModules =
@@ -1318,6 +1327,7 @@ internal object ToolPkgArchiveParser {
                 promptEstimateFinalizeHooks = promptEstimateFinalizeHooks,
                 summaryGenerateHooks = summaryGenerateHooks,
                 aiProviders = aiProviders,
+                logoResource = logoResource,
                 marketOrigin = mainRegistration.marketOrigin
             )
 
@@ -1619,4 +1629,36 @@ internal object ToolPkgArchiveParser {
     private fun hasLocalizedTextContent(text: LocalizedText?): Boolean {
         return text?.values?.values?.any { it.isNotBlank() } == true
     }
+
+    private fun resolveLogoResource(
+        logoResourceKey: String?,
+        resources: List<ToolPkgResourceRuntime>
+    ): ToolPkgResourceRuntime? {
+        val key = logoResourceKey?.trim().orEmpty()
+        if (key.isBlank()) return null
+
+        val resource =
+            resources.firstOrNull { it.key.equals(key, ignoreCase = true) }
+                ?: throw IllegalArgumentException(
+                    "manifest.logo must reference an existing resource key: $key"
+                )
+
+        if (isDirectoryResourceMime(resource.mime)) {
+            throw IllegalArgumentException("manifest.logo must reference a file resource: $key")
+        }
+
+        val extension = resource.path.substringAfterLast('.', "").lowercase()
+        val mime = resource.mime.trim().lowercase()
+        if (extension !in TOOLPKG_LOGO_EXTENSIONS && mime !in TOOLPKG_LOGO_MIME_TYPES) {
+            throw IllegalArgumentException(
+                "manifest.logo must reference an SVG, PNG, JPEG or WebP resource: $key"
+            )
+        }
+
+        return resource
+    }
+
+    private val TOOLPKG_LOGO_EXTENSIONS = setOf("svg", "png", "jpg", "jpeg", "webp")
+    private val TOOLPKG_LOGO_MIME_TYPES =
+        setOf("image/svg+xml", "image/png", "image/jpeg", "image/webp")
 }

--- a/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/api/MarketStatsApiService.kt
@@ -19,8 +19,10 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 
@@ -155,6 +157,12 @@ data class MarketV2AuthResponse(
     val githubId: Long = 0,
     val login: String = "",
     val avatarUrl: String = ""
+)
+
+@Serializable
+data class MarketV2LogoUploadResponse(
+    val ok: Boolean = false,
+    val url: String = ""
 )
 
 @Serializable
@@ -307,6 +315,7 @@ data class MarketV2Entry(
     val title: String = "",
     val description: String = "",
     val detail: String = "",
+    val logoUrl: String? = null,
     val authorId: String = "",
     val publisherId: String = "",
     val allowPublicUpdates: Boolean = true,
@@ -432,13 +441,15 @@ data class MarketV2PublishRequest(
     val version: MarketV2PublishVersion,
     val source: MarketV2PublishSource? = null,
     val repoVersion: MarketV2PublishRepoVersion? = null,
-    val asset: MarketV2PublishAsset? = null
+    val asset: MarketV2PublishAsset? = null,
+    val logoUrl: String? = null
 )
 
 @Serializable
 data class MarketV2NewVersionRequest(
     val entry: MarketV2NewVersionEntryPatch? = null,
     val version: MarketV2PublishVersion,
+    val logoUrl: String? = null,
     val repoVersion: MarketV2PublishRepoVersion? = null,
     val asset: MarketV2PublishAsset? = null
 )
@@ -449,7 +460,8 @@ data class MarketV2NewVersionEntryPatch(
     val description: String? = null,
     val detail: String? = null,
     val categoryId: String? = null,
-    val allowPublicUpdates: Boolean? = null
+    val allowPublicUpdates: Boolean? = null,
+    val logoUrl: String? = null
 )
 
 @Serializable
@@ -458,7 +470,8 @@ data class MarketV2EntryUpdateRequest(
     val description: String,
     val detail: String = "",
     val categoryId: String = "",
-    val allowPublicUpdates: Boolean? = null
+    val allowPublicUpdates: Boolean? = null,
+    val logoUrl: String? = null
 )
 
 @Serializable
@@ -785,6 +798,45 @@ class MarketStatsApiService {
             }
         }
 
+    suspend fun uploadMarketLogo(
+        fileName: String,
+        contentType: String,
+        bytes: ByteArray
+    ): Result<String> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                require(fileName.isNotBlank()) { "Logo file name is required" }
+                require(contentType.isNotBlank()) { "Logo content type is required" }
+                require(bytes.isNotEmpty()) { "Logo content is empty" }
+                val multipartBody =
+                    MultipartBody.Builder()
+                        .setType(MultipartBody.FORM)
+                        .addFormDataPart(
+                            "logo",
+                            fileName,
+                            bytes.toRequestBody(contentType.toMediaType())
+                        )
+                        .build()
+                requestDynamic(
+                    method = "POST",
+                    pathSegments = listOf("market", "v2", "logos"),
+                    body = null,
+                    requestBody = multipartBody,
+                    label = "uploadMarketLogo fileName=$fileName"
+                ) { responseBody, _ ->
+                    val response =
+                        json.decodeFromString(
+                            MarketV2LogoUploadResponse.serializer(),
+                            responseBody
+                        )
+                    require(response.ok && response.url.isNotBlank()) {
+                        "Market logo upload returned no hosted URL"
+                    }
+                    response.url
+                }
+            }
+        }
+
     suspend fun getComments(entryId: String, page: Int = 1): Result<List<MarketV2Comment>> =
         withContext(Dispatchers.IO) {
             runCatching {
@@ -936,6 +988,7 @@ class MarketStatsApiService {
                             title = request.title,
                             description = request.description,
                             detail = request.detail,
+                            logoUrl = request.logoUrl,
                             stateCode = "pending",
                             source = request.source?.let { MarketV2Source(kind = it.kind, url = it.url) }
                         )
@@ -978,6 +1031,7 @@ class MarketStatsApiService {
                             MarketV2NewVersionRequest(
                                 entry = entryPatch,
                                 version = request.version,
+                                logoUrl = request.logoUrl,
                                 repoVersion = request.repoVersion,
                                 asset = request.asset
                             )
@@ -1043,6 +1097,7 @@ class MarketStatsApiService {
         pathSegments: List<String>,
         label: String,
         body: String? = null,
+        requestBody: RequestBody? = null,
         queryParameters: Map<String, String> = emptyMap(),
         includeMarketSession: Boolean = true,
         followRedirects: Boolean = true,
@@ -1062,12 +1117,12 @@ class MarketStatsApiService {
             requestBuilder.addHeader("Authorization", "Bearer ${ensureMarketSession()}")
         }
 
-        val requestBody = body?.toRequestBody(JSON_MEDIA_TYPE)
+        val resolvedRequestBody = requestBody ?: body?.toRequestBody(JSON_MEDIA_TYPE)
         when (method.uppercase()) {
             "GET" -> requestBuilder.get()
-            "POST" -> requestBuilder.post(requestBody ?: ByteArray(0).toRequestBody(JSON_MEDIA_TYPE))
-            "PATCH" -> requestBuilder.patch(requestBody ?: ByteArray(0).toRequestBody(JSON_MEDIA_TYPE))
-            "DELETE" -> requestBuilder.delete(requestBody)
+            "POST" -> requestBuilder.post(resolvedRequestBody ?: ByteArray(0).toRequestBody(JSON_MEDIA_TYPE))
+            "PATCH" -> requestBuilder.patch(resolvedRequestBody ?: ByteArray(0).toRequestBody(JSON_MEDIA_TYPE))
+            "DELETE" -> requestBuilder.delete(resolvedRequestBody)
             else -> error("Unsupported HTTP method: $method")
         }
 
@@ -1249,6 +1304,7 @@ class MarketStatsApiService {
             title = title,
             description = description,
             detail = detail,
+            logoUrl = logoUrl,
             categoryId = categoryId,
             allowPublicUpdates = allowPublicUpdates,
             stateCode = "pending",
@@ -1262,6 +1318,7 @@ class MarketStatsApiService {
             title = this.title,
             description = this.description,
             detail = this.detail,
+            logoUrl = this.logoUrl,
             categoryId = this.categoryId,
             allowPublicUpdates = this.allowPublicUpdates ?: true,
             stateCode = "pending"

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/icons/ProviderLogoLoader.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/icons/ProviderLogoLoader.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
+import java.io.InputStream
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
@@ -56,18 +57,64 @@ object ProviderLogoLoader {
     fun loadLogoBitmap(context: Context, providerTypeId: String, sizePx: Int): Bitmap? {
         val path = findLogoAssetPath(context, providerTypeId) ?: return null
         return try {
-            val input = context.assets.open(path)
-            if (path.endsWith(".svg", ignoreCase = true)) {
-                renderSvgToBitmap(input, sizePx)
-            } else {
-                scalePngToBitmap(input, sizePx)
+            context.assets.open(path).use { input ->
+                LogoBitmapLoader.load(
+                    input = input,
+                    mimeType = null,
+                    fileName = path,
+                    sizePx = sizePx
+                )
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}
+
+object LogoBitmapLoader {
+    private val rasterExtensions = setOf("png", "jpg", "jpeg", "webp")
+    private val rasterMimeTypes = setOf("image/png", "image/jpeg", "image/webp")
+
+    fun load(
+        bytes: ByteArray,
+        mimeType: String?,
+        fileName: String?,
+        sizePx: Int
+    ): Bitmap? {
+        return bytes.inputStream().use { input ->
+            load(input = input, mimeType = mimeType, fileName = fileName, sizePx = sizePx)
+        }
+    }
+
+    fun load(
+        input: InputStream,
+        mimeType: String?,
+        fileName: String?,
+        sizePx: Int
+    ): Bitmap? {
+        require(sizePx > 0) { "Logo size must be positive" }
+        return try {
+            when {
+                isSvg(mimeType, fileName) -> renderSvgToBitmap(input, sizePx)
+                isRaster(mimeType, fileName) -> scaleBitmapToBitmap(input, sizePx)
+                else -> null
             }
         } catch (_: Exception) {
             null
         }
     }
 
-    private fun renderSvgToBitmap(input: java.io.InputStream, sizePx: Int): Bitmap? {
+    private fun isSvg(mimeType: String?, fileName: String?): Boolean {
+        return mimeType.equals("image/svg+xml", ignoreCase = true) ||
+            fileName.extension().equals("svg", ignoreCase = true)
+    }
+
+    private fun isRaster(mimeType: String?, fileName: String?): Boolean {
+        return mimeType?.trim()?.lowercase()?.let { it in rasterMimeTypes } == true ||
+            fileName.extension().lowercase() in rasterExtensions
+    }
+
+    private fun renderSvgToBitmap(input: InputStream, sizePx: Int): Bitmap? {
         val svg = SVG.getFromInputStream(input)
         val viewWidth = if (svg.documentWidth > 0f) svg.documentWidth else 24f
         val viewHeight = if (svg.documentHeight > 0f) svg.documentHeight else 24f
@@ -81,13 +128,12 @@ object ProviderLogoLoader {
         val picture = svg.renderToPicture()
         val bitmap = Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
-        // 内容居中
         canvas.translate((sizePx - scaledWidth) / 2f, (sizePx - scaledHeight) / 2f)
         picture.draw(canvas)
         return bitmap
     }
 
-    private fun scalePngToBitmap(input: java.io.InputStream, sizePx: Int): Bitmap? {
+    private fun scaleBitmapToBitmap(input: InputStream, sizePx: Int): Bitmap? {
         val source = BitmapFactory.decodeStream(input) ?: return null
         if (source.width == sizePx && source.height == sizePx) return source
         val scale = sizePx / max(source.width, source.height).toFloat()
@@ -106,14 +152,18 @@ object ProviderLogoLoader {
             ),
             null
         )
-        if (source != bitmap) source.recycle()
+        source.recycle()
         return bitmap
+    }
+
+    private fun String?.extension(): String {
+        return this?.substringAfterLast('.', "").orEmpty()
     }
 }
 
 /**
  * 以 Compose Painter 形式获取 provider logo。
- * provider 无 logo 素材时返回 null，调用方可回退到默认图标/首字母色块。
+ * provider 无 logo 素材时返回 null，调用方显示默认图标或首字母色块。
  */
 @Composable
 fun rememberProviderLogoPainter(providerTypeId: String?, size: Dp = 24.dp): Painter? {
@@ -129,6 +179,40 @@ fun rememberProviderLogoPainter(providerTypeId: String?, size: Dp = 24.dp): Pain
                     withContext(Dispatchers.IO) {
                         ProviderLogoLoader.loadLogoBitmap(context, providerTypeId, sizePx)
                             ?.asImageBitmap()
+                    }
+                }
+        }
+    return bitmap?.let { BitmapPainter(it) }
+}
+
+@Composable
+fun rememberLogoPainter(
+    logoKey: Any?,
+    bytes: ByteArray?,
+    mimeType: String?,
+    fileName: String?,
+    size: Dp = 24.dp
+): Painter? {
+    val density = LocalDensity.current
+    val sizePx = with(density) { size.roundToPx() }
+    val bitmap by
+        produceState<ImageBitmap?>(
+            initialValue = null,
+            logoKey,
+            bytes?.contentHashCode(),
+            mimeType,
+            fileName,
+            sizePx
+        ) {
+            value =
+                bytes?.let {
+                    withContext(Dispatchers.IO) {
+                        LogoBitmapLoader.load(
+                            bytes = it,
+                            mimeType = mimeType,
+                            fileName = fileName,
+                            sizePx = sizePx
+                        )?.asImageBitmap()
                     }
                 }
         }

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/icons/RemoteLogoLoader.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/icons/RemoteLogoLoader.kt
@@ -1,0 +1,124 @@
+package com.ai.assistance.operit.ui.common.icons
+
+import android.graphics.Bitmap
+import android.util.LruCache
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.ai.assistance.operit.util.AppLogger
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+private data class CachedLogo(
+    val bytes: ByteArray,
+    val contentType: String?
+)
+
+object RemoteLogoLoader {
+    private const val TAG = "RemoteLogoLoader"
+    private const val MAX_LOGO_BYTES = 512 * 1024L
+    private const val MAX_CACHE_BYTES = 4 * 1024 * 1024
+
+    private val cache =
+        object : LruCache<String, CachedLogo>(MAX_CACHE_BYTES) {
+            override fun sizeOf(key: String, value: CachedLogo): Int {
+                return value.bytes.size
+            }
+        }
+
+    private val client by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .followSslRedirects(false)
+            .build()
+    }
+
+    fun load(url: String, sizePx: Int): Bitmap? {
+        val parsedUrl = url.trim().toHttpUrlOrNull() ?: return null
+        if (parsedUrl.scheme != "https") return null
+
+        return try {
+            val cached = synchronized(cache) { cache.get(parsedUrl.toString()) }
+            val logo =
+                cached ?: fetch(parsedUrl.toString()).also { value ->
+                    if (value != null) {
+                        synchronized(cache) { cache.put(parsedUrl.toString(), value) }
+                    }
+                }
+            logo?.let { value ->
+                LogoBitmapLoader.load(
+                    bytes = value.bytes,
+                    mimeType = value.contentType,
+                    fileName = parsedUrl.encodedPath,
+                    sizePx = sizePx
+                )
+            }
+        } catch (error: Exception) {
+            AppLogger.e(TAG, "Failed to load remote logo host=${parsedUrl.host}", error)
+            null
+        }
+    }
+
+    private fun fetch(url: String): CachedLogo? {
+        val request = Request.Builder().url(url).get().build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body ?: return null
+            if (body.contentLength() > MAX_LOGO_BYTES) return null
+            val bytes =
+                body.byteStream().use { input ->
+                    val output = ByteArrayOutputStream()
+                    val buffer = ByteArray(8 * 1024)
+                    var totalBytes = 0L
+                    while (true) {
+                        val count = input.read(buffer)
+                        if (count < 0) break
+                        totalBytes += count
+                        if (totalBytes > MAX_LOGO_BYTES) return null
+                        output.write(buffer, 0, count)
+                    }
+                    output.toByteArray()
+                }
+            return CachedLogo(
+                bytes = bytes,
+                contentType = response.header("Content-Type")?.substringBefore(';')?.trim()
+            )
+        }
+    }
+}
+
+@Composable
+fun rememberRemoteLogoPainter(
+    logoUrl: String?,
+    size: Dp = 24.dp
+): Painter? {
+    val density = LocalDensity.current
+    val sizePx = with(density) { size.roundToPx() }
+    val bitmap by
+        produceState<ImageBitmap?>(initialValue = null, logoUrl, sizePx) {
+            value =
+                logoUrl
+                    ?.trim()
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { url ->
+                        withContext(Dispatchers.IO) {
+                            RemoteLogoLoader.load(url, sizePx)?.asImageBitmap()
+                        }
+                    }
+        }
+    return bitmap?.let { BitmapPainter(it) }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/dialogs/PackageDetailsDialog.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/dialogs/PackageDetailsDialog.kt
@@ -4,6 +4,7 @@ import com.ai.assistance.operit.util.AppLogger
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,6 +15,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -25,6 +27,7 @@ import com.ai.assistance.operit.R
 import com.ai.assistance.operit.core.tools.PackageTool
 import com.ai.assistance.operit.core.tools.ToolPackage
 import com.ai.assistance.operit.core.tools.packTool.PackageManager
+import com.ai.assistance.operit.ui.common.icons.rememberLogoPainter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -85,6 +88,33 @@ fun PackageDetailsDialog(
                 null
             }
     }
+
+    val logo by produceState<PackageManager.ToolPkgLogoBytes?>(
+        initialValue = null,
+        packageName,
+        toolPkgDetails?.logoResourceKey,
+        toolPkgDetails?.version
+    ) {
+        value =
+            if (toolPkgDetails?.logoResourceKey == null) {
+                null
+            } else {
+                try {
+                    withContext(Dispatchers.IO) { packageManager.readToolPkgLogoBytes(packageName) }
+                } catch (error: Exception) {
+                    AppLogger.e("PackageDetailsDialog", "Failed to load toolpkg logo", error)
+                    null
+                }
+            }
+    }
+    val logoPainter =
+        rememberLogoPainter(
+            logoKey = "${packageName}:${toolPkgDetails?.version}:${toolPkgDetails?.logoResourceKey}",
+            bytes = logo?.bytes,
+            mimeType = logo?.mimeType,
+            fileName = logo?.fileName,
+            size = 28.dp
+        )
 
     val activeStateId by produceState<String?>(initialValue = null, packageName, resolvedPackage) {
         value =
@@ -174,12 +204,21 @@ fun PackageDetailsDialog(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Extension,
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp),
-                        tint = MaterialTheme.colorScheme.primary
-                    )
+                    if (logoPainter != null) {
+                        Image(
+                            painter = logoPainter,
+                            contentDescription = packageDisplayName,
+                            contentScale = ContentScale.Fit,
+                            modifier = Modifier.size(28.dp)
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.Extension,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
                     Spacer(modifier = Modifier.width(8.dp))
                     Column(modifier = Modifier.weight(1f)) {
                         Text(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/ArtifactMarketModels.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/ArtifactMarketModels.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
 
 const val OPERIT_MARKET_OWNER = "AAswordman"
 const val OPERIT_FORGE_REPO_NAME = "OperitForge"
+const val PUBLISH_LOGO_MAX_BYTES = 512 * 1024
 
 private const val SCRIPT_MARKET_LABEL = "script-artifact"
 private const val PACKAGE_MARKET_LABEL = "package-artifact"
@@ -122,6 +123,12 @@ data class LocalPublishableArtifact(
     val inferredVersion: String? = null
 )
 
+data class PublishLogoAsset(
+    val fileName: String,
+    val contentType: String,
+    val bytes: ByteArray
+)
+
 sealed interface PublishArtifactSource {
     data class DirectUpload(
         val minifyArtifact: Boolean
@@ -154,6 +161,7 @@ data class ArtifactPublishClusterContext(
     val projectDescription: String,
     val marketDescription: String,
     val marketDetail: String,
+    val logoUrl: String? = null,
     val categoryId: String = "",
     val canEditEntry: Boolean = false
 )
@@ -207,7 +215,8 @@ data class MarketRegistrationPayload(
     val sourceFileName: String,
     val minSupportedAppVersion: String?,
     val maxSupportedAppVersion: String?,
-    val protection: String? = null
+    val protection: String? = null,
+    val logoUrl: String? = null
 )
 
 @Serializable
@@ -225,6 +234,7 @@ data class ArtifactMarketMetadata(
     val version: String = "",
     val displayName: String = "",
     val description: String = "",
+    val logoUrl: String? = null,
     val categoryId: String = "",
     val sourceFileName: String = "",
     val minSupportedAppVersion: String? = null,
@@ -271,6 +281,7 @@ fun ArtifactMarketMetadata.toPublishClusterContext(entryId: String? = null): Art
         projectDescription = effectiveProjectDescription(),
         marketDescription = description,
         marketDetail = effectiveProjectDescription(),
+        logoUrl = logoUrl,
         categoryId = categoryId
     )
 }
@@ -459,6 +470,7 @@ fun buildArtifactMarketMetadata(
         version = payload.version,
         displayName = payload.displayName,
         description = payload.description,
+        logoUrl = payload.logoUrl,
         categoryId = payload.categoryId,
         sourceFileName = payload.sourceFileName,
         minSupportedAppVersion = payload.minSupportedAppVersion,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/GitHubForgePublishService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/GitHubForgePublishService.kt
@@ -31,7 +31,8 @@ data class PublishArtifactRequest(
     val minSupportedAppVersion: String?,
     val maxSupportedAppVersion: String?,
     val publishContext: ArtifactPublishClusterContext? = null,
-    val source: PublishArtifactSource
+    val source: PublishArtifactSource,
+    val logo: PublishLogoAsset? = null
 )
 
 sealed class PublishAttemptResult {
@@ -127,6 +128,9 @@ class GitHubForgePublishService(
                     maxSupportedAppVersion = request.maxSupportedAppVersion,
                     publishContext = request.publishContext
                 )
+            require(request.logo == null || descriptor.type == PublishArtifactType.PACKAGE) {
+                "Logo selection is only supported for ToolPkg packages"
+            }
 
             val resolvedAsset =
                 when (val source = request.source) {
@@ -165,13 +169,20 @@ class GitHubForgePublishService(
                                 version = descriptor.version,
                                 author = listOf(currentUser.login)
                             )
-                        val fileBytes = ToolPkgArtifactMinifier.processArtifactFile(
+                        val processedFileBytes = ToolPkgArtifactMinifier.processArtifactFile(
                             context = context,
                             sourceFile = sourceFile,
                             isToolPkg = descriptor.type == PublishArtifactType.PACKAGE,
                             marketOrigin = marketOrigin,
                             minify = source.minifyArtifact
                         )
+                        val fileBytes =
+                            request.logo?.let { logo ->
+                                ToolPkgArtifactMinifier.injectToolPkgLogo(
+                                    artifactBytes = processedFileBytes,
+                                    logo = logo
+                                )
+                            } ?: processedFileBytes
                         val uploadedAsset =
                             uploadAssetReplacingExisting(
                                 owner = currentUser.login,
@@ -229,6 +240,7 @@ class GitHubForgePublishService(
                 }
 
             onProgress(PublishProgressStage.REGISTERING_MARKET)
+            val logoUrl = resolveMarketLogoUrl(request, descriptor)
             val payload =
                 MarketRegistrationPayload(
                     type = descriptor.type,
@@ -247,6 +259,7 @@ class GitHubForgePublishService(
                     displayName = descriptor.displayName,
                     description = descriptor.description,
                     detail = descriptor.detail,
+                    logoUrl = logoUrl,
                     categoryId = descriptor.categoryId,
                     allowPublicUpdates = descriptor.allowPublicUpdates,
                     sourceFileName = sourceFile.name,
@@ -441,6 +454,7 @@ class GitHubForgePublishService(
                 categoryId = payload.categoryId,
                 allowPublicUpdates = payload.allowPublicUpdates,
                 detail = payload.detail.ifBlank { payload.description },
+                logoUrl = payload.logoUrl,
                 version = MarketV2PublishVersion(
                     version = payload.version,
                     formatVer = payload.type.marketFormatVersion(),
@@ -473,6 +487,7 @@ class GitHubForgePublishService(
                 title = payload.displayName,
                 description = payload.description,
                 detail = payload.detail.ifBlank { payload.description },
+                logoUrl = payload.logoUrl,
                 stateCode = "pending",
                 latestVersion = MarketV2Version(
                     id = response.versionId,
@@ -499,7 +514,8 @@ class GitHubForgePublishService(
                     title = payload.displayName.takeIf { it != context.lockedDisplayName },
                     description = payload.description.takeIf { it != context.marketDescription },
                     detail = payload.detail.takeIf { it != context.marketDetail },
-                    categoryId = payload.categoryId.takeIf { it != context.categoryId }
+                    categoryId = payload.categoryId.takeIf { it != context.categoryId },
+                    logoUrl = payload.logoUrl.takeIf { it != context.logoUrl }
                 )
             } else {
                 MarketV2NewVersionEntryPatch(
@@ -512,7 +528,8 @@ class GitHubForgePublishService(
                 it.description != null ||
                 it.detail != null ||
                 it.categoryId != null ||
-                it.allowPublicUpdates != null
+                it.allowPublicUpdates != null ||
+                it.logoUrl != null
         }
     }
 
@@ -520,6 +537,36 @@ class GitHubForgePublishService(
         require(file.exists()) { "Source file not found: ${file.absolutePath}" }
         require(file.isFile) { "Source path is not a file: ${file.absolutePath}" }
         require(file.canRead()) { "Cannot read source file: ${file.absolutePath}" }
+    }
+
+    private suspend fun resolveMarketLogoUrl(
+        request: PublishArtifactRequest,
+        descriptor: PublishArtifactDescriptor
+    ): String? {
+        require(request.logo == null || descriptor.type == PublishArtifactType.PACKAGE) {
+            "Logo selection is only supported for ToolPkg packages"
+        }
+        val publishContext = request.publishContext
+        if (publishContext?.canEditEntry == false) {
+            return publishContext.logoUrl
+        }
+        if (descriptor.type != PublishArtifactType.PACKAGE) {
+            return publishContext?.logoUrl
+        }
+
+        val logoAsset =
+            request.logo
+                ?: ToolPkgArtifactMinifier.readToolPkgLogoAsset(descriptor.sourceFile)
+                ?: return publishContext?.logoUrl
+        return marketStatsApiService
+            .uploadMarketLogo(
+                fileName = logoAsset.fileName,
+                contentType = logoAsset.contentType,
+                bytes = logoAsset.bytes
+            )
+            .getOrElse { error ->
+                throw IllegalStateException("Failed to upload ToolPkg logo: ${error.message}", error)
+            }
     }
 
     private fun sha256Hex(bytes: ByteArray): String {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseEntryMappers.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseEntryMappers.kt
@@ -43,6 +43,7 @@ fun MarketV2Entry.toUnifiedMarketBrowseEntry(
             MarketBrowseCardModel(
                 title = title,
                 description = detail.ifBlank { description }.truncateMarketBrowseDescription(),
+                logoUrl = logoUrl,
                 ownerUsername = publisherLogin(),
                 thumbsUpCount = likeCount(),
                 heartCount = 0,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseList.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseList.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -342,10 +343,18 @@ fun MarketBrowseCard(
     model: MarketBrowseCardModel,
     onViewDetails: () -> Unit,
     onInstall: () -> Unit,
+    logoPainter: Painter? = null,
+    interactive: Boolean = true,
     modifier: Modifier = Modifier
 ) {
+    val cardModifier =
+        if (interactive) {
+            Modifier.clickable { onViewDetails() }
+        } else {
+            Modifier
+        }
     Card(
-        modifier = modifier.fillMaxWidth().clickable { onViewDetails() },
+        modifier = modifier.fillMaxWidth().then(cardModifier),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
     ) {
@@ -354,7 +363,11 @@ fun MarketBrowseCard(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            MarketBrowseLeadingIcon(title = model.title, logoUrl = model.logoUrl)
+            MarketBrowseLeadingIcon(
+                title = model.title,
+                logoUrl = model.logoUrl,
+                logoPainter = logoPainter
+            )
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
@@ -396,7 +409,11 @@ fun MarketBrowseCard(
 }
 
 @Composable
-private fun MarketBrowseLeadingIcon(title: String, logoUrl: String?) {
+private fun MarketBrowseLeadingIcon(
+    title: String,
+    logoUrl: String?,
+    logoPainter: Painter?
+) {
     val initial =
         title
             .trim()
@@ -409,14 +426,19 @@ private fun MarketBrowseLeadingIcon(title: String, logoUrl: String?) {
         shape = RoundedCornerShape(14.dp),
         color = MaterialTheme.colorScheme.primaryContainer
     ) {
-        val logoPainter = rememberRemoteLogoPainter(logoUrl = logoUrl, size = 48.dp)
+        val remoteLogoPainter =
+            rememberRemoteLogoPainter(
+                logoUrl = logoUrl.takeIf { logoPainter == null },
+                size = 48.dp
+            )
+        val resolvedLogoPainter = logoPainter ?: remoteLogoPainter
         Box(
             modifier = Modifier.size(48.dp),
             contentAlignment = Alignment.Center
         ) {
-            if (logoPainter != null) {
+            if (resolvedLogoPainter != null) {
                 Image(
-                    painter = logoPainter,
+                    painter = resolvedLogoPainter,
                     contentDescription = title,
                     contentScale = ContentScale.Fit,
                     modifier = Modifier.size(40.dp)

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseList.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketBrowseList.kt
@@ -2,6 +2,7 @@ package com.ai.assistance.operit.ui.features.packages.market
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -50,11 +51,13 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.ai.assistance.operit.R
+import com.ai.assistance.operit.ui.common.icons.rememberRemoteLogoPainter
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -63,6 +66,7 @@ import java.time.format.DateTimeFormatter
 data class MarketBrowseCardModel(
     val title: String,
     val description: String,
+    val logoUrl: String? = null,
     val ownerUsername: String = "",
     val thumbsUpCount: Int = 0,
     val heartCount: Int = 0,
@@ -350,7 +354,7 @@ fun MarketBrowseCard(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            MarketBrowseLeadingIcon(title = model.title)
+            MarketBrowseLeadingIcon(title = model.title, logoUrl = model.logoUrl)
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
@@ -392,7 +396,7 @@ fun MarketBrowseCard(
 }
 
 @Composable
-private fun MarketBrowseLeadingIcon(title: String) {
+private fun MarketBrowseLeadingIcon(title: String, logoUrl: String?) {
     val initial =
         title
             .trim()
@@ -405,16 +409,26 @@ private fun MarketBrowseLeadingIcon(title: String) {
         shape = RoundedCornerShape(14.dp),
         color = MaterialTheme.colorScheme.primaryContainer
     ) {
+        val logoPainter = rememberRemoteLogoPainter(logoUrl = logoUrl, size = 48.dp)
         Box(
             modifier = Modifier.size(48.dp),
             contentAlignment = Alignment.Center
         ) {
-            Text(
-                text = initial,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onPrimaryContainer
-            )
+            if (logoPainter != null) {
+                Image(
+                    painter = logoPainter,
+                    contentDescription = title,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.size(40.dp)
+                )
+            } else {
+                Text(
+                    text = initial,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketInstallMarker.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketInstallMarker.kt
@@ -5,6 +5,7 @@ import com.ai.assistance.operit.core.tools.packTool.PackageManager
 import com.ai.assistance.operit.data.api.MarketV2Entry
 import com.ai.assistance.operit.data.mcp.MCPLocalServer
 import com.ai.assistance.operit.data.skill.SkillRepository
+import com.ai.assistance.operit.util.AppLogger
 import com.google.gson.Gson
 import java.io.File
 
@@ -131,9 +132,23 @@ private fun readInstalledMarketMarkerRoots(
 
 private fun readMarketInstallMarker(root: File): MarketInstallMarker? {
     val markerFile = File(File(root, MARKET_MARKER_DIR_NAME), MARKET_MARKER_FILE_NAME)
-    if (!markerFile.exists() || !markerFile.isFile) return null
-    return Gson().fromJson(markerFile.readText(), MarketInstallMarker::class.java)
+    return try {
+        // A stale external-storage marker must not abort the market scan for every entry.
+        if (!markerFile.exists() || !markerFile.isFile) return null
+        Gson().fromJson(markerFile.readText(), MarketInstallMarker::class.java)
+            .takeIf { marker ->
+                marker.entryId.isNotBlank() && marker.versionId.isNotBlank()
+            }
+    } catch (error: Exception) {
+        AppLogger.w(
+            TAG,
+            "Skipping unreadable market install marker: ${markerFile.absolutePath}",
+            error
+        )
+        null
+    }
 }
 
+private const val TAG = "MarketInstallMarker"
 private const val MARKET_MARKER_DIR_NAME = ".operit"
 private const val MARKET_MARKER_FILE_NAME = "market.json"

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/PublishLogoSupport.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/PublishLogoSupport.kt
@@ -1,0 +1,76 @@
+package com.ai.assistance.operit.ui.features.packages.market
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import com.ai.assistance.operit.ui.common.icons.LogoBitmapLoader
+import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class PublishLogoReadException(cause: Throwable? = null) : IllegalArgumentException(cause)
+
+class PublishLogoTooLargeException : IllegalArgumentException()
+
+suspend fun readPublishLogoAsset(
+    context: Context,
+    uri: Uri
+): PublishLogoAsset = withContext(Dispatchers.IO) {
+    try {
+        val fileName =
+            context.contentResolver
+                .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                ?.use { cursor ->
+                    if (cursor.moveToFirst()) cursor.getString(0).orEmpty().trim() else ""
+                }
+                .orEmpty()
+        if (fileName.isBlank()) {
+            throw IllegalArgumentException("Logo file name is missing")
+        }
+
+        val contentType = logoContentTypeForFileName(fileName)
+        val bytes =
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                val output = ByteArrayOutputStream()
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read <= 0) break
+                    if (output.size() + read > PUBLISH_LOGO_MAX_BYTES) {
+                        throw PublishLogoTooLargeException()
+                    }
+                    output.write(buffer, 0, read)
+                }
+                output.toByteArray()
+            } ?: throw IllegalArgumentException("Logo content is unavailable")
+
+        val preview =
+            LogoBitmapLoader.load(
+                bytes = bytes,
+                mimeType = contentType,
+                fileName = fileName,
+                sizePx = 96
+            ) ?: throw IllegalArgumentException("Logo image cannot be decoded")
+        preview.recycle()
+
+        PublishLogoAsset(
+            fileName = fileName,
+            contentType = contentType,
+            bytes = bytes
+        )
+    } catch (error: PublishLogoTooLargeException) {
+        throw error
+    } catch (error: Exception) {
+        throw PublishLogoReadException(error)
+    }
+}
+
+fun logoContentTypeForFileName(fileName: String): String {
+    return when (fileName.substringAfterLast('.', "").lowercase()) {
+        "svg" -> "image/svg+xml"
+        "png" -> "image/png"
+        "jpg", "jpeg" -> "image/jpeg"
+        "webp" -> "image/webp"
+        else -> throw IllegalArgumentException("Unsupported logo format")
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
@@ -78,6 +78,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.data.api.MarketV2Comment
+import com.ai.assistance.operit.ui.common.icons.rememberRemoteLogoPainter
 import com.ai.assistance.operit.ui.common.displays.MarkdownTextComposable
 import com.ai.assistance.operit.ui.main.LocalTopBarTitleContent
 import com.ai.assistance.operit.ui.main.TopBarTitleContent
@@ -90,6 +91,7 @@ import java.util.TimeZone
 data class UnifiedMarketDetailHeader(
     val title: String,
     val fallbackAvatarText: String,
+    val logoUrl: String? = null,
     val participants: List<UnifiedMarketDetailParticipant> = emptyList(),
     val badges: List<String> = emptyList(),
     val metrics: List<UnifiedMarketDetailMetric> = emptyList(),
@@ -398,7 +400,8 @@ private fun UnifiedMarketDetailHeaderCard(
         ) {
             UnifiedMarketDetailLeadingIcon(
                 title = header.title,
-                fallbackAvatarText = header.fallbackAvatarText
+                fallbackAvatarText = header.fallbackAvatarText,
+                logoUrl = header.logoUrl
             )
 
             Column(
@@ -526,8 +529,10 @@ private fun UnifiedMarketDetailStickyTabs(
 @Composable
 private fun UnifiedMarketDetailLeadingIcon(
     title: String,
-    fallbackAvatarText: String
+    fallbackAvatarText: String,
+    logoUrl: String?
 ) {
+    val logoPainter = rememberRemoteLogoPainter(logoUrl = logoUrl, size = 76.dp)
     Surface(
         shape = RoundedCornerShape(20.dp),
         color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.85f)
@@ -536,12 +541,21 @@ private fun UnifiedMarketDetailLeadingIcon(
             modifier = Modifier.size(76.dp),
             contentAlignment = Alignment.Center
         ) {
-            Text(
-                text = fallbackAvatarText.ifBlank { marketDetailInitial(title) },
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onPrimaryContainer
-            )
+            if (logoPainter != null) {
+                Image(
+                    painter = logoPainter,
+                    contentDescription = title,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.size(64.dp)
+                )
+            } else {
+                Text(
+                    text = fallbackAvatarText.ifBlank { marketDetailInitial(title) },
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/UnifiedMarketDetailScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -386,8 +387,9 @@ fun UnifiedMarketDetailScreen(
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun UnifiedMarketDetailHeaderCard(
-    header: UnifiedMarketDetailHeader
+internal fun UnifiedMarketDetailHeaderCard(
+    header: UnifiedMarketDetailHeader,
+    logoPainter: Painter? = null
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -401,7 +403,8 @@ private fun UnifiedMarketDetailHeaderCard(
             UnifiedMarketDetailLeadingIcon(
                 title = header.title,
                 fallbackAvatarText = header.fallbackAvatarText,
-                logoUrl = header.logoUrl
+                logoUrl = header.logoUrl,
+                logoPainter = logoPainter
             )
 
             Column(
@@ -530,9 +533,15 @@ private fun UnifiedMarketDetailStickyTabs(
 private fun UnifiedMarketDetailLeadingIcon(
     title: String,
     fallbackAvatarText: String,
-    logoUrl: String?
+    logoUrl: String?,
+    logoPainter: Painter?
 ) {
-    val logoPainter = rememberRemoteLogoPainter(logoUrl = logoUrl, size = 76.dp)
+    val remoteLogoPainter =
+        rememberRemoteLogoPainter(
+            logoUrl = logoUrl.takeIf { logoPainter == null },
+            size = 76.dp
+        )
+    val resolvedLogoPainter = logoPainter ?: remoteLogoPainter
     Surface(
         shape = RoundedCornerShape(20.dp),
         color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.85f)
@@ -541,9 +550,9 @@ private fun UnifiedMarketDetailLeadingIcon(
             modifier = Modifier.size(76.dp),
             contentAlignment = Alignment.Center
         ) {
-            if (logoPainter != null) {
+            if (resolvedLogoPainter != null) {
                 Image(
-                    painter = logoPainter,
+                    painter = resolvedLogoPainter,
                     contentDescription = title,
                     contentScale = ContentScale.Fit,
                     modifier = Modifier.size(64.dp)

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
@@ -1,6 +1,7 @@
 package com.ai.assistance.operit.ui.features.packages.screens
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.Image as ComposeImage
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,6 +17,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Image as ImageIcon
+import androidx.compose.material.icons.filled.RestartAlt
+import androidx.compose.material.icons.filled.UploadFile
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -40,7 +44,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -60,11 +67,22 @@ import com.ai.assistance.operit.ui.features.packages.market.ArtifactPublishClust
 import com.ai.assistance.operit.ui.features.packages.market.GitHubForgePublishService
 import com.ai.assistance.operit.ui.features.packages.market.PublishArtifactSource
 import com.ai.assistance.operit.ui.features.packages.market.PublishArtifactType
+import com.ai.assistance.operit.ui.features.packages.market.PublishLogoAsset
 import com.ai.assistance.operit.ui.features.packages.market.PublishProgressStage
+import com.ai.assistance.operit.ui.features.packages.market.PublishLogoReadException
+import com.ai.assistance.operit.ui.features.packages.market.PublishLogoTooLargeException
+import com.ai.assistance.operit.ui.features.packages.market.readPublishLogoAsset
 import com.ai.assistance.operit.ui.features.packages.market.isOperit2VersionAllowed
 import com.ai.assistance.operit.ui.features.packages.market.sameArtifactRuntimePackageId
 import com.ai.assistance.operit.ui.features.packages.screens.artifact.viewmodel.ArtifactMarketViewModel
+import com.ai.assistance.operit.ui.common.icons.rememberLogoPainter
+import com.ai.assistance.operit.util.AppLogger
+import com.ai.assistance.operit.util.ToolPkgArtifactMinifier
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private data class ArtifactPublishEditInfo(
     val type: PublishArtifactType?,
@@ -78,7 +96,8 @@ private data class ArtifactPublishEditInfo(
     val maxSupportedAppVersion: String?,
     val runtimePackageId: String,
     val normalizedId: String,
-    val sourceFileName: String
+    val sourceFileName: String,
+    val logoUrl: String?
 )
 
 private fun com.ai.assistance.operit.data.api.MarketV2Entry.toArtifactPublishEditInfo(): ArtifactPublishEditInfo {
@@ -97,7 +116,8 @@ private fun com.ai.assistance.operit.data.api.MarketV2Entry.toArtifactPublishEdi
         maxSupportedAppVersion = versionValue?.maxAppVer,
         runtimePackageId = versionValue?.runtimePackageId.orEmpty(),
         normalizedId = id,
-        sourceFileName = assetValue?.assetName.orEmpty().ifBlank { assetValue?.name.orEmpty() }
+        sourceFileName = assetValue?.assetName.orEmpty().ifBlank { assetValue?.name.orEmpty() },
+        logoUrl = logoUrl
     )
 }
 
@@ -114,6 +134,7 @@ fun com.ai.assistance.operit.data.api.MarketV2Entry.toArtifactPublishClusterCont
         projectDescription = detail.ifBlank { description },
         marketDescription = description,
         marketDetail = detail,
+        logoUrl = logoUrl,
         categoryId = categoryId,
         canEditEntry = canEditEntry
     )
@@ -127,6 +148,7 @@ fun ArtifactPublishScreen(
     publishContext: ArtifactPublishClusterContext? = null
 ) {
     val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
     val isEditMode = editingEntry != null
     val viewModel: ArtifactMarketViewModel =
@@ -203,6 +225,10 @@ fun ArtifactPublishScreen(
     var version by rememberSaveable { mutableStateOf(initialInfo?.version.orEmpty().ifBlank { "1.0.0" }) }
     var minSupportedAppVersion by rememberSaveable { mutableStateOf(initialInfo?.minSupportedAppVersion.orEmpty()) }
     var maxSupportedAppVersion by rememberSaveable { mutableStateOf(initialInfo?.maxSupportedAppVersion.orEmpty()) }
+    var selectedLogoAsset by remember { mutableStateOf<PublishLogoAsset?>(null) }
+    var isLoadingLogo by remember { mutableStateOf(false) }
+    var logoSelectionError by remember { mutableStateOf<String?>(null) }
+    var logoSelectionGeneration by remember { mutableStateOf(0) }
 
     var selectorExpanded by remember { mutableStateOf(false) }
     var releaseSelectorExpanded by remember { mutableStateOf(false) }
@@ -253,6 +279,84 @@ fun ArtifactPublishScreen(
     val selectedArtifact = filteredArtifacts.firstOrNull { it.packageName == selectedPackageName }
     val selectedType = selectedArtifact?.type ?: initialInfo?.type
     val isPublishing = publishStage !in listOf(PublishProgressStage.IDLE, PublishProgressStage.COMPLETED)
+    val logoSelectionKey =
+        "${selectedPackageName}:${selectedArtifact?.sourceFile?.absolutePath}:${selectedType}"
+    val currentLogoSelectionKey = rememberUpdatedState(logoSelectionKey)
+    val canSelectLogo =
+        !isEditMode &&
+            selectedType == PublishArtifactType.PACKAGE &&
+            (activePublishContext == null || canEditContinuationEntry)
+    val packageLogo by
+        produceState<PublishLogoAsset?>(
+            initialValue = null,
+            selectedPackageName,
+            selectedArtifact?.sourceFile?.absolutePath,
+            selectedType
+        ) {
+            value =
+                if (selectedType == PublishArtifactType.PACKAGE && selectedArtifact != null) {
+                    try {
+                        withContext(Dispatchers.IO) {
+                            ToolPkgArtifactMinifier.readToolPkgLogoAsset(selectedArtifact.sourceFile)
+                        }
+                    } catch (error: Exception) {
+                        AppLogger.e("ArtifactPublishScreen", "Failed to load package logo", error)
+                        null
+                    }
+                } else {
+                    null
+                }
+        }
+    val displayedLogo = selectedLogoAsset ?: packageLogo
+    val logoPainter =
+        rememberLogoPainter(
+            logoKey = "${selectedPackageName}:${displayedLogo?.fileName}:${displayedLogo?.bytes?.contentHashCode()}",
+            bytes = displayedLogo?.bytes,
+            mimeType = displayedLogo?.contentType,
+            fileName = displayedLogo?.fileName,
+            size = 64.dp
+        )
+    val logoPickerLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            if (uri == null) return@rememberLauncherForActivityResult
+            val generation = logoSelectionGeneration + 1
+            val selectionKeyAtSelection = currentLogoSelectionKey.value
+            logoSelectionGeneration = generation
+            coroutineScope.launch {
+                isLoadingLogo = true
+                logoSelectionError = null
+                try {
+                    val logoAsset = readPublishLogoAsset(context, uri)
+                    if (logoSelectionGeneration == generation && currentLogoSelectionKey.value == selectionKeyAtSelection) {
+                        selectedLogoAsset = logoAsset
+                        viewModel.clearPendingMarketRegistrationRetry()
+                    }
+                } catch (error: PublishLogoTooLargeException) {
+                    if (logoSelectionGeneration == generation && currentLogoSelectionKey.value == selectionKeyAtSelection) {
+                        selectedLogoAsset = null
+                        logoSelectionError = context.getString(R.string.artifact_publish_logo_too_large)
+                    }
+                    AppLogger.e("ArtifactPublishScreen", "Selected logo is too large", error)
+                } catch (error: PublishLogoReadException) {
+                    if (logoSelectionGeneration == generation && currentLogoSelectionKey.value == selectionKeyAtSelection) {
+                        selectedLogoAsset = null
+                        logoSelectionError = context.getString(R.string.artifact_publish_logo_invalid)
+                    }
+                    AppLogger.e("ArtifactPublishScreen", "Failed to read selected logo", error)
+                } finally {
+                    if (logoSelectionGeneration == generation && currentLogoSelectionKey.value == selectionKeyAtSelection) {
+                        isLoadingLogo = false
+                    }
+                }
+            }
+        }
+
+    LaunchedEffect(logoSelectionKey) {
+        logoSelectionGeneration += 1
+        selectedLogoAsset = null
+        logoSelectionError = null
+        isLoadingLogo = false
+    }
     val selectorDisplayName =
         if (isEditMode) {
             selectedArtifact?.displayName
@@ -684,6 +788,24 @@ fun ArtifactPublishScreen(
             }
         }
 
+        if (canSelectLogo) {
+            ArtifactPublishLogoCard(
+                logoPainter = logoPainter,
+                selectedLogoAsset = selectedLogoAsset,
+                packageLogo = packageLogo,
+                isLoading = isLoadingLogo,
+                errorMessage = logoSelectionError,
+                onChoose = {
+                    logoPickerLauncher.launch(arrayOf("image/*", "image/svg+xml"))
+                },
+                onUsePackageLogo = {
+                    selectedLogoAsset = null
+                    logoSelectionError = null
+                    viewModel.clearPendingMarketRegistrationRetry()
+                }
+            )
+        }
+
         OutlinedTextField(
             value = displayName,
             onValueChange = {
@@ -930,6 +1052,7 @@ fun ArtifactPublishScreen(
                     description.isNotBlank() &&
                     categoryId.isNotBlank() &&
                     !isPublishing &&
+                    !isLoadingLogo &&
                     (
                         if (isEditMode) {
                             initialInfo?.type != null
@@ -1019,6 +1142,14 @@ fun ArtifactPublishScreen(
                         }
                         Text(stringResource(R.string.market_detail_category_label) + ": " + categoryId)
                         Text(stringResource(R.string.version_colon, version))
+                        if (selectedType == PublishArtifactType.PACKAGE && displayedLogo != null) {
+                            Text(
+                                stringResource(
+                                    R.string.artifact_publish_logo_confirmation,
+                                    displayedLogo.fileName
+                                )
+                            )
+                        }
                         Text(
                             stringResource(
                                 R.string.artifact_publish_asset_source_confirmation,
@@ -1094,7 +1225,8 @@ fun ArtifactPublishScreen(
                                     minSupportedAppVersion = minSupportedAppVersion.ifBlank { null },
                                     maxSupportedAppVersion = maxSupportedAppVersion.ifBlank { GitHubForgePublishService.DEFAULT_MAX_SUPPORTED_APP_VERSION },
                                     publishContext = activePublishContext,
-                                    source = selectedSource
+                                    source = selectedSource,
+                                    logo = selectedLogoAsset
                                 )
                             }
                         }
@@ -1221,5 +1353,134 @@ fun ArtifactPublishScreen(
                 }
             }
         )
+    }
+}
+
+@Composable
+private fun ArtifactPublishLogoCard(
+    logoPainter: androidx.compose.ui.graphics.painter.Painter?,
+    selectedLogoAsset: PublishLogoAsset?,
+    packageLogo: PublishLogoAsset?,
+    isLoading: Boolean,
+    errorMessage: String?,
+    onChoose: () -> Unit,
+    onUsePackageLogo: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Surface(
+                    modifier = Modifier.size(64.dp),
+                    shape = MaterialTheme.shapes.medium,
+                    color = MaterialTheme.colorScheme.surface
+                ) {
+                    if (logoPainter != null) {
+                        ComposeImage(
+                            painter = logoPainter,
+                            contentDescription = stringResource(R.string.artifact_publish_logo_preview),
+                            modifier = Modifier.padding(6.dp)
+                        )
+                    } else {
+                        androidx.compose.material3.Icon(
+                            imageVector = ImageIcon,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(18.dp)
+                        )
+                    }
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.artifact_publish_logo_title),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = stringResource(R.string.artifact_publish_logo_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    val selectedFileName = selectedLogoAsset?.fileName
+                    val packageFileName = packageLogo?.fileName
+                    if (selectedFileName != null) {
+                        Text(
+                            text = stringResource(R.string.artifact_publish_logo_selected, selectedFileName),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    } else if (packageFileName != null) {
+                        Text(
+                            text = stringResource(R.string.artifact_publish_logo_from_package, packageFileName),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Button(
+                    onClick = onChoose,
+                    enabled = !isLoading,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    if (isLoading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
+                    } else {
+                        androidx.compose.material3.Icon(
+                            imageVector = UploadFile,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(R.string.artifact_publish_logo_choose))
+                }
+                if (selectedLogoAsset != null) {
+                    OutlinedButton(
+                        onClick = onUsePackageLogo,
+                        enabled = !isLoading,
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        androidx.compose.material3.Icon(
+                            imageVector = RestartAlt,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(stringResource(R.string.artifact_publish_logo_use_package))
+                    }
+                }
+            }
+
+            if (errorMessage != null) {
+                Text(
+                    text = errorMessage,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.UploadFile
+import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -238,6 +239,7 @@ fun ArtifactPublishScreen(
     var showConfirmationDialog by remember { mutableStateOf(false) }
     var showOperit2WarningDialog by remember { mutableStateOf(false) }
     var showSecondForgeConfirm by remember { mutableStateOf(false) }
+    var showMarketPreview by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.refreshPublishableArtifacts()
@@ -356,6 +358,7 @@ fun ArtifactPublishScreen(
         selectedLogoAsset = null
         logoSelectionError = null
         isLoadingLogo = false
+        showMarketPreview = false
     }
     val selectorDisplayName =
         if (isEditMode) {
@@ -795,6 +798,7 @@ fun ArtifactPublishScreen(
                 packageLogo = packageLogo,
                 isLoading = isLoadingLogo,
                 errorMessage = logoSelectionError,
+                onPreview = { showMarketPreview = true },
                 onChoose = {
                     logoPickerLauncher.launch(arrayOf("image/*", "image/svg+xml"))
                 },
@@ -1354,6 +1358,18 @@ fun ArtifactPublishScreen(
             }
         )
     }
+
+    if (showMarketPreview && canSelectLogo) {
+        MarketPublishPreviewDialog(
+            title = displayName,
+            description = description,
+            detail = detail,
+            version = version,
+            author = selectedArtifact?.author?.firstOrNull().orEmpty(),
+            logoAsset = displayedLogo,
+            onDismiss = { showMarketPreview = false }
+        )
+    }
 }
 
 @Composable
@@ -1363,6 +1379,7 @@ private fun ArtifactPublishLogoCard(
     packageLogo: PublishLogoAsset?,
     isLoading: Boolean,
     errorMessage: String?,
+    onPreview: () -> Unit,
     onChoose: () -> Unit,
     onUsePackageLogo: () -> Unit
 ) {
@@ -1472,6 +1489,20 @@ private fun ArtifactPublishLogoCard(
                         Text(stringResource(R.string.artifact_publish_logo_use_package))
                     }
                 }
+            }
+
+            OutlinedButton(
+                onClick = onPreview,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                androidx.compose.material3.Icon(
+                    imageVector = Icons.Default.Visibility,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.artifact_publish_logo_market_preview))
             }
 
             if (errorMessage != null) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material.icons.filled.Image as ImageIcon
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.UploadFile
 import androidx.compose.material3.AlertDialog
@@ -1392,7 +1392,7 @@ private fun ArtifactPublishLogoCard(
                         )
                     } else {
                         androidx.compose.material3.Icon(
-                            imageVector = ImageIcon,
+                            imageVector = Icons.Default.Image,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(18.dp)
@@ -1449,7 +1449,7 @@ private fun ArtifactPublishLogoCard(
                         )
                     } else {
                         androidx.compose.material3.Icon(
-                            imageVector = UploadFile,
+                            imageVector = Icons.Default.UploadFile,
                             contentDescription = null,
                             modifier = Modifier.size(18.dp)
                         )
@@ -1464,7 +1464,7 @@ private fun ArtifactPublishLogoCard(
                         modifier = Modifier.weight(1f)
                     ) {
                         androidx.compose.material3.Icon(
-                            imageVector = RestartAlt,
+                            imageVector = Icons.Default.RestartAlt,
                             contentDescription = null,
                             modifier = Modifier.size(18.dp)
                         )

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/MarketPublishPreview.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/MarketPublishPreview.kt
@@ -1,0 +1,266 @@
+package com.ai.assistance.operit.ui.features.packages.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Dialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import com.ai.assistance.operit.R
+import com.ai.assistance.operit.ui.common.icons.rememberLogoPainter
+import com.ai.assistance.operit.ui.features.packages.market.MarketBrowseCard
+import com.ai.assistance.operit.ui.features.packages.market.MarketBrowseCardModel
+import com.ai.assistance.operit.ui.features.packages.market.PublishLogoAsset
+import com.ai.assistance.operit.ui.features.packages.market.UnifiedMarketDetailHeader
+import com.ai.assistance.operit.ui.features.packages.market.UnifiedMarketDetailHeaderCard
+import com.ai.assistance.operit.ui.features.packages.market.UnifiedMarketDetailMetric
+import com.ai.assistance.operit.ui.features.packages.market.UnifiedMarketDetailParticipant
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun MarketPublishPreviewDialog(
+    title: String,
+    description: String,
+    detail: String,
+    version: String,
+    author: String,
+    logoAsset: PublishLogoAsset?,
+    onDismiss: () -> Unit
+) {
+    var selectedMode by rememberSaveable { mutableIntStateOf(0) }
+    var selectedDetailTab by rememberSaveable { mutableIntStateOf(0) }
+    val previewTitle = title.trim().ifBlank { stringResource(R.string.artifact_publish_logo_market_preview_untitled) }
+    val previewDescription =
+        description.trim().ifBlank { stringResource(R.string.artifact_publish_logo_market_preview_empty_description) }
+    val previewDetail = detail.trim().ifBlank { previewDescription }
+    val previewAuthor = author.trim().ifBlank { stringResource(R.string.artifact_publish_logo_market_preview_account) }
+    val previewVersion = version.trim().ifBlank { "1.0.0" }
+    val logoKey =
+        "market-preview:${previewTitle}:${previewVersion}:${logoAsset?.fileName}:${logoAsset?.bytes?.contentHashCode()}"
+    val listLogoPainter =
+        rememberLogoPainter(
+            logoKey = "$logoKey:list",
+            bytes = logoAsset?.bytes,
+            mimeType = logoAsset?.contentType,
+            fileName = logoAsset?.fileName,
+            size = 48.dp
+        )
+    val detailLogoPainter =
+        rememberLogoPainter(
+            logoKey = "$logoKey:detail",
+            bytes = logoAsset?.bytes,
+            mimeType = logoAsset?.contentType,
+            fileName = logoAsset?.fileName,
+            size = 76.dp
+        )
+    val fallbackAvatarText = previewAuthor.take(1).ifBlank { "?" }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                TopAppBar(
+                    title = { Text(stringResource(R.string.artifact_publish_logo_market_preview_title)) },
+                    navigationIcon = {
+                        IconButton(onClick = onDismiss) {
+                            Icon(
+                                imageVector = Icons.Default.ArrowBack,
+                                contentDescription = stringResource(R.string.cancel)
+                            )
+                        }
+                    },
+                    colors =
+                        TopAppBarDefaults.topAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                            navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                )
+
+                TabRow(
+                    selectedTabIndex = selectedMode,
+                    containerColor = MaterialTheme.colorScheme.background,
+                    contentColor = MaterialTheme.colorScheme.primary
+                ) {
+                    Tab(
+                        selected = selectedMode == 0,
+                        onClick = { selectedMode = 0 },
+                        text = { Text(stringResource(R.string.artifact_publish_logo_market_list)) }
+                    )
+                    Tab(
+                        selected = selectedMode == 1,
+                        onClick = { selectedMode = 1 },
+                        text = { Text(stringResource(R.string.artifact_publish_logo_market_detail)) }
+                    )
+                }
+
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .verticalScroll(rememberScrollState())
+                                .padding(horizontal = 16.dp, vertical = 14.dp)
+                                .padding(bottom = if (selectedMode == 1) 88.dp else 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(14.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.artifact_publish_logo_market_preview_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+
+                        if (selectedMode == 0) {
+                            MarketBrowseCard(
+                                model =
+                                    MarketBrowseCardModel(
+                                        title = previewTitle,
+                                        description = previewDescription,
+                                        ownerUsername = previewAuthor,
+                                        showAction = false
+                                    ),
+                                onViewDetails = {},
+                                onInstall = {},
+                                logoPainter = listLogoPainter,
+                                interactive = false
+                            )
+                        } else {
+                            UnifiedMarketDetailHeaderCard(
+                                header =
+                                    UnifiedMarketDetailHeader(
+                                        title = previewTitle,
+                                        fallbackAvatarText = previewTitle.take(1),
+                                        badges =
+                                            listOf(
+                                                stringResource(R.string.artifact_type_package),
+                                                "v$previewVersion"
+                                            ),
+                                        participants =
+                                            listOf(
+                                                UnifiedMarketDetailParticipant(
+                                                    roleLabel = stringResource(R.string.market_detail_author_role),
+                                                    name = previewAuthor,
+                                                    fallbackAvatarText = fallbackAvatarText
+                                                ),
+                                                UnifiedMarketDetailParticipant(
+                                                    roleLabel = stringResource(R.string.market_detail_sharer_role),
+                                                    name = previewAuthor,
+                                                    fallbackAvatarText = fallbackAvatarText
+                                                )
+                                            ),
+                                        metrics =
+                                            listOf(
+                                                UnifiedMarketDetailMetric(
+                                                    value = "--",
+                                                    label = stringResource(R.string.market_sort_downloads)
+                                                ),
+                                                UnifiedMarketDetailMetric(
+                                                    value = "--",
+                                                    label = stringResource(R.string.market_sort_likes)
+                                                ),
+                                                UnifiedMarketDetailMetric(
+                                                    value = "--",
+                                                    label = stringResource(R.string.market_detail_published_label)
+                                                )
+                                            )
+                                    ),
+                                logoPainter = detailLogoPainter
+                            )
+
+                            TabRow(
+                                selectedTabIndex = selectedDetailTab,
+                                containerColor = MaterialTheme.colorScheme.background,
+                                contentColor = MaterialTheme.colorScheme.primary
+                            ) {
+                                Tab(
+                                    selected = selectedDetailTab == 0,
+                                    onClick = { selectedDetailTab = 0 },
+                                    text = { Text(stringResource(R.string.market_detail_about_title)) }
+                                )
+                                Tab(
+                                    selected = selectedDetailTab == 1,
+                                    onClick = { selectedDetailTab = 1 },
+                                    text = { Text(stringResource(R.string.comments_with_count, 0)) }
+                                )
+                            }
+
+                            if (selectedDetailTab == 0) {
+                                Text(
+                                    text = previewDetail,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                            } else {
+                                Text(
+                                    text = stringResource(R.string.no_comments_yet),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+
+                    if (selectedMode == 1) {
+                        Surface(
+                            modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
+                            shadowElevation = 8.dp,
+                            color = MaterialTheme.colorScheme.surface
+                        ) {
+                            Button(
+                                onClick = {},
+                                enabled = false,
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
+                                colors = ButtonDefaults.buttonColors()
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Download,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(stringResource(R.string.artifact_publish_logo_market_preview_action))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/MarketPublishPreview.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/MarketPublishPreview.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Dialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -37,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.ui.common.icons.rememberLogoPainter

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
@@ -786,7 +786,7 @@ fun PackageManagerScreen(
                                 selectedPackage = packageName
                                 showDetails = true
                             },
-                            onTogglePlugin = { details, isChecked ->
+                             onTogglePlugin = { details, isChecked ->
                                 val currentImported =
                                     visibleImportedPackages.value.toMutableList()
                                 if (isChecked) {
@@ -831,9 +831,12 @@ fun PackageManagerScreen(
                                                 }
                                         )
                                     }
-                                }
-                            },
-                            pluginOrder = pluginOrder,
+                                 }
+                             },
+                             loadPluginLogo = { packageName ->
+                                 packageManager.readToolPkgLogoBytes(packageName)
+                             },
+                             pluginOrder = pluginOrder,
                             onSavePluginOrder = { newOrder ->
                                 pluginOrder = newOrder
                                 scope.launch {
@@ -1157,4 +1160,3 @@ fun PackageManagerScreen(
         }
     }
 }
-

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PluginTabContent.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PluginTabContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.Image
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material3.Card
@@ -30,18 +31,23 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.core.tools.packTool.PackageManager
+import com.ai.assistance.operit.ui.common.icons.rememberLogoPainter
 import com.ai.assistance.operit.ui.features.packages.components.EmptyState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
@@ -53,6 +59,7 @@ fun PluginTabContent(
     isSearchActive: Boolean,
     onPluginClick: (String) -> Unit,
     onTogglePlugin: (PackageManager.ToolPkgContainerDetails, Boolean) -> Unit,
+    loadPluginLogo: suspend (String) -> PackageManager.ToolPkgLogoBytes?,
     pluginOrder: List<String> = emptyList(),
     onSavePluginOrder: (List<String>) -> Unit = {},
 ) {
@@ -116,6 +123,28 @@ fun PluginTabContent(
                     key = { _, (packageName, _) -> packageName }
                 ) { index, (packageName, details) ->
                     val isEnabled = enabledPackageNames.contains(packageName)
+                    val logo by
+                        produceState<PackageManager.ToolPkgLogoBytes?>(
+                            initialValue = null,
+                            packageName,
+                            details.version,
+                            details.logoResourceKey
+                        ) {
+                            value =
+                                if (details.logoResourceKey == null) {
+                                    null
+                                } else {
+                                    withContext(Dispatchers.IO) { loadPluginLogo(packageName) }
+                                }
+                        }
+                    val logoPainter =
+                        rememberLogoPainter(
+                            logoKey = "${packageName}:${details.version}:${details.logoResourceKey}",
+                            bytes = logo?.bytes,
+                            mimeType = logo?.mimeType,
+                            fileName = logo?.fileName,
+                            size = 32.dp
+                        )
                     ReorderableItem(
                         reorderableState,
                         key = packageName,
@@ -160,12 +189,21 @@ fun PluginTabContent(
                                         .padding(12.dp),
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Icon(
-                                        imageVector = Icons.Default.Apps,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(22.dp),
-                                        tint = MaterialTheme.colorScheme.primary
-                                    )
+                                    if (logoPainter != null) {
+                                        Image(
+                                            painter = logoPainter,
+                                            contentDescription = details.displayName,
+                                            contentScale = ContentScale.Fit,
+                                            modifier = Modifier.size(32.dp)
+                                        )
+                                    } else {
+                                        Icon(
+                                            imageVector = Icons.Default.Apps,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(22.dp),
+                                            tint = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
                                     Spacer(modifier = Modifier.width(10.dp))
                                     Column(
                                         modifier = Modifier

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/UnifiedMarketDetailEntryScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/UnifiedMarketDetailEntryScreen.kt
@@ -184,6 +184,7 @@ fun UnifiedMarketDetailEntryScreen(
             UnifiedMarketDetailHeader(
                 title = entry.title,
                 fallbackAvatarText = marketDetailInitial(entry.title),
+                logoUrl = entry.logoUrl,
                 participants =
                     listOf(
                         UnifiedMarketDetailParticipant(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/artifact/viewmodel/ArtifactMarketViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/artifact/viewmodel/ArtifactMarketViewModel.kt
@@ -23,6 +23,7 @@ import com.ai.assistance.operit.ui.features.packages.market.PublishArtifactReque
 import com.ai.assistance.operit.ui.features.packages.market.PublishArtifactSource
 import com.ai.assistance.operit.ui.features.packages.market.PublishArtifactType
 import com.ai.assistance.operit.ui.features.packages.market.PublishAttemptResult
+import com.ai.assistance.operit.ui.features.packages.market.PublishLogoAsset
 import com.ai.assistance.operit.ui.features.packages.market.PublishProgressStage
 import com.ai.assistance.operit.ui.features.packages.market.formatSupportedAppVersions
 import com.ai.assistance.operit.ui.features.packages.market.normalizeMarketArtifactId
@@ -148,7 +149,8 @@ class ArtifactMarketViewModel(
         minSupportedAppVersion: String?,
         maxSupportedAppVersion: String?,
         publishContext: ArtifactPublishClusterContext? = null,
-        source: PublishArtifactSource
+        source: PublishArtifactSource,
+        logo: PublishLogoAsset? = null
     ) {
         val localArtifact = _publishableArtifacts.value.firstOrNull { it.packageName == packageName }
         if (localArtifact == null) {
@@ -175,7 +177,8 @@ class ArtifactMarketViewModel(
                 minSupportedAppVersion = minSupportedAppVersion,
                 maxSupportedAppVersion = maxSupportedAppVersion,
                 publishContext = publishContext,
-                source = source
+                source = source,
+                logo = logo
             )
         executePublish(request, allowCreateForgeRepo = false)
     }
@@ -249,7 +252,8 @@ class ArtifactMarketViewModel(
                         description = payload.description,
                         detail = payload.projectDescription,
                         categoryId = categoryId,
-                        allowPublicUpdates = allowPublicUpdates
+                        allowPublicUpdates = allowPublicUpdates,
+                        logoUrl = payload.logoUrl
                     )
                 ).fold(
                     onSuccess = {
@@ -444,6 +448,7 @@ class ArtifactMarketViewModel(
             displayName = trimmedDisplayName,
             description = trimmedDescription,
             detail = trimmedDetail,
+            logoUrl = entry.logoUrl,
             categoryId = entry.categoryId,
             sourceFileName = assetName,
             minSupportedAppVersion = normalizeAppVersionOrNull(minSupportedAppVersion),

--- a/app/src/main/java/com/ai/assistance/operit/util/ToolPkgArtifactMinifier.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/ToolPkgArtifactMinifier.kt
@@ -4,17 +4,196 @@ import android.content.Context
 import com.ai.assistance.operit.core.tools.packTool.ToolPkgArchiveParser
 import com.ai.assistance.operit.core.tools.packTool.ToolPkgMarketOrigin
 import com.ai.assistance.operit.core.tools.packTool.ToolPkgMarketOriginCodec
+import com.ai.assistance.operit.ui.features.packages.market.PUBLISH_LOGO_MAX_BYTES
+import com.ai.assistance.operit.ui.features.packages.market.PublishLogoAsset
 import java.io.ByteArrayOutputStream
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.hjson.JsonValue
 import org.json.JSONObject
 
 /** Produces publish artifacts with optional AST minification and mandatory market provenance. */
 object ToolPkgArtifactMinifier {
+    fun readToolPkgLogoAsset(sourceFile: File): PublishLogoAsset? {
+        val manifestPreview =
+            ToolPkgArchiveParser.readToolPkgManifestPreview { sourceFile.inputStream() }
+                ?: throw IllegalArgumentException("manifest.hjson or manifest.json not found")
+        val logoKey = manifestPreview.manifest.logo?.trim().orEmpty()
+        if (logoKey.isBlank()) return null
+
+        val resource =
+            manifestPreview.manifest.resources.firstOrNull {
+                it.key.equals(logoKey, ignoreCase = true)
+            } ?: throw IllegalArgumentException("manifest.logo must reference an existing resource key: $logoKey")
+        if (ToolPkgArchiveParser.isDirectoryResourceMime(resource.mime)) {
+            throw IllegalArgumentException("manifest.logo must reference a file resource: $logoKey")
+        }
+
+        val manifestBasePath = manifestPreview.entryName.substringBeforeLast('/', "")
+        val normalizedPath =
+            ToolPkgArchiveParser.resolveManifestRelativeResourcePath(
+                manifestBasePath,
+                resource.path
+            ) ?: throw IllegalArgumentException("Invalid logo resource path: ${resource.path}")
+        val fileName = normalizedPath.substringAfterLast('/')
+        val contentType = logoContentType(resource.mime, fileName)
+
+        ZipFile(sourceFile).use { archive ->
+            val entryIndex = ToolPkgArchiveParser.buildZipEntryIndex(archive)
+            val bytes =
+                ToolPkgArchiveParser.readZipEntryBytes(archive, entryIndex, normalizedPath)
+                    ?: throw IllegalArgumentException("Cannot read logo resource: ${resource.path}")
+            require(bytes.size <= PUBLISH_LOGO_MAX_BYTES) {
+                "ToolPkg logo must be at most ${PUBLISH_LOGO_MAX_BYTES / 1024} KiB"
+            }
+            return PublishLogoAsset(
+                fileName = fileName,
+                contentType = contentType,
+                bytes = bytes
+            )
+        }
+    }
+
+    fun injectToolPkgLogo(
+        artifactBytes: ByteArray,
+        logo: PublishLogoAsset
+    ): ByteArray {
+        require(logo.bytes.isNotEmpty()) { "Logo content is empty" }
+        require(logo.bytes.size <= PUBLISH_LOGO_MAX_BYTES) {
+            "ToolPkg logo must be at most ${PUBLISH_LOGO_MAX_BYTES / 1024} KiB"
+        }
+
+        val manifestPreview =
+            ToolPkgArchiveParser.readToolPkgManifestPreview { ByteArrayInputStream(artifactBytes) }
+                ?: throw IllegalArgumentException("manifest.hjson or manifest.json not found")
+        val manifestEntryName =
+            ToolPkgArchiveParser.normalizeZipEntryPath(manifestPreview.entryName)
+                ?: throw IllegalArgumentException("Invalid toolpkg manifest entry name")
+        val manifestBasePath = manifestEntryName.substringBeforeLast('/', "")
+        val logoExtension = logo.fileName.substringAfterLast('.', "").lowercase()
+        require(logoExtension in TOOLPKG_LOGO_EXTENSIONS) {
+            "Unsupported ToolPkg logo format: ${logo.fileName}"
+        }
+        val logoResourceKey =
+            "$TOOLPKG_LOGO_RESOURCE_KEY_PREFIX${UUID.randomUUID().toString().replace("-", "")}"
+        val logoRelativePath = "resources/$logoResourceKey.$logoExtension"
+        val logoEntryPath =
+            ToolPkgArchiveParser.resolveManifestRelativeResourcePath(
+                manifestBasePath,
+                logoRelativePath
+            ) ?: throw IllegalArgumentException("Invalid generated logo resource path")
+        val entries = readArchiveEntries(artifactBytes)
+        val manifestEntry =
+            entries.firstOrNull { entry ->
+                ToolPkgArchiveParser.normalizeZipEntryPath(entry.name)
+                    ?.equals(manifestEntryName, ignoreCase = true) == true
+            } ?: throw IllegalArgumentException("ToolPkg manifest entry is missing")
+        val updatedManifest =
+            buildManifestWithLogo(
+                manifestText = manifestEntry.bytes.toString(StandardCharsets.UTF_8),
+                manifestEntryName = manifestEntryName,
+                logoRelativePath = logoRelativePath,
+                logoResourceKey = logoResourceKey,
+                logo = logo
+            )
+
+        val outputBytes = ByteArrayOutputStream()
+        var logoEntryReplaced = false
+        ZipOutputStream(outputBytes).use { zipOutput ->
+            entries.forEach { entry ->
+                val normalizedName = ToolPkgArchiveParser.normalizeZipEntryPath(entry.name)
+                val outputEntryBytes =
+                    when {
+                        normalizedName?.equals(manifestEntryName, ignoreCase = true) == true -> updatedManifest
+                        normalizedName?.equals(logoEntryPath, ignoreCase = true) == true -> {
+                            logoEntryReplaced = true
+                            logo.bytes
+                        }
+                        else -> entry.bytes
+                    }
+                zipOutput.putNextEntry(
+                    ZipEntry(entry.name).apply {
+                        if (entry.time >= 0L) time = entry.time
+                        comment = entry.comment
+                    }
+                )
+                zipOutput.write(outputEntryBytes)
+                zipOutput.closeEntry()
+            }
+            if (!logoEntryReplaced) {
+                zipOutput.putNextEntry(ZipEntry(logoEntryPath))
+                zipOutput.write(logo.bytes)
+                zipOutput.closeEntry()
+            }
+        }
+        return outputBytes.toByteArray()
+    }
+
+    private fun buildManifestWithLogo(
+        manifestText: String,
+        manifestEntryName: String,
+        logoRelativePath: String,
+        logoResourceKey: String,
+        logo: PublishLogoAsset
+    ): ByteArray {
+        val manifestJson =
+            if (manifestEntryName.endsWith(".hjson", ignoreCase = true)) {
+                JsonValue.readHjson(manifestText).toString()
+            } else {
+                manifestText
+            }
+        val root =
+            Json.parseToJsonElement(manifestJson) as? JsonObject
+                ?: throw IllegalArgumentException("ToolPkg manifest root must be an object")
+        val resources =
+            (root["resources"] as? JsonArray)?.toMutableList() ?: mutableListOf<JsonElement>()
+        resources +=
+            buildJsonObject {
+                put("key", logoResourceKey)
+                put("path", logoRelativePath)
+                put("mime", logo.contentType)
+            }
+        val updatedManifest =
+            buildJsonObject {
+                root.forEach { (key, value) -> put(key, value) }
+                put("logo", logoResourceKey)
+                put("resources", JsonArray(resources))
+            }
+        return Json.encodeToString(JsonObject.serializer(), updatedManifest)
+            .toByteArray(StandardCharsets.UTF_8)
+    }
+
+    private fun readArchiveEntries(artifactBytes: ByteArray): List<ToolPkgArchiveEntryBytes> {
+        val entries = mutableListOf<ToolPkgArchiveEntryBytes>()
+        ZipInputStream(ByteArrayInputStream(artifactBytes)).use { zipInput ->
+            while (true) {
+                val entry = zipInput.nextEntry ?: break
+                entries +=
+                    ToolPkgArchiveEntryBytes(
+                        name = entry.name,
+                        time = entry.time,
+                        comment = entry.comment,
+                        bytes = zipInput.readBytes()
+                    )
+                zipInput.closeEntry()
+            }
+        }
+        return entries
+    }
+
     internal fun processArtifactFile(
         context: Context,
         sourceFile: File,
@@ -312,6 +491,13 @@ object ToolPkgArtifactMinifier {
         return extension in setOf("js", "mjs", "cjs", "ts", "jsx", "tsx")
     }
 
+    private data class ToolPkgArchiveEntryBytes(
+        val name: String,
+        val time: Long,
+        val comment: String?,
+        val bytes: ByteArray
+    )
+
     private data class MetadataBlock(
         val comment: String,
         val content: String,
@@ -319,7 +505,20 @@ object ToolPkgArtifactMinifier {
     )
 
     private const val SCRIPT_MARKET_ORIGIN_METADATA_KEY = "__operit_market_origin"
+    private const val TOOLPKG_LOGO_RESOURCE_KEY_PREFIX = "operit_publish_logo_"
+    private val TOOLPKG_LOGO_EXTENSIONS = setOf("svg", "png", "jpg", "jpeg", "webp")
     private val metadataContentPattern = Regex("""(?s)/\*\s*METADATA\s*(.*?)\*/""")
     private val staticModuleReferencePattern =
-        Regex("""(?:require\s*\(\s*[\"']([^\"']+)[\"']\s*\)|(?:from|import)\s*[\"']([^\"']+)[\"'])""")
+            Regex("""(?:require\s*\(\s*[\"']([^\"']+)[\"']\s*\)|(?:from|import)\s*[\"']([^\"']+)[\"'])""")
+
+    private fun logoContentType(mime: String, fileName: String): String {
+        val extension = fileName.substringAfterLast('.', "").lowercase()
+        return when {
+            mime.equals("image/svg+xml", ignoreCase = true) || extension == "svg" -> "image/svg+xml"
+            mime.equals("image/png", ignoreCase = true) || extension == "png" -> "image/png"
+            mime.equals("image/jpeg", ignoreCase = true) || extension == "jpg" || extension == "jpeg" -> "image/jpeg"
+            mime.equals("image/webp", ignoreCase = true) || extension == "webp" -> "image/webp"
+            else -> throw IllegalArgumentException("Unsupported ToolPkg logo format: $fileName")
+        }
+    }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8127,6 +8127,16 @@
     <string name="artifact_publish_asset_source_upload">Upload current local package</string>
     <string name="artifact_publish_asset_source_github_release">Reference GitHub Release asset</string>
     <string name="artifact_publish_asset_source_confirmation">Release asset source: %1$s</string>
+    <string name="artifact_publish_logo_title">Package Logo</string>
+    <string name="artifact_publish_logo_description">Choose an image for the package. Direct upload writes it into the published package; GitHub Release mode updates the market logo only.</string>
+    <string name="artifact_publish_logo_choose">Choose Logo</string>
+    <string name="artifact_publish_logo_use_package">Use Package Logo</string>
+    <string name="artifact_publish_logo_selected">Selected: %1$s</string>
+    <string name="artifact_publish_logo_from_package">Package logo: %1$s</string>
+    <string name="artifact_publish_logo_confirmation">Logo: %1$s</string>
+    <string name="artifact_publish_logo_preview">Logo preview</string>
+    <string name="artifact_publish_logo_invalid">Could not read the logo. Choose a valid SVG, PNG, JPEG, or WebP file.</string>
+    <string name="artifact_publish_logo_too_large">The logo file must be 512 KiB or smaller.</string>
     <string name="artifact_publish_github_repository_url">Author GitHub repository link</string>
     <string name="artifact_publish_load_github_releases">Load Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8137,6 +8137,14 @@
     <string name="artifact_publish_logo_preview">Logo preview</string>
     <string name="artifact_publish_logo_invalid">Could not read the logo. Choose a valid SVG, PNG, JPEG, or WebP file.</string>
     <string name="artifact_publish_logo_too_large">The logo file must be 512 KiB or smaller.</string>
+    <string name="artifact_publish_logo_market_preview">Preview Market Effect</string>
+    <string name="artifact_publish_logo_market_preview_title">Market Preview</string>
+    <string name="artifact_publish_logo_market_list">List</string>
+    <string name="artifact_publish_logo_market_detail">Details</string>
+    <string name="artifact_publish_logo_market_preview_action">Install Package (Preview)</string>
+    <string name="artifact_publish_logo_market_preview_account">Current account</string>
+    <string name="artifact_publish_logo_market_preview_untitled">Untitled package</string>
+    <string name="artifact_publish_logo_market_preview_empty_description">No description</string>
     <string name="artifact_publish_github_repository_url">Author GitHub repository link</string>
     <string name="artifact_publish_load_github_releases">Load Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7472,6 +7472,16 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="artifact_publish_asset_source_upload">Subir el paquete local actual</string>
     <string name="artifact_publish_asset_source_github_release">Referenciar activo de GitHub Release</string>
     <string name="artifact_publish_asset_source_confirmation">Origen del recurso a publicar: %1$s</string>
+    <string name="artifact_publish_logo_title">Logo del paquete</string>
+    <string name="artifact_publish_logo_description">Elige una imagen para el paquete. La carga directa la incluye en el paquete publicado; el modo GitHub Release solo actualiza el logo del mercado.</string>
+    <string name="artifact_publish_logo_choose">Elegir logo</string>
+    <string name="artifact_publish_logo_use_package">Usar logo del paquete</string>
+    <string name="artifact_publish_logo_selected">Seleccionado: %1$s</string>
+    <string name="artifact_publish_logo_from_package">Logo del paquete: %1$s</string>
+    <string name="artifact_publish_logo_confirmation">Logo: %1$s</string>
+    <string name="artifact_publish_logo_preview">Vista previa del logo</string>
+    <string name="artifact_publish_logo_invalid">No se pudo leer el logo. Elige un archivo SVG, PNG, JPEG o WebP válido.</string>
+    <string name="artifact_publish_logo_too_large">El archivo del logo debe tener 512 KiB o menos.</string>
     <string name="artifact_publish_github_repository_url">Enlace al repositorio de GitHub del autor</string>
     <string name="artifact_publish_load_github_releases">Cargar Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7482,6 +7482,14 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="artifact_publish_logo_preview">Vista previa del logo</string>
     <string name="artifact_publish_logo_invalid">No se pudo leer el logo. Elige un archivo SVG, PNG, JPEG o WebP válido.</string>
     <string name="artifact_publish_logo_too_large">El archivo del logo debe tener 512 KiB o menos.</string>
+    <string name="artifact_publish_logo_market_preview">Vista previa del mercado</string>
+    <string name="artifact_publish_logo_market_preview_title">Vista previa del mercado</string>
+    <string name="artifact_publish_logo_market_list">Lista</string>
+    <string name="artifact_publish_logo_market_detail">Detalles</string>
+    <string name="artifact_publish_logo_market_preview_action">Instalar paquete (vista previa)</string>
+    <string name="artifact_publish_logo_market_preview_account">Cuenta actual</string>
+    <string name="artifact_publish_logo_market_preview_untitled">Paquete sin nombre</string>
+    <string name="artifact_publish_logo_market_preview_empty_description">Sin descripción</string>
     <string name="artifact_publish_github_repository_url">Enlace al repositorio de GitHub del autor</string>
     <string name="artifact_publish_load_github_releases">Cargar Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7414,6 +7414,14 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="artifact_publish_logo_preview">Pratinjau logo</string>
     <string name="artifact_publish_logo_invalid">Logo tidak dapat dibaca. Pilih file SVG, PNG, JPEG, atau WebP yang valid.</string>
     <string name="artifact_publish_logo_too_large">Ukuran file logo harus 512 KiB atau lebih kecil.</string>
+    <string name="artifact_publish_logo_market_preview">Pratinjau pasar</string>
+    <string name="artifact_publish_logo_market_preview_title">Pratinjau pasar</string>
+    <string name="artifact_publish_logo_market_list">Daftar</string>
+    <string name="artifact_publish_logo_market_detail">Detail</string>
+    <string name="artifact_publish_logo_market_preview_action">Instal Paket (Pratinjau)</string>
+    <string name="artifact_publish_logo_market_preview_account">Akun saat ini</string>
+    <string name="artifact_publish_logo_market_preview_untitled">Paket tanpa nama</string>
+    <string name="artifact_publish_logo_market_preview_empty_description">Tidak ada deskripsi</string>
     <string name="artifact_publish_github_repository_url">Tautan repositori GitHub penulis</string>
     <string name="artifact_publish_load_github_releases">Muat Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7404,6 +7404,16 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="artifact_publish_asset_source_upload">Unggah paket lokal saat ini</string>
     <string name="artifact_publish_asset_source_github_release">Rujuk aset GitHub Release</string>
     <string name="artifact_publish_asset_source_confirmation">Sumber Aset Publikasi: %1$s</string>
+    <string name="artifact_publish_logo_title">Logo Paket</string>
+    <string name="artifact_publish_logo_description">Pilih gambar untuk paket. Unggah langsung akan menulisnya ke paket yang dipublikasikan; mode GitHub Release hanya memperbarui logo pasar.</string>
+    <string name="artifact_publish_logo_choose">Pilih Logo</string>
+    <string name="artifact_publish_logo_use_package">Gunakan Logo Paket</string>
+    <string name="artifact_publish_logo_selected">Dipilih: %1$s</string>
+    <string name="artifact_publish_logo_from_package">Logo paket: %1$s</string>
+    <string name="artifact_publish_logo_confirmation">Logo: %1$s</string>
+    <string name="artifact_publish_logo_preview">Pratinjau logo</string>
+    <string name="artifact_publish_logo_invalid">Logo tidak dapat dibaca. Pilih file SVG, PNG, JPEG, atau WebP yang valid.</string>
+    <string name="artifact_publish_logo_too_large">Ukuran file logo harus 512 KiB atau lebih kecil.</string>
     <string name="artifact_publish_github_repository_url">Tautan repositori GitHub penulis</string>
     <string name="artifact_publish_load_github_releases">Muat Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7251,6 +7251,16 @@
     <string name="artifact_publish_asset_source_upload">현재 로컬 패키지 업로드</string>
     <string name="artifact_publish_asset_source_github_release">GitHub Release 자산 참조</string>
     <string name="artifact_publish_asset_source_confirmation">출시 리소스 출처: %1$s</string>
+    <string name="artifact_publish_logo_title">패키지 로고</string>
+    <string name="artifact_publish_logo_description">패키지에 사용할 이미지를 선택합니다. 직접 업로드 모드에서는 게시 패키지에 포함되고, GitHub Release 모드에서는 마켓 로고만 변경됩니다.</string>
+    <string name="artifact_publish_logo_choose">로고 선택</string>
+    <string name="artifact_publish_logo_use_package">패키지 로고 사용</string>
+    <string name="artifact_publish_logo_selected">선택됨: %1$s</string>
+    <string name="artifact_publish_logo_from_package">패키지 로고: %1$s</string>
+    <string name="artifact_publish_logo_confirmation">로고: %1$s</string>
+    <string name="artifact_publish_logo_preview">로고 미리보기</string>
+    <string name="artifact_publish_logo_invalid">로고를 읽을 수 없습니다. 올바른 SVG, PNG, JPEG 또는 WebP 파일을 선택하세요.</string>
+    <string name="artifact_publish_logo_too_large">로고 파일은 512KiB 이하여야 합니다.</string>
     <string name="artifact_publish_github_repository_url">작성자 GitHub 저장소 링크</string>
     <string name="artifact_publish_load_github_releases">Release 로드</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7261,6 +7261,14 @@
     <string name="artifact_publish_logo_preview">로고 미리보기</string>
     <string name="artifact_publish_logo_invalid">로고를 읽을 수 없습니다. 올바른 SVG, PNG, JPEG 또는 WebP 파일을 선택하세요.</string>
     <string name="artifact_publish_logo_too_large">로고 파일은 512KiB 이하여야 합니다.</string>
+    <string name="artifact_publish_logo_market_preview">마켓 효과 미리보기</string>
+    <string name="artifact_publish_logo_market_preview_title">마켓 미리보기</string>
+    <string name="artifact_publish_logo_market_list">목록</string>
+    <string name="artifact_publish_logo_market_detail">상세</string>
+    <string name="artifact_publish_logo_market_preview_action">패키지 설치 (미리보기)</string>
+    <string name="artifact_publish_logo_market_preview_account">현재 계정</string>
+    <string name="artifact_publish_logo_market_preview_untitled">이름 없는 패키지</string>
+    <string name="artifact_publish_logo_market_preview_empty_description">설명 없음</string>
     <string name="artifact_publish_github_repository_url">작성자 GitHub 저장소 링크</string>
     <string name="artifact_publish_load_github_releases">Release 로드</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7401,6 +7401,16 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="artifact_publish_asset_source_upload">Muat Naik Pakej Tempatan Semasa</string>
     <string name="artifact_publish_asset_source_github_release">Rujuk Aset Siaran GitHub</string>
     <string name="artifact_publish_asset_source_confirmation">Sumber Aset Penerbitan: %1$s</string>
+    <string name="artifact_publish_logo_title">Logo Pakej</string>
+    <string name="artifact_publish_logo_description">Pilih imej untuk pakej. Muat naik terus akan menulisnya ke dalam pakej yang diterbitkan; mod GitHub Release hanya mengemas kini logo pasaran.</string>
+    <string name="artifact_publish_logo_choose">Pilih Logo</string>
+    <string name="artifact_publish_logo_use_package">Gunakan Logo Pakej</string>
+    <string name="artifact_publish_logo_selected">Dipilih: %1$s</string>
+    <string name="artifact_publish_logo_from_package">Logo pakej: %1$s</string>
+    <string name="artifact_publish_logo_confirmation">Logo: %1$s</string>
+    <string name="artifact_publish_logo_preview">Pratonton logo</string>
+    <string name="artifact_publish_logo_invalid">Logo tidak dapat dibaca. Pilih fail SVG, PNG, JPEG atau WebP yang sah.</string>
+    <string name="artifact_publish_logo_too_large">Fail logo mestilah 512 KiB atau lebih kecil.</string>
     <string name="artifact_publish_github_repository_url">Pautan Repositori GitHub Pengarang</string>
     <string name="artifact_publish_load_github_releases">Muat Siaran</string>
     <string name="artifact_publish_github_release">Siaran GitHub</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7411,6 +7411,14 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="artifact_publish_logo_preview">Pratonton logo</string>
     <string name="artifact_publish_logo_invalid">Logo tidak dapat dibaca. Pilih fail SVG, PNG, JPEG atau WebP yang sah.</string>
     <string name="artifact_publish_logo_too_large">Fail logo mestilah 512 KiB atau lebih kecil.</string>
+    <string name="artifact_publish_logo_market_preview">Pratonton kesan pasaran</string>
+    <string name="artifact_publish_logo_market_preview_title">Pratonton Pasaran</string>
+    <string name="artifact_publish_logo_market_list">Senarai</string>
+    <string name="artifact_publish_logo_market_detail">Butiran</string>
+    <string name="artifact_publish_logo_market_preview_action">Pasang Pakej (Pratonton)</string>
+    <string name="artifact_publish_logo_market_preview_account">Akaun semasa</string>
+    <string name="artifact_publish_logo_market_preview_untitled">Pakej tanpa nama</string>
+    <string name="artifact_publish_logo_market_preview_empty_description">Tiada penerangan</string>
     <string name="artifact_publish_github_repository_url">Pautan Repositori GitHub Pengarang</string>
     <string name="artifact_publish_load_github_releases">Muat Siaran</string>
     <string name="artifact_publish_github_release">Siaran GitHub</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7242,6 +7242,16 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="artifact_publish_asset_source_upload">Enviar pacote local atual</string>
     <string name="artifact_publish_asset_source_github_release">Referenciar ativo do GitHub Release</string>
     <string name="artifact_publish_asset_source_confirmation">Origem do recurso de publicação: %1$s</string>
+    <string name="artifact_publish_logo_title">Logo do pacote</string>
+    <string name="artifact_publish_logo_description">Escolha uma imagem para o pacote. O envio direto grava a imagem no pacote publicado; o modo GitHub Release atualiza apenas o logo do mercado.</string>
+    <string name="artifact_publish_logo_choose">Escolher logo</string>
+    <string name="artifact_publish_logo_use_package">Usar logo do pacote</string>
+    <string name="artifact_publish_logo_selected">Selecionado: %1$s</string>
+    <string name="artifact_publish_logo_from_package">Logo do pacote: %1$s</string>
+    <string name="artifact_publish_logo_confirmation">Logo: %1$s</string>
+    <string name="artifact_publish_logo_preview">Prévia do logo</string>
+    <string name="artifact_publish_logo_invalid">Não foi possível ler o logo. Escolha um arquivo SVG, PNG, JPEG ou WebP válido.</string>
+    <string name="artifact_publish_logo_too_large">O arquivo do logo deve ter no máximo 512 KiB.</string>
     <string name="artifact_publish_github_repository_url">Link do repositório GitHub do autor</string>
     <string name="artifact_publish_load_github_releases">Carregar Releases</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7252,6 +7252,14 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="artifact_publish_logo_preview">Prévia do logo</string>
     <string name="artifact_publish_logo_invalid">Não foi possível ler o logo. Escolha um arquivo SVG, PNG, JPEG ou WebP válido.</string>
     <string name="artifact_publish_logo_too_large">O arquivo do logo deve ter no máximo 512 KiB.</string>
+    <string name="artifact_publish_logo_market_preview">Visualizar efeito no mercado</string>
+    <string name="artifact_publish_logo_market_preview_title">Prévia do mercado</string>
+    <string name="artifact_publish_logo_market_list">Lista</string>
+    <string name="artifact_publish_logo_market_detail">Detalhes</string>
+    <string name="artifact_publish_logo_market_preview_action">Instalar pacote (prévia)</string>
+    <string name="artifact_publish_logo_market_preview_account">Conta atual</string>
+    <string name="artifact_publish_logo_market_preview_untitled">Pacote sem nome</string>
+    <string name="artifact_publish_logo_market_preview_empty_description">Sem descrição</string>
     <string name="artifact_publish_github_repository_url">Link do repositório GitHub do autor</string>
     <string name="artifact_publish_load_github_releases">Carregar Releases</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -4355,6 +4355,14 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="artifact_publish_logo_preview">Previzualizare siglă</string>
     <string name="artifact_publish_logo_invalid">Sigla nu poate fi citită. Alege un fișier SVG, PNG, JPEG sau WebP valid.</string>
     <string name="artifact_publish_logo_too_large">Fișierul siglei trebuie să aibă cel mult 512 KiB.</string>
+    <string name="artifact_publish_logo_market_preview">Previzualizare efect în piață</string>
+    <string name="artifact_publish_logo_market_preview_title">Previzualizare piață</string>
+    <string name="artifact_publish_logo_market_list">Listă</string>
+    <string name="artifact_publish_logo_market_detail">Detalii</string>
+    <string name="artifact_publish_logo_market_preview_action">Instalează pachetul (previzualizare)</string>
+    <string name="artifact_publish_logo_market_preview_account">Contul curent</string>
+    <string name="artifact_publish_logo_market_preview_untitled">Pachet fără nume</string>
+    <string name="artifact_publish_logo_market_preview_empty_description">Fără descriere</string>
     <string name="artifact_publish_github_repository_url">Autorul GitHub Link către depozit</string>
     <string name="artifact_publish_load_github_releases">Se încarcă Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -4345,6 +4345,16 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="artifact_publish_asset_source_upload">Încărcarea pachetului local curent</string>
     <string name="artifact_publish_asset_source_github_release">Citat GitHub Release Active</string>
     <string name="artifact_publish_asset_source_confirmation">Sursa resurselor publicate: %1$s</string>
+    <string name="artifact_publish_logo_title">Sigla pachetului</string>
+    <string name="artifact_publish_logo_description">Alege o imagine pentru pachet. Încărcarea directă o scrie în pachetul publicat; modul GitHub Release actualizează doar sigla din magazin.</string>
+    <string name="artifact_publish_logo_choose">Alege sigla</string>
+    <string name="artifact_publish_logo_use_package">Folosește sigla pachetului</string>
+    <string name="artifact_publish_logo_selected">Selectat: %1$s</string>
+    <string name="artifact_publish_logo_from_package">Sigla pachetului: %1$s</string>
+    <string name="artifact_publish_logo_confirmation">Siglă: %1$s</string>
+    <string name="artifact_publish_logo_preview">Previzualizare siglă</string>
+    <string name="artifact_publish_logo_invalid">Sigla nu poate fi citită. Alege un fișier SVG, PNG, JPEG sau WebP valid.</string>
+    <string name="artifact_publish_logo_too_large">Fișierul siglei trebuie să aibă cel mult 512 KiB.</string>
     <string name="artifact_publish_github_repository_url">Autorul GitHub Link către depozit</string>
     <string name="artifact_publish_load_github_releases">Se încarcă Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4465,6 +4465,16 @@
     <string name="artifact_publish_asset_source_upload">上传当前本地包</string>
     <string name="artifact_publish_asset_source_github_release">引用 GitHub Release 资产</string>
     <string name="artifact_publish_asset_source_confirmation">发布资源来源: %1$s</string>
+    <string name="artifact_publish_logo_title">包 Logo</string>
+    <string name="artifact_publish_logo_description">可选择新的图片。直接上传会把它写入发布包，GitHub Release 模式只更新市场 Logo。</string>
+    <string name="artifact_publish_logo_choose">选择 Logo</string>
+    <string name="artifact_publish_logo_use_package">使用包内 Logo</string>
+    <string name="artifact_publish_logo_selected">已选择: %1$s</string>
+    <string name="artifact_publish_logo_from_package">包内 Logo: %1$s</string>
+    <string name="artifact_publish_logo_confirmation">Logo: %1$s</string>
+    <string name="artifact_publish_logo_preview">Logo 预览</string>
+    <string name="artifact_publish_logo_invalid">无法读取 Logo，请选择有效的 SVG、PNG、JPEG 或 WebP 文件</string>
+    <string name="artifact_publish_logo_too_large">Logo 文件不能超过 512 KiB</string>
     <string name="artifact_publish_github_repository_url">作者 GitHub 仓库链接</string>
     <string name="artifact_publish_load_github_releases">加载 Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4475,6 +4475,14 @@
     <string name="artifact_publish_logo_preview">Logo 预览</string>
     <string name="artifact_publish_logo_invalid">无法读取 Logo，请选择有效的 SVG、PNG、JPEG 或 WebP 文件</string>
     <string name="artifact_publish_logo_too_large">Logo 文件不能超过 512 KiB</string>
+    <string name="artifact_publish_logo_market_preview">预览市场效果</string>
+    <string name="artifact_publish_logo_market_preview_title">市场效果预览</string>
+    <string name="artifact_publish_logo_market_list">列表</string>
+    <string name="artifact_publish_logo_market_detail">详情</string>
+    <string name="artifact_publish_logo_market_preview_action">安装插件（预览）</string>
+    <string name="artifact_publish_logo_market_preview_account">当前账号</string>
+    <string name="artifact_publish_logo_market_preview_untitled">未命名工具包</string>
+    <string name="artifact_publish_logo_market_preview_empty_description">暂无描述</string>
     <string name="artifact_publish_github_repository_url">作者 GitHub 仓库链接</string>
     <string name="artifact_publish_load_github_releases">加载 Release</string>
     <string name="artifact_publish_github_release">GitHub Release</string>

--- a/docs/TODO/toolpkg_logo_support_20260820/1_manifest-and-runtime.md
+++ b/docs/TODO/toolpkg_logo_support_20260820/1_manifest-and-runtime.md
@@ -1,0 +1,23 @@
+# Manifest And Runtime
+
+## Existing
+
+`ToolPkgManifest` validates declared resources but has no package-level logo
+reference. The runtime cache already extracts every archive entry, so a declared
+logo resource can be read without adding another archive format.
+
+## Change
+
+- Parse optional `manifest.logo` as a resource key.
+- Require the key to resolve to a file resource with a supported image MIME or
+  extension.
+- Carry the resolved resource key and MIME through the ToolPkg runtime and public
+  container details.
+- Expose a package-manager method that reads the cached logo bytes.
+
+## Compatibility
+
+Archives without `logo` keep their existing generic icon. No manifest version
+upgrade is required.
+
+[DONE]

--- a/docs/TODO/toolpkg_logo_support_20260820/2-rendering-and-ui.md
+++ b/docs/TODO/toolpkg_logo_support_20260820/2-rendering-and-ui.md
@@ -1,0 +1,18 @@
+# Rendering And UI
+
+## Existing
+
+`ProviderLogoLoader` renders APK asset SVG and PNG files. Plugin lists and market
+cards currently render fixed Material icons or title-derived initials.
+
+## Change
+
+- Reuse the AndroidSVG and bitmap scaling implementation through a generic
+  byte/stream renderer.
+- Keep provider-specific asset lookup and provider color tinting in the existing
+  provider API.
+- Render plugin logos with their original colors in the package manager, market
+  list and market detail header.
+- Keep the current generic icon for packages and entries without a logo.
+
+[DONE]

--- a/docs/TODO/toolpkg_logo_support_20260820/3-market-publish.md
+++ b/docs/TODO/toolpkg_logo_support_20260820/3-market-publish.md
@@ -1,0 +1,28 @@
+# Market Publish
+
+## Existing
+
+Artifact publication registers JSON metadata and a release asset. The market
+entry model has no logo field, and this repository does not contain the market
+Worker implementation.
+
+## Change
+
+- Extract the declared ToolPkg logo from the local archive during publication.
+- Upload it through an authenticated market logo endpoint.
+- Include the returned hosted logo reference in publish, metadata update and
+  new-version requests.
+- Decode the optional logo URL in static market entries.
+- Keep old entries valid when the field is absent.
+
+The Android client contract is `POST /market/v2/logos` with a multipart field
+named `logo`. The response is `{ "ok": true, "url": "https://..." }`. Publish
+and update requests carry the returned URL as the optional `logoUrl` field.
+
+The Worker/API implementation is outside this Android repository and must expose
+this contract before production publishing is enabled.
+
+[DONE]
+
+The API endpoint and static market generator must be implemented or coordinated
+outside this Android worktree before the full publish flow can be exercised.

--- a/docs/TODO/toolpkg_logo_support_20260820/index.md
+++ b/docs/TODO/toolpkg_logo_support_20260820/index.md
@@ -48,6 +48,8 @@ manifest field is optional and `schema_version` remains unchanged.
 - Static review only in this change; no build or test command is run by default
 - The ToolPkg publish screen accepts a local SVG or bitmap logo, previews the selected
   image, and writes it only into the temporary direct-upload archive when needed.
+- The publish screen also previews the logo in the real market list-card and detail-header
+  layouts without uploading or publishing the artifact.
 
 Android client implementation is complete. The market Worker/API remains an
 external dependency because it is not part of this repository.

--- a/docs/TODO/toolpkg_logo_support_20260820/index.md
+++ b/docs/TODO/toolpkg_logo_support_20260820/index.md
@@ -1,0 +1,53 @@
+---
+fork: https://github.com/AAswordman/Operit.git
+status: complete
+---
+
+# ToolPkg Logo Support
+
+## Current State
+
+ToolPkg containers do not expose a package logo. The package manager renders the
+generic Apps icon, while the market list and detail header render a title-derived
+avatar. The model provider logo loader already contains AndroidSVG and bitmap
+scaling code, but it is tied to APK assets and provider identifiers.
+
+## Intent
+
+Add an optional package logo resource that travels inside a ToolPkg archive. The
+same resource is rendered locally from the package cache and is uploaded to the
+market as a separately hosted image for pre-install market screens.
+
+Existing ToolPkg archives and existing market entries remain valid. The new
+manifest field is optional and `schema_version` remains unchanged.
+
+## Manifest Contract
+
+```json
+{
+  "logo": "plugin_logo",
+  "resources": [
+    {
+      "key": "plugin_logo",
+      "path": "resources/logo.svg",
+      "mime": "image/svg+xml"
+    }
+  ]
+}
+```
+
+`logo` is a resource key. Supported static formats are SVG, PNG, JPEG and WebP.
+
+## Scope
+
+- ToolPkg manifest parsing, cache access and package-manager rendering
+- Generic SVG and bitmap logo rendering shared with provider logos
+- Artifact publication logo extraction and market-hosted upload
+- Market list and detail rendering
+- ToolPkg format documentation and a small example resource
+- Static review only in this change; no build or test command is run by default
+- The ToolPkg publish screen accepts a local SVG or bitmap logo, previews the selected
+  image, and writes it only into the temporary direct-upload archive when needed.
+
+Android client implementation is complete. The market Worker/API remains an
+external dependency because it is not part of this repository.

--- a/docs/TOOLPKG_FORMAT_GUIDE.md
+++ b/docs/TOOLPKG_FORMAT_GUIDE.md
@@ -42,6 +42,7 @@ windows_control.toolpkg (ZIP 压缩包)
 ├── modules/                               # 可选 WASM 核心模块
 │   └── core.wasm                          # AssemblyScript 编译产物
 ├── resources/                             # 资源文件目录
+│   ├── logo.svg                            # 可选包 Logo
 │   └── pc_agent/
 │       └── operit-pc-agent/              # 目录资源（readResource 时自动导出为 zip）
 └── i18n/                                  # 国际化文件（可选）
@@ -84,6 +85,7 @@ windows_control.toolpkg (ZIP 压缩包)
     "zh": "Windows 一键配置与控制工具包",
     "en": "Windows one-click setup and control bundle"
   },
+  "logo": "package_logo",
   "subpackages": [
     {
       "id": "windows_control",
@@ -100,6 +102,11 @@ windows_control.toolpkg (ZIP 压缩包)
     }
   ],
   "resources": [
+    {
+      "key": "package_logo",
+      "path": "resources/logo.svg",
+      "mime": "image/svg+xml"
+    },
     {
       "key": "pc_agent_zip",
       "path": "resources/pc_agent/operit-pc-agent.zip",
@@ -160,11 +167,17 @@ windows_control.toolpkg (ZIP 压缩包)
 | `main` | string | 是 | ToolPkg 主入口脚本路径（相对于 ZIP 根目录），用于执行注册函数 |
 | `display_name` | LocalizedText | 否 | 包的显示名称，支持多语言 |
 | `description` | LocalizedText | 否 | 包的描述信息，支持多语言 |
+| `logo` | string | 否 | 包 Logo 对应的 `resources[].key`；支持 SVG、PNG、JPEG 和 WebP |
 | `subpackages` | array | 否 | 子包列表，每个子包是一个独立的工具集 |
 | `resources` | array | 否 | 资源文件列表，可以是任意类型的文件 |
 | `wasm_modules` | array | 否 | 企业核心算法模块列表，当前用于声明和校验 `.wasm` 产物 |
 | `workflow_templates` | array | 否 | 注册到宿主“工作流”入口的工作流模板列表 |
 | `workspace_templates` | array | 否 | 注册到宿主“工作区创建”入口的工作区模板列表 |
+
+发布 ToolPkg 时可以在发布页面选择 Logo。直接上传模式会把选择的图片写入临时
+发布副本的 `manifest.logo` 和 `resources`，不会修改本地原包。引用已有 GitHub
+Release 资产时，远程资产保持不变，选择的图片只作为市场 Logo 上传；已发布条目
+的 Logo 需要通过发布新版本修改。
 
 #### 压缩发布
 

--- a/docs/doc-src/package-dev/toolpkg.md
+++ b/docs/doc-src/package-dev/toolpkg.md
@@ -561,7 +561,8 @@ ToolPkg 可以把包 Logo 作为普通资源随归档分发。`logo` 填写资�
 在 ToolPkg 发布页面也可以直接选择 Logo。直接上传模式会生成临时发布副本，
 把选择的图片写入 `manifest.logo` 和 `resources`，不会修改本地原包。引用已有
 GitHub Release 资产时，远程资产保持不变，选择的图片只作为市场 Logo 上传。
-已发布条目的 Logo 需要通过发布新版本修改。
+发布页面还提供市场列表和详情效果预览；预览直接使用本地选择的图片，不会
+触发上传。已发布条目的 Logo 需要通过发布新版本修改。
 
 ## AssemblyScript WASM 模块
 

--- a/docs/doc-src/package-dev/toolpkg.md
+++ b/docs/doc-src/package-dev/toolpkg.md
@@ -536,6 +536,33 @@ const jarPath = await ToolPkg.readResource('apktool_lib_jar', 'apktool-lib.jar')
 - 如果资源 `mime` 是目录类型（例如 `inode/directory`、`vnd.android.document/directory`），运行时会先把该目录压成 zip，再返回这个 zip 文件的绝对路径；默认文件名会自动补 `.zip`。
 - `registerToolPkg()` 执行期间不可调用；调用会立即抛出异常。
 
+## ToolPkg Logo
+
+ToolPkg 可以把包 Logo 作为普通资源随归档分发。`logo` 填写资源 key，资源
+必须是文件，支持 SVG、PNG、JPEG 和 WebP：
+
+```json
+{
+  "logo": "package_logo",
+  "resources": [
+    {
+      "key": "package_logo",
+      "path": "resources/logo.svg",
+      "mime": "image/svg+xml"
+    }
+  ]
+}
+```
+
+没有 `logo` 字段的旧包继续使用宿主默认图标。发布到市场时，宿主会读取该
+资源并上传到市场 Logo 托管接口；包管理页面直接从已安装的 ToolPkg 缓存中
+读取资源。
+
+在 ToolPkg 发布页面也可以直接选择 Logo。直接上传模式会生成临时发布副本，
+把选择的图片写入 `manifest.logo` 和 `resources`，不会修改本地原包。引用已有
+GitHub Release 资产时，远程资产保持不变，选择的图片只作为市场 Logo 上传。
+已发布条目的 Logo 需要通过发布新版本修改。
+
 ## AssemblyScript WASM 模块
 
 企业插件可以在 `manifest.json` 中声明 AssemblyScript 编译得到的 `.wasm` 核心模块：

--- a/examples/template_try/manifest.json
+++ b/examples/template_try/manifest.json
@@ -11,9 +11,15 @@
     "zh": "用于演示 ToolPkg 工作流模板与工作区模板在宿主中的注册、展示与导入。",
     "en": "Demonstrates ToolPkg workflow and workspace template registration, display, and import in the host app."
   },
+  "logo": "package_logo",
   "enabled_by_default": false,
   "subpackages": [],
   "resources": [
+    {
+      "key": "package_logo",
+      "path": "resources/logo.svg",
+      "mime": "image/svg+xml"
+    },
     {
       "key": "demo_workflow_template",
       "path": "resources/workflow_template.json",

--- a/examples/template_try/resources/logo.svg
+++ b/examples/template_try/resources/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <title>Template Integration Demo</title>
+  <path fill="#6750A4" d="M32 4 56 18v28L32 60 8 46V18z"/>
+  <path fill="#FFFFFF" d="m32 15 14 8v18l-14 8-14-8V23zm0 8-7 4v10l7 4 7-4V27z"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add optional SVG/PNG/JPEG/WebP logos to ToolPkg manifests and runtime package details.
- Render package logos in local package management and market list/detail views.
- Add publish-page logo selection, preview, temporary ToolPkg injection, and market-hosted logo upload support.
- Keep GitHub Release assets unchanged when only the market logo is updated.

## Validation
- `git diff --check` passed.
- Remote builder `build_dev` succeeded for commit `386150de` and produced the Dev APK.
- Market logo upload endpoint remains an external Worker/API contract documented in the repository.