### PR TITLE
fix(stats): skip legacy function token keys

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -398,7 +398,7 @@ android {
         minSdk = 26
         targetSdk = 34
         versionCode = 46
-        versionName = "1.12.1"
+        versionName = "1.12.1+1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -398,7 +398,7 @@ android {
         minSdk = 26
         targetSdk = 34
         versionCode = 46
-        versionName = "1.12.1+1"
+        versionName = "1.12.1+2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/TokenTrackingAIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/TokenTrackingAIService.kt
@@ -302,6 +302,7 @@ class TokenTrackingAIService(
                 configId = configId,
                 provider = providerModel.substring(0, separator),
                 model = providerModel.substring(separator + 1),
+                requestCount = 1L,
                 uncachedInputTokens = snapshot.uncachedInputTokens,
                 cachedInputTokens = snapshot.cachedInputTokens,
                 cacheWriteTokens =

--- a/app/src/main/java/com/ai/assistance/operit/core/application/OperitApplication.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/application/OperitApplication.kt
@@ -45,6 +45,7 @@ import com.ai.assistance.operit.data.preferences.initAndroidPermissionPreference
 import com.ai.assistance.operit.data.preferences.initUserPreferencesManager
 import com.ai.assistance.operit.data.preferences.preferencesManager
 import com.ai.assistance.operit.data.repository.CustomEmojiRepository
+import com.ai.assistance.operit.data.stats.TokenUsageRepository
 import com.ai.assistance.operit.ui.features.chat.webview.LocalWebServer
 import com.ai.assistance.operit.ui.features.chat.webview.workspace.editor.language.LanguageFactory
 import com.ai.assistance.operit.util.GlobalExceptionHandler
@@ -177,6 +178,16 @@ class OperitApplication : Application(), ImageLoaderFactory, WorkConfiguration.P
         val defaultProfileName = applicationContext.getString(R.string.default_profile)
         initUserPreferencesManager(applicationContext, defaultProfileName)
         AppLogger.d(TAG, "【启动计时】用户偏好管理器初始化完成 - ${System.currentTimeMillis() - startTime}ms")
+
+        // Run the legacy token import during startup so upgrades retain statistics
+        // even when the user opens another screen before visiting token stats.
+        applicationScope.launch {
+            try {
+                TokenUsageRepository.getInstance(applicationContext).ensureInitialized()
+            } catch (error: Throwable) {
+                AppLogger.e(TAG, "Token statistics migration failed", error)
+            }
+        }
 
         AppLogger.d(TAG, "【启动计时】Android权限偏好管理器已就绪 - ${System.currentTimeMillis() - startTime}ms")
 

--- a/app/src/main/java/com/ai/assistance/operit/data/dao/TokenUsageDao.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/dao/TokenUsageDao.kt
@@ -39,6 +39,9 @@ abstract class TokenUsageDao {
     abstract suspend fun insertRecord(record: TokenUsageRecordEntity): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertRecords(records: List<TokenUsageRecordEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun upsertStatsModel(model: TokenStatsModelEntity)
 
     @Query(
@@ -91,17 +94,17 @@ abstract class TokenUsageDao {
             provider AS provider,
             model AS model,
             configId AS configId,
-            COUNT(*) AS requests,
+            COALESCE(SUM(requestCount), 0) AS requests,
             COALESCE(SUM(uncachedInputTokens), 0) AS uncachedInputTokens,
-            COUNT(uncachedInputTokens) AS uncachedInputKnown,
+            COALESCE(SUM(CASE WHEN uncachedInputTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS uncachedInputKnown,
             COALESCE(SUM(cachedInputTokens), 0) AS cachedInputTokens,
-            COUNT(cachedInputTokens) AS cachedInputKnown,
+            COALESCE(SUM(CASE WHEN cachedInputTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS cachedInputKnown,
             COALESCE(SUM(cacheWriteTokens), 0) AS cacheWriteTokens,
-            COUNT(cacheWriteTokens) AS cacheWriteKnown,
+            COALESCE(SUM(CASE WHEN cacheWriteTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS cacheWriteKnown,
             COALESCE(SUM(totalInputTokens), 0) AS totalInputTokens,
-            COUNT(totalInputTokens) AS totalInputKnown,
+            COALESCE(SUM(CASE WHEN totalInputTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS totalInputKnown,
             COALESCE(SUM(outputTokens), 0) AS outputTokens,
-            COUNT(outputTokens) AS outputKnown
+            COALESCE(SUM(CASE WHEN outputTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS outputKnown
         FROM token_usage_records
         WHERE (:allModels OR (provider || ':' || model) IN (:providerModels))
         GROUP BY provider, model, configId
@@ -119,17 +122,17 @@ abstract class TokenUsageDao {
             provider AS provider,
             model AS model,
             configId AS configId,
-            COUNT(*) AS requests,
+            COALESCE(SUM(requestCount), 0) AS requests,
             COALESCE(SUM(uncachedInputTokens), 0) AS uncachedInputTokens,
-            COUNT(uncachedInputTokens) AS uncachedInputKnown,
+            COALESCE(SUM(CASE WHEN uncachedInputTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS uncachedInputKnown,
             COALESCE(SUM(cachedInputTokens), 0) AS cachedInputTokens,
-            COUNT(cachedInputTokens) AS cachedInputKnown,
+            COALESCE(SUM(CASE WHEN cachedInputTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS cachedInputKnown,
             COALESCE(SUM(cacheWriteTokens), 0) AS cacheWriteTokens,
-            COUNT(cacheWriteTokens) AS cacheWriteKnown,
+            COALESCE(SUM(CASE WHEN cacheWriteTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS cacheWriteKnown,
             COALESCE(SUM(totalInputTokens), 0) AS totalInputTokens,
-            COUNT(totalInputTokens) AS totalInputKnown,
+            COALESCE(SUM(CASE WHEN totalInputTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS totalInputKnown,
             COALESCE(SUM(outputTokens), 0) AS outputTokens,
-            COUNT(outputTokens) AS outputKnown
+            COALESCE(SUM(CASE WHEN outputTokens IS NOT NULL THEN requestCount ELSE 0 END), 0) AS outputKnown
         FROM token_usage_records
         WHERE occurredAtMs >= :startMs AND occurredAtMs < :endMs
             AND (:allModels OR (provider || ':' || model) IN (:providerModels))

--- a/app/src/main/java/com/ai/assistance/operit/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/db/AppDatabase.kt
@@ -250,10 +250,12 @@ abstract class AppDatabase : RoomDatabase() {
                         """
                         CREATE TABLE IF NOT EXISTS `token_usage_records` (
                             `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                            `occurredAtMs` INTEGER NOT NULL,
+                            `importKey` TEXT,
+                            `occurredAtMs` INTEGER,
                             `configId` TEXT NOT NULL,
                             `provider` TEXT NOT NULL,
                             `model` TEXT NOT NULL,
+                            `requestCount` INTEGER NOT NULL DEFAULT 1,
                             `uncachedInputTokens` INTEGER,
                             `cachedInputTokens` INTEGER,
                             `cacheWriteTokens` INTEGER,
@@ -287,6 +289,44 @@ abstract class AppDatabase : RoomDatabase() {
                             `pricePerRequest` REAL,
                             PRIMARY KEY(`configId`, `provider`, `model`)
                         )
+                        """.trimIndent()
+                    )
+                    exec(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS `index_token_usage_records_importKey` " +
+                            "ON `token_usage_records` (`importKey`)"
+                    )
+                    // Preserve token-bearing history before the new ledger starts recording requests.
+                    exec(
+                        """
+                        INSERT INTO `token_usage_records` (
+                            `occurredAtMs`, `configId`, `provider`, `model`,
+                            `requestCount`, `uncachedInputTokens`, `cachedInputTokens`, `totalInputTokens`, `outputTokens`
+                        )
+                        SELECT
+                            `timestamp`, '', `provider`, `modelName`, 1,
+                            MAX(`inputTokens` - `cachedInputTokens`, 0), `cachedInputTokens`,
+                            `inputTokens`, `outputTokens`
+                        FROM `messages`
+                        WHERE `sender` = 'ai'
+                            AND TRIM(`provider`) <> ''
+                            AND TRIM(`modelName`) <> ''
+                            AND (`inputTokens` > 0 OR `cachedInputTokens` > 0 OR `outputTokens` > 0)
+                        """.trimIndent()
+                    )
+                    exec(
+                        """
+                        INSERT INTO `token_usage_records` (
+                            `occurredAtMs`, `configId`, `provider`, `model`,
+                            `requestCount`, `uncachedInputTokens`, `cachedInputTokens`, `totalInputTokens`, `outputTokens`
+                        )
+                        SELECT
+                            `messageTimestamp`, '', `provider`, `modelName`, 1,
+                            MAX(`inputTokens` - `cachedInputTokens`, 0), `cachedInputTokens`,
+                            `inputTokens`, `outputTokens`
+                        FROM `message_variants`
+                        WHERE TRIM(`provider`) <> ''
+                            AND TRIM(`modelName`) <> ''
+                            AND (`inputTokens` > 0 OR `cachedInputTokens` > 0 OR `outputTokens` > 0)
                         """.trimIndent()
                     )
                 }

--- a/app/src/main/java/com/ai/assistance/operit/data/model/TokenUsageRecordEntity.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/model/TokenUsageRecordEntity.kt
@@ -10,14 +10,17 @@ import androidx.room.PrimaryKey
     indices = [
         Index(value = ["occurredAtMs"]),
         Index(value = ["provider", "model", "configId", "occurredAtMs"]),
+        Index(value = ["importKey"], unique = true),
     ],
 )
 data class TokenUsageRecordEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0L,
-    val occurredAtMs: Long,
+    val importKey: String? = null,
+    val occurredAtMs: Long?,
     val configId: String,
     val provider: String,
     val model: String,
+    val requestCount: Long,
     val uncachedInputTokens: Long? = null,
     val cachedInputTokens: Long? = null,
     val cacheWriteTokens: Long? = null,

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ApiPreferences.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ApiPreferences.kt
@@ -18,8 +18,10 @@ import com.ai.assistance.operit.data.model.ModelParameter
 import com.ai.assistance.operit.data.model.ParameterCategory
 import com.ai.assistance.operit.data.model.ParameterValueType
 import com.ai.assistance.operit.data.stats.ModelPriceSettings
+import com.ai.assistance.operit.data.stats.ReleasedProviderModelKey
 import com.ai.assistance.operit.data.stats.ReleasedProviderModelKeyDecoder
 import com.ai.assistance.operit.plugins.toolpkg.ToolPkgAiProviderRegistry
+import com.ai.assistance.operit.util.AppLogger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -532,8 +534,23 @@ class ApiPreferences private constructor(private val context: Context) {
                 ?.let { prefix -> encodedPrices += key.name.removePrefix(prefix) }
         }
         val providerAliases = releasedTokenProviderAliases()
+        val skippedLegacyKeys = linkedSetOf<String>()
+
+        // These keys are from the pre-provider/model format. They cannot be assigned
+        // accurately, so skip them while allowing the rest of the migration to finish.
+        fun decodeReleasedKeyOrSkip(encoded: String): ReleasedProviderModelKey? {
+            val decoded = ReleasedProviderModelKeyDecoder.decodeOrNull(encoded, providerAliases)
+            if (decoded == null && skippedLegacyKeys.add(encoded)) {
+                AppLogger.w(
+                    "ApiPreferences",
+                    "Skipping legacy token statistics key without provider/model: $encoded",
+                )
+            }
+            return decoded
+        }
+
         val totals = encodedTotals.mapNotNull { encoded ->
-            val key = ReleasedProviderModelKeyDecoder.decode(encoded, providerAliases)
+            val key = decodeReleasedKeyOrSkip(encoded) ?: return@mapNotNull null
             val input = readTokenCount(preferences, getTokenInputKey(key.storedProviderModel).name)
             val cached = readTokenCount(preferences, getTokenCachedInputKey(key.storedProviderModel).name)
             val output = readTokenCount(preferences, getTokenOutputKey(key.storedProviderModel).name)
@@ -549,7 +566,7 @@ class ApiPreferences private constructor(private val context: Context) {
         }.groupBy { it.provider to it.model }
             .map { (_, values) -> values.reduce(ReleasedTokenUsageTotal::plus) }
         val prices = encodedPrices.mapNotNull { encoded ->
-            val key = ReleasedProviderModelKeyDecoder.decode(encoded, providerAliases)
+            val key = decodeReleasedKeyOrSkip(encoded) ?: return@mapNotNull null
             val billingMode = preferences[getBillingModeKey(key.storedProviderModel)]?.let(BillingMode::valueOf)
             val inputPrice = positivePrice(preferences[getModelInputPriceKey(key.storedProviderModel)])
             val cachedInputPrice = positivePrice(preferences[getModelCachedInputPriceKey(key.storedProviderModel)])

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ApiPreferences.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ApiPreferences.kt
@@ -5,13 +5,21 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.ai.assistance.operit.data.collects.PricingCurrency
+import com.ai.assistance.operit.data.model.ApiProviderType
+import com.ai.assistance.operit.data.model.BillingMode
 import com.ai.assistance.operit.data.model.FunctionType
 import com.ai.assistance.operit.data.model.ModelParameter
 import com.ai.assistance.operit.data.model.ParameterCategory
 import com.ai.assistance.operit.data.model.ParameterValueType
+import com.ai.assistance.operit.data.stats.ModelPriceSettings
+import com.ai.assistance.operit.data.stats.ReleasedProviderModelKeyDecoder
+import com.ai.assistance.operit.plugins.toolpkg.ToolPkgAiProviderRegistry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -31,6 +39,9 @@ class ApiPreferences private constructor(private val context: Context) {
     companion object {
         @Volatile
         private var INSTANCE: ApiPreferences? = null
+
+        internal var toolPkgProviderAliasesProvider: (() -> Map<String, String>)? = null
+        internal var configuredProviderIdsProvider: (suspend () -> List<String>)? = null
 
         fun getInstance(context: Context): ApiPreferences {
             return INSTANCE ?: synchronized(this) {
@@ -68,6 +79,30 @@ class ApiPreferences private constructor(private val context: Context) {
                 getInstance(context).saveFeatureToggle(normalized, enabled)
             }
         }
+
+        private fun getTokenInputKey(providerModel: String) =
+            longPreferencesKey("token_input_${providerModel.replace(":", "_")}")
+        private fun getTokenCachedInputKey(providerModel: String) =
+            longPreferencesKey("token_cached_input_${providerModel.replace(":", "_")}")
+        private fun getTokenOutputKey(providerModel: String) =
+            longPreferencesKey("token_output_${providerModel.replace(":", "_")}")
+        private fun getModelInputPriceKey(providerModel: String) =
+            floatPreferencesKey("model_input_price_${providerModel.replace(":", "_")}")
+        private fun getModelCachedInputPriceKey(providerModel: String) =
+            floatPreferencesKey("model_cached_input_price_${providerModel.replace(":", "_")}")
+        private fun getModelOutputPriceKey(providerModel: String) =
+            floatPreferencesKey("model_output_price_${providerModel.replace(":", "_")}")
+        private fun getRequestCountKey(providerModel: String) =
+            intPreferencesKey("request_count_${providerModel.replace(":", "_")}")
+        private fun getBillingModeKey(providerModel: String) =
+            stringPreferencesKey("billing_mode_${providerModel.replace(":", "_")}")
+        private fun getPricePerRequestKey(providerModel: String) =
+            floatPreferencesKey("price_per_request_${providerModel.replace(":", "_")}")
+        private val RELEASED_MODEL_PRICE_KEY_PREFIXES = listOf(
+            "model_input_price_", "model_cached_input_price_", "model_output_price_",
+            "billing_mode_", "price_per_request_",
+        )
+        private val USD_TO_CNY_EXCHANGE_RATE = floatPreferencesKey("usd_to_cny_exchange_rate")
 
         val KEEP_SCREEN_ON = booleanPreferencesKey("keep_screen_on")
         val FEATURE_TOGGLES_JSON = stringPreferencesKey("feature_toggles_json")
@@ -477,6 +512,123 @@ class ApiPreferences private constructor(private val context: Context) {
         }
     }
 
+    /** Reads released cumulative statistics once before Room takes ownership. */
+    suspend fun readTokenStatsMigrationSnapshot(): TokenStatsMigrationSnapshot {
+        val preferences = context.apiDataStore.data.first()
+        val counterPrefixes = listOf(
+            "token_input_",
+            "token_cached_input_",
+            "token_output_",
+            "request_count_",
+        )
+        val encodedTotals = linkedSetOf<String>()
+        val encodedPrices = linkedSetOf<String>()
+        preferences.asMap().keys.forEach { key ->
+            counterPrefixes.firstOrNull { key.name.startsWith(it) }?.let { prefix ->
+                encodedTotals += key.name.removePrefix(prefix)
+            }
+            RELEASED_MODEL_PRICE_KEY_PREFIXES
+                .firstOrNull { key.name.startsWith(it) }
+                ?.let { prefix -> encodedPrices += key.name.removePrefix(prefix) }
+        }
+        val providerAliases = releasedTokenProviderAliases()
+        val totals = encodedTotals.mapNotNull { encoded ->
+            val key = ReleasedProviderModelKeyDecoder.decode(encoded, providerAliases)
+            val input = readTokenCount(preferences, getTokenInputKey(key.storedProviderModel).name)
+            val cached = readTokenCount(preferences, getTokenCachedInputKey(key.storedProviderModel).name)
+            val output = readTokenCount(preferences, getTokenOutputKey(key.storedProviderModel).name)
+            val requestCount = preferences.asMap().entries
+                .firstOrNull { it.key.name == getRequestCountKey(key.storedProviderModel).name }
+                ?.value
+                ?.let { it as? Number }
+                ?.toLong()
+                ?.coerceAtLeast(0L)
+                ?: 0L
+            ReleasedTokenUsageTotal(key.provider, key.model, input, cached, output, requestCount)
+                .takeIf { input > 0L || cached > 0L || output > 0L || requestCount > 0L }
+        }.groupBy { it.provider to it.model }
+            .map { (_, values) -> values.reduce(ReleasedTokenUsageTotal::plus) }
+        val prices = encodedPrices.mapNotNull { encoded ->
+            val key = ReleasedProviderModelKeyDecoder.decode(encoded, providerAliases)
+            val billingMode = preferences[getBillingModeKey(key.storedProviderModel)]?.let(BillingMode::valueOf)
+            val inputPrice = positivePrice(preferences[getModelInputPriceKey(key.storedProviderModel)])
+            val cachedInputPrice = positivePrice(preferences[getModelCachedInputPriceKey(key.storedProviderModel)])
+            val outputPrice = positivePrice(preferences[getModelOutputPriceKey(key.storedProviderModel)])
+            val pricePerRequest = positivePrice(preferences[getPricePerRequestKey(key.storedProviderModel)])
+            if (billingMode == null && inputPrice == null && cachedInputPrice == null &&
+                outputPrice == null && pricePerRequest == null) return@mapNotNull null
+            ReleasedTokenPriceSetting(
+                key.provider,
+                key.model,
+                ModelPriceSettings(
+                    billingMode = billingMode,
+                    currency = if (billingMode == BillingMode.COUNT) PricingCurrency.CNY else PricingCurrency.USD,
+                    inputPricePerMillion = inputPrice,
+                    cachedInputPricePerMillion = cachedInputPrice,
+                    outputPricePerMillion = outputPrice,
+                    pricePerRequest = pricePerRequest,
+                )
+            )
+        }.groupBy { it.provider to it.model }.map { (identity, values) ->
+            val settings = values.map(ReleasedTokenPriceSetting::settings).distinct()
+            require(settings.size == 1) { "Conflicting released prices for ${identity.first}:${identity.second}" }
+            ReleasedTokenPriceSetting(identity.first, identity.second, settings.single())
+        }
+        return TokenStatsMigrationSnapshot(
+            totals = totals,
+            prices = prices,
+            usdToCnyRate = preferences[USD_TO_CNY_EXCHANGE_RATE]
+                ?.takeIf { it.isFinite() && it > 0f }
+                ?.toDouble(),
+        )
+    }
+
+    /** Removes only old statistics keys after their Room import is complete. */
+    suspend fun clearMigratedTokenStatsData() {
+        context.apiDataStore.edit { preferences ->
+            val prefixes = listOf(
+                "token_input_", "token_cached_input_", "token_output_", "request_count_",
+                "model_input_price_", "model_cached_input_price_", "model_cache_write_price_",
+                "model_output_price_", "model_pricing_currency_", "billing_mode_",
+                "price_per_request_", "stats_",
+            )
+            preferences.asMap().keys
+                .filter { it == USD_TO_CNY_EXCHANGE_RATE || prefixes.any(it.name::startsWith) }
+                .forEach { key ->
+                    @Suppress("UNCHECKED_CAST")
+                    preferences.remove(key as Preferences.Key<Any>)
+                }
+        }
+    }
+
+    private fun readTokenCount(preferences: Preferences, keyName: String): Long {
+        val values = preferences.asMap().entries.filter { it.key.name == keyName }.map { it.value }
+        return when (val value = values.firstOrNull { it is Long } ?: values.firstOrNull()) {
+            is Long -> value
+            is Int -> if (value < 0) value.toLong() and 0xFFFF_FFFFL else value.toLong()
+            else -> 0L
+        }
+    }
+
+    private suspend fun releasedTokenProviderAliases(): Map<String, String> {
+        val registered = toolPkgProviderAliasesProvider?.invoke()
+            ?: ToolPkgAiProviderRegistry.releasedTokenProviderAliases()
+        val configured = configuredProviderIdsProvider?.invoke()
+            ?: ModelConfigManager(context).getAllConfigSummaries().map { it.apiProviderTypeId }
+        return buildMap {
+            configured.map(String::trim).filter(String::isNotEmpty)
+                .filter { ApiProviderType.fromProviderTypeId(it) == null }
+                .forEach { providerId ->
+                    put(providerId, providerId)
+                    put("TOOLPKG_${providerId.lowercase()}", providerId)
+                }
+            putAll(registered)
+        }
+    }
+
+    private fun positivePrice(value: Float?): Double? =
+        value?.toDouble()?.takeIf { it.isFinite() && it > 0.0 }
+
     suspend fun saveMaxImageHistoryUserTurns(turns: Int) {
         context.apiDataStore.edit { preferences ->
             preferences[MAX_IMAGE_HISTORY_USER_TURNS] = turns
@@ -506,3 +658,34 @@ class ApiPreferences private constructor(private val context: Context) {
         }
     }
 }
+
+data class TokenStatsMigrationSnapshot(
+    val totals: List<ReleasedTokenUsageTotal>,
+    val prices: List<ReleasedTokenPriceSetting>,
+    val usdToCnyRate: Double?,
+)
+
+data class ReleasedTokenUsageTotal(
+    val provider: String,
+    val model: String,
+    val inputTokens: Long,
+    val cachedInputTokens: Long,
+    val outputTokens: Long,
+    val requestCount: Long,
+) {
+    operator fun plus(other: ReleasedTokenUsageTotal): ReleasedTokenUsageTotal {
+        require(provider == other.provider && model == other.model)
+        return copy(
+            inputTokens = Math.addExact(inputTokens, other.inputTokens),
+            cachedInputTokens = Math.addExact(cachedInputTokens, other.cachedInputTokens),
+            outputTokens = Math.addExact(outputTokens, other.outputTokens),
+            requestCount = Math.addExact(requestCount, other.requestCount),
+        )
+    }
+}
+
+data class ReleasedTokenPriceSetting(
+    val provider: String,
+    val model: String,
+    val settings: ModelPriceSettings,
+)

--- a/app/src/main/java/com/ai/assistance/operit/data/stats/ReleasedProviderModelKeyDecoder.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/stats/ReleasedProviderModelKeyDecoder.kt
@@ -40,4 +40,15 @@ internal object ReleasedProviderModelKeyDecoder {
             model = model,
         )
     }
+
+    /** Used by migration code for released keys from before provider/model identities existed. */
+    fun decodeOrNull(
+        encoded: String,
+        additionalProviderAliases: Map<String, String> = emptyMap(),
+    ): ReleasedProviderModelKey? =
+        try {
+            decode(encoded, additionalProviderAliases)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
 }

--- a/app/src/main/java/com/ai/assistance/operit/data/stats/ReleasedProviderModelKeyDecoder.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/stats/ReleasedProviderModelKeyDecoder.kt
@@ -1,0 +1,43 @@
+package com.ai.assistance.operit.data.stats
+
+import com.ai.assistance.operit.data.model.ApiProviderType
+
+internal data class ReleasedProviderModelKey(
+    val storedProviderModel: String,
+    val provider: String,
+    val model: String,
+)
+
+/** Decodes released `provider:model` keys stored as `provider_model`. */
+internal object ReleasedProviderModelKeyDecoder {
+    private val builtInProviderAliases = ApiProviderType.entries.associate { it.name to it.name }
+
+    fun decode(
+        encoded: String,
+        additionalProviderAliases: Map<String, String> = emptyMap(),
+    ): ReleasedProviderModelKey {
+        val aliases = buildMap {
+            putAll(builtInProviderAliases)
+            additionalProviderAliases.forEach { (rawAlias, rawIdentity) ->
+                val alias = rawAlias.trim()
+                val identity = rawIdentity.trim()
+                require(alias.isNotEmpty() && identity.isNotEmpty())
+                val previous = put(alias, identity)
+                require(previous == null || previous == identity)
+            }
+        }
+        val known = aliases.keys.sortedByDescending(String::length)
+            .firstOrNull { encoded == it || encoded.startsWith("${it}_") }
+        val separator = known?.length ?: encoded.indexOf('_')
+        require(separator > 0 && separator < encoded.lastIndex) {
+            "released token key does not contain a provider and model: $encoded"
+        }
+        val providerAlias = encoded.substring(0, separator)
+        val model = encoded.substring(separator + 1)
+        return ReleasedProviderModelKey(
+            storedProviderModel = "$providerAlias:$model",
+            provider = if (known == null) providerAlias else aliases.getValue(providerAlias),
+            model = model,
+        )
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/data/stats/TokenStatsPreferences.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/stats/TokenStatsPreferences.kt
@@ -21,9 +21,19 @@ internal class TokenStatsPreferences(context: Context) {
         private val USD_TO_CNY_RATE = doublePreferencesKey("usd_to_cny_rate")
         private val TIME_RANGE_START = longPreferencesKey("time_range_start")
         private val TIME_RANGE_END = longPreferencesKey("time_range_end")
+        private val IMPORTED_AT = longPreferencesKey("imported_at_ms")
     }
 
     private val dataStore = context.applicationContext.tokenStatsDataStore
+
+    suspend fun importedAtMs(): Long? = dataStore.data.first()[IMPORTED_AT]
+
+    suspend fun completeMigration(importedAtMs: Long, releasedUsdToCnyRate: Double?) {
+        dataStore.edit { preferences ->
+            releasedUsdToCnyRate?.let { preferences[USD_TO_CNY_RATE] = it }
+            preferences[IMPORTED_AT] = importedAtMs
+        }
+    }
 
     suspend fun loadRateWithEstimate(): Pair<Double, Boolean> {
         val stored = dataStore.data.first()[USD_TO_CNY_RATE]

--- a/app/src/main/java/com/ai/assistance/operit/data/stats/TokenUsageRepository.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/stats/TokenUsageRepository.kt
@@ -1,15 +1,20 @@
 package com.ai.assistance.operit.data.stats
 
 import android.content.Context
+import androidx.room.withTransaction
 import com.ai.assistance.operit.data.dao.TokenUsageDao
 import com.ai.assistance.operit.data.db.AppDatabase
+import com.ai.assistance.operit.data.model.TokenStatsModelEntity
 import com.ai.assistance.operit.data.model.TokenUsageRecordEntity
+import com.ai.assistance.operit.data.preferences.ApiPreferences
+import com.ai.assistance.operit.util.AppLogger
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /** Room owner for successful formal-inference usage and pricing. */
 class TokenUsageRepository private constructor(context: Context) {
     companion object {
+        private const val TAG = "TokenUsageRepository"
         @Volatile
         private var instance: TokenUsageRepository? = null
         private val databaseAccessMutex = Mutex()
@@ -28,9 +33,72 @@ class TokenUsageRepository private constructor(context: Context) {
     }
 
     private val appContext = context.applicationContext
+    private val legacyDataSource = ApiPreferences.getInstance(appContext)
+    private val statsPreferences = TokenStatsPreferences(appContext)
+    private val importMutex = Mutex()
 
-    internal suspend fun <T> withDao(block: suspend (TokenUsageDao) -> T): T =
-        withDatabaseAccess { block(AppDatabase.getDatabase(appContext).tokenUsageDao()) }
+    @Volatile
+    private var initializationComplete = false
+
+    suspend fun ensureInitialized() {
+        if (initializationComplete) return
+        importMutex.withLock {
+            if (initializationComplete) return
+            if (statsPreferences.importedAtMs() == null) {
+                val snapshot = legacyDataSource.readTokenStatsMigrationSnapshot()
+                withDatabaseAccess {
+                    val database = AppDatabase.getDatabase(appContext)
+                    database.withTransaction {
+                        val dao = database.tokenUsageDao()
+                        dao.insertRecords(
+                            snapshot.totals.map { total ->
+                                TokenUsageRecordEntity(
+                                    importKey = "legacy-cumulative:${total.provider}:${total.model}",
+                                    occurredAtMs = null,
+                                    configId = "",
+                                    provider = total.provider,
+                                    model = total.model,
+                                    requestCount = total.requestCount,
+                                    uncachedInputTokens =
+                                        (total.inputTokens - total.cachedInputTokens).coerceAtLeast(0L),
+                                    cachedInputTokens = total.cachedInputTokens,
+                                    totalInputTokens = total.inputTokens,
+                                    outputTokens = total.outputTokens,
+                                )
+                            }
+                        )
+                        snapshot.prices.forEach { price ->
+                            val current = dao.getStatsModel("", price.provider, price.model)
+                                ?: TokenStatsModelEntity("", price.provider, price.model)
+                            dao.upsertStatsModel(
+                                current.copy(
+                                    billingMode = price.settings.billingMode?.name,
+                                    currency = price.settings.currency?.name,
+                                    inputPricePerMillion = price.settings.inputPricePerMillion,
+                                    cachedInputPricePerMillion = price.settings.cachedInputPricePerMillion,
+                                    cacheWritePricePerMillion = price.settings.cacheWritePricePerMillion,
+                                    outputPricePerMillion = price.settings.outputPricePerMillion,
+                                    pricePerRequest = price.settings.pricePerRequest,
+                                )
+                            )
+                        }
+                    }
+                }
+                statsPreferences.completeMigration(
+                    importedAtMs = System.currentTimeMillis(),
+                    releasedUsdToCnyRate = snapshot.usdToCnyRate,
+                )
+                AppLogger.i(TAG, "Imported ${snapshot.totals.size} cumulative totals and ${snapshot.prices.size} price settings")
+            }
+            legacyDataSource.clearMigratedTokenStatsData()
+            initializationComplete = true
+        }
+    }
+
+    internal suspend fun <T> withDao(block: suspend (TokenUsageDao) -> T): T {
+        ensureInitialized()
+        return withDatabaseAccess { block(AppDatabase.getDatabase(appContext).tokenUsageDao()) }
+    }
 
     suspend fun record(record: TokenUsageRecordEntity) {
         withDao { dao -> dao.insertRecord(record) }

--- a/app/src/test/java/com/ai/assistance/operit/data/stats/ReleasedProviderModelKeyDecoderTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/stats/ReleasedProviderModelKeyDecoderTest.kt
@@ -1,0 +1,28 @@
+package com.ai.assistance.operit.data.stats
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReleasedProviderModelKeyDecoderTest {
+    @Test
+    fun `provider model key decodes with provider aliases`() {
+        assertEquals(
+            ReleasedProviderModelKey(
+                storedProviderModel = "TOOLPKG_example_provider:deepseek-chat",
+                provider = "Example Provider",
+                model = "deepseek-chat",
+            ),
+            ReleasedProviderModelKeyDecoder.decodeOrNull(
+                "TOOLPKG_example_provider_deepseek-chat",
+                mapOf("TOOLPKG_example_provider" to "Example Provider"),
+            ),
+        )
+    }
+
+    @Test
+    fun `pre provider model function key is skipped`() {
+        assertNull(ReleasedProviderModelKeyDecoder.decodeOrNull("CHAT"))
+        assertNull(ReleasedProviderModelKeyDecoder.decodeOrNull("FILE_BINDING"))
+    }
+}

--- a/docs/TODO/token_stats_restore_20260821/1_migration_paths.md
+++ b/docs/TODO/token_stats_restore_20260821/1_migration_paths.md
@@ -1,0 +1,8 @@
+# Migration Paths
+
+The Room migration owns rows that already exist in `messages` and
+`message_variants`. The repository importer owns released cumulative counters and
+pricing because those values live outside Room. Both paths are one-time operations
+and retain data before removing obsolete legacy keys.
+
+[DONE]

--- a/docs/TODO/token_stats_restore_20260821/1_migration_paths.md
+++ b/docs/TODO/token_stats_restore_20260821/1_migration_paths.md
@@ -5,4 +5,9 @@ The Room migration owns rows that already exist in `messages` and
 pricing because those values live outside Room. Both paths are one-time operations
 and retain data before removing obsolete legacy keys.
 
+Legacy counters whose suffix is only a function name, such as `CHAT`, `SUMMARY`, or
+`FILE_BINDING`, predate provider/model identities. They are intentionally skipped
+during import because they cannot be assigned to a provider and model; the normal
+post-import cleanup removes those obsolete keys after the migration succeeds.
+
 [DONE]

--- a/docs/TODO/token_stats_restore_20260821/index.md
+++ b/docs/TODO/token_stats_restore_20260821/index.md
@@ -21,10 +21,14 @@ token-bearing chat history while keeping new requests in the current Room schema
 - `MIGRATION_20_21` copies existing assistant messages and message variants.
 - The first token repository initialization imports old cumulative counters and
   custom prices from `api_settings`, then marks and clears the legacy keys.
+- Pre-provider/model function counters are intentionally skipped because they
+  cannot be attributed to a model; their obsolete keys are cleared with the rest
+  of the migrated statistics.
 - No build or test commands are run locally.
 
 ## Steps
 
 1. [DONE] Restore the Room history copy.
 2. [DONE] Restore the legacy DataStore import marker and importer.
-3. [DONE] Review the resulting migration paths.
+3. [DONE] Skip pre-provider/model counters without aborting migration.
+4. [DONE] Review the resulting migration paths.

--- a/docs/TODO/token_stats_restore_20260821/index.md
+++ b/docs/TODO/token_stats_restore_20260821/index.md
@@ -1,0 +1,30 @@
+---
+fork_repository: https://github.com/luojiaping/Operit.git
+working_branch: feat/release-version-bump
+---
+
+# Restore Token Statistics Migration
+
+## Background
+
+The token statistics rewrite removed the one-time import from released `api_settings`
+keys and removed copying token-bearing assistant messages into the Room ledger.
+That would make an upgrade appear to lose historical usage.
+
+## Intent
+
+Restore a one-time, idempotent migration for both legacy cumulative statistics and
+token-bearing chat history while keeping new requests in the current Room schema.
+
+## Scope
+
+- `MIGRATION_20_21` copies existing assistant messages and message variants.
+- The first token repository initialization imports old cumulative counters and
+  custom prices from `api_settings`, then marks and clears the legacy keys.
+- No build or test commands are run locally.
+
+## Steps
+
+1. [DONE] Restore the Room history copy.
+2. [DONE] Restore the legacy DataStore import marker and importer.
+3. [DONE] Review the resulting migration paths.

--- a/docs/TODO/token_stats_success_only_20260816/2_remove_filters_and_legacy.md
+++ b/docs/TODO/token_stats_success_only_20260816/2_remove_filters_and_legacy.md
@@ -8,15 +8,15 @@ imports legacy cumulative totals.
 
 ## Intended Behavior
 
-Range analysis retains model filtering only. The ledger contains direct formal
-inference facts rather than copied conversations or cumulative counters.
+Range analysis retains model filtering only. The ledger records direct formal
+inference facts and preserves historical data through one-time upgrade imports.
 
 ## Work
 
 - Delete category and status types, UI controls, strings, query parameters, SQL
   clauses, breakdown queries, entity columns, and indexes.
-- Delete legacy usage-row import code and the historical conversation copy from
-  the unpublished schema creation.
+- Keep the one-time legacy usage-row import and historical conversation copy;
+  removing them would discard user-visible statistics during upgrade.
 - Keep current pricing settings and their storage because normal-request cost
   calculations still need them.
 
@@ -25,9 +25,9 @@ inference facts rather than copied conversations or cumulative counters.
 [DONE]
 
 - Category and status types, UI controls, strings, query parameters, SQL
-  clauses, entity columns, indexes, and the historical chat-copy and cumulative
-  usage imports are deleted; range analysis keeps model filtering only.
+  clauses, entity columns, and indexes are deleted; range analysis keeps model
+  filtering only. Historical chat-copy and cumulative usage imports remain as
+  one-time upgrade paths.
 - Pricing decision: released `api_settings` custom prices and the legacy
-  `usd_to_cny_exchange_rate` are NOT migrated. The unpublished v21 storage
-  starts fresh with built-in model prices and the estimated default rate, so
-  `ReleasedProviderModelKeyDecoder` and its bridge stay deleted.
+  `usd_to_cny_exchange_rate` are migrated once into Room and token-stat
+  preferences.

--- a/docs/TODO/token_stats_success_only_20260816/index.md
+++ b/docs/TODO/token_stats_success_only_20260816/index.md
@@ -25,13 +25,13 @@ page use only the active primary and secondary theme families.
 
 - The current v20-to-v21 token statistics schema is unpublished. Edit it as the
   final schema and do not introduce another database version transition.
-- Do not import historical chat counters or legacy cumulative token totals into
-  the new ledger because they cannot prove the success-only invariant.
+- Import historical chat counters and legacy cumulative token totals once during
+  upgrade so users do not lose visible statistics. Timestamp-free cumulative
+  rows remain outside dated trend buckets.
 - Retain pricing, including per-request pricing and cache-write pricing where a
   provider requires it for billing.
-- Released `api_settings` prices and the legacy exchange rate are NOT migrated
-  into the new storage; confirmed as a fresh start. No legacy usage, chat, or
-  cumulative token data is imported under any circumstance.
+- Released `api_settings` prices and the legacy exchange rate are migrated once
+  into the new storage after the Room import completes.
 - Do not run local compilation, builds, or tests. Dispatch the Android build in
   GitHub Actions after the completed commit is pushed.
 


### PR DESCRIPTION
## Summary
- skip pre-provider/model token statistic keys such as CHAT, SUMMARY, and FILE_BINDING during migration
- preserve provider/model migration and complete cleanup
- bump version to 1.12.1+2
- add decoder regression coverage and migration documentation

No build or tests were run locally per repository instructions.