### PR TITLE
修复：细化模型提供商地域提醒

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
@@ -1,10 +1,10 @@
 package com.ai.assistance.operit.ui.features.settings.sections
 
 import android.annotation.SuppressLint
+import androidx.annotation.StringRes
 import com.ai.assistance.operit.util.AppLogger
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -73,6 +73,31 @@ val TAG = "ModelApiSettings"
 
 private val modelApiSettingsSaveMutex = Mutex()
 
+internal enum class ProviderRegionWarningType {
+    OVERSEAS,
+    INTERNATIONAL_PROXY
+}
+
+internal fun providerRegionWarningType(providerType: ApiProviderType?): ProviderRegionWarningType? =
+    when (providerType) {
+        ApiProviderType.OPENROUTER,
+        ApiProviderType.FOUR_ROUTER -> ProviderRegionWarningType.INTERNATIONAL_PROXY
+        ApiProviderType.OPENAI,
+        ApiProviderType.GOOGLE,
+        ApiProviderType.ANTHROPIC,
+        ApiProviderType.MISTRAL,
+        ApiProviderType.NVIDIA,
+        ApiProviderType.NOUS_PORTAL -> ProviderRegionWarningType.OVERSEAS
+        else -> null
+    }
+
+@StringRes
+private fun ProviderRegionWarningType.messageResource(): Int =
+    when (this) {
+        ProviderRegionWarningType.OVERSEAS -> R.string.overseas_provider_warning
+        ProviderRegionWarningType.INTERNATIONAL_PROXY -> R.string.international_proxy_provider_warning
+    }
+
 private data class ProviderSelectionOption(
     val id: String,
     val displayName: String
@@ -90,8 +115,8 @@ fun ModelApiSettingsSection(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
-    // 区域告警可见性
-    var showRegionWarning by remember { mutableStateOf(false) }
+    // 区域告警类型；null 表示当前无需显示。
+    var regionWarningType by remember(config.id) { mutableStateOf<ProviderRegionWarningType?>(null) }
 
     fun getDefaultModelName(providerTypeId: String): String {
         val providerType = ApiProviderType.fromProviderTypeId(providerTypeId) ?: return ""
@@ -283,29 +308,22 @@ fun ModelApiSettingsSection(
     // 当API提供商改变时更新端点
     LaunchedEffect(selectedProviderTypeId) {
         AppLogger.d("ModelApiSettingsSection", "API提供商改变")
-        if (
-            selectedApiProvider == ApiProviderType.OPENAI ||
-                selectedApiProvider == ApiProviderType.OPENAI_RESPONSES ||
-                selectedApiProvider == ApiProviderType.OPENAI_RESPONSES_GENERIC ||
-                selectedApiProvider == ApiProviderType.OPENAI_GENERIC ||
-                selectedApiProvider == ApiProviderType.GOOGLE ||
-                selectedApiProvider == ApiProviderType.GEMINI_GENERIC ||
-                selectedApiProvider == ApiProviderType.ANTHROPIC ||
-                selectedApiProvider == ApiProviderType.ANTHROPIC_GENERIC ||
-                selectedApiProvider == ApiProviderType.MISTRAL ||
-                selectedApiProvider == ApiProviderType.NVIDIA ||
-                selectedApiProvider == ApiProviderType.NOUS_PORTAL
-        ) {
+        // 仅对明确归类的海外官方服务或国际中转服务进行地域提醒。
+        val warningType = providerRegionWarningType(selectedApiProvider)
+        if (warningType != null) {
             val inChina = LocationUtils.isDeviceInMainlandChina(context)
-            showRegionWarning = inChina
+            regionWarningType = warningType.takeIf { inChina }
             if (inChina) {
-                AppLogger.d("ModelApiSettingsSection", "检测到位于中国大陆")
-                showNotification(context.getString(R.string.overseas_provider_warning))
+                AppLogger.d(
+                    "ModelApiSettingsSection",
+                    "检测到位于中国大陆，显示 ${warningType.name} 提醒"
+                )
+                showNotification(context.getString(warningType.messageResource()))
             } else {
                 AppLogger.d("ModelApiSettingsSection", "检测到位于海外")
             }
         } else {
-            showRegionWarning = false
+            regionWarningType = null
         }
 
         val shouldSyncEndpointByProviderChange = hasInitializedProviderEndpointSync
@@ -464,8 +482,8 @@ fun ModelApiSettingsSection(
                 )
             }
 
-            AnimatedVisibility(visible = showRegionWarning) {
-                SettingsInfoBanner(text = stringResource(R.string.overseas_provider_warning))
+            regionWarningType?.let { warningType ->
+                SettingsInfoBanner(text = stringResource(warningType.messageResource()))
             }
 
             if (isMnnProvider) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -4451,6 +4451,7 @@
 
     <!-- Model Configuration -->
     <string name="overseas_provider_warning">Detected that you are in mainland China but selected an overseas service provider. Please confirm whether you have enabled proxy tools</string>
+    <string name="international_proxy_provider_warning">This service routes requests through an international third-party proxy. Access from mainland China requires a proxy tool. Request data will be relayed by a third party; review your network environment, terms of service, and data compliance requirements.</string>
 
         <!-- Token Config WebView & URL Config Dialog -->
     <string name="custom_url_config">Custom URL Configuration</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3781,6 +3781,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="parameter_value">Valor del parámetro</string>
     <string name="parameter_range_format">Rango: %1$s - %2$s</string>
     <string name="overseas_provider_warning">Detectamos que se encuentra en China continental, pero ha seleccionado un proveedor extranjero. Confirme si ha activado la herramienta proxy</string>
+    <string name="international_proxy_provider_warning">Este servicio enruta las solicitudes mediante un proxy internacional de terceros. El acceso desde China continental requiere una herramienta proxy. Los datos de las solicitudes serán retransmitidos por un tercero; revise su entorno de red, los términos del servicio y los requisitos de cumplimiento de datos.</string>
     <string name="custom_parameter_added">Parámetro personalizado agregado</string>
     <string name="parameter_name">Nombre del parámetro</string>
     <string name="parameter_name_placeholder">Por ejemplo: Mi parámetro</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -3499,6 +3499,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="parameter_value">Nilai Parameter</string>
     <string name="parameter_range_format">Rentang: %1$s - %2$s</string>
     <string name="overseas_provider_warning">Terdeteksi Anda berada di Tiongkok Daratan, tetapi memilih penyedia layanan luar negeri. Harap konfirmasi apakah alat proxy telah diaktifkan</string>
+    <string name="international_proxy_provider_warning">Layanan ini meneruskan permintaan melalui proksi pihak ketiga internasional. Akses dari Tiongkok Daratan memerlukan alat proksi. Data permintaan akan diteruskan oleh pihak ketiga; perhatikan lingkungan jaringan, ketentuan layanan, dan persyaratan kepatuhan data.</string>
     <string name="custom_parameter_added">Parameter kustom telah ditambahkan</string>
     <string name="parameter_name">Nama Parameter</string>
     <string name="parameter_name_placeholder">Contoh: Parameter Saya</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -3566,6 +3566,7 @@
     <string name="parameter_value">매개변수 값</string>
     <string name="parameter_range_format">범위: %1$s - %2$s</string>
     <string name="overseas_provider_warning">귀하가 중국 본토에 있는 것으로 감지되었지만 해외 서비스 제공업체를 선택했습니다. 프록시 도구를 활성화했는지 확인하세요.</string>
+    <string name="international_proxy_provider_warning">이 서비스는 국제 제3자 프록시를 통해 요청을 중계합니다. 중국 본토에서 접속하려면 프록시 도구가 필요합니다. 요청 데이터가 제3자를 통해 전달되므로 네트워크 환경, 서비스 약관 및 데이터 규정 준수 요건을 확인하세요.</string>
     <string name="custom_parameter_added">맞춤 매개변수 추가됨</string>
     <string name="parameter_name">매개변수 이름</string>
     <string name="parameter_name_placeholder">예: 내 매개변수</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -3500,6 +3500,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="parameter_value">Nilai parameter</string>
     <string name="parameter_range_format">Julat: %1$s - %2$s</string>
     <string name="overseas_provider_warning">Dikesan anda berada di tanah besar China, tetapi memilih pembekal perkhidmatan luar negara. Sila sahkan sama ada alat proksi telah dihidupkan</string>
+    <string name="international_proxy_provider_warning">Perkhidmatan ini menyalurkan permintaan melalui proksi pihak ketiga antarabangsa. Akses dari tanah besar China memerlukan alat proksi. Data permintaan akan dihantar melalui pihak ketiga; semak persekitaran rangkaian, terma perkhidmatan dan keperluan pematuhan data.</string>
     <string name="custom_parameter_added">Parameter tersuai telah ditambah</string>
     <string name="parameter_name">Nama parameter</string>
     <string name="parameter_name_placeholder">Contoh: Parameter saya</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -3424,6 +3424,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="parameter_value">Valor do parâmetro</string>
     <string name="parameter_range_format">Intervalo: %1$s - %2$s</string>
     <string name="overseas_provider_warning">Foi detectado que você está na China continental, mas escolheu um provedor de serviços estrangeiro. Por favor, confirme se a ferramenta proxy está habilitada</string>
+    <string name="international_proxy_provider_warning">Este serviço encaminha solicitações por meio de um proxy internacional de terceiros. O acesso a partir da China continental requer uma ferramenta de proxy. Os dados das solicitações serão retransmitidos por terceiros; verifique o ambiente de rede, os termos de serviço e os requisitos de conformidade de dados.</string>
     <string name="custom_parameter_added">Parâmetros personalizados foram adicionados</string>
     <string name="parameter_name">Nome do parâmetro</string>
     <string name="parameter_name_placeholder">Por exemplo: meus parâmetros</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3942,6 +3942,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="parameter_value">Valorile parametrilor</string>
     <string name="parameter_range_format">Domeniu de aplicare: %1$s - %2$s</string>
     <string name="overseas_provider_warning">S-a detectat că vă aflați în China continentală, dar ați selectat un furnizor de servicii din străinătate. Vă rugăm să verificați dacă ați activat instrumentul de proxy.</string>
+    <string name="international_proxy_provider_warning">Acest serviciu direcționează solicitările printr-un proxy internațional terț. Accesul din China continentală necesită un instrument proxy. Datele solicitărilor vor fi retransmise de o terță parte; verificați mediul de rețea, termenii serviciului și cerințele de conformitate a datelor.</string>
 
     <!-- 自定义参数对话框 -->
     <string name="custom_parameter_added">Au fost adăugate parametri personalizați</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4057,6 +4057,7 @@
     <string name="parameter_value">参数值</string>
     <string name="parameter_range_format">范围: %1$s - %2$s</string>
     <string name="overseas_provider_warning">检测到您在中国大陆，但选择了海外服务商。请确认是否已开启代理工具</string>
+    <string name="international_proxy_provider_warning">该服务通过国际第三方代理中转。在中国大陆访问需要代理工具；请求数据将经第三方转发，请留意网络环境、服务条款与数据合规政策。</string>
     
     <!-- 自定义参数对话框 -->
     <string name="custom_parameter_added">自定义参数已新增</string>

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/settings/sections/ProviderRegionWarningTypeTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/settings/sections/ProviderRegionWarningTypeTest.kt
@@ -1,0 +1,51 @@
+package com.ai.assistance.operit.ui.features.settings.sections
+
+import com.ai.assistance.operit.data.model.ApiProviderType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ProviderRegionWarningTypeTest {
+    @Test
+    fun `generic and responses providers do not force an overseas warning`() {
+        listOf(
+            ApiProviderType.OPENAI_GENERIC,
+            ApiProviderType.OPENAI_RESPONSES,
+            ApiProviderType.OPENAI_RESPONSES_GENERIC,
+            ApiProviderType.ANTHROPIC_GENERIC,
+            ApiProviderType.GEMINI_GENERIC
+        ).forEach { provider ->
+            assertNull(providerRegionWarningType(provider))
+        }
+    }
+
+    @Test
+    fun `router providers use the international proxy warning`() {
+        listOf(
+            ApiProviderType.OPENROUTER,
+            ApiProviderType.FOUR_ROUTER
+        ).forEach { provider ->
+            assertEquals(
+                ProviderRegionWarningType.INTERNATIONAL_PROXY,
+                providerRegionWarningType(provider)
+            )
+        }
+    }
+
+    @Test
+    fun `known overseas official providers keep the overseas warning`() {
+        listOf(
+            ApiProviderType.OPENAI,
+            ApiProviderType.GOOGLE,
+            ApiProviderType.ANTHROPIC,
+            ApiProviderType.MISTRAL,
+            ApiProviderType.NVIDIA,
+            ApiProviderType.NOUS_PORTAL
+        ).forEach { provider ->
+            assertEquals(
+                ProviderRegionWarningType.OVERSEAS,
+                providerRegionWarningType(provider)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 变更说明

细化模型配置页的地域提醒逻辑，避免把通用接口和 OpenAI Responses API 误判为海外服务，同时为明确的国际中转服务提供专属提示。

## 主要改动

- 移除对以下类型的强制“海外服务商”提醒：
  - `OPENAI_GENERIC`
  - `OPENAI_RESPONSES`
  - `OPENAI_RESPONSES_GENERIC`
  - `ANTHROPIC_GENERIC`
  - `GEMINI_GENERIC`
- 保留对明确海外官方服务的提醒：OpenAI、Google、Anthropic、Mistral、NVIDIA、Nous Portal。
- 为 OpenRouter 和 FOUR_ROUTER 增加独立的国际第三方中转提醒：
  - 中国大陆访问需要代理工具；
  - 请求数据会经过第三方转发；
  - 提醒用户留意网络环境、服务条款和数据合规政策。
- 为现有 8 个语言资源补充对应文案。
- 增加 `ProviderRegionWarningTypeTest`，覆盖通用接口、Responses、OpenRouter/FOUR_ROUTER 和海外官方服务的分类逻辑。

## 验证

- `git diff --check`：通过
- `python3 -B -m unittest discover -s ci/test -p 'test_*.py'`：46/46 通过
- 8 个 `strings.xml`：XML 解析通过

本地 Android Gradle 测试受到当前环境缺少 `ffmpeg-kit-local.aar`、terminal 子模块生成 AIDL 文件、外部 native library 和不可运行的本机 `aidl` 阻塞，未将这些环境问题混入本次代码修改。请由 PR CI 完成 Android 编译与 JVM 测试。