### PR TITLE
Fix SecurityException when resolving SAF path without grant

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/SafFileSystemTools.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/SafFileSystemTools.kt
@@ -90,16 +90,18 @@ class SafFileSystemTools(
         val segments = abs.trim('/').split('/').filter { it.isNotEmpty() }
         for (seg in segments) {
             val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(baseTreeUri, currentDocId)
-            val cursor = contentResolver.query(
-                childrenUri,
-                arrayOf(
-                    DocumentsContract.Document.COLUMN_DOCUMENT_ID,
-                    DocumentsContract.Document.COLUMN_DISPLAY_NAME
-                ),
-                null,
-                null,
-                null
-            ) ?: return null
+            val cursor = runCatching {
+                contentResolver.query(
+                    childrenUri,
+                    arrayOf(
+                        DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                        DocumentsContract.Document.COLUMN_DISPLAY_NAME
+                    ),
+                    null,
+                    null,
+                    null
+                )
+            }.getOrNull() ?: return null
 
             var nextDocId: String? = null
             cursor.use {


### PR DESCRIPTION
## Problem

Reading/writing a file under a SAF (Storage Access Framework) tree that was not granted via `ACTION_OPEN_DOCUMENT`/`ACTION_OPEN_DOCUMENT_TREE` crashes with:

```
java.lang.SecurityException: Permission Denial: opening provider com.android.externalstorage.ExternalStorageProvider ...
    requires that you obtain access using ACTION_OPEN_DOCUMENT or related APIs
    at ...SafFileSystemTools.resolveSafPathToDocumentUriOrNull(SafFileSystemTools.kt:93)
```

## Root cause

`resolveSafPathToDocumentUriOrNull` traverses path segments via `contentResolver.query(...)` without any exception handling. When the target provider is not authorized, the query throws `SecurityException` and propagates up to `readFile`, instead of returning `null` like the rest of the function (which already guards other calls with `runCatching`).

## Fix

Wrap the `contentResolver.query` call in `runCatching { ... }.getOrNull()` so an unauthorized provider resolves to `null`, which the caller treats as "path not reachable" rather than crashing.

Minimal diff, consistent with the existing `runCatching` pattern elsewhere in the same file (`queryMimeType`, `openInputStreamOrNull`, etc.).
