### PR TITLE
新增：接入 xAI Grok 提供商

### DIFF
--- a/app/src/main/assets/model_logos/XAI/xai.svg
+++ b/app/src/main/assets/model_logos/XAI/xai.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>xAI</title><path d="M4.2 3.5h3.15l4.53 6.18L16.4 3.5h3.4l-6.28 8.15L20 20.5h-3.3l-4.82-6.6-4.9 6.6H3.6l6.45-8.55z"/></svg>

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIServiceFactory.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIServiceFactory.kt
@@ -316,6 +316,20 @@ object AIServiceFactory {
 
         return when (providerType) {
             // OpenAI格式，支持原生和兼容OpenAI API的服务
+            // xAI uses the OpenAI-compatible Chat Completions protocol.
+            ApiProviderType.XAI ->
+                XaiProvider(
+                    apiEndpoint = config.apiEndpoint,
+                    apiKeyProvider = apiKeyProvider,
+                    modelName = config.modelName,
+                    client = httpClient,
+                    customHeaders = customHeaders,
+                    supportsVision = supportsVision,
+                    supportsAudio = supportsAudio,
+                    supportsVideo = supportsVideo,
+                    enableToolCall = enableToolCall
+                )
+
             ApiProviderType.OPENAI ->
                 OpenAIProvider(
                     apiEndpoint = config.apiEndpoint,

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
@@ -65,6 +65,7 @@ object ModelListFetcher {
         val modelsUrl =
                 when (apiProviderType) {
                     ApiProviderType.OPENAI,
+                    ApiProviderType.XAI,
                     ApiProviderType.OPENAI_RESPONSES,
                     ApiProviderType.OPENAI_RESPONSES_GENERIC,
                     ApiProviderType.OPENAI_GENERIC,
@@ -294,7 +295,7 @@ object ModelListFetcher {
                         val errorBody = response.body?.string() ?: context.getString(R.string.model_fetch_no_error_details)
                         val responseCode = response.code
                         response.close()
-                        if ((apiProviderType == ApiProviderType.OPENAI || apiProviderType == ApiProviderType.OPENAI_RESPONSES || apiProviderType == ApiProviderType.OPENAI_RESPONSES_GENERIC || apiProviderType == ApiProviderType.OPENAI_GENERIC || apiProviderType == ApiProviderType.OPENAI_LOCAL || apiProviderType == ApiProviderType.IFLOW || apiProviderType == ApiProviderType.NVIDIA || apiProviderType == ApiProviderType.LMSTUDIO || apiProviderType == ApiProviderType.OLLAMA || apiProviderType == ApiProviderType.FOUR_ROUTER || apiProviderType == ApiProviderType.NOUS_PORTAL || apiProviderType == ApiProviderType.MIMO) &&
+                        if ((apiProviderType == ApiProviderType.OPENAI || apiProviderType == ApiProviderType.XAI || apiProviderType == ApiProviderType.OPENAI_RESPONSES || apiProviderType == ApiProviderType.OPENAI_RESPONSES_GENERIC || apiProviderType == ApiProviderType.OPENAI_GENERIC || apiProviderType == ApiProviderType.OPENAI_LOCAL || apiProviderType == ApiProviderType.IFLOW || apiProviderType == ApiProviderType.NVIDIA || apiProviderType == ApiProviderType.LMSTUDIO || apiProviderType == ApiProviderType.OLLAMA || apiProviderType == ApiProviderType.FOUR_ROUTER || apiProviderType == ApiProviderType.NOUS_PORTAL || apiProviderType == ApiProviderType.MIMO) &&
                                         modelsUrl.endsWith("/v1/models")) {
                             val fallbackUrl = modelsUrl.removeSuffix("/v1/models") + "/models"
                             AppLogger.w(TAG, "API请求失败，尝试兼容路径: $fallbackUrl")
@@ -346,6 +347,7 @@ object ModelListFetcher {
                             try {
                                 when (apiProviderType) {
                                     ApiProviderType.OPENAI,
+                                    ApiProviderType.XAI,
                                     ApiProviderType.OPENAI_RESPONSES,
                                     ApiProviderType.OPENAI_RESPONSES_GENERIC,
                                     ApiProviderType.OPENAI_GENERIC,

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/XaiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/XaiProvider.kt
@@ -78,18 +78,19 @@ class XaiProvider(
         if (xaiModelSupportsReasoningEffort(modelName)) {
             val existingEffort = requestJson.optString("reasoning_effort", "").trim()
             if (existingEffort.isEmpty()) {
-                val qualityLevel = runCatching {
+                val qualityLevel = try {
                     runBlocking {
                         ApiPreferences.getInstance(context).thinkingQualityLevelFlow.first()
                     }
-                }.getOrElse {
-                    AppLogger.w(
+                } catch (error: Exception) {
+                    AppLogger.e(
                         "XaiProvider",
-                        "Failed to read thinking quality level; using xAI low effort",
-                        it
+                        "Failed to read thinking quality level; aborting xAI request",
+                        error
                     )
-                    1
+                    throw error
                 }
+
                 requestJson.put(
                     "reasoning_effort",
                     XaiReasoningMapper.effortForQuality(enableThinking, qualityLevel)

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/XaiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/XaiProvider.kt
@@ -1,0 +1,102 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import android.content.Context
+import com.ai.assistance.operit.core.chat.hooks.PromptTurn
+import com.ai.assistance.operit.data.model.ApiProviderType
+import com.ai.assistance.operit.data.model.ModelParameter
+import com.ai.assistance.operit.data.model.ToolPrompt
+import com.ai.assistance.operit.data.preferences.ApiPreferences
+import com.ai.assistance.operit.util.AppLogger
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody
+import org.json.JSONObject
+
+/** Maps the app's five quality levels to xAI's supported reasoning efforts. */
+internal object XaiReasoningMapper {
+    private val enabledEfforts = listOf("low", "medium", "medium", "high", "xhigh")
+
+    fun effortForQuality(enableThinking: Boolean, qualityLevel: Int): String {
+        if (!enableThinking) {
+            // xAI reasoning models cannot disable reasoning; use the lowest supported effort.
+            return "low"
+        }
+        return enabledEfforts[qualityLevel.coerceIn(1, 5) - 1]
+    }
+}
+
+internal fun xaiModelSupportsReasoningEffort(modelName: String): Boolean {
+    val normalized = modelName.trim().lowercase()
+    return normalized.startsWith("grok-4.5") || normalized.startsWith("grok-4.6")
+}
+
+/** xAI's OpenAI-compatible Chat Completions provider for Grok models. */
+class XaiProvider(
+    apiEndpoint: String,
+    apiKeyProvider: ApiKeyProvider,
+    modelName: String,
+    client: OkHttpClient,
+    customHeaders: Map<String, String> = emptyMap(),
+    supportsVision: Boolean = false,
+    supportsAudio: Boolean = false,
+    supportsVideo: Boolean = false,
+    enableToolCall: Boolean = false
+) : OpenAIProvider(
+    apiEndpoint = apiEndpoint,
+    apiKeyProvider = apiKeyProvider,
+    modelName = modelName,
+    client = client,
+    customHeaders = customHeaders,
+    providerType = ApiProviderType.XAI,
+    supportsVision = supportsVision,
+    supportsAudio = supportsAudio,
+    supportsVideo = supportsVideo,
+    enableToolCall = enableToolCall,
+    includeUsageInStream = true
+) {
+    override fun createRequestBody(
+        context: Context,
+        chatHistory: List<PromptTurn>,
+        modelParameters: List<ModelParameter<*>>,
+        enableThinking: Boolean,
+        stream: Boolean,
+        availableTools: List<ToolPrompt>?,
+        preserveThinkInHistory: Boolean
+    ): RequestBody {
+        val requestJson = JSONObject(
+            super.createRequestBodyInternal(
+                context,
+                chatHistory,
+                modelParameters,
+                stream,
+                availableTools,
+                preserveThinkInHistory
+            )
+        )
+
+        if (xaiModelSupportsReasoningEffort(modelName)) {
+            val existingEffort = requestJson.optString("reasoning_effort", "").trim()
+            if (existingEffort.isEmpty()) {
+                val qualityLevel = runCatching {
+                    runBlocking {
+                        ApiPreferences.getInstance(context).thinkingQualityLevelFlow.first()
+                    }
+                }.getOrElse {
+                    AppLogger.w(
+                        "XaiProvider",
+                        "Failed to read thinking quality level; using xAI low effort",
+                        it
+                    )
+                    1
+                }
+                requestJson.put(
+                    "reasoning_effort",
+                    XaiReasoningMapper.effortForQuality(enableThinking, qualityLevel)
+                )
+            }
+        }
+
+        return createJsonRequestBody(requestJson.toString())
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/data/collects/ApiProviderConfigCollect.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/collects/ApiProviderConfigCollect.kt
@@ -24,6 +24,11 @@ object ApiProviderConfigs {
             defaultApiEndpoint = "https://api.openai.com/v1/chat/completions"
         ),
         ProviderApiConfig(
+            providerType = ApiProviderType.XAI,
+            defaultModelName = "grok-4.6",
+            defaultApiEndpoint = "https://api.x.ai/v1/chat/completions"
+        ),
+        ProviderApiConfig(
             providerType = ApiProviderType.OPENAI_RESPONSES,
             defaultModelName = "gpt-4o",
             defaultApiEndpoint = "https://api.openai.com/v1/responses"

--- a/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class ApiProviderType {
         OPENAI, // OpenAI (GPT系列)
+        XAI, // xAI (Grok)
         OPENAI_RESPONSES, // OpenAI Responses API
         OPENAI_RESPONSES_GENERIC, // OpenAI Responses通用（自定义端点）
         OPENAI_GENERIC, // OpenAI通用（自定义端点）

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
@@ -285,6 +285,7 @@ fun ModelApiSettingsSection(
         AppLogger.d("ModelApiSettingsSection", "API提供商改变")
         if (
             selectedApiProvider == ApiProviderType.OPENAI ||
+                selectedApiProvider == ApiProviderType.XAI ||
                 selectedApiProvider == ApiProviderType.OPENAI_RESPONSES ||
                 selectedApiProvider == ApiProviderType.OPENAI_RESPONSES_GENERIC ||
                 selectedApiProvider == ApiProviderType.OPENAI_GENERIC ||
@@ -1056,6 +1057,7 @@ fun ModelApiSettingsSection(
 private fun getBuiltInProviderDisplayName(provider: ApiProviderType, context: android.content.Context): String {
     return when (provider) {
         ApiProviderType.OPENAI -> context.getString(R.string.provider_openai)
+        ApiProviderType.XAI -> context.getString(R.string.provider_xai)
         ApiProviderType.OPENAI_RESPONSES -> context.getString(R.string.provider_openai_responses)
         ApiProviderType.OPENAI_RESPONSES_GENERIC -> context.getString(R.string.provider_openai_responses_generic)
         ApiProviderType.OPENAI_GENERIC -> context.getString(R.string.provider_openai_generic)
@@ -1735,6 +1737,7 @@ private fun getProviderColor(providerTypeId: String): androidx.compose.ui.graphi
     }
     return when (provider) {
         ApiProviderType.OPENAI -> MaterialTheme.colorScheme.primary
+        ApiProviderType.XAI -> MaterialTheme.colorScheme.primary.copy(alpha = 0.94f)
         ApiProviderType.OPENAI_RESPONSES -> MaterialTheme.colorScheme.primary.copy(alpha = 0.92f)
         ApiProviderType.OPENAI_RESPONSES_GENERIC -> MaterialTheme.colorScheme.primary.copy(alpha = 0.88f)
         ApiProviderType.OPENAI_GENERIC -> MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -4028,6 +4028,7 @@
     <string name="auto_save_failed">Auto save failed</string>
     <!-- API Provider names -->
     <string name="provider_openai">OpenAI (GPT Series)</string>
+    <string name="provider_xai">xAI (Grok)</string>
     <string name="provider_openai_responses">OpenAI (Responses API)</string>
     <string name="provider_openai_responses_generic">OpenAI Responses (Generic)</string>
     <string name="provider_anthropic">Anthropic (Claude Series)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1223,6 +1223,7 @@
     
     <!-- API Provider names -->
     <string name="provider_openai">OpenAI (Serie GPT)</string>
+    <string name="provider_xai">xAI (Grok)</string>
     <string name="provider_openai_responses">OpenAI (API Responses)</string>
     <string name="provider_openai_responses_generic">OpenAI Responses (Genérico)</string>
     <string name="provider_openai_generic">OpenAI genérico</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -3263,6 +3263,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="model_name_multiple_hint"> (dapat dipisahkan dengan koma untuk beberapa model)</string>
     <string name="auto_save_failed">Penyimpanan otomatis gagal</string>
     <string name="provider_openai">OpenAI (Seri GPT)</string>
+    <string name="provider_xai">xAI (Grok)</string>
     <string name="provider_openai_responses">OpenAI (Responses API)</string>
     <string name="provider_openai_responses_generic">OpenAI Responses Umum</string>
     <string name="provider_anthropic">Anthropic (Seri Claude)</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -3492,6 +3492,7 @@
     <string name="model_name_multiple_hint"> (쉼표로 여러 모델을 구분할 수 있음)</string>
     <string name="auto_save_failed">자동 저장 실패</string>
     <string name="provider_openai">OpenAI(GPT 시리즈)</string>
+    <string name="provider_xai">xAI (Grok)</string>
     <string name="provider_openai_responses">OpenAI(Responses API)</string>
     <string name="provider_openai_responses_generic">OpenAI Responses(일반)</string>
     <string name="provider_anthropic">Anthropic(Claude 시리즈)</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -3263,6 +3263,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="model_name_multiple_hint"> (boleh pisahkan berbilang model dengan koma)</string>
     <string name="auto_save_failed">Simpanan automatik gagal</string>
     <string name="provider_openai">OpenAI (siri GPT)</string>
+    <string name="provider_xai">xAI (Grok)</string>
     <string name="provider_openai_responses">OpenAI (Responses API)</string>
     <string name="provider_openai_responses_generic">OpenAI Responses generik</string>
     <string name="provider_anthropic">Anthropic (siri Claude)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -3353,6 +3353,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="model_name_multiple_hint">(Você pode separar vários modelos com vírgulas)</string>
     <string name="auto_save_failed">Falha no salvamento automático</string>
     <string name="provider_openai">OpenAI (série GPT)</string>
+    <string name="provider_xai">xAI (Grok)</string>
     <string name="provider_openai_responses">OpenAI (API de respostas)</string>
     <string name="provider_openai_responses_generic">Respostas OpenAIGeral</string>
     <string name="provider_anthropic">Antrópico (Série Claude)</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3867,6 +3867,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="auto_save_failed">Salvarea automată a eșuat</string>
     <!-- API Provider names -->
     <string name="provider_openai">OpenAI (GPTSerie)</string>
+    <string name="provider_xai">xAI (Grok)</string>
     <string name="provider_openai_responses">OpenAI (Responses API)</string>
     <string name="provider_openai_responses_generic">OpenAI ResponsesGeneralități</string>
     <string name="provider_anthropic">Anthropic (ClaudeSerie)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3982,6 +3982,7 @@
     <string name="auto_save_failed">自动保存失败</string>
     <!-- API Provider names -->
     <string name="provider_openai">OpenAI (GPT系列)</string>
+    <string name="provider_xai">xAI (Grok)</string>
     <string name="provider_openai_responses">OpenAI (Responses API)</string>
     <string name="provider_openai_responses_generic">OpenAI Responses通用</string>
     <string name="provider_anthropic">Anthropic (Claude系列)</string>

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/XaiProviderReasoningTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/XaiProviderReasoningTest.kt
@@ -1,0 +1,52 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import com.ai.assistance.operit.data.collects.ApiProviderConfigs
+import com.ai.assistance.operit.data.model.ApiProviderType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class XaiProviderReasoningTest {
+    @Test
+    fun defaultConfigUsesTheOfficialXaiEndpointAndModel() {
+        assertEquals(
+            "grok-4.6",
+            ApiProviderConfigs.getDefaultModelName(ApiProviderType.XAI)
+        )
+        assertEquals(
+            "https://api.x.ai/v1/chat/completions",
+            ApiProviderConfigs.getDefaultApiEndpoint(ApiProviderType.XAI)
+        )
+        assertEquals(
+            "https://api.x.ai/v1/models",
+            ModelListFetcher.getModelsListUrl(
+                "https://api.x.ai/v1/chat/completions",
+                ApiProviderType.XAI
+            )
+        )
+    }
+
+    @Test
+    fun enabledQualityLevelsMapToXaiEfforts() {
+        assertEquals(
+            listOf("low", "medium", "medium", "high", "xhigh"),
+            (1..5).map { XaiReasoningMapper.effortForQuality(enableThinking = true, qualityLevel = it) }
+        )
+    }
+
+    @Test
+    fun disabledThinkingUsesTheLowestSupportedEffort() {
+        assertEquals(
+            List(5) { "low" },
+            (1..5).map { XaiReasoningMapper.effortForQuality(enableThinking = false, qualityLevel = it) }
+        )
+    }
+
+    @Test
+    fun reasoningEffortIsLimitedToDocumentedGrokModels() {
+        assertTrue(xaiModelSupportsReasoningEffort("grok-4.6"))
+        assertTrue(xaiModelSupportsReasoningEffort("grok-4.5-latest"))
+        assertFalse(xaiModelSupportsReasoningEffort("grok-3-mini"))
+    }
+}


### PR DESCRIPTION
## 变更说明

新增 xAI（Grok）内置提供商，使用 xAI 官方 OpenAI 兼容 Chat Completions API。

## 主要改动

- 新增 `XAI` Provider，默认模型为 `grok-4.6`
- 默认端点：`https://api.x.ai/v1/chat/completions`
- 复用 OpenAI 兼容请求、Bearer API Key、流式 usage 与模型列表解析
- 支持从 `https://api.x.ai/v1/models` 获取模型列表
- 针对 Grok 4.5/4.6 增加 `reasoning_effort` 映射：`low`、`medium`、`medium`、`high`、`xhigh`
- xAI 推理模型不可关闭；关闭应用思考开关时请求最低 `low` 档，而不发送无效的 `none`
- 补充 xAI Logo、设置页展示、地域提醒及 8 个语言资源
- 新增单元测试，覆盖默认端点/模型、模型列表路径、思考映射和模型能力判断

## 验证

- `git diff --check` 通过
- 项目 Python CI：46/46 通过
- 8 个 `strings.xml` XML 解析通过，`provider_xai` 资源完整
- 本地 Gradle JVM 测试受 Android SDK 的 `aidl` 二进制启动失败阻塞；远程 CI 可完成 Android 编译与 JVM 单元测试