### PR TITLE
feat(deepseek): support Responses web search

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
@@ -394,6 +394,15 @@ class EnhancedAIService private constructor(private val context: Context) {
         _inputProcessingState.value = newState
     }
 
+    /** 服务端工具事件只携带协议类型，本地化文案统一在 UI 状态边界生成。 */
+    private fun serverToolRunningMessage(toolType: String): String {
+        return if (toolType == "web_search") {
+            context.getString(R.string.searching)
+        } else {
+            context.getString(R.string.server_tool_running, toolType)
+        }
+    }
+
     // Per-request token counts
     private val _perRequestTokenCounts = MutableStateFlow<Pair<Long, Long>?>(null)
     val perRequestTokenCounts: StateFlow<Pair<Long, Long>?> = _perRequestTokenCounts.asStateFlow()
@@ -850,9 +859,9 @@ class EnhancedAIService private constructor(private val context: Context) {
             finalProcessedInput = ChatUtils.stripGeminiThoughtSignatureMeta(finalProcessedInput)
             finalPreparedHistory = ChatUtils.stripGeminiThoughtSignatureMetaTurns(finalPreparedHistory)
         }
-        if (!ChatUtils.isOpenAIResponsesProviderModel(serviceForFunction.providerModel)) {
-            finalProcessedInput = ChatUtils.stripOpenAiResponsesReasoningMeta(finalProcessedInput)
-            finalPreparedHistory = ChatUtils.stripOpenAiResponsesReasoningMetaTurns(finalPreparedHistory)
+        if (!serviceForFunction.usesResponsesApi) {
+            finalProcessedInput = ChatUtils.stripOpenAiResponsesMetadata(finalProcessedInput)
+            finalPreparedHistory = ChatUtils.stripOpenAiResponsesMetadataTurns(finalPreparedHistory)
         }
 
         val requestHistory =
@@ -1071,9 +1080,9 @@ class EnhancedAIService private constructor(private val context: Context) {
                         finalProcessedInput = ChatUtils.stripGeminiThoughtSignatureMeta(finalProcessedInput)
                         finalPreparedHistory = ChatUtils.stripGeminiThoughtSignatureMetaTurns(finalPreparedHistory)
                     }
-                    if (!ChatUtils.isOpenAIResponsesProviderModel(serviceForFunction.providerModel)) {
-                        finalProcessedInput = ChatUtils.stripOpenAiResponsesReasoningMeta(finalProcessedInput)
-                        finalPreparedHistory = ChatUtils.stripOpenAiResponsesReasoningMetaTurns(finalPreparedHistory)
+                    if (!serviceForFunction.usesResponsesApi) {
+                        finalProcessedInput = ChatUtils.stripOpenAiResponsesMetadata(finalProcessedInput)
+                        finalPreparedHistory = ChatUtils.stripOpenAiResponsesMetadataTurns(finalPreparedHistory)
                     }
                     val requestHistory =
                         applyFinalizedCurrentUserTurn(
@@ -1150,6 +1159,27 @@ class EnhancedAIService private constructor(private val context: Context) {
                                                 execContext.streamBuffer.clear()
                                                 execContext.streamBuffer.append(snapshot)
                                                 execContext.roundManager.updateContent(snapshot)
+                                            }
+
+                                            TextStreamEventType.SERVER_TOOL_STARTED -> {
+                                                if (!isSubTask) {
+                                                    val message = serverToolRunningMessage(
+                                                        checkNotNull(event.toolType)
+                                                    )
+                                                    withContext(Dispatchers.Main) {
+                                                        _inputProcessingState.value =
+                                                            InputProcessingState.Receiving(message)
+                                                    }
+                                                }
+                                            }
+
+                                            TextStreamEventType.SERVER_TOOL_COMPLETED -> {
+                                                if (!isSubTask) {
+                                                    withContext(Dispatchers.Main) {
+                                                        _inputProcessingState.value =
+                                                            InputProcessingState.Receiving(context.getString(R.string.enhanced_receiving_response))
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -2376,6 +2406,27 @@ class EnhancedAIService private constructor(private val context: Context) {
                                             context.streamBuffer.clear()
                                             context.streamBuffer.append(snapshot)
                                             context.roundManager.updateContent(snapshot)
+                                        }
+
+                                        TextStreamEventType.SERVER_TOOL_STARTED -> {
+                                            if (!isSubTask) {
+                                                val message = serverToolRunningMessage(
+                                                    checkNotNull(event.toolType)
+                                                )
+                                                withContext(Dispatchers.Main) {
+                                                    _inputProcessingState.value =
+                                                        InputProcessingState.Receiving(message)
+                                                }
+                                            }
+                                        }
+
+                                        TextStreamEventType.SERVER_TOOL_COMPLETED -> {
+                                            if (!isSubTask) {
+                                                withContext(Dispatchers.Main) {
+                                                    _inputProcessingState.value =
+                                                        InputProcessingState.Receiving(this@EnhancedAIService.context.getString(R.string.enhanced_receiving_tool_result))
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationMarkupManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationMarkupManager.kt
@@ -30,7 +30,8 @@ class ConversationMarkupManager {
             return createToolResultXml(
                 toolName = toolName,
                 status = "error",
-                content = "<content><error>${errorMessage}</error></content>"
+                content = "<content><error>${errorMessage}</error></content>",
+                toolCallId = null
             )
         }
 
@@ -58,7 +59,8 @@ class ConversationMarkupManager {
                     createBoundedToolResultXml(
                         toolName = result.toolName,
                         status = "success",
-                        rawPayload = toolPayload
+                        rawPayload = toolPayload,
+                        toolCallId = result.toolCallId
                     ) { payload ->
                         "<content>$payload</content>"
                     }
@@ -83,7 +85,8 @@ class ConversationMarkupManager {
                 createBoundedToolResultXml(
                     toolName = result.toolName,
                     status = "error",
-                    rawPayload = errorPayload
+                    rawPayload = errorPayload,
+                    toolCallId = result.toolCallId
                 ) { payload ->
                     "<content><error>$payload</error></content>"
                 }
@@ -158,22 +161,42 @@ class ConversationMarkupManager {
             return createToolErrorStatus(toolName, errorMessage)
         }
 
-        private fun createToolResultXml(toolName: String, status: String, content: String): String {
+        private fun createToolResultXml(
+            toolName: String,
+            status: String,
+            content: String,
+            toolCallId: String?
+        ): String {
             val tagName = ChatMarkupRegex.generateRandomToolResultTagName()
-            return """<$tagName name="$toolName" status="$status">$content</$tagName>""".trimIndent()
+            val callIdAttribute =
+                toolCallId
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { " call_id=\"${escapeXmlAttribute(it)}\"" }
+                    .orEmpty()
+            return """<$tagName name="$toolName" status="$status"$callIdAttribute>$content</$tagName>""".trimIndent()
+        }
+
+        private fun escapeXmlAttribute(value: String): String {
+            return value
+                .replace("&", "&amp;")
+                .replace("\"", "&quot;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
         }
 
         private fun createBoundedToolResultXml(
             toolName: String,
             status: String,
             rawPayload: String,
+            toolCallId: String?,
             bodyBuilder: (String) -> String
         ): String {
             val emptyXml =
                 createToolResultXml(
                     toolName = toolName,
                     status = status,
-                    content = bodyBuilder("")
+                    content = bodyBuilder(""),
+                    toolCallId = toolCallId
                 )
             val maxPayloadChars =
                 (ToolExecutionLimits.MAX_FINAL_TOOL_RESULT_MESSAGE_CHARS - emptyXml.length)
@@ -182,7 +205,8 @@ class ConversationMarkupManager {
             return createToolResultXml(
                 toolName = toolName,
                 status = status,
-                content = bodyBuilder(boundedPayload)
+                content = bodyBuilder(boundedPayload),
+                toolCallId = toolCallId
             )
         }
 

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationService.kt
@@ -126,7 +126,7 @@ class ConversationService(
                 systemPrompt += "\n\n${customRules.trim()}"
             }
             val sanitizedMessages =
-                ChatUtils.stripOpenAiResponsesReasoningMetaTurns(
+                ChatUtils.stripOpenAiResponsesMetadataTurns(
                     ChatUtils.stripGeminiThoughtSignatureMetaTurns(messages)
                 )
 

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
@@ -193,7 +193,8 @@ object ToolExecutionManager {
             toolName = resolveDisplayToolName(invocation.tool),
             success = false,
             result = StringResultData(""),
-            error = context.getString(R.string.character_card_tool_access_denied_runtime)
+            error = context.getString(R.string.character_card_tool_access_denied_runtime),
+            toolCallId = invocation.toolCallId
         )
     }
 
@@ -239,7 +240,8 @@ object ToolExecutionManager {
             toolName = resultToolName,
             success = false,
             result = StringResultData(""),
-            error = errorMessage
+            error = errorMessage,
+            toolCallId = invocation.toolCallId
         )
     }
 
@@ -325,10 +327,17 @@ object ToolExecutionManager {
                         }
 
                     val tool = AITool(name = toolName, parameters = parameters)
+                    val toolCallId =
+                        ChatMarkupRegex.toolCallIdAttr.find(toolMatch.value)
+                            ?.groupValues
+                            ?.getOrNull(1)
+                            ?.let(::unescapeXml)
+                            ?.takeIf { it.isNotBlank() }
                     invocations.add(
                         ToolInvocation(
                             tool = tool,
                             rawText = toolMatch.value,
+                            toolCallId = toolCallId,
                             responseLocation = toolMatch.range
                         )
                     )
@@ -579,7 +588,7 @@ object ToolExecutionManager {
                     if (hasPermission) {
                         permittedInvocations.add(invocation)
                     } else {
-                        errorResult?.let {
+                        errorResult?.copy(toolCallId = invocation.toolCallId)?.let {
                             permissionDeniedResults.add(it)
                             val toolResultStatusContent =
                                 ConversationMarkupManager.formatToolResultForMessage(it)
@@ -593,7 +602,7 @@ object ToolExecutionManager {
                         toolHandler.buildToolInterceptionResult(
                             resolveDisplayToolName(invocation.tool),
                             interception
-                        )
+                        ).copy(toolCallId = invocation.toolCallId)
                     hookDeniedResults.add(interceptedResult)
                     toolHandler.notifyToolExecutionResult(invocation.tool, interceptedResult)
                     toolHandler.notifyToolExecutionFinished(invocation.tool)
@@ -697,16 +706,17 @@ object ToolExecutionManager {
                     // 如果仍然为 null，则构建错误消息
                     val errorMessage =
                         buildToolNotAvailableErrorMessage(toolName, packageManager, toolHandler)
-                    val notAvailableContent =
-                        ConversationMarkupManager.createToolNotAvailableError(toolName, errorMessage)
-                    collector.emit(ensureEndsWithNewline(notAvailableContent))
                     val notAvailableResult =
                         ToolResult(
                             toolName = displayToolName,
                             success = false,
                             result = StringResultData(""),
-                            error = errorMessage
+                            error = errorMessage,
+                            toolCallId = invocation.toolCallId
                         )
+                    val notAvailableContent =
+                        ConversationMarkupManager.formatToolResultForMessage(notAvailableResult)
+                    collector.emit(ensureEndsWithNewline(notAvailableContent))
                     toolHandler.notifyToolExecutionResult(invocation.tool, notAvailableResult)
                     return@withContext notAvailableResult
                 }
@@ -715,10 +725,11 @@ object ToolExecutionManager {
 
                 val collectedResults = mutableListOf<ToolResult>()
                 executeToolSafely(invocation, executor, toolHandler).collect { result ->
-                    collectedResults.add(result)
+                    val boundResult = result.copy(toolCallId = invocation.toolCallId)
+                    collectedResults.add(boundResult)
                     // 实时输出每个结果
                     val toolResultStatusContent =
-                        ConversationMarkupManager.formatToolResultForMessage(result)
+                        ConversationMarkupManager.formatToolResultForMessage(boundResult)
                     collector.emit(ensureEndsWithNewline(toolResultStatusContent))
                 }
 
@@ -729,7 +740,8 @@ object ToolExecutionManager {
                             toolName = displayToolName,
                             success = false,
                             result = StringResultData(""),
-                            error = "The tool execution returned no results."
+                            error = "The tool execution returned no results.",
+                            toolCallId = invocation.toolCallId
                         )
                     toolHandler.notifyToolExecutionResult(invocation.tool, emptyResult)
                     return@withContext emptyResult
@@ -745,7 +757,8 @@ object ToolExecutionManager {
                         toolName = displayToolName,
                         success = lastResult.success,
                         result = StringResultData(combinedResultString),
-                        error = lastResult.error
+                        error = lastResult.error,
+                        toolCallId = invocation.toolCallId
                     )
                 toolHandler.notifyToolExecutionResult(invocation.tool, finalResult)
                 return@withContext finalResult

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIService.kt
@@ -22,6 +22,10 @@ interface AIService {
     /** 获取供应商:模型标识符，格式如"DEEPSEEK:deepseek-chat" */
     val providerModel: String
 
+    /** 请求是否使用 Responses API 传输格式。 */
+    val usesResponsesApi: Boolean
+        get() = false
+
     /** 重置token计数器 */
     fun resetTokenCounts()
 

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIServiceFactory.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/AIServiceFactory.kt
@@ -563,20 +563,40 @@ object AIServiceFactory {
                     thinkingOptionId = config.thinkingOptionId,
                 )
             ApiProviderType.DEEPSEEK ->
-                DeepseekProvider(
-                    apiEndpoint = config.apiEndpoint,
-                    apiKeyProvider = apiKeyProvider,
-                    modelName = config.modelName,
-                    client = httpClient,
-                    customHeaders = customHeaders,
-                    providerType = providerType,
-                    supportsVision = supportsVision,
-                    supportsAudio = supportsAudio,
-                    supportsVideo = supportsVideo,
-                    enableToolCall = enableToolCall,
-                    thinkingConfigurations = config.thinkingConfigurations,
-                    thinkingOptionId = config.thinkingOptionId,
-                )
+                when (EndpointCompleter.resolveDeepSeekProtocol(config.apiEndpoint)) {
+                    DeepSeekApiProtocol.CHAT_COMPLETIONS ->
+                        DeepseekProvider(
+                            apiEndpoint = config.apiEndpoint,
+                            apiKeyProvider = apiKeyProvider,
+                            modelName = config.modelName,
+                            client = httpClient,
+                            customHeaders = customHeaders,
+                            providerType = providerType,
+                            supportsVision = supportsVision,
+                            supportsAudio = supportsAudio,
+                            supportsVideo = supportsVideo,
+                            enableToolCall = enableToolCall,
+                            thinkingConfigurations = config.thinkingConfigurations,
+                            thinkingOptionId = config.thinkingOptionId,
+                        )
+
+                    DeepSeekApiProtocol.RESPONSES ->
+                        OpenAIResponsesProvider(
+                            responsesApiEndpoint = config.apiEndpoint,
+                            apiKeyProvider = apiKeyProvider,
+                            modelName = config.modelName,
+                            client = httpClient,
+                            customHeaders = customHeaders,
+                            responsesProviderType = providerType,
+                            supportsVision = supportsVision,
+                            supportsAudio = supportsAudio,
+                            supportsVideo = supportsVideo,
+                            enableToolCall = enableToolCall,
+                            thinkingConfigurations = config.thinkingConfigurations,
+                            thinkingOptionId = config.thinkingOptionId,
+                            enableServerWebSearch = config.enableDeepSeekWebSearch,
+                        )
+                }
             ApiProviderType.MISTRAL ->
                 MistralProvider(
                     apiEndpoint = config.apiEndpoint,

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/EndpointCompleter.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/EndpointCompleter.kt
@@ -3,10 +3,36 @@ package com.ai.assistance.operit.api.chat.llmprovider
 import com.ai.assistance.operit.data.model.ApiProviderType
 import java.net.URL
 
+/** DeepSeek 的请求协议由用户配置的端点路径决定，不写入模型配置。 */
+enum class DeepSeekApiProtocol {
+    CHAT_COMPLETIONS,
+    RESPONSES
+}
+
 /**
  * 用于自动补全API端点URL的工具类。
  */
 object EndpointCompleter {
+
+    /**
+     * 根据端点路径解析 DeepSeek 请求协议。
+     *
+     * 只有以 `/responses` 结尾的端点使用 Responses，其余端点（包括旧版 Chat
+     * Completions 端点、根端点和 `/v1` 端点）都保持 Chat Completions。该判定只
+     * 用于当前运行时，不会改写或持久化用户输入。
+     */
+    fun resolveDeepSeekProtocol(endpoint: String): DeepSeekApiProtocol {
+        val path = endpoint
+            .trim()
+            .removeSuffix("#")
+            .substringBefore('?')
+            .substringBefore('#')
+        return if (path.removeSuffix("/").endsWith("/responses", ignoreCase = true)) {
+            DeepSeekApiProtocol.RESPONSES
+        } else {
+            DeepSeekApiProtocol.CHAT_COMPLETIONS
+        }
+    }
 
     /**
      * 为类似OpenAI的服务自动补全API端点URL。

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/LlmRetryPolicy.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/LlmRetryPolicy.kt
@@ -4,6 +4,10 @@ internal object LlmRetryPolicy {
     const val MAX_RETRY_ATTEMPTS = 5
     private const val RETRY_BASE_DELAY_MS = 1000L
 
+    internal fun isRetryableClientStatus(statusCode: Int): Boolean {
+        return statusCode == 408 || statusCode == 429
+    }
+
     fun nextDelayMs(retryAttempt: Int): Long {
         val normalizedAttempt = retryAttempt.coerceAtLeast(1)
         return RETRY_BASE_DELAY_MS * (1L shl (normalizedAttempt - 1))

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -114,9 +114,7 @@ open class OpenAIProvider(
     @Volatile
     private var isManuallyCancelled = false
 
-    /**
-     * 由客户端错误（如4xx状态码）触发的API异常，是否重试由统一策略决定
-     */
+    /** 由客户端请求错误触发的终止异常。重复同一请求不会改变服务端校验结果。 */
     class NonRetriableException(
         message: String,
         override val statusCode: Int,
@@ -127,6 +125,9 @@ open class OpenAIProvider(
     val tokenCacheManager = TokenCacheManager()
 
     protected open val useResponsesApi: Boolean = false
+
+    override val usesResponsesApi: Boolean
+        get() = useResponsesApi
 
     // 公开token计数
     override val inputTokenCount: Long
@@ -943,7 +944,14 @@ open class OpenAIProvider(
             for (i in 0 until toolCalls.length()) {
                 val sourceToolCall = toolCalls.optJSONObject(i) ?: continue
                 val toolCall = JSONObject(sourceToolCall.toString())
-                val callId = generatedToolCallId(nextToolCallOrdinal++)
+                val sourceCallId = sourceToolCall.optString("id", "").trim()
+                val callId =
+                    if (useResponsesApi && sourceCallId.isNotEmpty()) {
+                        sourceCallId
+                    } else {
+                        generatedToolCallId(nextToolCallOrdinal)
+                    }
+                nextToolCallOrdinal++
                 toolCall.put("id", callId)
                 queuedToolCalls.put(toolCall)
                 queuedToolCallIds.add(callId)
@@ -1084,25 +1092,37 @@ open class OpenAIProvider(
                             val resultsList = toolResults ?: emptyList()
 
                             if (resultsList.isNotEmpty() && openToolCallIds.isNotEmpty()) {
-                                val validCount = minOf(resultsList.size, openToolCallIds.size)
-                                repeat(validCount) { index ->
-                                    val (_, resultContent) = resultsList[index]
+                                var matchedCount = 0
+                                for ((resultCallId, resultContent) in resultsList) {
+                                    if (openToolCallIds.isEmpty()) break
+                                    val openCallIndex =
+                                        if (resultCallId == null) {
+                                            0
+                                        } else {
+                                            openToolCallIds.indexOf(resultCallId)
+                                        }
+                                    if (openCallIndex < 0) {
+                                        AppLogger.w(
+                                            "AIService",
+                                            "tool_result call_id does not match an open tool call: $resultCallId"
+                                        )
+                                        continue
+                                    }
+                                    val matchedCallId = openToolCallIds.removeAt(openCallIndex)
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "tool")
-                                            put("tool_call_id", openToolCallIds[index])
+                                            put("tool_call_id", matchedCallId)
                                             put("content", resultContent)
                                         }
                                     )
-                                }
-                                repeat(validCount) {
-                                    openToolCallIds.removeAt(0)
+                                    matchedCount++
                                 }
 
-                                if (resultsList.size > validCount) {
+                                if (resultsList.size > matchedCount) {
                                     AppLogger.w(
                                         "AIService",
-                                        "发现多余的tool_result: ${resultsList.size} results vs ${validCount} pending tool_calls"
+                                        "发现未匹配的tool_result: ${resultsList.size} results vs $matchedCount matched tool_calls"
                                     )
                                 }
 
@@ -1276,7 +1296,14 @@ open class OpenAIProvider(
 
             // 构建XML格式
             val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-            xml.append("\n<$toolTagName name=\"$name\">")
+            val callId = toolCall.optString("id", "").trim()
+            val callIdAttribute =
+                if (useResponsesApi && callId.isNotEmpty()) {
+                    " call_id=\"${escapeXml(callId)}\""
+                } else {
+                    ""
+                }
+            xml.append("\n<$toolTagName name=\"$name\"$callIdAttribute>")
 
             // 添加所有参数
             val keys = params.keys()
@@ -1436,6 +1463,26 @@ open class OpenAIProvider(
             return true
         }
 
+        suspend fun emitServerToolStarted(id: String, toolType: String) {
+            eventChannel.emit(
+                TextStreamEvent(
+                    eventType = TextStreamEventType.SERVER_TOOL_STARTED,
+                    id = id,
+                    toolType = toolType
+                )
+            )
+        }
+
+        suspend fun emitServerToolCompleted(id: String, toolType: String) {
+            eventChannel.emit(
+                TextStreamEvent(
+                    eventType = TextStreamEventType.SERVER_TOOL_COMPLETED,
+                    id = id,
+                    toolType = toolType
+                )
+            )
+        }
+
         /**
          * 处理 StreamingJsonXmlConverter 事件，转换为 XML 输出
          */
@@ -1497,6 +1544,9 @@ open class OpenAIProvider(
         buildRetryMessage: (String, Int) -> String
     ): Int {
         if (exception is UserCancellationException || exception is CancellationException) {
+            throw exception
+        }
+        if (exception is NonRetriableException) {
             throw exception
         }
         checkCancellation(context, exception)
@@ -1589,6 +1639,12 @@ open class OpenAIProvider(
         matches.forEach { match ->
             val toolName = match.groupValues[2]
             val toolBody = match.groupValues[3]
+            val sourceCallId =
+                ChatMarkupRegex.toolCallIdAttr.find(match.value)
+                    ?.groupValues
+                    ?.getOrNull(1)
+                    ?.let(XmlEscaper::unescape)
+                    ?.takeIf { it.isNotBlank() }
 
             // 解析参数
             val params = JSONObject()
@@ -1603,7 +1659,9 @@ open class OpenAIProvider(
             // 使用工具名和参数的哈希生成确定性ID
             val toolNamePart = sanitizeToolCallId(toolName)
             val hashPart = stableIdHashPart("${toolName}:${params}")
-            val callId = sanitizeToolCallId("call_${toolNamePart}_${hashPart}_$callIndex")
+            val callId =
+                sourceCallId
+                    ?: sanitizeToolCallId("call_${toolNamePart}_${hashPart}_$callIndex")
             toolCalls.put(JSONObject().apply {
                 put("id", callId)
                 put("type", "function")
@@ -1626,7 +1684,7 @@ open class OpenAIProvider(
      * 解析XML格式的tool_result，转换为OpenAI Tool消息格式
      * @return List<Pair<tool_call_id, result_content>>
      */
-    fun parseXmlToolResults(content: String): Pair<String, List<Pair<String, String>>?> {
+    fun parseXmlToolResults(content: String): Pair<String, List<Pair<String?, String>>?> {
         // 匹配带属性的tool_result标签，例如: <tool_result name="..." status="...">...</tool_result>
         val matches = ChatMarkupRegex.toolResultAnyPattern.findAll(content)
 
@@ -1634,11 +1692,16 @@ open class OpenAIProvider(
             return Pair(content, null)
         }
 
-        val results = mutableListOf<Pair<String, String>>()
+        val results = mutableListOf<Pair<String?, String>>()
         var textContent = content
-        var resultIndex = 0
 
         matches.forEach { match ->
+            val callId =
+                ChatMarkupRegex.toolCallIdAttr.find(match.value)
+                    ?.groupValues
+                    ?.getOrNull(1)
+                    ?.let(XmlEscaper::unescape)
+                    ?.takeIf { it.isNotBlank() }
             // 提取<content>标签内的内容，如果有的话
             val fullContent = match.groupValues[2].trim()
             val contentMatch = ChatMarkupRegex.contentTag.find(fullContent)
@@ -1648,12 +1711,10 @@ open class OpenAIProvider(
                 fullContent
             }
 
-            // 生成一个tool_call_id（这里需要与之前的call对应，但因为历史记录可能不完整，我们使用索引）
-            results.add(Pair("call_result_${resultIndex}", resultContent))
+            results.add(Pair(callId, resultContent))
 
             // 从文本内容中移除tool_result标签（包括前后的空白符）
             textContent = textContent.replace(match.value, "").trim()
-            resultIndex++
         }
 
         // trim 确保移除所有空白字符
@@ -1716,7 +1777,9 @@ open class OpenAIProvider(
         val accumulatedToolCalls: MutableMap<Int, JSONObject> = mutableMapOf(),
         val toolCallState: ToolCallState = ToolCallState(),
         var lastProcessedToolIndex: Int? = null,
-        val imageBuffers: MutableMap<Int, ImageBufferState> = mutableMapOf()
+        val imageBuffers: MutableMap<Int, ImageBufferState> = mutableMapOf(),
+        var activeWebSearchCalls: Set<Int> = emptySet(),
+        var emittedWebSearchCallIds: Set<String> = emptySet()
     )
 
     /**
@@ -1769,7 +1832,14 @@ open class OpenAIProvider(
                 val toolTagName = state.toolCallState.getTagName(index)
                 val toolStartTag = if (state.toolCallState.emitted[index] != true) {
                     state.toolCallState.emitted[index] = true
-                    "\n<$toolTagName name=\"$name\">"
+                    val callId = accumulated.optString("id", "").trim()
+                    val callIdAttribute =
+                        if (useResponsesApi && callId.isNotEmpty()) {
+                            " call_id=\"${escapeXml(callId)}\""
+                        } else {
+                            ""
+                        }
+                    "\n<$toolTagName name=\"$name\"$callIdAttribute>"
                 } else {
                     ""
                 }
@@ -1994,6 +2064,113 @@ open class OpenAIProvider(
         return chunks.joinToString("\n\n")
     }
 
+    private fun responsesWebSearchCallKey(event: JSONObject): Int? {
+        val outputIndex = event.optInt("output_index", -1)
+        return outputIndex.takeIf { it >= 0 }
+    }
+
+    private suspend fun markWebSearchStarted(
+        event: JSONObject,
+        state: StreamingState,
+        emitter: StreamEmitter
+    ) {
+        val key = responsesWebSearchCallKey(event) ?: return
+        if (key in state.activeWebSearchCalls) {
+            return
+        }
+        val wasEmpty = state.activeWebSearchCalls.isEmpty()
+        state.activeWebSearchCalls = state.activeWebSearchCalls + key
+        if (wasEmpty) {
+            emitter.emitServerToolStarted(key.toString(), "web_search")
+        }
+    }
+
+    private suspend fun markWebSearchCompleted(
+        event: JSONObject,
+        state: StreamingState,
+        emitter: StreamEmitter
+    ) {
+        val key = responsesWebSearchCallKey(event) ?: return
+        if (key !in state.activeWebSearchCalls) {
+            return
+        }
+        state.activeWebSearchCalls = state.activeWebSearchCalls - key
+        if (state.activeWebSearchCalls.isEmpty()) {
+            emitter.emitServerToolCompleted(key.toString(), "web_search")
+        }
+    }
+
+    private suspend fun emitWebSearchMetadata(
+        item: JSONObject,
+        state: StreamingState,
+        emitter: StreamEmitter
+    ) {
+        val itemId = item.optString("id", "").trim()
+        if (itemId.isEmpty() || itemId in state.emittedWebSearchCallIds) {
+            return
+        }
+        state.emittedWebSearchCallIds = state.emittedWebSearchCallIds + itemId
+        if (state.isInReasoningMode) {
+            state.isInReasoningMode = false
+            emitter.emitTag("</think>")
+            state.hasEmittedThinkStart = false
+        }
+        OpenAIResponsesPayloadAdapter.createWebSearchMetadataTag(item)?.let { metadataTag ->
+            emitter.emitTag(metadataTag)
+        }
+    }
+
+    private suspend fun emitWebSearchMetadataFromResponse(
+        responseObj: JSONObject?,
+        state: StreamingState,
+        emitter: StreamEmitter
+    ) {
+        val output = responseObj?.optJSONArray("output") ?: return
+        for (index in 0 until output.length()) {
+            val item = output.optJSONObject(index) ?: continue
+            if (item.optString("type", "") == "web_search_call") {
+                emitWebSearchMetadata(item, state, emitter)
+            }
+        }
+    }
+
+    private suspend fun finalizeResponsesStream(
+        responseObj: JSONObject?,
+        state: StreamingState,
+        emitter: StreamEmitter,
+        onTokensUpdated: suspend (input: Long, cachedInput: Long, output: Long) -> Unit,
+        onUsageReported: (suspend (com.ai.assistance.operit.data.stats.ProviderUsageSnapshot, attempt: Int) -> Unit)?,
+        attemptNumber: Int
+    ) {
+        val usage = responseObj?.optJSONObject("usage")
+        val reasoningTokens =
+            usage?.optJSONObject("output_tokens_details")?.optLong("reasoning_tokens", 0L) ?: 0L
+        if (reasoningTokens > 0 || hasResponsesReasoningItem(responseObj)) {
+            state.reasoningObserved = true
+        }
+
+        if (state.isInReasoningMode) {
+            state.isInReasoningMode = false
+            emitter.emitTag("</think>")
+            state.hasEmittedThinkStart = false
+        } else {
+            val lateReasoningText = extractResponsesReasoningText(responseObj)
+            if (lateReasoningText.isNotEmpty() && state.streamedReasoningContentLength == 0) {
+                emitCompletedResponsesReasoningText(lateReasoningText, state, emitter)
+            }
+        }
+
+        emitWebSearchMetadataFromResponse(responseObj, state, emitter)
+        closeAllOpenToolCalls(state, emitter)
+        applyUsageToCounters(usage, onTokensUpdated, onUsageReported, attemptNumber)
+        if (state.activeWebSearchCalls.isNotEmpty()) {
+            val lastKey = state.activeWebSearchCalls.last().toString()
+            state.activeWebSearchCalls = emptySet()
+            emitter.emitServerToolCompleted(lastKey, "web_search")
+        }
+        state.streamCompletionConfirmed = true
+    }
+
     private suspend fun processResponsesStreamingEvent(
         context: Context,
         jsonResponse: JSONObject,
@@ -2049,10 +2226,32 @@ open class OpenAIProvider(
                 }
             }
 
+            "response.web_search_call.in_progress", "response.web_search_call.searching" -> {
+                markWebSearchStarted(jsonResponse, state, emitter)
+            }
+
+            "response.web_search_call.completed" -> {
+                markWebSearchCompleted(jsonResponse, state, emitter)
+            }
+
             "response.output_item.added", "response.output_item.done" -> {
                 val outputIndex = jsonResponse.optInt("output_index", -1)
                 val item = jsonResponse.optJSONObject("item")
-                if (outputIndex < 0 || item == null) {
+                if (item == null) {
+                    return
+                }
+
+                if (item.optString("type", "") == "web_search_call") {
+                    if (eventType == "response.output_item.added") {
+                        markWebSearchStarted(jsonResponse, state, emitter)
+                    }
+                    if (eventType == "response.output_item.done") {
+                        emitWebSearchMetadata(item, state, emitter)
+                    }
+                    return
+                }
+
+                if (outputIndex < 0) {
                     return
                 }
 
@@ -2146,32 +2345,15 @@ open class OpenAIProvider(
                 }
             }
 
-            "response.completed" -> {
-                val responseObj = jsonResponse.optJSONObject("response")
-                val usage = responseObj?.optJSONObject("usage")
-                val reasoningTokens =
-                    usage
-                        ?.optJSONObject("output_tokens_details")
-                        ?.optLong("reasoning_tokens", 0L)
-                        ?: 0L
-                if (reasoningTokens > 0 || hasResponsesReasoningItem(responseObj)) {
-                    state.reasoningObserved = true
-                }
-
-                if (state.isInReasoningMode) {
-                    state.isInReasoningMode = false
-                    emitter.emitTag("</think>")
-                    state.hasEmittedThinkStart = false
-                } else {
-                    val lateReasoningText = extractResponsesReasoningText(responseObj)
-                    if (lateReasoningText.isNotEmpty() && state.streamedReasoningContentLength == 0) {
-                        emitCompletedResponsesReasoningText(lateReasoningText, state, emitter)
-                    }
-                }
-
-                closeAllOpenToolCalls(state, emitter)
-                applyUsageToCounters(usage, onTokensUpdated, onUsageReported, attemptNumber)
-                state.streamCompletionConfirmed = true
+            "response.completed", "response.incomplete" -> {
+                finalizeResponsesStream(
+                    responseObj = jsonResponse.optJSONObject("response"),
+                    state = state,
+                    emitter = emitter,
+                    onTokensUpdated = onTokensUpdated,
+                    onUsageReported = onUsageReported,
+                    attemptNumber = attemptNumber
+                )
             }
 
             "response.failed", "response.error" -> {
@@ -2623,6 +2805,9 @@ open class OpenAIProvider(
                                         }
                                     }
                                     parsed.reasoningMetadataTags.forEach { metadataTag ->
+                                        emitter.emitTag(metadataTag)
+                                    }
+                                    parsed.webSearchMetadataTags.forEach { metadataTag ->
                                         emitter.emitTag(metadataTag)
                                     }
 

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -114,7 +114,7 @@ open class OpenAIProvider(
     @Volatile
     private var isManuallyCancelled = false
 
-    /** 由客户端请求错误触发的终止异常。重复同一请求不会改变服务端校验结果。 */
+    /** 由客户端请求错误触发的异常；是否重试由 HTTP 状态码策略决定。 */
     class NonRetriableException(
         message: String,
         override val statusCode: Int,
@@ -1546,7 +1546,10 @@ open class OpenAIProvider(
         if (exception is UserCancellationException || exception is CancellationException) {
             throw exception
         }
-        if (exception is NonRetriableException) {
+        if (
+            exception is NonRetriableException &&
+                !LlmRetryPolicy.isRetryableClientStatus(exception.statusCode)
+        ) {
             throw exception
         }
         checkCancellation(context, exception)

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -2270,7 +2270,7 @@ open class OpenAIProvider(
                         emitCompletedResponsesReasoningText(itemReasoningText, state, emitter)
                     }
                     if (eventType == "response.output_item.done") {
-                        OpenAIResponsesPayloadAdapter.createReasoningMetadataTag(item)?.let { metadataTag ->
+                        OpenAIResponsesPayloadAdapter.createReasoningMetadataTag(item, providerType)?.let { metadataTag ->
                             if (state.isInReasoningMode) {
                                 state.isInReasoningMode = false
                                 emitter.emitTag("</think>")
@@ -2800,7 +2800,10 @@ open class OpenAIProvider(
                                 val handledImages = tryHandleOpenAiImageResponse(jsonResponse, emitter, null)
 
                                 if (useResponsesApi) {
-                                    val parsed = OpenAIResponsesPayloadAdapter.parseNonStreamingResponse(jsonResponse)
+                                    val parsed = OpenAIResponsesPayloadAdapter.parseNonStreamingResponse(
+                                        jsonResponse,
+                                        providerType
+                                    )
 
                                     parsed.reasoningChunks.forEach { reasoningChunk ->
                                         if (reasoningChunk.isNotEmpty()) {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
@@ -322,7 +322,10 @@ object OpenAIResponsesPayloadAdapter {
         requestJson.put("reasoning", reasoningObject)
     }
 
-    fun parseNonStreamingResponse(jsonResponse: JSONObject): ParsedResponseOutput {
+    fun parseNonStreamingResponse(
+        jsonResponse: JSONObject,
+        providerType: ApiProviderType = ApiProviderType.OPENAI_RESPONSES
+    ): ParsedResponseOutput {
         val textChunks = mutableListOf<String>()
         val reasoningChunks = mutableListOf<String>()
         val reasoningMetadataTags = mutableListOf<String>()
@@ -361,7 +364,9 @@ object OpenAIResponsesPayloadAdapter {
 
                     "reasoning" -> {
                         reasoningObserved = true
-                        createReasoningMetadataTag(item)?.let { reasoningMetadataTags.add(it) }
+                        createReasoningMetadataTag(item, providerType)?.let {
+                            reasoningMetadataTags.add(it)
+                        }
                         val summaryArray = item.optJSONArray("summary")
                         if (summaryArray != null) {
                             for (j in 0 until summaryArray.length()) {
@@ -462,9 +467,12 @@ object OpenAIResponsesPayloadAdapter {
             }
 
             if (role == "assistant") {
-                appendReasoningItemsFromAssistantMessage(message, input)
+                val reasoningItemReplayed = appendReasoningItemsFromAssistantMessage(message, input)
                 appendWebSearchItemsFromAssistantMessage(message, input)
-                val convertedContent = convertMessageContentForResponses(message.opt("content"))
+                val convertedContent = convertMessageContentForResponses(
+                    content = message.opt("content"),
+                    removeThinkingContent = reasoningItemReplayed
+                )
                 val hasContent =
                     when (convertedContent) {
                         is String -> convertedContent.isNotBlank()
@@ -538,10 +546,13 @@ object OpenAIResponsesPayloadAdapter {
         return input
     }
 
-    private fun convertMessageContentForResponses(content: Any?): Any {
+    private fun convertMessageContentForResponses(
+        content: Any?,
+        removeThinkingContent: Boolean = false
+    ): Any {
         return when (content) {
             null -> ""
-            is String -> removeResponsesMetadata(content)
+            is String -> sanitizeResponsesMessageText(content, removeThinkingContent)
             is JSONArray -> {
                 val convertedParts = JSONArray()
 
@@ -549,7 +560,10 @@ object OpenAIResponsesPayloadAdapter {
                     val part = content.optJSONObject(i) ?: continue
                     when (part.optString("type", "")) {
                         "text", "output_text", "input_text" -> {
-                            val text = removeResponsesMetadata(part.optString("text", ""))
+                            val text = sanitizeResponsesMessageText(
+                                part.optString("text", ""),
+                                removeThinkingContent
+                            )
                             if (text.isNotEmpty()) {
                                 convertedParts.put(
                                     JSONObject().apply {
@@ -605,7 +619,10 @@ object OpenAIResponsesPayloadAdapter {
                         }
 
                         else -> {
-                            val plainText = removeResponsesMetadata(part.optString("text", ""))
+                            val plainText = sanitizeResponsesMessageText(
+                                part.optString("text", ""),
+                                removeThinkingContent
+                            )
                             if (plainText.isNotEmpty()) {
                                 convertedParts.put(
                                     JSONObject().apply {
@@ -623,6 +640,15 @@ object OpenAIResponsesPayloadAdapter {
 
             else -> content.toString()
         }
+    }
+
+    private fun sanitizeResponsesMessageText(
+        content: String,
+        removeThinkingContent: Boolean
+    ): String {
+        val visibleContent =
+            if (removeThinkingContent) ChatUtils.removeThinkingContent(content) else content
+        return removeResponsesMetadata(visibleContent)
     }
 
     private fun removeResponsesMetadata(content: String): String {
@@ -654,12 +680,36 @@ object OpenAIResponsesPayloadAdapter {
         }
     }
 
-    fun createReasoningMetadataTag(item: JSONObject): String? {
+    fun createReasoningMetadataTag(
+        item: JSONObject,
+        providerType: ApiProviderType = ApiProviderType.OPENAI_RESPONSES
+    ): String? {
         if (item.optString("type", "") != "reasoning") {
             return null
         }
 
         val id = item.optString("id", "").trim()
+
+        if (providerType == ApiProviderType.DEEPSEEK) {
+            val content = item.optJSONArray("content") ?: return null
+            val hasReasoningText = (0 until content.length()).any { index ->
+                val part = content.optJSONObject(index) ?: return@any false
+                part.optString("type", "") == "reasoning_text" &&
+                    part.optString("text", "").isNotEmpty()
+            }
+            if (id.isEmpty() || !hasReasoningText) {
+                return null
+            }
+
+            val payload = JSONObject().apply {
+                put("reasoning_id", id)
+                put("content", JSONArray(content.toString()))
+            }
+            val payloadBase64 =
+                Base64.encodeToString(payload.toString().toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+            return ChatMarkupRegex.openAiResponsesReasoningMetaTag(payloadBase64)
+        }
+
         val encryptedContent = item.optString("encrypted_content", "").trim()
         if (id.isEmpty() || encryptedContent.isEmpty()) {
             return null
@@ -677,22 +727,29 @@ object OpenAIResponsesPayloadAdapter {
         return ChatMarkupRegex.openAiResponsesReasoningMetaTag(payloadBase64)
     }
 
-    private fun appendReasoningItemsFromAssistantMessage(message: JSONObject, input: JSONArray) {
+    private fun appendReasoningItemsFromAssistantMessage(
+        message: JSONObject,
+        input: JSONArray
+    ): Boolean {
         val content = message.opt("content")
         val payloads = when (content) {
             is String -> ChatMarkupRegex.extractOpenAiResponsesReasoningPayloads(content)
             is JSONArray -> extractReasoningPayloadsFromContentArray(content)
             else -> emptyList()
         }
+        var itemReplayed = false
 
         payloads.forEach { payloadBase64 ->
             runCatching {
                 val decodedPayload = String(Base64.decode(payloadBase64, Base64.DEFAULT), Charsets.UTF_8)
-                appendReasoningItemFromMetadata(JSONObject(decodedPayload), input)
+                if (appendReasoningItemFromMetadata(JSONObject(decodedPayload), input)) {
+                    itemReplayed = true
+                }
             }.onFailure { e ->
                 AppLogger.w("OpenAIResponsesProvider", "OpenAI Responses reasoning metadata decode failed", e)
             }
         }
+        return itemReplayed
     }
 
     private fun extractReasoningPayloadsFromContentArray(content: JSONArray): List<String> {
@@ -719,11 +776,34 @@ object OpenAIResponsesPayloadAdapter {
         return payloads
     }
 
-    private fun appendReasoningItemFromMetadata(metadata: JSONObject, input: JSONArray) {
+    private fun appendReasoningItemFromMetadata(
+        metadata: JSONObject,
+        input: JSONArray
+    ): Boolean {
         val reasoningId = metadata.optString("reasoning_id", "").trim()
+        if (metadata.has("content")) {
+            val content = metadata.optJSONArray("content") ?: return false
+            val hasReasoningText = (0 until content.length()).any { index ->
+                val part = content.optJSONObject(index) ?: return@any false
+                part.optString("type", "") == "reasoning_text" &&
+                    part.optString("text", "").isNotEmpty()
+            }
+            if (reasoningId.isEmpty() || !hasReasoningText) {
+                return false
+            }
+            input.put(
+                JSONObject().apply {
+                    put("type", "reasoning")
+                    put("id", reasoningId)
+                    put("content", JSONArray(content.toString()))
+                }
+            )
+            return true
+        }
+
         val encryptedContent = metadata.optString("encrypted_content", "").trim()
         if (reasoningId.isEmpty() || encryptedContent.isEmpty()) {
-            return
+            return false
         }
 
         input.put(
@@ -735,6 +815,7 @@ object OpenAIResponsesPayloadAdapter {
                 put("summary", JSONArray(summary.toString()))
             }
         )
+        return true
     }
 
     private fun appendWebSearchItemsFromAssistantMessage(message: JSONObject, input: JSONArray) {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
@@ -28,7 +28,8 @@ open class OpenAIResponsesProvider(
     supportsFiles: Boolean = false,
     enableToolCall: Boolean = false,
     thinkingConfigurations: String = "",
-    thinkingOptionId: String = ""
+    thinkingOptionId: String = "",
+    private val enableServerWebSearch: Boolean = false
 ) : OpenAIProvider(
     apiEndpoint = responsesApiEndpoint,
     apiKeyProvider = apiKeyProvider,
@@ -72,6 +73,10 @@ open class OpenAIResponsesProvider(
         val jsonObject = JSONObject(baseRequestBodyJson)
 
         applyResponsesReasoningEffort(context, jsonObject, enableThinking)
+        OpenAIResponsesPayloadAdapter.appendServerWebSearchTool(
+            requestJson = jsonObject,
+            enabled = enableServerWebSearch
+        )
 
         val logJson = JSONObject(jsonObject.toString())
         if (logJson.has("tools")) {
@@ -205,6 +210,7 @@ object OpenAIResponsesPayloadAdapter {
         val textChunks: List<String>,
         val reasoningChunks: List<String>,
         val reasoningMetadataTags: List<String>,
+        val webSearchMetadataTags: List<String>,
         val reasoningObserved: Boolean,
         val toolCalls: JSONArray,
         val usage: UsageCounts?
@@ -215,6 +221,24 @@ object OpenAIResponsesPayloadAdapter {
             "max_tokens" -> "max_output_tokens"
             else -> apiName
         }
+    }
+
+    internal fun appendServerWebSearchTool(requestJson: JSONObject, enabled: Boolean) {
+        if (!enabled) {
+            return
+        }
+
+        val tools = requestJson.optJSONArray("tools") ?: JSONArray().also {
+            requestJson.put("tools", it)
+        }
+        val isAlreadyDeclared =
+            (0 until tools.length()).any { index ->
+                tools.optJSONObject(index)?.optString("type", "") == "web_search"
+            }
+        if (isAlreadyDeclared) {
+            return
+        }
+        tools.put(JSONObject().put("type", "web_search"))
     }
 
     fun parseUsageCounts(usage: JSONObject?): UsageCounts? {
@@ -302,6 +326,7 @@ object OpenAIResponsesPayloadAdapter {
         val textChunks = mutableListOf<String>()
         val reasoningChunks = mutableListOf<String>()
         val reasoningMetadataTags = mutableListOf<String>()
+        val webSearchMetadataTags = mutableListOf<String>()
         val toolCalls = JSONArray()
         var reasoningObserved = false
 
@@ -355,6 +380,12 @@ object OpenAIResponsesPayloadAdapter {
                             toolCalls.put(toolCall)
                         }
                     }
+
+                    "web_search_call" -> {
+                        createWebSearchMetadataTag(item)?.let { metadataTag ->
+                            webSearchMetadataTags.add(metadataTag)
+                        }
+                    }
                 }
             }
         }
@@ -363,6 +394,7 @@ object OpenAIResponsesPayloadAdapter {
             textChunks = textChunks,
             reasoningChunks = reasoningChunks,
             reasoningMetadataTags = reasoningMetadataTags,
+            webSearchMetadataTags = webSearchMetadataTags,
             reasoningObserved = reasoningObserved,
             toolCalls = toolCalls,
             usage = parseUsageCounts(jsonResponse.optJSONObject("usage"))
@@ -431,6 +463,28 @@ object OpenAIResponsesPayloadAdapter {
 
             if (role == "assistant") {
                 appendReasoningItemsFromAssistantMessage(message, input)
+                appendWebSearchItemsFromAssistantMessage(message, input)
+                val convertedContent = convertMessageContentForResponses(message.opt("content"))
+                val hasContent =
+                    when (convertedContent) {
+                        is String -> convertedContent.isNotBlank()
+                        is JSONArray -> convertedContent.length() > 0
+                        else -> false
+                    }
+
+                // Responses requires function_call items to be followed immediately by their
+                // function_call_output items. Emit the visible assistant message first so it
+                // cannot split the function-call/output sequence.
+                if (hasContent) {
+                    input.put(
+                        JSONObject().apply {
+                            put("type", "message")
+                            put("role", "assistant")
+                            put("content", convertedContent)
+                        }
+                    )
+                }
+
                 val toolCalls = message.optJSONArray("tool_calls")
                 if (toolCalls != null && toolCalls.length() > 0) {
                     for (j in 0 until toolCalls.length()) {
@@ -453,6 +507,7 @@ object OpenAIResponsesPayloadAdapter {
                         input.put(callItem)
                     }
                 }
+                continue
             }
 
             val convertedContent = convertMessageContentForResponses(message.opt("content"))
@@ -486,7 +541,7 @@ object OpenAIResponsesPayloadAdapter {
     private fun convertMessageContentForResponses(content: Any?): Any {
         return when (content) {
             null -> ""
-            is String -> ChatMarkupRegex.removeOpenAiResponsesReasoningMeta(content)
+            is String -> removeResponsesMetadata(content)
             is JSONArray -> {
                 val convertedParts = JSONArray()
 
@@ -494,7 +549,7 @@ object OpenAIResponsesPayloadAdapter {
                     val part = content.optJSONObject(i) ?: continue
                     when (part.optString("type", "")) {
                         "text", "output_text", "input_text" -> {
-                            val text = ChatMarkupRegex.removeOpenAiResponsesReasoningMeta(part.optString("text", ""))
+                            val text = removeResponsesMetadata(part.optString("text", ""))
                             if (text.isNotEmpty()) {
                                 convertedParts.put(
                                     JSONObject().apply {
@@ -550,12 +605,12 @@ object OpenAIResponsesPayloadAdapter {
                         }
 
                         else -> {
-                            val fallbackText = part.optString("text", "")
-                            if (fallbackText.isNotEmpty()) {
+                            val plainText = removeResponsesMetadata(part.optString("text", ""))
+                            if (plainText.isNotEmpty()) {
                                 convertedParts.put(
                                     JSONObject().apply {
                                         put("type", "input_text")
-                                        put("text", fallbackText)
+                                        put("text", plainText)
                                     }
                                 )
                             }
@@ -568,6 +623,12 @@ object OpenAIResponsesPayloadAdapter {
 
             else -> content.toString()
         }
+    }
+
+    private fun removeResponsesMetadata(content: String): String {
+        return ChatMarkupRegex.removeOpenAiResponsesWebSearchMeta(
+            ChatMarkupRegex.removeOpenAiResponsesReasoningMeta(content)
+        )
     }
 
     private fun extractToolOutputText(content: Any?): String {
@@ -611,7 +672,8 @@ object OpenAIResponsesPayloadAdapter {
             val summaryArray = item.optJSONArray("summary") ?: JSONArray()
             put("summary", JSONArray(summaryArray.toString()))
         }
-        val payloadBase64 = Base64.encodeToString(payload.toString().toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+        val payloadBase64 =
+            Base64.encodeToString(payload.toString().toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
         return ChatMarkupRegex.openAiResponsesReasoningMetaTag(payloadBase64)
     }
 
@@ -645,6 +707,18 @@ object OpenAIResponsesPayloadAdapter {
         return payloads
     }
 
+    private fun extractWebSearchPayloadsFromContentArray(content: JSONArray): List<String> {
+        val payloads = mutableListOf<String>()
+        for (i in 0 until content.length()) {
+            val part = content.optJSONObject(i) ?: continue
+            val text = part.optString("text", "")
+            if (text.isNotEmpty()) {
+                payloads.addAll(ChatMarkupRegex.extractOpenAiResponsesWebSearchPayloads(text))
+            }
+        }
+        return payloads
+    }
+
     private fun appendReasoningItemFromMetadata(metadata: JSONObject, input: JSONArray) {
         val reasoningId = metadata.optString("reasoning_id", "").trim()
         val encryptedContent = metadata.optString("encrypted_content", "").trim()
@@ -661,6 +735,39 @@ object OpenAIResponsesPayloadAdapter {
                 put("summary", JSONArray(summary.toString()))
             }
         )
+    }
+
+    private fun appendWebSearchItemsFromAssistantMessage(message: JSONObject, input: JSONArray) {
+        val content = message.opt("content")
+        val payloads = when (content) {
+            is String -> ChatMarkupRegex.extractOpenAiResponsesWebSearchPayloads(content)
+            is JSONArray -> extractWebSearchPayloadsFromContentArray(content)
+            else -> emptyList()
+        }
+
+        payloads.forEach { payloadBase64 ->
+            runCatching {
+                val decodedPayload = String(Base64.decode(payloadBase64, Base64.DEFAULT), Charsets.UTF_8)
+                val item = JSONObject(decodedPayload)
+                if (item.optString("type", "") == "web_search_call") {
+                    input.put(item)
+                }
+            }.onFailure { error ->
+                AppLogger.w("OpenAIResponsesProvider", "Responses web search metadata decode failed", error)
+            }
+        }
+    }
+
+    fun createWebSearchMetadataTag(item: JSONObject): String? {
+        if (
+            item.optString("type", "") != "web_search_call" ||
+                item.optString("id", "").isBlank()
+        ) {
+            return null
+        }
+        val payloadBase64 =
+            Base64.encodeToString(item.toString().toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+        return ChatMarkupRegex.openAiResponsesWebSearchMetaTag(payloadBase64)
     }
 
     private fun convertFunctionCallItemToChatToolCall(item: JSONObject): JSONObject? {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/TokenTrackingAIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/TokenTrackingAIService.kt
@@ -39,6 +39,7 @@ class TokenTrackingAIService(
     override val cachedInputTokenCount: Long get() = delegate.cachedInputTokenCount
     override val outputTokenCount: Long get() = delegate.outputTokenCount
     override val providerModel: String get() = delegate.providerModel
+    override val usesResponsesApi: Boolean get() = delegate.usesResponsesApi
 
     override fun resetTokenCounts() = delegate.resetTokenCounts()
     override fun cancelStreaming() {

--- a/app/src/main/java/com/ai/assistance/operit/data/collects/ApiProviderConfigCollect.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/collects/ApiProviderConfigCollect.kt
@@ -72,7 +72,17 @@ object ApiProviderConfigs {
         ProviderApiConfig(
             providerType = ApiProviderType.DEEPSEEK,
             defaultModelName = "deepseek-v4-flash",
-            defaultApiEndpoint = "https://api.deepseek.com/v1/chat/completions"
+            defaultApiEndpoint = "https://api.deepseek.com/v1/chat/completions",
+            endpointOptions = listOf(
+                ProviderEndpointOption(
+                    endpoint = "https://api.deepseek.com/v1/chat/completions",
+                    label = "Chat Completions"
+                ),
+                ProviderEndpointOption(
+                    endpoint = "https://api.deepseek.com/v1/responses",
+                    label = "Responses"
+                )
+            )
         ),
         ProviderApiConfig(
             providerType = ApiProviderType.BAIDU,

--- a/app/src/main/java/com/ai/assistance/operit/data/model/AITool.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/model/AITool.kt
@@ -21,7 +21,8 @@ data class ToolInvocation(
         val tool: AITool,
         val rawText: String,
         @Contextual
-        val responseLocation: IntRange // Where in the response this tool invocation was found
+        val responseLocation: IntRange, // Where in the response this tool invocation was found
+        val toolCallId: String? = null
 )
 
 /** Represents the result of a tool execution */
@@ -30,7 +31,8 @@ data class ToolResult(
         val toolName: String,
         val success: Boolean,
         val result: ToolResultData,
-        val error: String? = null
+        val error: String? = null,
+        val toolCallId: String? = null
 )
 
 /** Represents the validation result for tool parameters */

--- a/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
@@ -159,6 +159,9 @@ data class ModelConfigData(
         // Gemini特定配置
         val enableGoogleSearch: Boolean = false, // 是否启用Google Search Grounding (仅Gemini支持)
 
+        // DeepSeek特定配置
+        val enableDeepSeekWebSearch: Boolean = true,
+
         // Claude特定配置
         val enableClaude1hPromptCache: Boolean = false, // 是否启用1小时提示缓存TTL (仅Claude支持)
 

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
@@ -479,6 +479,7 @@ class ModelConfigManager(private val context: Context) {
             enableDirectAudioProcessing: Boolean,
             enableDirectVideoProcessing: Boolean,
             enableGoogleSearch: Boolean,
+            enableDeepSeekWebSearch: Boolean,
             enableClaude1hPromptCache: Boolean,
             enableToolCall: Boolean
     ): ModelConfigData {
@@ -500,6 +501,7 @@ class ModelConfigManager(private val context: Context) {
                     enableDirectAudioProcessing = enableDirectAudioProcessing,
                     enableDirectVideoProcessing = enableDirectVideoProcessing,
                     enableGoogleSearch = enableGoogleSearch,
+                    enableDeepSeekWebSearch = enableDeepSeekWebSearch,
                     enableClaude1hPromptCache = enableClaude1hPromptCache,
                     enableToolCall = enableToolCall
             )

--- a/app/src/main/java/com/ai/assistance/operit/services/core/MessageProcessingDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/MessageProcessingDelegate.kt
@@ -1329,6 +1329,9 @@ class MessageProcessingDelegate(
                                                         tryEmitScrollToBottomThrottled(chatId)
                                                     }
                                                 }
+
+                                                TextStreamEventType.SERVER_TOOL_STARTED,
+                                                TextStreamEventType.SERVER_TOOL_COMPLETED -> Unit
                                             }
                                         }
                                     }
@@ -1741,6 +1744,9 @@ class MessageProcessingDelegate(
                                             } ?: return@collect
                                         aiMessage.content = snapshot
                                     }
+
+                                    TextStreamEventType.SERVER_TOOL_STARTED,
+                                    TextStreamEventType.SERVER_TOOL_COMPLETED -> Unit
                                 }
                             }
                         }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
@@ -120,6 +120,7 @@ internal fun cleanMessageContentForCopy(content: String): String {
         // Provider元数据必须保留在消息中供后续轮次使用，但不能暴露在复制内容中
         .let(ChatMarkupRegex::removeGeminiThoughtSignatureMeta)
         .let(ChatMarkupRegex::removeOpenAiResponsesReasoningMeta)
+        .let(ChatMarkupRegex::removeOpenAiResponsesWebSearchMeta)
         // 移除状态标签
         .replace(ChatMarkupRegex.statusTag, "")
         .replace(ChatMarkupRegex.statusSelfClosingTag, "")

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/RevisableTextStreamRemember.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/RevisableTextStreamRemember.kt
@@ -68,6 +68,9 @@ fun rememberRevisableTextStream(sourceStream: Stream<String>?): Stream<String>? 
                             displayStream = rollbackStream
                             previousOutputStream.resetReplayCache()
                         }
+
+                        TextStreamEventType.SERVER_TOOL_STARTED,
+                        TextStreamEventType.SERVER_TOOL_COMPLETED -> Unit
                     }
                 }
             }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/CustomXmlRenderer.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/CustomXmlRenderer.kt
@@ -88,6 +88,20 @@ class CustomXmlRenderer(
         val trimmedContent = xmlContent.trim()
         val tagName = extractTagName(trimmedContent)
 
+        if (tagName == "meta") {
+            val serverToolCall = ChatMarkupRegex.parseOpenAiResponsesServerToolCall(trimmedContent)
+            if (serverToolCall != null) {
+                Box(modifier = modifier) {
+                    ServerToolDisplay(
+                        record = serverToolCall,
+                        textColor = textColor,
+                        enableDialog = enableDialogs,
+                    )
+                }
+                return
+            }
+        }
+
         if (shouldHideHiddenMeta(trimmedContent, tagName)) {
             return
         }
@@ -207,7 +221,7 @@ class CustomXmlRenderer(
     private fun shouldHideHiddenMeta(content: String, tagName: String?): Boolean {
         return tagName == "meta" &&
             Regex(
-                """\bprovider\s*=\s*["'](?:gemini:thought_signature|openai:responses_reasoning)["']""",
+                """\bprovider\s*=\s*["'](?:gemini:thought_signature|openai:responses_reasoning|openai:responses_web_search)["']""",
                 RegexOption.IGNORE_CASE
             )
                 .containsMatchIn(content)

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/ToolDisplayComponents.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/ToolDisplayComponents.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material.icons.filled.Web
+import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -33,10 +34,56 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ai.assistance.operit.R
+import com.ai.assistance.operit.util.ServerToolCallRecord
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
+
+/** 只读展示模型供应商在服务端执行的工具；不会进入本地工具执行或授权流程。 */
+@Composable
+fun ServerToolDisplay(
+    record: ServerToolCallRecord,
+    textColor: Color,
+    modifier: Modifier = Modifier,
+    enableDialog: Boolean = true,
+) {
+    val context = LocalContext.current
+    val toolName = record.toolType
+    val statusLabel =
+        when (record.status) {
+            "completed" -> context.getString(R.string.tools_completed)
+            "in_progress", "searching" -> context.getString(R.string.searching)
+            else -> record.status
+        }
+    val summary =
+        remember(record.actionSummary, statusLabel) {
+            listOf(record.actionSummary, statusLabel)
+                .filter { it.isNotBlank() }
+                .joinToString(" · ")
+        }
+    var showDetailDialog by remember { mutableStateOf(false) }
+
+    if (showDetailDialog && enableDialog) {
+        ContentDetailDialog(
+            title = "$toolName · ${context.getString(R.string.details)}",
+            content = record.rawJson,
+            icon = Icons.Outlined.Cloud,
+            onDismiss = { showDetailDialog = false },
+        )
+    }
+
+    CanvasToolSummaryRow(
+        toolName = toolName,
+        summary = summary,
+        semanticDescription = "Server tool · $toolName: $summary",
+        leadingIcon = Icons.Outlined.Cloud,
+        titleColor = MaterialTheme.colorScheme.primary,
+        summaryColor = textColor.copy(alpha = 0.7f),
+        modifier = modifier,
+        onClick = if (enableDialog) ({ showDetailDialog = true }) else null,
+    )
+}
 
 /** 简洁样式的工具调用显示组件 使用箭头图标+工具名+参数的简洁行样式 */
 @Composable

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.VisualTransformation
 import com.ai.assistance.operit.R
+import com.ai.assistance.operit.api.chat.llmprovider.DeepSeekApiProtocol
 import com.ai.assistance.operit.api.chat.llmprovider.EndpointCompleter
 import com.ai.assistance.operit.api.chat.EnhancedAIService
 import com.ai.assistance.operit.api.chat.llmprovider.AIServiceFactory
@@ -209,6 +210,10 @@ fun ModelApiSettingsSection(
     // Google Search Grounding 配置状态 (仅Gemini)
     var enableGoogleSearchInput by remember(config.id) { mutableStateOf(config.enableGoogleSearch) }
 
+    var enableDeepSeekWebSearchInput by remember(config.id) {
+        mutableStateOf(config.enableDeepSeekWebSearch)
+    }
+
     // Claude 1小时提示缓存配置状态 (仅Claude)
     var enableClaude1hPromptCacheInput by remember(config.id) {
         mutableStateOf(config.enableClaude1hPromptCache)
@@ -241,6 +246,7 @@ fun ModelApiSettingsSection(
         val enableDirectAudioProcessing: Boolean,
         val enableDirectVideoProcessing: Boolean,
         val enableGoogleSearch: Boolean,
+        val enableDeepSeekWebSearch: Boolean,
         val enableClaude1hPromptCache: Boolean,
         val enableToolCall: Boolean,
     )
@@ -265,6 +271,7 @@ fun ModelApiSettingsSection(
                     enableDirectAudioProcessing = state.enableDirectAudioProcessing,
                     enableDirectVideoProcessing = state.enableDirectVideoProcessing,
                     enableGoogleSearch = state.enableGoogleSearch,
+                    enableDeepSeekWebSearch = state.enableDeepSeekWebSearch,
                     enableClaude1hPromptCache = state.enableClaude1hPromptCache,
                     enableToolCall = state.enableToolCall,
                 )
@@ -292,6 +299,7 @@ fun ModelApiSettingsSection(
             enableDirectAudioProcessing = enableDirectAudioProcessingInput,
             enableDirectVideoProcessing = enableDirectVideoProcessingInput,
             enableGoogleSearch = enableGoogleSearchInput,
+            enableDeepSeekWebSearch = enableDeepSeekWebSearchInput,
             enableClaude1hPromptCache = enableClaude1hPromptCacheInput,
             enableToolCall = enableToolCallInput,
         )
@@ -868,6 +876,17 @@ fun ModelApiSettingsSection(
                             checked = enableGoogleSearchInput,
                             onCheckedChange = { enableGoogleSearchInput = it }
                     )
+            }
+
+            if (selectedApiProvider == ApiProviderType.DEEPSEEK &&
+                EndpointCompleter.resolveDeepSeekProtocol(apiEndpointInput) ==
+                    DeepSeekApiProtocol.RESPONSES) {
+                SettingsSwitchRow(
+                    title = stringResource(R.string.enable_deepseek_web_search),
+                    subtitle = stringResource(R.string.enable_deepseek_web_search_desc),
+                    checked = enableDeepSeekWebSearchInput,
+                    onCheckedChange = { enableDeepSeekWebSearchInput = it }
+                )
             }
 
             // Claude 1小时提示缓存开关 (仅Claude支持)

--- a/app/src/main/java/com/ai/assistance/operit/util/ChatMarkupRegex.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/ChatMarkupRegex.kt
@@ -1,11 +1,23 @@
 package com.ai.assistance.operit.util
 
 import java.security.SecureRandom
+import java.util.Base64
+import org.json.JSONObject
+
+data class ServerToolCallRecord(
+    val callId: String,
+    val toolType: String,
+    val status: String,
+    val actionType: String,
+    val actionSummary: String,
+    val rawJson: String,
+)
 
 object ChatMarkupRegex {
     private const val TOOL_TAG_SUFFIX_REGEX_SOURCE = "[A-Za-z0-9_]+"
     private const val GEMINI_THOUGHT_SIGNATURE_PROVIDER = "gemini:thought_signature"
     private const val OPENAI_RESPONSES_REASONING_PROVIDER = "openai:responses_reasoning"
+    private const val OPENAI_RESPONSES_WEB_SEARCH_PROVIDER = "openai:responses_web_search"
     const val TOOL_TAG_NAME_REGEX_SOURCE =
         "tool(?:_(?!result(?:_|\\b))$TOOL_TAG_SUFFIX_REGEX_SOURCE)?"
     const val TOOL_RESULT_TAG_NAME_REGEX_SOURCE = "tool_result(?:_${TOOL_TAG_SUFFIX_REGEX_SOURCE})?"
@@ -90,6 +102,8 @@ object ChatMarkupRegex {
     val toolParamPattern = Regex("<param\\s+name=\"([^\"]+)\">([\\s\\S]*?)</param>")
 
     val nameAttr = Regex("name\\s*=\\s*\"([^\"]+)\"", RegexOption.IGNORE_CASE)
+
+    val toolCallIdAttr = Regex("call_id\\s*=\\s*\"([^\"]+)\"", RegexOption.IGNORE_CASE)
 
     val statusAttr = Regex("status\\s*=\\s*\"([^\"]+)\"", RegexOption.IGNORE_CASE)
 
@@ -242,6 +256,10 @@ object ChatMarkupRegex {
         return """<meta provider="$OPENAI_RESPONSES_REASONING_PROVIDER">$payloadBase64</meta>"""
     }
 
+    fun openAiResponsesWebSearchMetaTag(payloadBase64: String): String {
+        return """<meta provider="$OPENAI_RESPONSES_WEB_SEARCH_PROVIDER">$payloadBase64</meta>"""
+    }
+
     fun extractGeminiThoughtSignature(content: String): String? {
         return metaTag.findAll(content)
             .mapNotNull { match ->
@@ -276,6 +294,52 @@ object ChatMarkupRegex {
             .toList()
     }
 
+    fun extractOpenAiResponsesWebSearchPayloads(content: String): List<String> {
+        return metaTag.findAll(content)
+            .mapNotNull { match ->
+                val tagContent = match.value
+                val provider = extractMetaProvider(tagContent)
+                if (!provider.equals(OPENAI_RESPONSES_WEB_SEARCH_PROVIDER, ignoreCase = true)) {
+                    return@mapNotNull null
+                }
+                metaBodyRegex.find(tagContent)
+                    ?.groupValues
+                    ?.getOrNull(1)
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() }
+            }
+            .toList()
+    }
+
+    fun parseOpenAiResponsesServerToolCall(content: String): ServerToolCallRecord? {
+        val payload = extractOpenAiResponsesWebSearchPayloads(content).singleOrNull() ?: return null
+
+        return runCatching {
+            val decodedPayload = String(Base64.getDecoder().decode(payload), Charsets.UTF_8)
+            val item = JSONObject(decodedPayload)
+            val callId = item.optString("id", "").trim()
+            val status = item.optString("status", "").trim()
+            if (
+                item.optString("type", "") != "web_search_call" ||
+                    callId.isEmpty() ||
+                    status.isEmpty()
+            ) {
+                return null
+            }
+
+            val action = item.optJSONObject("action")
+            val actionType = action?.optString("type", "")?.trim().orEmpty()
+            ServerToolCallRecord(
+                callId = callId,
+                toolType = "web_search",
+                status = status,
+                actionType = actionType,
+                actionSummary = extractWebSearchActionSummary(action, actionType),
+                rawJson = item.toString(2),
+            )
+        }.getOrNull()
+    }
+
     fun removeGeminiThoughtSignatureMeta(content: String): String {
         var removed = false
         val result = metaTag.replace(content) { match ->
@@ -304,11 +368,48 @@ object ChatMarkupRegex {
         return if (removed) result.trimEnd() else result
     }
 
+    fun removeOpenAiResponsesWebSearchMeta(content: String): String {
+        var removed = false
+        val result = metaTag.replace(content) { match ->
+            val provider = extractMetaProvider(match.value)
+            if (provider.equals(OPENAI_RESPONSES_WEB_SEARCH_PROVIDER, ignoreCase = true)) {
+                removed = true
+                ""
+            } else {
+                match.value
+            }
+        }
+        return if (removed) result.trimEnd() else result
+    }
+
     private fun extractMetaProvider(metaTagContent: String): String? {
         return metaProviderAttrRegex
             .find(metaTagContent.substringBefore('>'))
             ?.groupValues
             ?.getOrNull(1)
+    }
+
+    private fun extractWebSearchActionSummary(action: JSONObject?, actionType: String): String {
+        if (action == null) return ""
+
+        return when (actionType) {
+            "search" -> {
+                val query = action.optString("query", "").trim()
+                if (query.isNotEmpty()) {
+                    query
+                } else {
+                    val queries = action.optJSONArray("queries") ?: return ""
+                    buildList {
+                        for (index in 0 until queries.length()) {
+                            queries.optString(index, "").trim().takeIf { it.isNotEmpty() }?.let(::add)
+                        }
+                    }.joinToString(" · ")
+                }
+            }
+            "open_page" -> action.optString("url", "").trim()
+            "find" -> action.optString("pattern", "").trim()
+            else -> ""
+        }
     }
 
     private fun generateRandomTagCode(length: Int = 4): String {

--- a/app/src/main/java/com/ai/assistance/operit/util/ChatUtils.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/ChatUtils.kt
@@ -31,6 +31,20 @@ object ChatUtils {
         }
     }
 
+    fun stripOpenAiResponsesWebSearchMeta(content: String): String {
+        return ChatMarkupRegex.removeOpenAiResponsesWebSearchMeta(content)
+    }
+
+    fun stripOpenAiResponsesMetadata(content: String): String {
+        return stripOpenAiResponsesWebSearchMeta(stripOpenAiResponsesReasoningMeta(content))
+    }
+
+    fun stripOpenAiResponsesMetadataTurns(messages: List<PromptTurn>): List<PromptTurn> {
+        return messages.map { turn ->
+            turn.withContent(stripOpenAiResponsesMetadata(turn.content))
+        }
+    }
+
     fun isGeminiProviderModel(providerModel: String): Boolean {
         return when (providerModel.substringBefore(":").uppercase()) {
             "GOOGLE", "GEMINI_GENERIC" -> true

--- a/app/src/main/java/com/ai/assistance/operit/util/stream/RevisableTextStream.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/stream/RevisableTextStream.kt
@@ -4,12 +4,15 @@ import kotlinx.coroutines.CoroutineScope
 
 data class TextStreamEvent(
     val eventType: TextStreamEventType,
-    val id: String
+    val id: String,
+    val toolType: String? = null
 )
 
 enum class TextStreamEventType {
     SAVEPOINT,
-    ROLLBACK
+    ROLLBACK,
+    SERVER_TOOL_STARTED,
+    SERVER_TOOL_COMPLETED
 }
 
 interface TextStreamEventCarrier {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -4007,6 +4007,8 @@
     <string name="enable_direct_video_processing_desc">When enabled, video will be sent directly to the AI for processing instead of tool-based frame extraction/analysis</string>
     <string name="enable_google_search">Enable Google Search</string>
     <string name="enable_google_search_desc">When enabled, Gemini will use Google Search to enhance responses (may incur additional charges)</string>
+    <string name="enable_deepseek_web_search">Enable DeepSeek web search</string>
+    <string name="enable_deepseek_web_search_desc">Allow the DeepSeek Responses API to call its server-side web search tool.</string>
     <string name="enable_claude_1h_prompt_cache">Enable Claude 1-hour prompt cache</string>
     <string name="enable_claude_1h_prompt_cache_desc">When enabled, Claude and Claude-compatible providers use a 1-hour prompt cache TTL</string>
     <string name="enable_tool_call">Model supports ToolCall</string>
@@ -7049,6 +7051,8 @@
     <string name="enhanced_processing_message">Processing message...</string>
     <string name="enhanced_connecting_service">Connecting to AI service...</string>
     <string name="enhanced_receiving_response">Receiving AI response...</string>
+    <string name="server_tool_running">Calling server-side tool: %1$s...</string>
+    <string name="server_tool_label">Server tool</string>
     <string name="enhanced_error_with_message">Error: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Warning: Please output main content and do not output thinking-only responses.</string>
     <string name="enhanced_truncated_tool_call_warning">Warning: A tool call was truncated by the model output limit. All tool calls in this round were invalidated and will not be executed. Try reducing single-turn output, splitting the task, or switching to a more suitable model/provider.</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -7052,7 +7052,6 @@
     <string name="enhanced_connecting_service">Connecting to AI service...</string>
     <string name="enhanced_receiving_response">Receiving AI response...</string>
     <string name="server_tool_running">Calling server-side tool: %1$s...</string>
-    <string name="server_tool_label">Server tool</string>
     <string name="enhanced_error_with_message">Error: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Warning: Please output main content and do not output thinking-only responses.</string>
     <string name="enhanced_truncated_tool_call_warning">Warning: A tool call was truncated by the model output limit. All tool calls in this round were invalidated and will not be executed. Try reducing single-turn output, splitting the task, or switching to a more suitable model/provider.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3763,6 +3763,8 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="enable_direct_video_processing_desc">Al activarlo, el video se enviará directamente a la IA para su procesamiento, en lugar de extraer fotogramas/analizar mediante una herramienta</string>
     <string name="enable_google_search">Habilitar Google Search</string>
     <string name="enable_google_search_desc">Al activarlo, Gemini usará Google Search para mejorar las respuestas (pueden generarse costos adicionales)</string>
+    <string name="enable_deepseek_web_search">Habilitar búsqueda web de DeepSeek</string>
+    <string name="enable_deepseek_web_search_desc">Permite que la API Responses de DeepSeek use su herramienta de búsqueda web del servidor.</string>
     <string name="enable_claude_1h_prompt_cache">Habilitar caché de prompts de Claude de 1 hora</string>
     <string name="enable_claude_1h_prompt_cache_desc">Al activarlo, Claude y proveedores compatibles con Claude usarán un TTL de caché de prompts de 1 hora</string>
     <string name="search_sources">Fuentes de búsqueda</string>
@@ -6903,6 +6905,8 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="enhanced_processing_message">Procesando mensaje...</string>
     <string name="enhanced_connecting_service">Conectando al servicio de IA...</string>
     <string name="enhanced_receiving_response">Recibiendo respuesta de la IA...</string>
+    <string name="server_tool_running">Llamando a la herramienta del servidor: %1$s...</string>
+    <string name="server_tool_label">Herramienta del servidor</string>
     <string name="enhanced_error_with_message">Error: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Advertencia: por favor, genere contenido del cuerpo del texto; no está permitido generar solo contenido de pensamiento.</string>
     <string name="enhanced_truncated_tool_call_warning">Advertencia: se detectó que la salida de la invocación de herramientas fue truncada. Todas las invocaciones de herramientas de esta ronda han sido invalidadas y no se ejecutarán. Intente reducir la salida única, dividir la tarea o cambiar a un modelo/proveedor más adecuado y vuelva a intentarlo.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6906,7 +6906,6 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="enhanced_connecting_service">Conectando al servicio de IA...</string>
     <string name="enhanced_receiving_response">Recibiendo respuesta de la IA...</string>
     <string name="server_tool_running">Llamando a la herramienta del servidor: %1$s...</string>
-    <string name="server_tool_label">Herramienta del servidor</string>
     <string name="enhanced_error_with_message">Error: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Advertencia: por favor, genere contenido del cuerpo del texto; no está permitido generar solo contenido de pensamiento.</string>
     <string name="enhanced_truncated_tool_call_warning">Advertencia: se detectó que la salida de la invocación de herramientas fue truncada. Todas las invocaciones de herramientas de esta ronda han sido invalidadas y no se ejecutarán. Intente reducir la salida única, dividir la tarea o cambiar a un modelo/proveedor más adecuado y vuelva a intentarlo.</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -6418,7 +6418,6 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="enhanced_connecting_service">Menghubungkan ke layanan AI...</string>
     <string name="enhanced_receiving_response">Menerima respons AI...</string>
     <string name="server_tool_running">Memanggil alat sisi server: %1$s...</string>
-    <string name="server_tool_label">Alat sisi server</string>
     <string name="enhanced_error_with_message">Kesalahan: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Peringatan: Harap keluarkan konten utama, dilarang hanya mengeluarkan konten pemikiran.</string>
     <string name="enhanced_truncated_tool_call_warning">Peringatan: Terdeteksi output panggilan alat terpotong. Semua panggilan alat pada putaran ini telah dibatalkan dan tidak akan dieksekusi. Coba kurangi output sekali pakai, pecah tugas, atau ganti model/penyedia yang lebih sesuai dan coba lagi.</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -3574,6 +3574,8 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="enable_direct_video_processing_desc">Setelah diaktifkan, video akan langsung dikirim ke AI untuk diproses, bukan dianalisis melalui alat ekstraksi frame/analisis</string>
     <string name="enable_google_search">Aktifkan Google Search</string>
     <string name="enable_google_search_desc">Setelah diaktifkan, Gemini akan menggunakan Google Search untuk meningkatkan jawaban (mungkin menimbulkan biaya tambahan)</string>
+    <string name="enable_deepseek_web_search">Aktifkan pencarian web DeepSeek</string>
+    <string name="enable_deepseek_web_search_desc">Izinkan API Responses DeepSeek memanggil alat pencarian web di server.</string>
     <string name="enable_claude_1h_prompt_cache">Aktifkan cache prompt Claude 1 jam</string>
     <string name="enable_claude_1h_prompt_cache_desc">Setelah diaktifkan, Claude dan penyedia kompatibel Claude akan memakai TTL cache prompt 1 jam</string>
     <string name="enable_tool_call">Model mendukung ToolCall</string>
@@ -6415,6 +6417,8 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="enhanced_processing_message">Memproses pesan...</string>
     <string name="enhanced_connecting_service">Menghubungkan ke layanan AI...</string>
     <string name="enhanced_receiving_response">Menerima respons AI...</string>
+    <string name="server_tool_running">Memanggil alat sisi server: %1$s...</string>
+    <string name="server_tool_label">Alat sisi server</string>
     <string name="enhanced_error_with_message">Kesalahan: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Peringatan: Harap keluarkan konten utama, dilarang hanya mengeluarkan konten pemikiran.</string>
     <string name="enhanced_truncated_tool_call_warning">Peringatan: Terdeteksi output panggilan alat terpotong. Semua panggilan alat pada putaran ini telah dibatalkan dan tidak akan dieksekusi. Coba kurangi output sekali pakai, pecah tugas, atau ganti model/penyedia yang lebih sesuai dan coba lagi.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -6522,7 +6522,6 @@
     <string name="enhanced_connecting_service">AI 서비스에 연결하는 중...</string>
     <string name="enhanced_receiving_response">AI 응답을 받는 중...</string>
     <string name="server_tool_running">서버 도구 호출 중: %1$s...</string>
-    <string name="server_tool_label">서버 도구</string>
     <string name="enhanced_error_with_message">오류: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">경고: 주요 내용을 출력하고 생각만 하는 응답은 출력하지 마십시오.</string>
     <string name="enhanced_truncated_tool_call_warning">경고: 모델 출력 제한으로 인해 도구 호출이 잘렸습니다. 이번 라운드의 모든 도구 호출이 무효화되어 실행되지 않습니다. 단일 회전 출력을 줄이거나, 작업을 분할하거나, 더 적합한 모델/공급업체로 전환해 보세요.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -3469,6 +3469,8 @@
     <string name="enable_direct_video_processing_desc">활성화되면 도구 기반 프레임 추출/분석 대신 처리를 위해 비디오가 AI로 직접 전송됩니다.</string>
     <string name="enable_google_search">Google 검색 활성화</string>
     <string name="enable_google_search_desc">활성화하면 Gemini는 Google 검색을 사용하여 응답을 향상합니다(추가 비용이 발생할 수 있음).</string>
+    <string name="enable_deepseek_web_search">DeepSeek 웹 검색 활성화</string>
+    <string name="enable_deepseek_web_search_desc">DeepSeek Responses API가 서버 웹 검색 도구를 호출하도록 허용합니다.</string>
     <string name="enable_claude_1h_prompt_cache">Claude 1시간 프롬프트 캐시 활성화</string>
     <string name="enable_claude_1h_prompt_cache_desc">활성화되면 Claude 및 Claude 호환 제공자는 1시간 프롬프트 캐시 TTL을 사용합니다.</string>
     <string name="enable_tool_call">ToolCall을 지원하는 모델</string>
@@ -6519,6 +6521,8 @@
     <string name="enhanced_processing_message">메시지 처리 중...</string>
     <string name="enhanced_connecting_service">AI 서비스에 연결하는 중...</string>
     <string name="enhanced_receiving_response">AI 응답을 받는 중...</string>
+    <string name="server_tool_running">서버 도구 호출 중: %1$s...</string>
+    <string name="server_tool_label">서버 도구</string>
     <string name="enhanced_error_with_message">오류: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">경고: 주요 내용을 출력하고 생각만 하는 응답은 출력하지 마십시오.</string>
     <string name="enhanced_truncated_tool_call_warning">경고: 모델 출력 제한으로 인해 도구 호출이 잘렸습니다. 이번 라운드의 모든 도구 호출이 무효화되어 실행되지 않습니다. 단일 회전 출력을 줄이거나, 작업을 분할하거나, 더 적합한 모델/공급업체로 전환해 보세요.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -3448,6 +3448,8 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="enable_direct_video_processing_desc">Setelah diaktifkan, video akan dihantar terus kepada AI untuk diproses, bukan melalui alat yang mengekstrak bingkai/menganalisis</string>
     <string name="enable_google_search">Aktifkan Google Search</string>
     <string name="enable_google_search_desc">Setelah diaktifkan, Gemini akan menggunakan carian Google untuk meningkatkan jawapan (mungkin menyebabkan kos tambahan)</string>
+    <string name="enable_deepseek_web_search">Aktifkan carian web DeepSeek</string>
+    <string name="enable_deepseek_web_search_desc">Benarkan API Responses DeepSeek memanggil alat carian web pada pelayan.</string>
     <string name="enable_claude_1h_prompt_cache">Aktifkan cache prompt Claude 1 jam</string>
     <string name="enable_claude_1h_prompt_cache_desc">Setelah diaktifkan, Claude dan penyedia serasi Claude akan menggunakan TTL cache prompt 1 jam</string>
     <string name="enable_tool_call">Model menyokong ToolCall</string>
@@ -6455,6 +6457,8 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="enhanced_processing_message">Memproses mesej...</string>
     <string name="enhanced_connecting_service">Menyambung ke perkhidmatan AI...</string>
     <string name="enhanced_receiving_response">Menerima respons AI...</string>
+    <string name="server_tool_running">Memanggil alat sisi pelayan: %1$s...</string>
+    <string name="server_tool_label">Alat sisi pelayan</string>
     <string name="enhanced_error_with_message">Ralat: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Amaran: Sila keluarkan kandungan teks, dilarang hanya mengeluarkan kandungan pemikiran.</string>
     <string name="enhanced_truncated_tool_call_warning">Amaran: Pengeluaran panggilan alat dikesan dipotong. Semua panggilan alat dalam pusingan ini telah dibatalkan dan tidak akan dilaksanakan. Cuba kurangkan keluaran tunggal, pecahkan tugas, atau tukar kepada model/pembekal yang lebih sesuai dan cuba semula.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -6458,7 +6458,6 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="enhanced_connecting_service">Menyambung ke perkhidmatan AI...</string>
     <string name="enhanced_receiving_response">Menerima respons AI...</string>
     <string name="server_tool_running">Memanggil alat sisi pelayan: %1$s...</string>
-    <string name="server_tool_label">Alat sisi pelayan</string>
     <string name="enhanced_error_with_message">Ralat: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Amaran: Sila keluarkan kandungan teks, dilarang hanya mengeluarkan kandungan pemikiran.</string>
     <string name="enhanced_truncated_tool_call_warning">Amaran: Pengeluaran panggilan alat dikesan dipotong. Semua panggilan alat dalam pusingan ini telah dibatalkan dan tidak akan dilaksanakan. Cuba kurangkan keluaran tunggal, pecahkan tugas, atau tukar kepada model/pembekal yang lebih sesuai dan cuba semula.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -6080,7 +6080,6 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="enhanced_connecting_service">Conectando ao serviço de IA...</string>
     <string name="enhanced_receiving_response">Recebendo resposta de IA...</string>
     <string name="server_tool_running">Chamando ferramenta do servidor: %1$s...</string>
-    <string name="server_tool_label">Ferramenta do servidor</string>
     <string name="enhanced_error_with_message">Erro: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Aviso: Por favor, produza o conteúdo do texto. É proibido produzir apenas o conteúdo pensante.</string>
     <string name="enhanced_truncated_tool_call_warning">Aviso: Saída de chamada de ferramenta truncada detectada. Todas as chamadas de ferramenta desta rodada foram invalidadas e não serão executadas. Tente reduzir a produção única, divida a tarefa ou tente novamente após mudar para um modelo/fornecedor mais adequado.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -3330,6 +3330,8 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="enable_direct_video_processing_desc">Quando ativado, o vídeo será enviado diretamente para processamento de IA em vez de extração/análise de quadros pela ferramenta</string>
     <string name="enable_google_search">Ativar Pesquisa Google</string>
     <string name="enable_google_search_desc">Quando ativado, o Gemini usará a Pesquisa Google para aprimorar as respostas (podem ser aplicadas taxas adicionais)</string>
+    <string name="enable_deepseek_web_search">Ativar pesquisa web do DeepSeek</string>
+    <string name="enable_deepseek_web_search_desc">Permita que a API Responses do DeepSeek use a ferramenta de pesquisa web do servidor.</string>
     <string name="enable_claude_1h_prompt_cache">Ativar cache de prompt Claude de 1 hora</string>
     <string name="enable_claude_1h_prompt_cache_desc">Quando ativado, Claude e provedores compatíveis com Claude usarão TTL de cache de prompt de 1 hora</string>
     <string name="enable_tool_call">Modelo suporta ToolCall</string>
@@ -6077,6 +6079,8 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="enhanced_processing_message">Processando mensagem...</string>
     <string name="enhanced_connecting_service">Conectando ao serviço de IA...</string>
     <string name="enhanced_receiving_response">Recebendo resposta de IA...</string>
+    <string name="server_tool_running">Chamando ferramenta do servidor: %1$s...</string>
+    <string name="server_tool_label">Ferramenta do servidor</string>
     <string name="enhanced_error_with_message">Erro: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Aviso: Por favor, produza o conteúdo do texto. É proibido produzir apenas o conteúdo pensante.</string>
     <string name="enhanced_truncated_tool_call_warning">Aviso: Saída de chamada de ferramenta truncada detectada. Todas as chamadas de ferramenta desta rodada foram invalidadas e não serão executadas. Tente reduzir a produção única, divida a tarefa ou tente novamente após mudar para um modelo/fornecedor mais adequado.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3843,6 +3843,8 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="enable_direct_video_processing_desc">După activare, videoclipul va fi trimis direct cătreAIPrelucrare, nu extragerea cadrelor cu ajutorul unor instrumente/Analiză</string>
     <string name="enable_google_search">Activare Google Search</string>
     <string name="enable_google_search_desc">După activare,Gemini Se va utiliza Google Căutare pentru a îmbunătăți răspunsul (pot apărea costuri suplimentare)</string>
+    <string name="enable_deepseek_web_search">Activare căutare web DeepSeek</string>
+    <string name="enable_deepseek_web_search_desc">Permiteți API-ului Responses DeepSeek să apeleze instrumentul de căutare web al serverului.</string>
     <string name="enable_claude_1h_prompt_cache">Activare Claude 1 Cache pentru alerte orare</string>
     <string name="enable_claude_1h_prompt_cache_desc">După activare,Claude și Claude Cache-ul de sugestii compatibil cu furnizorul TTL Se va utiliza 1 oră</string>
     <string name="enable_tool_call">Suport pentru modeleToolCall</string>
@@ -7426,6 +7428,8 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="enhanced_processing_message">Se procesează mesajul...</string>
     <string name="enhanced_connecting_service">Se conecteazăAIServicii...</string>
     <string name="enhanced_receiving_response">Se recepționeazăAIRăspuns...</string>
+    <string name="server_tool_running">Se apelează instrumentul de pe server: %1$s...</string>
+    <string name="server_tool_label">Instrument de pe server</string>
     <string name="enhanced_error_with_message">Eroare: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Avertisment: Vă rugăm să introduceți conținutul principal; nu este permisă introducerea exclusivă a gândurilor personale.</string>
     <string name="enhanced_truncated_tool_call_warning">Avertisment: s-a detectat că ieșirea apelurilor de instrumente a fost trunchiată. Toate apelurile de instrumente din această rundă au fost anulate și nu vor fi executate. Vă rugăm să încercați să reduceți ieșirea pe apel, să împărțiți sarcina sau să utilizați un model mai adecvat./Încercați din nou după ce ați selectat furnizorul.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -7429,7 +7429,6 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="enhanced_connecting_service">Se conecteazăAIServicii...</string>
     <string name="enhanced_receiving_response">Se recepționeazăAIRăspuns...</string>
     <string name="server_tool_running">Se apelează instrumentul de pe server: %1$s...</string>
-    <string name="server_tool_label">Instrument de pe server</string>
     <string name="enhanced_error_with_message">Eroare: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">Avertisment: Vă rugăm să introduceți conținutul principal; nu este permisă introducerea exclusivă a gândurilor personale.</string>
     <string name="enhanced_truncated_tool_call_warning">Avertisment: s-a detectat că ieșirea apelurilor de instrumente a fost trunchiată. Toate apelurile de instrumente din această rundă au fost anulate și nu vor fi executate. Vă rugăm să încercați să reduceți ieșirea pe apel, să împărțiți sarcina sau să utilizați un model mai adecvat./Încercați din nou după ce ați selectat furnizorul.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3967,6 +3967,8 @@
     <string name="enable_direct_video_processing_desc">启用后，视频将直接发送给AI处理，而不是通过工具抽帧/分析</string>
     <string name="enable_google_search">启用 Google Search</string>
     <string name="enable_google_search_desc">启用后，Gemini 将使用 Google 搜索来增强回答（可能产生额外费用）</string>
+    <string name="enable_deepseek_web_search">启用 DeepSeek 网络搜索</string>
+    <string name="enable_deepseek_web_search_desc">选择 Responses 端点时，允许 DeepSeek 自动调用服务器网络搜索工具。</string>
     <string name="enable_claude_1h_prompt_cache">启用 Claude 1 小时提示缓存</string>
     <string name="enable_claude_1h_prompt_cache_desc">启用后，Claude 和 Claude 兼容供应商的提示缓存 TTL 将使用 1 小时</string>
     <string name="enable_tool_call">模型支持ToolCall</string>
@@ -7570,6 +7572,8 @@
     <string name="enhanced_processing_message">正在处理消息...</string>
     <string name="enhanced_connecting_service">正在连接AI服务...</string>
     <string name="enhanced_receiving_response">正在接收AI响应...</string>
+    <string name="server_tool_running">正在调用服务端工具：%1$s...</string>
+    <string name="server_tool_label">服务端工具</string>
     <string name="enhanced_error_with_message">错误: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">警告：请输出正文内容，禁止仅输出思考内容。</string>
     <string name="enhanced_truncated_tool_call_warning">警告：检测到工具调用输出被截断。本轮所有工具调用均已作废且不会执行。请尝试减少单次输出、拆分任务，或更换更合适的模型/供应商后重试。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7573,7 +7573,6 @@
     <string name="enhanced_connecting_service">正在连接AI服务...</string>
     <string name="enhanced_receiving_response">正在接收AI响应...</string>
     <string name="server_tool_running">正在调用服务端工具：%1$s...</string>
-    <string name="server_tool_label">服务端工具</string>
     <string name="enhanced_error_with_message">错误: %1$s</string>
     <string name="enhanced_pure_thinking_only_warning">警告：请输出正文内容，禁止仅输出思考内容。</string>
     <string name="enhanced_truncated_tool_call_warning">警告：检测到工具调用输出被截断。本轮所有工具调用均已作废且不会执行。请尝试减少单次输出、拆分任务，或更换更合适的模型/供应商后重试。</string>

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ConversationMarkupManagerTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ConversationMarkupManagerTest.kt
@@ -1,0 +1,44 @@
+package com.ai.assistance.operit.api.chat.enhance
+
+import com.ai.assistance.operit.core.tools.StringResultData
+import com.ai.assistance.operit.data.model.ToolResult
+import com.ai.assistance.operit.util.ChatMarkupRegex
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ConversationMarkupManagerTest {
+
+    @Test
+    fun `tool call id is retained in execution result markup`() {
+        val markup =
+            ConversationMarkupManager.formatToolResultForMessage(
+                ToolResult(
+                    toolName = "list_files",
+                    success = true,
+                    result = StringResultData("files"),
+                    toolCallId = "daxkro1vn"
+                )
+            )
+
+        val callId =
+            ChatMarkupRegex.toolCallIdAttr.find(markup)
+                ?.groupValues
+                ?.getOrNull(1)
+        assertEquals("daxkro1vn", callId)
+    }
+
+    @Test
+    fun `tool results without a call id keep the released markup shape`() {
+        val markup =
+            ConversationMarkupManager.formatToolResultForMessage(
+                ToolResult(
+                    toolName = "query_memory",
+                    success = true,
+                    result = StringResultData("memory")
+                )
+            )
+
+        assertNull(ChatMarkupRegex.toolCallIdAttr.find(markup))
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/EndpointCompleterDeepSeekTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/EndpointCompleterDeepSeekTest.kt
@@ -1,0 +1,59 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EndpointCompleterDeepSeekTest {
+
+    @Test
+    fun releasedChatEndpoint_resolvesToChatCompletions() {
+        assertEquals(
+            DeepSeekApiProtocol.CHAT_COMPLETIONS,
+            EndpointCompleter.resolveDeepSeekProtocol(
+                "https://api.deepseek.com/v1/chat/completions"
+            )
+        )
+    }
+
+    @Test
+    fun releasedResponsesEndpoint_resolvesToResponses() {
+        assertEquals(
+            DeepSeekApiProtocol.RESPONSES,
+            EndpointCompleter.resolveDeepSeekProtocol("https://api.deepseek.com/v1/responses")
+        )
+    }
+
+    @Test
+    fun rootAndV1Endpoints_remainChatCompletions() {
+        assertEquals(
+            DeepSeekApiProtocol.CHAT_COMPLETIONS,
+            EndpointCompleter.resolveDeepSeekProtocol("https://api.deepseek.com")
+        )
+        assertEquals(
+            DeepSeekApiProtocol.CHAT_COMPLETIONS,
+            EndpointCompleter.resolveDeepSeekProtocol("https://proxy.example.com/custom/v1")
+        )
+    }
+
+    @Test
+    fun customResponsesEndpoint_resolvesToResponsesWithoutPersistingChanges() {
+        val endpoint = "  https://proxy.example.com/custom/responses/?region=cn#  "
+
+        assertEquals(
+            DeepSeekApiProtocol.RESPONSES,
+            EndpointCompleter.resolveDeepSeekProtocol(endpoint)
+        )
+    }
+
+    @Test
+    fun nonResponsesEndpointForms_resolveToChatCompletions() {
+        assertEquals(
+            DeepSeekApiProtocol.CHAT_COMPLETIONS,
+            EndpointCompleter.resolveDeepSeekProtocol("https://proxy.example.com/custom/search")
+        )
+        assertEquals(
+            DeepSeekApiProtocol.CHAT_COMPLETIONS,
+            EndpointCompleter.resolveDeepSeekProtocol("https://proxy.example.com/custom/chat")
+        )
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/LlmRetryPolicyTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/LlmRetryPolicyTest.kt
@@ -1,0 +1,22 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LlmRetryPolicyTest {
+    @Test
+    fun retryableClientStatusIncludes408And429() {
+        assertTrue(LlmRetryPolicy.isRetryableClientStatus(408))
+        assertTrue(LlmRetryPolicy.isRetryableClientStatus(429))
+    }
+
+    @Test
+    fun nonRetryableClientStatusExcludesDeterministic4xx() {
+        assertFalse(LlmRetryPolicy.isRetryableClientStatus(400))
+        assertFalse(LlmRetryPolicy.isRetryableClientStatus(401))
+        assertFalse(LlmRetryPolicy.isRetryableClientStatus(403))
+        assertFalse(LlmRetryPolicy.isRetryableClientStatus(404))
+        assertFalse(LlmRetryPolicy.isRetryableClientStatus(422))
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProviderToolCallIdTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProviderToolCallIdTest.kt
@@ -1,0 +1,39 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import com.ai.assistance.operit.data.model.ApiProviderType
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OpenAIProviderToolCallIdTest {
+    private val provider =
+        OpenAIProvider(
+            apiEndpoint = "https://example.com/v1/chat/completions",
+            apiKeyProvider = SingleApiKeyProvider("test-key"),
+            modelName = "test-model",
+            client = OkHttpClient(),
+            providerType = ApiProviderType.OPENAI,
+            enableToolCall = true
+        )
+
+    @Test
+    fun `tool call id is parsed from responses tool markup`() {
+        val (_, calls) =
+            provider.parseXmlToolCalls(
+                """<tool_test name="list_files" call_id="daxkro1vn"><param name="path">/tmp</param></tool_test>"""
+            )
+
+        assertEquals("daxkro1vn", calls!!.getJSONObject(0).getString("id"))
+    }
+
+    @Test
+    fun `tool result id is parsed independently from completion order`() {
+        val (_, results) =
+            provider.parseXmlToolResults(
+                """<tool_result_test name="list_files" status="success" call_id="daxkro1vn"><content>files</content></tool_result_test>"""
+            )
+
+        assertEquals("daxkro1vn", results!!.single().first)
+        assertEquals("files", results.single().second)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesPayloadAdapterTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesPayloadAdapterTest.kt
@@ -1,5 +1,7 @@
 package com.ai.assistance.operit.api.chat.llmprovider
 
+import java.util.Base64
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -13,6 +15,24 @@ import org.junit.Test
  * - usage 对象完全缺失/无任何相关字段 → null（未观察到）。
  */
 class OpenAIResponsesPayloadAdapterTest {
+
+    @Test
+    fun `server web search is optional and keeps existing function tools`() {
+        val functionTool = JSONObject("""{"type":"function","name":"read_file"}""")
+        val disabledRequest = JSONObject().put("tools", JSONArray().put(functionTool))
+        OpenAIResponsesPayloadAdapter.appendServerWebSearchTool(disabledRequest, enabled = false)
+        assertEquals(1, disabledRequest.getJSONArray("tools").length())
+
+        val enabledRequest = JSONObject(disabledRequest.toString())
+        OpenAIResponsesPayloadAdapter.appendServerWebSearchTool(enabledRequest, enabled = true)
+        val tools = enabledRequest.getJSONArray("tools")
+        assertEquals(2, tools.length())
+        assertEquals("function", tools.getJSONObject(0).getString("type"))
+        assertEquals("web_search", tools.getJSONObject(1).getString("type"))
+
+        OpenAIResponsesPayloadAdapter.appendServerWebSearchTool(enabledRequest, enabled = true)
+        assertEquals(2, enabledRequest.getJSONArray("tools").length())
+    }
 
     @Test
     fun `explicit zero payload is observed usage with zero fields`() {
@@ -62,4 +82,114 @@ class OpenAIResponsesPayloadAdapterTest {
             )
         )
     }
+
+    @Test
+    fun `web search output is preserved as hidden replay metadata`() {
+        val outputItem =
+            JSONObject(
+                """{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"operit"}}"""
+            )
+        val parsed =
+            OpenAIResponsesPayloadAdapter.parseNonStreamingResponse(
+                JSONObject("""{"output":[${outputItem}]}""")
+            )
+
+        assertEquals(1, parsed.webSearchMetadataTags.size)
+        val payload = parsed.webSearchMetadataTags.single()
+            .substringAfter(">")
+            .substringBefore("</meta>")
+        val decoded = String(Base64.getDecoder().decode(payload), Charsets.UTF_8)
+        assertEquals(outputItem.toString(), JSONObject(decoded).toString())
+    }
+
+    @Test
+    fun `web search metadata is replayed as the original input item`() {
+        val outputItem =
+            JSONObject(
+                """{"type":"web_search_call","id":"ws_2","status":"completed","action":{"type":"search","query":"history"}}"""
+            )
+        val metadataTag =
+            OpenAIResponsesPayloadAdapter.parseNonStreamingResponse(
+                JSONObject("""{"output":[${outputItem}]}""")
+            ).webSearchMetadataTags.single()
+        val chatStyleRequest = JSONObject().apply {
+            put("model", "deepseek-chat")
+            put(
+                "messages",
+                org.json.JSONArray()
+                    .put(JSONObject().put("role", "assistant").put("content", "answer$metadataTag"))
+            )
+        }
+        val request = OpenAIResponsesPayloadAdapter.toResponsesRequest(chatStyleRequest)
+
+        assertEquals(outputItem.toString(), request.getJSONArray("input").getJSONObject(0).toString())
+    }
+
+    @Test
+    fun `assistant message precedes function calls so outputs stay adjacent with matching ids`() {
+        val firstCallId = "daxkrp0vn"
+        val secondCallId = "daxkro1vn"
+        val assistantMessage = JSONObject().apply {
+            put("role", "assistant")
+            put("content", "I will inspect both locations.")
+            put(
+                "tool_calls",
+                JSONArray()
+                    .put(
+                        JSONObject().apply {
+                            put("id", firstCallId)
+                            put("type", "function")
+                            put(
+                                "function",
+                                JSONObject()
+                                    .put("name", "query_memory")
+                                    .put("arguments", "{\"query\":\"history\"}")
+                            )
+                        }
+                    )
+                    .put(
+                        JSONObject().apply {
+                            put("id", secondCallId)
+                            put("type", "function")
+                            put(
+                                "function",
+                                JSONObject()
+                                    .put("name", "list_files")
+                                    .put("arguments", "{\"path\":\"/tmp\"}")
+                            )
+                        }
+                    )
+            )
+        }
+        val request = JSONObject().apply {
+            put("messages", JSONArray().apply {
+                put(assistantMessage)
+                put(
+                    JSONObject()
+                        .put("role", "tool")
+                        .put("tool_call_id", firstCallId)
+                        .put("content", "memory result")
+                )
+                put(
+                    JSONObject()
+                        .put("role", "tool")
+                        .put("tool_call_id", secondCallId)
+                        .put("content", "file result")
+                )
+            })
+        }
+
+        val input = OpenAIResponsesPayloadAdapter.toResponsesRequest(request).getJSONArray("input")
+
+        assertEquals("message", input.getJSONObject(0).getString("type"))
+        assertEquals("function_call", input.getJSONObject(1).getString("type"))
+        assertEquals(firstCallId, input.getJSONObject(1).getString("call_id"))
+        assertEquals("function_call", input.getJSONObject(2).getString("type"))
+        assertEquals(secondCallId, input.getJSONObject(2).getString("call_id"))
+        assertEquals("function_call_output", input.getJSONObject(3).getString("type"))
+        assertEquals(firstCallId, input.getJSONObject(3).getString("call_id"))
+        assertEquals("function_call_output", input.getJSONObject(4).getString("type"))
+        assertEquals(secondCallId, input.getJSONObject(4).getString("call_id"))
+    }
+
 }

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesPayloadAdapterTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesPayloadAdapterTest.kt
@@ -1,9 +1,11 @@
 package com.ai.assistance.operit.api.chat.llmprovider
 
+import com.ai.assistance.operit.data.model.ApiProviderType
 import java.util.Base64
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -126,6 +128,92 @@ class OpenAIResponsesPayloadAdapterTest {
     }
 
     @Test
+    fun `deepseek plaintext reasoning is preserved and replayed before function calls`() {
+        val reasoningContent =
+            JSONArray().put(
+                JSONObject()
+                    .put("type", "reasoning_text")
+                    .put("text", "I need to inspect the workspace first.")
+            )
+        val reasoningItem =
+            JSONObject()
+                .put("type", "reasoning")
+                .put("id", "rs_plain_1")
+                .put("content", reasoningContent)
+        val metadataTag =
+            OpenAIResponsesPayloadAdapter.parseNonStreamingResponse(
+                JSONObject("""{"output":[$reasoningItem]}"""),
+                ApiProviderType.DEEPSEEK
+            ).reasoningMetadataTags.single()
+        val chatStyleRequest = singleToolContinuationRequest(
+            assistantContent =
+                "<think>I need to inspect the workspace first.</think>" +
+                    "I will inspect the workspace.$metadataTag",
+            callId = "call_plain_1",
+            toolName = "list_files",
+            arguments = "{\"path\":\"/workspace\"}"
+        )
+
+        val input = OpenAIResponsesPayloadAdapter.toResponsesRequest(chatStyleRequest)
+            .getJSONArray("input")
+
+        assertEquals("reasoning", input.getJSONObject(0).getString("type"))
+        assertEquals("rs_plain_1", input.getJSONObject(0).getString("id"))
+        assertEquals(
+            reasoningContent.toString(),
+            input.getJSONObject(0).getJSONArray("content").toString()
+        )
+        assertFalse(input.getJSONObject(0).has("encrypted_content"))
+        assertFalse(input.getJSONObject(0).has("summary"))
+        assertEquals("message", input.getJSONObject(1).getString("type"))
+        assertEquals(
+            "I will inspect the workspace.",
+            input.getJSONObject(1).getString("content")
+        )
+        assertEquals("function_call", input.getJSONObject(2).getString("type"))
+        assertEquals("call_plain_1", input.getJSONObject(2).getString("call_id"))
+        assertEquals("function_call_output", input.getJSONObject(3).getString("type"))
+        assertEquals("call_plain_1", input.getJSONObject(3).getString("call_id"))
+    }
+
+    @Test
+    fun `encrypted reasoning metadata remains replayable before function calls`() {
+        val reasoningItem =
+            JSONObject()
+                .put("type", "reasoning")
+                .put("id", "rs_encrypted_1")
+                .put("encrypted_content", "encrypted-reasoning")
+                .put(
+                    "summary",
+                    JSONArray().put(
+                        JSONObject()
+                            .put("type", "summary_text")
+                            .put("text", "Inspecting the workspace.")
+                    )
+                )
+        val metadataTag =
+            OpenAIResponsesPayloadAdapter.parseNonStreamingResponse(
+                JSONObject("""{"output":[$reasoningItem]}""")
+            ).reasoningMetadataTags.single()
+        val chatStyleRequest = singleToolContinuationRequest(
+            assistantContent = "I will inspect the workspace.$metadataTag",
+            callId = "call_encrypted_1",
+            toolName = "list_files",
+            arguments = "{}"
+        )
+
+        val input = OpenAIResponsesPayloadAdapter.toResponsesRequest(chatStyleRequest)
+            .getJSONArray("input")
+
+        assertEquals("reasoning", input.getJSONObject(0).getString("type"))
+        assertEquals("rs_encrypted_1", input.getJSONObject(0).getString("id"))
+        assertEquals("encrypted-reasoning", input.getJSONObject(0).getString("encrypted_content"))
+        assertEquals("message", input.getJSONObject(1).getString("type"))
+        assertEquals("function_call", input.getJSONObject(2).getString("type"))
+        assertEquals("function_call_output", input.getJSONObject(3).getString("type"))
+    }
+
+    @Test
     fun `assistant message precedes function calls so outputs stay adjacent with matching ids`() {
         val firstCallId = "daxkrp0vn"
         val secondCallId = "daxkro1vn"
@@ -190,6 +278,43 @@ class OpenAIResponsesPayloadAdapterTest {
         assertEquals(firstCallId, input.getJSONObject(3).getString("call_id"))
         assertEquals("function_call_output", input.getJSONObject(4).getString("type"))
         assertEquals(secondCallId, input.getJSONObject(4).getString("call_id"))
+    }
+
+    private fun singleToolContinuationRequest(
+        assistantContent: String,
+        callId: String,
+        toolName: String,
+        arguments: String
+    ): JSONObject = JSONObject().apply {
+        put(
+            "messages",
+            JSONArray()
+                .put(
+                    JSONObject()
+                        .put("role", "assistant")
+                        .put("content", assistantContent)
+                        .put(
+                            "tool_calls",
+                            JSONArray().put(
+                                JSONObject()
+                                    .put("id", callId)
+                                    .put("type", "function")
+                                    .put(
+                                        "function",
+                                        JSONObject()
+                                            .put("name", toolName)
+                                            .put("arguments", arguments)
+                                    )
+                            )
+                        )
+                )
+                .put(
+                    JSONObject()
+                        .put("role", "tool")
+                        .put("tool_call_id", callId)
+                        .put("content", "workspace result")
+                )
+        )
     }
 
 }

--- a/app/src/test/java/com/ai/assistance/operit/data/model/ModelConfigDataDeepSeekCompatibilityTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/model/ModelConfigDataDeepSeekCompatibilityTest.kt
@@ -1,0 +1,19 @@
+package com.ai.assistance.operit.data.model
+
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelConfigDataDeepSeekCompatibilityTest {
+
+    @Test
+    fun releasedConfigWithoutDeepSeekSearchField_keepsSearchPreferenceEnabled() {
+        val config =
+            Json.decodeFromString<ModelConfigData>(
+                """{"id":"released-config","name":"DeepSeek"}"""
+            )
+
+        assertTrue(config.enableDeepSeekWebSearch)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
@@ -26,6 +26,13 @@ class MessageCopyTextTest {
         assertEquals("prefixsuffix", cleanMessageContentForCopy(content))
     }
 
+    @Test fun cleanMessageContentForCopy_removesResponsesWebSearchMetadata() {
+        val content =
+            "answer<meta provider=\"openai:responses_web_search\">payload</meta>suffix"
+
+        assertEquals("answersuffix", cleanMessageContentForCopy(content))
+    }
+
     @Test fun cleanMessageContentForCopy_preservesOtherMetaAndMarkdown() {
         val content = "<meta provider=\"other\">value</meta>\n**answer**"
 

--- a/app/src/test/java/com/ai/assistance/operit/util/ChatMarkupRegexMetaTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/util/ChatMarkupRegexMetaTest.kt
@@ -1,7 +1,9 @@
 package com.ai.assistance.operit.util
 
+import java.util.Base64
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatMarkupRegexMetaTest {
@@ -42,5 +44,49 @@ class ChatMarkupRegexMetaTest {
         val content = "<meta>provider=\"openai:responses_reasoning\"</meta>"
 
         assertEquals(content, ChatMarkupRegex.removeOpenAiResponsesReasoningMeta(content))
+    }
+
+    @Test fun webSearchMetadata_roundTripsAndIsRemovedFromModelVisibleContent() {
+        val metadata =
+            ChatMarkupRegex.openAiResponsesWebSearchMetaTag(
+                "eyJ0eXBlIjoid2ViX3NlYXJjaF9jYWxsIn0="
+            )
+        val content = "answer$metadata"
+
+        assertEquals(
+            listOf("eyJ0eXBlIjoid2ViX3NlYXJjaF9jYWxsIn0="),
+            ChatMarkupRegex.extractOpenAiResponsesWebSearchPayloads(content)
+        )
+        assertEquals(content, ChatMarkupRegex.removeOpenAiResponsesReasoningMeta(content))
+        assertEquals("answer", ChatMarkupRegex.removeOpenAiResponsesWebSearchMeta(content))
+    }
+
+    @Test fun webSearchMetadata_parsesAsReadOnlyServerToolRecord() {
+        val json =
+            """{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"Operit"}}"""
+        val payload = Base64.getEncoder().encodeToString(json.toByteArray(Charsets.UTF_8))
+        val record =
+            ChatMarkupRegex.parseOpenAiResponsesServerToolCall(
+                ChatMarkupRegex.openAiResponsesWebSearchMetaTag(payload)
+            )!!
+
+        assertEquals("ws_1", record.callId)
+        assertEquals("web_search", record.toolType)
+        assertEquals("completed", record.status)
+        assertEquals("search", record.actionType)
+        assertEquals("Operit", record.actionSummary)
+        assertTrue(record.rawJson.contains("web_search_call"))
+    }
+
+    @Test fun invalidWebSearchMetadata_doesNotCreateServerToolRecord() {
+        val payload = Base64.getEncoder().encodeToString(
+            """{"type":"web_search_call","status":"completed"}""".toByteArray(Charsets.UTF_8)
+        )
+
+        assertNull(
+            ChatMarkupRegex.parseOpenAiResponsesServerToolCall(
+                ChatMarkupRegex.openAiResponsesWebSearchMetaTag(payload)
+            )
+        )
     }
 }

--- a/app/src/test/java/com/ai/assistance/operit/util/stream/TextStreamEventTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/util/stream/TextStreamEventTest.kt
@@ -1,0 +1,26 @@
+package com.ai.assistance.operit.util.stream
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TextStreamEventTest {
+
+    @Test
+    fun serverToolEvent_carriesToolType() {
+        val event = TextStreamEvent(
+            eventType = TextStreamEventType.SERVER_TOOL_STARTED,
+            id = "0",
+            toolType = "web_search"
+        )
+
+        assertEquals("web_search", event.toolType)
+    }
+
+    @Test
+    fun revisionEvent_hasNoToolTypeByDefault() {
+        val event = TextStreamEvent(TextStreamEventType.SAVEPOINT, "savepoint-1")
+
+        assertNull(event.toolType)
+    }
+}

--- a/docs/TODO/deepseek_responses_web_search_20260821/01_configuration_and_routing.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/01_configuration_and_routing.md
@@ -1,0 +1,17 @@
+# 配置兼容与运行时路由
+
+## 兼容契约
+
+- API 端点是协议的唯一配置来源。`/responses` 端点使用 Responses，其余已发布 DeepSeek 端点形式保持 Chat Completions。
+- 搜索开关仅在 Responses 端点生效；Chat Completions 不读取该开关。
+- Responses 端点复用 `ApiProviderType.DEEPSEEK`，保持模型统计、价格和配置归属不变。
+- 设置界面直接保存用户选择的完整端点，不额外保存协议字段，也不在运行时互相改写 Chat 与 Responses 路径。
+
+## 实现单元
+
+- DeepSeek Chat 与 Responses 端点选项
+- 集中的 DeepSeek 端点协议判定
+- AI service factory 的 Chat/Responses 分流
+- 端点准备状态与相关单元测试代码
+
+[DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/02_web_search_stream_and_history.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/02_web_search_stream_and_history.md
@@ -1,0 +1,19 @@
+# 搜索状态与历史协议
+
+## 请求
+
+DeepSeek Responses 且搜索开关开启时，在现有函数工具之外声明 `{"type":"web_search"}`。关闭搜索时不声明该工具，也不改变函数工具。
+
+## 流式状态
+
+`response.web_search_call.in_progress`、`searching` 和 `completed` 转换成通用服务端工具流事件，并携带 `toolType=web_search`。开始事件驱动当前输入处理状态显示“正在搜索...”，完成事件恢复为接收回复；这些事件不写入最终可见正文。
+
+## 历史
+
+服务端返回的 `web_search_call` 输出项以隐藏元数据保存在 assistant 消息中。下一轮 Responses 请求恢复为原始 input item；普通展示、复制和非 Responses 请求移除该元数据。
+
+## 终止事件
+
+Responses 流同时处理 `response.completed`、`response.incomplete` 和 `response.failed`。其中 incomplete 是服务端已确认的终止状态，不按网络中断处理。
+
+[DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/03_ui_docs_and_verification.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/03_ui_docs_and_verification.md
@@ -1,0 +1,38 @@
+# 界面、文档与验证
+
+## 界面
+
+- DeepSeek API 端点列表显示 Chat Completions 与 Responses 两个完整端点。
+- 仅在 Responses 端点显示服务器搜索开关。
+- 旧配置保存的 Chat Completions 端点保持不变。
+
+## 文档
+
+在 feature protocol 中记录配置兼容、端点解析、搜索事件和历史恢复契约，供后续 provider 协作者复用。
+
+## 验证计划
+
+- 已发布 Chat Completions 端点保持原协议
+- 官方 Responses 端点选择 Responses 协议
+- 搜索工具开关和函数工具共存
+- 非流式与流式 `web_search_call` 保存、恢复
+- 搜索开始/完成事件不进入最终正文
+- Chat Completions 请求保持原状
+
+用户报告编译错误并明确要求检查打包后，使用项目级 mise JDK 21 执行编译和 Debug 打包验证。
+
+## 完成记录
+
+- 已静态确认旧配置保存的 Chat Completions 端点保持原协议，搜索开关默认开启但只在 Responses 端点生效。
+- 已静态确认 DeepSeek Chat 与 Responses 使用同一 provider identity，协议由保存的端点直接判定。
+- 已静态确认搜索工具与函数工具并列、开关关闭时不添加搜索工具。
+- 已静态确认流式搜索状态使用 `output_index` 维护并行调用，隐藏元数据在下一轮恢复为原始 `web_search_call`。
+- 已静态确认隐藏元数据不会进入普通请求、摘要、渲染或复制文本。
+- `git diff --check` 通过。
+- `mise exec -- ./gradlew :app:compileDebugKotlin` 通过。
+- `mise exec -- ./gradlew :app:testDebugUnitTest` 通过。
+- `mise exec -- ./gradlew assembleDebug` 通过，APK 输出到 `app/build/outputs/apk/debug/app-debug.apk`。
+
+以上 Gradle 结果产生于端点驱动协议调整之前。本轮调整遵守工程执行准则，未重新运行 Gradle 编译、构建或测试。
+
+[DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/04_responses_tool_history_integrity.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/04_responses_tool_history_integrity.md
@@ -16,7 +16,7 @@ DeepSeek Responses 在包含客户端函数工具的多轮历史上返回 `400 N
 - Responses input 中先写 assistant 可见消息，再写该轮全部 `function_call`，使后续结果不被消息边界隔开
 - 将服务端 `call_id` 写入内部工具标记，并由工具执行结果原样带回
 - 构建下一轮历史时按 `call_id` 绑定并行结果；已发布历史没有该字段时维持原有位置绑定
-- 4xx 请求校验错误立即结束，不重复发送同一个无效请求
+- 确定性的 4xx 请求校验错误立即结束，不重复发送同一个无效请求；408 与 429 继续使用既有重试和多密钥轮询链路
 
 ## 验证
 
@@ -30,8 +30,11 @@ DeepSeek Responses 在包含客户端函数工具的多轮历史上返回 `400 N
 - 设备请求日志确认旧顺序为 `function_call`、assistant message、`function_call_output`，服务端在该边界返回 400。
 - Responses 转换已调整为 assistant message、该轮全部 `function_call`、对应 `function_call_output`。
 - 新工具调用的 `call_id` 已贯穿 XML 标记、并行执行与结果标记；旧标记继续按位置读取。
-- `NonRetriableException` 不再进入重试循环。
+- `NonRetriableException` 按状态码分类：确定性 4xx 不再进入重试循环，408 与 429 保持可重试。
+- 已增加 408、429 与确定性 4xx 的状态分类回归测试代码；本轮未运行 Gradle 测试或构建。
 - 针对性协议测试与完整 `:app:testDebugUnitTest` 通过。
 - `:app:compileDebugKotlin` 与 `assembleDebug` 通过。
+
+以上通过记录产生于本次 HTTP 状态码分类调整之前。
 
 [DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/04_responses_tool_history_integrity.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/04_responses_tool_history_integrity.md
@@ -1,0 +1,37 @@
+---
+status: done
+For_Agent: 保持 DeepSeek 无状态历史中的函数调用、结果和可见消息边界完整
+---
+
+# Responses 工具历史完整性
+
+## 直接现象
+
+DeepSeek Responses 在包含客户端函数工具的多轮历史上返回 `400 No tool output found for tool call`。客户端又把确定性的 400 重试五次，最终错误被描述为连接超时。
+
+设备请求日志显示，assistant 的可见文本位于 `function_call` 与 `function_call_output` 之间。并行工具结果按完成时间写入消息时，原实现还会按位置把结果绑定到调用，导致调用名与结果内容错配。
+
+## 修正意图
+
+- Responses input 中先写 assistant 可见消息，再写该轮全部 `function_call`，使后续结果不被消息边界隔开
+- 将服务端 `call_id` 写入内部工具标记，并由工具执行结果原样带回
+- 构建下一轮历史时按 `call_id` 绑定并行结果；已发布历史没有该字段时维持原有位置绑定
+- 4xx 请求校验错误立即结束，不重复发送同一个无效请求
+
+## 验证
+
+- 两个并行调用的 Responses item 顺序与 ID 对应测试
+- 工具调用和结果标记的 ID 往返测试
+- 旧工具结果标记不含 ID 时的兼容测试
+- Kotlin 编译和 debug 打包
+
+## 完成记录
+
+- 设备请求日志确认旧顺序为 `function_call`、assistant message、`function_call_output`，服务端在该边界返回 400。
+- Responses 转换已调整为 assistant message、该轮全部 `function_call`、对应 `function_call_output`。
+- 新工具调用的 `call_id` 已贯穿 XML 标记、并行执行与结果标记；旧标记继续按位置读取。
+- `NonRetriableException` 不再进入重试循环。
+- 针对性协议测试与完整 `:app:testDebugUnitTest` 通过。
+- `:app:compileDebugKotlin` 与 `assembleDebug` 通过。
+
+[DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/05_endpoint_driven_protocol.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/05_endpoint_driven_protocol.md
@@ -1,0 +1,36 @@
+---
+status: done
+For_Agent: DeepSeek API 端点是协议的唯一配置来源
+---
+
+# 端点驱动协议路由
+
+## 原实现问题
+
+独立的 DeepSeek API 模式与 API 端点表达同一件事。保存的端点可以是 Chat Completions，而运行时模式又将请求改写成 Responses，导致界面值、持久化值和实际请求地址不一致。
+
+## 修正意图
+
+- 在既有 API 端点选择器中提供官方 Chat Completions 与 Responses 地址
+- 仅根据端点路径选择 `DeepseekProvider` 或 `OpenAIResponsesProvider`
+- 删除 `deepSeekApiMode` 配置字段、设置状态和协议选择弹窗
+- Web Search 开关仅在 Responses 端点显示并生效
+- 已发布配置保存的 Chat Completions 地址保持不变
+
+## 验证范围
+
+- Chat Completions、Responses、尾部斜杠、查询参数和 `#` 精确地址的协议判定
+- Factory、配置准备状态和设置界面使用同一个端点协议判定
+- 工程中不再引用 `DeepSeekApiMode` 或 `deepSeekApiMode`
+- 静态差异与空白检查
+
+## 完成记录
+
+- DeepSeek 端点选择器已提供 Chat Completions 与 Responses 官方地址
+- `EndpointCompleter.resolveDeepSeekProtocol` 成为 UI 与 Factory 共用的协议判定入口
+- 持久化协议字段、保存参数和独立协议弹窗已删除
+- 已发布 Chat Completions 端点保持原地址和请求实现
+- `git diff --check` 通过
+- 按工程执行准则，本轮未运行 Gradle 编译、构建或测试
+
+[DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/06_server_tool_status.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/06_server_tool_status.md
@@ -1,0 +1,43 @@
+---
+status: done
+For_Agent: 服务端工具状态是流式旁路事件，不进入模型正文或聊天历史
+---
+
+# 服务端工具状态展示
+
+## 原实现问题
+
+服务端搜索状态使用 `WEB_SEARCH_STARTED` 与 `WEB_SEARCH_COMPLETED` 专用事件。该命名把 UI 状态通道绑定到一种工具，后续增加其他服务端工具时需要重复扩展事件和消费逻辑。
+
+## 修正意图
+
+- 使用 `SERVER_TOOL_STARTED` 与 `SERVER_TOOL_COMPLETED` 表达通用服务端工具生命周期
+- 事件携带 `toolType`，由 UI 状态层决定本地化文案
+- `web_search` 显示“正在搜索...”，其他服务端工具显示工具类型
+- 完成最后一个活动服务端工具后恢复“正在接收回复”
+- 状态只显示在既有输入处理指示器和悬浮窗状态区，不写入 assistant 正文或聊天历史
+
+## 当前协议映射
+
+DeepSeek Responses 的 `response.web_search_call.in_progress`、`searching` 与 `completed` 映射到通用服务端工具事件，`toolType` 固定为 `web_search`。客户端函数工具继续使用原有工具执行状态，不混入服务端工具事件。
+
+## 验证范围
+
+- 工程中不再引用搜索专用流事件枚举
+- 服务端工具开始事件携带 `toolType`
+- Web Search 使用本地化搜索文案
+- 未识别工具类型使用通用服务端工具文案
+- 完成事件恢复当前响应阶段对应的接收状态
+- 静态差异、资源占位符和 XML 解析检查
+
+## 完成记录
+
+- 流式旁路事件已改为通用服务端工具开始与完成事件，并携带 `toolType`
+- DeepSeek Web Search 已映射为 `toolType=web_search`，输入处理指示器显示“正在搜索...”
+- 其他服务端工具类型使用通用本地化文案展示
+- 并行 Web Search 保持首个调用开始显示、全部调用完成后恢复接收状态
+- Classic、Agent 与悬浮窗继续复用既有 `InputProcessingState.Receiving` 展示状态
+- 已增加服务端工具事件数据契约测试代码
+- 按工程执行准则，本轮未运行 Gradle 编译、构建或测试
+
+[DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/07_server_tool_call_record.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/07_server_tool_call_record.md
@@ -1,0 +1,35 @@
+---
+status: done
+For_Agent: 服务端工具记录只从供应商 metadata 派生，不得转换成客户端 tool 或 tool_result
+---
+
+# 服务端工具调用记录
+
+## 原实现问题
+
+Responses Web Search 执行期间只显示“正在搜索...”。调用完成后，`web_search_call` 仅作为隐藏 metadata 保存，用户无法在消息记录中确认模型是否调用过服务端工具。
+
+普通 `<tool>` 记录会进入客户端工具解析、授权和执行流程，因此不能用它模拟服务端工具。服务端搜索也不提供与函数工具等价的 `function_call_output`，最终答案和引用属于 assistant 消息。
+
+## 修正意图
+
+- 保留原始 `openai:responses_web_search` metadata，继续用于下一轮 Responses 历史恢复
+- 渲染时严格解码并校验 `web_search_call`，生成只读的服务端工具记录
+- 主标题直接显示具体工具名，使用前置云端图标标识调用来源
+- 标题展示协议工具标识 `web_search`，摘要展示搜索动作和状态，详情展示服务端返回的完整调用条目
+- 不生成 `<tool>`、`AITool`、`ToolInvocation` 或 `<tool_result>`
+- metadata 格式不合法时保持隐藏，不把内部协议内容暴露给用户
+
+## 输出边界
+
+默认 `web_search_call` 能提供调用 ID、状态和 action。搜索 action 通常包含 query 或 queries；最终回答中的引用仍由 assistant 文本承载。只有请求显式包含 `web_search_call.action.sources` 时，服务端调用条目才会包含完整来源列表，本步骤不改变请求字段。
+
+## 完成记录
+
+- Android 消息渲染已使用云端图标加具体工具名展示只读服务端调用
+- Web Chat 消息渲染已使用相同规则展示只读服务端调用
+- 原始 metadata、复制隔离和 Responses 历史恢复路径保持不变
+- 已增加 metadata 到服务端工具记录的解析测试代码
+- 按工程执行准则，本轮未运行编译、构建或测试
+
+[DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/07_server_tool_call_record.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/07_server_tool_call_record.md
@@ -28,8 +28,9 @@ Responses Web Search 执行期间只显示“正在搜索...”。调用完成�
 
 - Android 消息渲染已使用云端图标加具体工具名展示只读服务端调用
 - Web Chat 消息渲染已使用相同规则展示只读服务端调用
+- 修复运行时发现的协议差异：DeepSeek 批量搜索使用 `action.queries`，Web Chat 现已严格校验并汇总 `query` 与 `queries`
 - 原始 metadata、复制隔离和 Responses 历史恢复路径保持不变
 - 已增加 metadata 到服务端工具记录的解析测试代码
-- 按工程执行准则，本轮未运行编译、构建或测试
+- Web Chat 类型检查与生产构建通过；当前子项目未配置测试脚本
 
 [DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/07_server_tool_call_record.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/07_server_tool_call_record.md
@@ -27,7 +27,7 @@ Responses Web Search 执行期间只显示“正在搜索...”。调用完成�
 ## 完成记录
 
 - Android 消息渲染已使用云端图标加具体工具名展示只读服务端调用
-- Web Chat 消息渲染已使用相同规则展示只读服务端调用
+- Web Chat 消息渲染已使用相同规则展示只读服务端调用，点击记录行可通过 `ContentDetailDialog` 查看完整 raw JSON
 - 修复运行时发现的协议差异：DeepSeek 批量搜索使用 `action.queries`，Web Chat 现已严格校验并汇总 `query` 与 `queries`
 - 原始 metadata、复制隔离和 Responses 历史恢复路径保持不变
 - 已增加 metadata 到服务端工具记录的解析测试代码

--- a/docs/TODO/deepseek_responses_web_search_20260821/08_reasoning_item_replay.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/08_reasoning_item_replay.md
@@ -1,0 +1,55 @@
+---
+status: done
+For_Agent: 保持 DeepSeek Responses 工具续轮中的纯文本 reasoning item 完整
+---
+
+# Responses reasoning item 回放
+
+## 直接现象
+
+DeepSeek Responses 在思考模式下先返回纯文本 `reasoning` item，再返回客户端函数调用。客户端执行工具并发送下一轮请求时，服务端返回：
+
+```text
+The `reasoning_text` in the thinking mode must be passed back to the API.
+```
+
+通用 Responses 历史只保存带 `encrypted_content` 的 reasoning item。DeepSeek 使用 `content` 中的 `reasoning_text`，因此首轮推理虽然能够显示，却没有进入隐藏历史协议，工具续轮缺少服务端要求的 reasoning item。
+
+## 修正意图
+
+- DeepSeek 的纯文本 reasoning item 使用现有隐藏 metadata 通道保存
+- 下一轮 Responses input 在函数调用和结果之前恢复原 reasoning item
+- 现有 OpenAI 加密 reasoning item 的保存格式和读取行为保持不变
+- 流式与非流式响应共用同一组 reasoning metadata 编解码规则
+
+## 作用域
+
+- Responses reasoning metadata 的生成与恢复
+- 纯文本和加密 reasoning item 的针对性单元测试
+- 本协议文档中的无状态工具续轮约定
+
+## 非目标
+
+- 不改变思考内容的界面展示
+- 不改变客户端工具授权与执行流程
+- 不改变 HTTP 状态码和重试策略
+- 不修改 DeepSeek Chat Completions 历史格式
+
+## 验证
+
+- 纯文本 reasoning item 保存后可按原 ID 和内容恢复
+- 恢复后的顺序为 reasoning、assistant message、function call、function output
+- 加密 reasoning item 的既有格式继续可读写
+
+## 完成记录
+
+- 流式与非流式 Responses 解析按 provider 生成对应的 reasoning metadata。
+- DeepSeek 纯文本 reasoning item 已保存原 ID 与 `reasoning_text` content，并在工具调用前恢复。
+- 成功恢复 reasoning item 时，对应 assistant message 不再重复携带 `<think>` 内容。
+- 现有 OpenAI 加密 reasoning metadata 格式保持不变。
+- 已增加纯文本、加密 reasoning item 与函数工具续轮顺序的回归测试代码。
+- `git diff --check`、46 个 CI 门禁单测、仓库 hygiene、Markdown 链接、本地化与 WebChat typecheck 通过。
+- 最新 `development` 合并候选上的 `OpenAIResponsesPayloadAdapterTest` 与 `assembleDebug` 通过。
+- 完整 JVM 单测执行 1212 项，其中 6 项失败；最新 `development` 基线运行对应 23 项得到相同 6 项失败，本次改动未新增失败。
+
+[DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/index.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/index.md
@@ -42,5 +42,6 @@ For_Agent: 按三个最小单元实施，未经明确授权不运行 Gradle 构�
 5. [端点驱动协议路由 [DONE]](./05_endpoint_driven_protocol.md)
 6. [服务端工具状态展示 [DONE]](./06_server_tool_status.md)
 7. [服务端工具调用记录 [DONE]](./07_server_tool_call_record.md)
+8. [Responses reasoning item 回放 [DONE]](./08_reasoning_item_replay.md)
 
 [DONE]

--- a/docs/TODO/deepseek_responses_web_search_20260821/index.md
+++ b/docs/TODO/deepseek_responses_web_search_20260821/index.md
@@ -1,0 +1,46 @@
+---
+issue: https://github.com/AAswordman/Operit/issues/877
+branch: feat/deepseek-responses-web-search
+status: done
+For_Agent: 按三个最小单元实施，未经明确授权不运行 Gradle 构建或测试
+---
+
+# DeepSeek Responses 与服务器搜索
+
+## 原本状况
+
+已发布版本的 DeepSeek 配置只使用 Chat Completions。工程已有通用 Responses 请求与流式解析能力，但 DeepSeek 没有选择协议的入口，也没有声明 `web_search`、显示搜索阶段或保存 `web_search_call`。
+
+## 修改意图
+
+在保留 `ApiProviderType.DEEPSEEK` 和既有 Chat Completions 行为的前提下，为 DeepSeek 配置增加 Responses 端点和可关闭的服务器搜索。API 端点是协议的唯一配置来源，旧配置保存的 Chat Completions 端点继续保持原行为。
+
+## 作用域
+
+- DeepSeek 端点选项、设置界面、协议判定与服务路由
+- Responses 请求中的 `web_search` 工具声明
+- 搜索阶段的临时状态，以及 `web_search_call` 的隐藏持久化与下一轮恢复
+- 服务端工具调用的只读记录，并与客户端工具调用明确区分
+- 复制、渲染和普通消息请求对隐藏协议元数据的隔离
+- 对应开发文档与单元测试代码
+- 使用 mise 固定项目要求的 JDK 21 构建环境
+
+## 非目标
+
+- 不新增独立的 DeepSeek provider 类型
+- 不改变 Chat Completions 的请求与历史格式
+- 不实现搜索引用的专用展示
+- 不增加独立的持久化协议字段
+- 不迁移或重写既有端点配置
+
+## 细化步骤
+
+1. [配置兼容与运行时路由 [DONE]](./01_configuration_and_routing.md)
+2. [搜索状态与历史协议 [DONE]](./02_web_search_stream_and_history.md)
+3. [界面、文档与验证 [DONE]](./03_ui_docs_and_verification.md)
+4. [Responses 工具历史完整性 [DONE]](./04_responses_tool_history_integrity.md)
+5. [端点驱动协议路由 [DONE]](./05_endpoint_driven_protocol.md)
+6. [服务端工具状态展示 [DONE]](./06_server_tool_status.md)
+7. [服务端工具调用记录 [DONE]](./07_server_tool_call_record.md)
+
+[DONE]

--- a/docs/doc-src/feature-protocol/deepseek_responses_web_search.md
+++ b/docs/doc-src/feature-protocol/deepseek_responses_web_search.md
@@ -59,6 +59,8 @@ Responses 流以 `response.completed`、`response.incomplete` 或 `response.fail
 
 `call_id` 从 Responses 输出进入内部工具调用标记，经过并行执行后写入对应的工具结果标记。下一轮按该 ID 绑定调用与结果，不依赖并行任务的完成顺序。旧聊天记录没有 `call_id` 时仍按已发布版本的位置关系读取。
 
+思考模式下发生客户端函数调用时，DeepSeek 返回的纯文本 `reasoning` item 也属于后续请求必须携带的无状态历史。该 item 使用现有 Responses reasoning 隐藏 metadata 保存，并在下一轮 input 中恢复到对应的 assistant message 与 `function_call` 之前。纯文本 `content` 必须保留原始 `reasoning_text` 和 item ID；OpenAI Responses 的加密 reasoning item 继续使用既有 `encrypted_content` 格式。
+
 ## 当前边界
 
 本协议不定义搜索引用的专用 UI。若服务端最终文本包含引用，它仍作为普通响应文本展示；结构化引用展示需要独立设计和兼容契约。

--- a/docs/doc-src/feature-protocol/deepseek_responses_web_search.md
+++ b/docs/doc-src/feature-protocol/deepseek_responses_web_search.md
@@ -1,0 +1,64 @@
+---
+title: DeepSeek Responses 与服务器搜索协议
+description: DeepSeek Chat Completions 兼容、Responses 路由、搜索状态和历史恢复约定
+keywords: DeepSeek,Responses,web_search,配置兼容,聊天历史
+For_Agent: 本文是协作实现协议，不代表功能已经进入发布版本
+---
+
+# DeepSeek Responses 与服务器搜索协议
+
+## 配置兼容
+
+DeepSeek 继续使用 `ApiProviderType.DEEPSEEK`。API 端点是该 provider 内部传输协议的唯一配置来源，不建立新的 provider 身份，因此模型价格、Token 统计和既有配置归属保持不变。
+
+已发布版本保存的 `/chat/completions` 端点继续使用 Chat Completions。端点路径以 `/responses` 结尾时使用 Responses。服务器搜索开关只在 Responses 端点生效；关闭开关或使用 Chat Completions 时不声明 `web_search`。
+
+设置中的 API 端点选择器提供官方 Chat Completions 与 Responses 完整地址，并直接保存用户选择的地址。运行时不再保存独立协议字段，也不互相改写两种协议路径。
+
+## Responses 请求
+
+Responses 端点复用通用 Responses provider，并保持 `DEEPSEEK` 作为运行时身份。启用服务器搜索时，在已有函数工具旁加入以下工具声明：
+
+```json
+{"type":"web_search"}
+```
+
+工具声明允许模型选择是否搜索，不把每轮搜索设为强制行为。
+
+## 服务端工具状态
+
+服务端工具生命周期通过 `SERVER_TOOL_STARTED` 与 `SERVER_TOOL_COMPLETED` 两种内部流事件传递。事件携带 `toolType`，只驱动用户界面状态，不写入模型正文或聊天历史。
+
+DeepSeek Web Search 的以下服务器事件转换为 `toolType=web_search` 的服务端工具事件：
+
+- `response.web_search_call.in_progress`
+- `response.web_search_call.searching`
+- `response.web_search_call.completed`
+
+开始和搜索中事件把当前输入处理状态显示为正在搜索；完成事件恢复为接收回复。多个搜索调用同时活动时，只有全部完成后才恢复接收回复状态。其他服务端工具可以复用同一事件通道，并由 `toolType` 映射对应的本地化状态文案。
+
+Responses 流以 `response.completed`、`response.incomplete` 或 `response.failed` 结束。`completed` 和 `incomplete` 都是服务器确认的终止事件；`failed` 按响应错误处理。连接在收到终止事件前结束仍视为网络中断。
+
+## 搜索历史恢复
+
+服务端 `output` 中的 `web_search_call` 保存为 assistant 内容里的隐藏协议元数据。下一轮 Responses 请求从该元数据恢复原始 input item，维持 DeepSeek 的无状态多轮搜索上下文。
+
+隐藏元数据不是自然语言聊天内容：复制和非 Responses 请求必须移除它。普通渲染器可以从通过校验的 `web_search_call` 派生只读的服务端工具记录，但不得显示 Base64 内容或把它转换成客户端 `<tool>`。Responses 请求在恢复 item 后也从 message 文本中移除对应标签，避免把协议数据作为自然语言重复发送。
+
+## 服务端工具记录
+
+服务端工具记录与客户端函数工具严格分离。它不进入 `AITool`、`ToolInvocation`、工具授权、工具执行或 `function_call_output` 链路，只用于呈现供应商已经执行的调用。
+
+`web_search` 记录从 `web_search_call` 读取调用 ID、状态和 action。消息列表直接以协议工具标识 `web_search` 作为标题，并用前置云端图标区分调用来源；摘要包含 query 和状态，详情保留服务端返回的原始调用 JSON。格式错误或缺少调用 ID 的 metadata 不渲染。
+
+默认 Responses 返回的是调用条目和最终回答，并不提供与客户端函数工具等价的独立工具输出。引用由最终文本中的 `url_citation` 承载；完整来源列表需要请求显式声明 `web_search_call.action.sources`，当前协议不主动请求该字段。
+
+## 客户端函数工具历史
+
+同一 assistant 轮次同时包含可见文本和客户端函数调用时，Responses input 先写可见 message，再写该轮的 `function_call`。对应的 `function_call_output` 随后写入，不能由另一条 message 隔开。
+
+`call_id` 从 Responses 输出进入内部工具调用标记，经过并行执行后写入对应的工具结果标记。下一轮按该 ID 绑定调用与结果，不依赖并行任务的完成顺序。旧聊天记录没有 `call_id` 时仍按已发布版本的位置关系读取。
+
+## 当前边界
+
+本协议不定义搜索引用的专用 UI。若服务端最终文本包含引用，它仍作为普通响应文本展示；结构化引用展示需要独立设计和兼容契约。

--- a/web-chat/src/ui/features/chat/components/part/CustomXmlRenderer.tsx
+++ b/web-chat/src/ui/features/chat/components/part/CustomXmlRenderer.tsx
@@ -35,6 +35,25 @@ const READ_ONLY_GROUPABLE_TOOL_NAMES = new Set([
   'visit_web'
 ]);
 
+const RESPONSES_WEB_SEARCH_PROVIDER = 'openai:responses_web_search';
+
+interface ResponsesWebSearchPayload {
+  type?: string;
+  id?: string;
+  status?: string;
+  action?: {
+    type?: string;
+    query?: string;
+  } | null;
+}
+
+interface ServerToolRecord {
+  toolName: string;
+  id: string;
+  status: string;
+  query: string | null;
+}
+
 type ToolCollapseMode = 'read_only' | 'all' | 'full' | string;
 
 function readThinkingExpandedPreference() {
@@ -56,6 +75,83 @@ function shouldHideGeminiThoughtSignatureMeta(block: WebMessageContentBlock) {
     block.tag_name === 'meta' &&
     (block.attrs?.provider?.trim()?.toLowerCase() ?? '') === 'gemini:thought_signature'
   );
+}
+
+function isResponsesWebSearchMeta(block: WebMessageContentBlock) {
+  return (
+    block.tag_name === 'meta' &&
+    (block.attrs?.provider?.trim() ?? '') === RESPONSES_WEB_SEARCH_PROVIDER
+  );
+}
+
+function decodeBase64Utf8(payload: string) {
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(payload) || payload.length % 4 !== 0) {
+    throw new Error('invalid base64 payload');
+  }
+
+  const binary = atob(payload);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+}
+
+function decodeResponsesWebSearchRecord(block: WebMessageContentBlock): ServerToolRecord | null {
+  if (!isResponsesWebSearchMeta(block) || block.closed === false) {
+    return null;
+  }
+
+  try {
+    const encodedPayload = block.content?.trim() ?? '';
+    if (!encodedPayload) {
+      throw new Error('empty payload');
+    }
+
+    const decodedPayload = decodeBase64Utf8(encodedPayload);
+    const payload = JSON.parse(decodedPayload) as ResponsesWebSearchPayload;
+    if (
+      payload === null ||
+      typeof payload !== 'object' ||
+      Array.isArray(payload) ||
+      payload.type !== 'web_search_call' ||
+      typeof payload.id !== 'string' ||
+      !payload.id.trim() ||
+      typeof payload.status !== 'string' ||
+      !payload.status.trim()
+    ) {
+      throw new Error('invalid web_search_call payload');
+    }
+
+    let query: string | null = null;
+    if (payload.action !== undefined) {
+      if (
+        payload.action === null ||
+        typeof payload.action !== 'object' ||
+        Array.isArray(payload.action)
+      ) {
+        throw new Error('invalid web search action');
+      }
+
+      if (payload.action.type === 'search') {
+        if (typeof payload.action.query !== 'string' || !payload.action.query.trim()) {
+          throw new Error('search action is missing a query');
+        }
+        query = payload.action.query.trim();
+      }
+    }
+
+    return {
+      toolName: 'web_search',
+      id: payload.id.trim(),
+      status: payload.status.trim(),
+      query
+    };
+  } catch (error) {
+    console.error('[CustomXmlRenderer] Invalid Responses web search metadata', error);
+    return null;
+  }
 }
 
 function shouldHideStatusBlock(block: WebMessageContentBlock, showStatusTags: boolean) {
@@ -320,6 +416,49 @@ function StatusBlock({ block }: { block: WebMessageContentBlock }) {
   return <div className={`structured-status-card is-${statusType}`}>{statusText}</div>;
 }
 
+function ServerToolSourceIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="structured-server-tool-source-icon"
+      fill="none"
+      height="16"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      width="16"
+    >
+      <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4c-2.89 0-5.4 1.64-6.65 4.04A5.994 5.994 0 0 0 6 20h13a5 5 0 0 0 .35-9.96Z" />
+    </svg>
+  );
+}
+
+function ServerToolRecordBlock({ record }: { record: ServerToolRecord }) {
+  const queryLabel = record.query ? `，查询：${record.query}` : '';
+  const semanticDescription = `Server tool · ${record.toolName}，状态：${record.status}${queryLabel}`;
+
+  return (
+    <section
+      aria-label={semanticDescription}
+      className="structured-server-tool-row"
+      data-tool-call-id={record.id}
+    >
+      <ServerToolSourceIcon />
+      <div className="structured-server-tool-copy">
+        <strong className="structured-server-tool-title">{record.toolName}</strong>
+        <div className="structured-server-tool-details">
+          <span className="structured-server-tool-status">{record.status}</span>
+          {record.query ? (
+            <span className="structured-server-tool-query">{record.query}</span>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function GenericXmlBlock({ block }: { block: WebMessageContentBlock }) {
   return (
     <section className="structured-card generic-card">
@@ -338,6 +477,11 @@ function renderXmlBlock(
   streaming: boolean
 ) {
   const tagName = block.tag_name;
+
+  const serverToolRecord = decodeResponsesWebSearchRecord(block);
+  if (serverToolRecord) {
+    return <ServerToolRecordBlock record={serverToolRecord} />;
+  }
 
   if (shouldHideGeminiThoughtSignatureMeta(block)) {
     return null;

--- a/web-chat/src/ui/features/chat/components/part/CustomXmlRenderer.tsx
+++ b/web-chat/src/ui/features/chat/components/part/CustomXmlRenderer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { DetailsTagRenderer } from './DetailsTagRenderer';
+import { ContentDetailDialog } from './DialogComponents';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { AnimatedExpandBody, StructuredExpandRow } from './StructuredExpand';
 import { ToolDisplayComponent } from './ToolDisplayComponents';
@@ -54,6 +55,7 @@ interface ResponsesWebSearchPayload {
 interface ServerToolRecord {
   toolName: string;
   id: string;
+  rawJson: string;
   status: string;
   query: string | null;
 }
@@ -181,6 +183,7 @@ function decodeResponsesWebSearchRecord(block: WebMessageContentBlock): ServerTo
     return {
       toolName: 'web_search',
       id: payload.id.trim(),
+      rawJson: JSON.stringify(payload, null, 2),
       status: payload.status.trim(),
       query
     };
@@ -474,24 +477,37 @@ function ServerToolSourceIcon() {
 function ServerToolRecordBlock({ record }: { record: ServerToolRecord }) {
   const queryLabel = record.query ? `，查询：${record.query}` : '';
   const semanticDescription = `Server tool · ${record.toolName}，状态：${record.status}${queryLabel}`;
+  const [detailOpen, setDetailOpen] = useState(false);
 
   return (
-    <section
-      aria-label={semanticDescription}
-      className="structured-server-tool-row"
-      data-tool-call-id={record.id}
-    >
-      <ServerToolSourceIcon />
-      <div className="structured-server-tool-copy">
-        <strong className="structured-server-tool-title">{record.toolName}</strong>
-        <div className="structured-server-tool-details">
-          <span className="structured-server-tool-status">{record.status}</span>
-          {record.query ? (
-            <span className="structured-server-tool-query">{record.query}</span>
-          ) : null}
-        </div>
-      </div>
-    </section>
+    <>
+      <button
+        aria-label={`${semanticDescription}，查看详情`}
+        className="structured-server-tool-row"
+        data-tool-call-id={record.id}
+        onClick={() => setDetailOpen(true)}
+        type="button"
+      >
+        <ServerToolSourceIcon />
+        <span className="structured-server-tool-copy">
+          <strong className="structured-server-tool-title">{record.toolName}</strong>
+          <span className="structured-server-tool-details">
+            <span className="structured-server-tool-status">{record.status}</span>
+            {record.query ? (
+              <span className="structured-server-tool-query">{record.query}</span>
+            ) : null}
+          </span>
+        </span>
+      </button>
+      {detailOpen ? (
+        <ContentDetailDialog
+          content={record.rawJson}
+          iconName="search"
+          onDismiss={() => setDetailOpen(false)}
+          title={`${record.toolName} 服务端调用详情`}
+        />
+      ) : null}
+    </>
   );
 }
 

--- a/web-chat/src/ui/features/chat/components/part/CustomXmlRenderer.tsx
+++ b/web-chat/src/ui/features/chat/components/part/CustomXmlRenderer.tsx
@@ -37,14 +37,18 @@ const READ_ONLY_GROUPABLE_TOOL_NAMES = new Set([
 
 const RESPONSES_WEB_SEARCH_PROVIDER = 'openai:responses_web_search';
 
+interface ResponsesWebSearchAction {
+  type?: string;
+  query?: string;
+  // DeepSeek 批量搜索返回 queries；未解析该字段会隐藏合法 metadata。
+  queries?: string[];
+}
+
 interface ResponsesWebSearchPayload {
   type?: string;
   id?: string;
   status?: string;
-  action?: {
-    type?: string;
-    query?: string;
-  } | null;
+  action?: ResponsesWebSearchAction | null;
 }
 
 interface ServerToolRecord {
@@ -98,6 +102,43 @@ function decodeBase64Utf8(payload: string) {
   return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
 }
 
+function decodeWebSearchActionQuery(action: ResponsesWebSearchAction) {
+  const hasType = Object.prototype.hasOwnProperty.call(action, 'type');
+  const hasQuery = Object.prototype.hasOwnProperty.call(action, 'query');
+  const hasQueries = Object.prototype.hasOwnProperty.call(action, 'queries');
+  if (hasType && (typeof action.type !== 'string' || !action.type.trim())) {
+    throw new Error('invalid web search action type');
+  }
+
+  const singleQuery = action.query;
+  if (hasQuery && (typeof singleQuery !== 'string' || !singleQuery.trim())) {
+    throw new Error('invalid web search query');
+  }
+
+  const batchQueries = action.queries;
+  if (
+    hasQueries &&
+    (!Array.isArray(batchQueries) ||
+      batchQueries.length === 0 ||
+      batchQueries.some((batchQuery) => typeof batchQuery !== 'string' || !batchQuery.trim()))
+  ) {
+    throw new Error('invalid web search queries');
+  }
+
+  if (action.type !== 'search') {
+    return null;
+  }
+
+  const normalizedQueries = [
+    ...(typeof singleQuery === 'string' ? [singleQuery.trim()] : []),
+    ...(Array.isArray(batchQueries) ? batchQueries.map((batchQuery) => batchQuery.trim()) : [])
+  ];
+  if (normalizedQueries.length === 0) {
+    throw new Error('search action is missing a query');
+  }
+  return normalizedQueries.join(' · ');
+}
+
 function decodeResponsesWebSearchRecord(block: WebMessageContentBlock): ServerToolRecord | null {
   if (!isResponsesWebSearchMeta(block) || block.closed === false) {
     return null;
@@ -134,12 +175,7 @@ function decodeResponsesWebSearchRecord(block: WebMessageContentBlock): ServerTo
         throw new Error('invalid web search action');
       }
 
-      if (payload.action.type === 'search') {
-        if (typeof payload.action.query !== 'string' || !payload.action.query.trim()) {
-          throw new Error('search action is missing a query');
-        }
-        query = payload.action.query.trim();
-      }
+      query = decodeWebSearchActionQuery(payload.action);
     }
 
     return {

--- a/web-chat/src/ui/features/chat/util/styles/chat-structured.css
+++ b/web-chat/src/ui/features/chat/util/styles/chat-structured.css
@@ -11,6 +11,60 @@
   background: var(--chat-card-soft);
 }
 
+.structured-server-tool-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  padding: 4px 0;
+}
+
+.structured-server-tool-source-icon {
+  flex: 0 0 16px;
+  margin-top: 2px;
+  color: color-mix(in srgb, var(--chat-primary) 76%, var(--chat-text-soft));
+}
+
+.structured-server-tool-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.structured-server-tool-title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--chat-primary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.3333;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.structured-server-tool-details {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-width: 0;
+  color: color-mix(in srgb, var(--chat-text-main) 72%, transparent);
+  font-size: 12px;
+  line-height: 1.3333;
+}
+
+.structured-server-tool-status {
+  color: color-mix(in srgb, var(--chat-text-main) 84%, transparent);
+}
+
+.structured-server-tool-query {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .tool-card,
 .tool-result-card,
 .status-card,

--- a/web-chat/src/ui/features/chat/util/styles/chat-structured.css
+++ b/web-chat/src/ui/features/chat/util/styles/chat-structured.css
@@ -13,10 +13,23 @@
 
 .structured-server-tool-row {
   display: flex;
+  width: 100%;
   align-items: flex-start;
   gap: 8px;
   min-width: 0;
   padding: 4px 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.structured-server-tool-row:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--chat-primary) 78%, transparent);
+  outline-offset: 3px;
+  border-radius: 6px;
 }
 
 .structured-server-tool-source-icon {


### PR DESCRIPTION
## 变更说明 / Description

为 DeepSeek 增加由 API 端点驱动的 Responses API 支持，并接入服务端 `web_search`。现有 `/chat/completions` 配置继续使用 Chat Completions；只有将端点切换为 `/responses` 后才会进入 Responses 协议。

本 PR 保留 Responses 无状态多轮请求所需的 `web_search_call` 和函数工具调用结构，并将服务端已执行的工具记录与 Operit 本地工具的权限、执行链路分离。

## 改动范围 / Scope

### 已包含 / Included

- DeepSeek API 端点决定协议：`/chat/completions` 使用 Chat Completions，`/responses` 使用 Responses API。
- 增加 DeepSeek Responses 服务端搜索开关；关闭时不声明 `web_search`。
- 在现有客户端函数工具之外追加 `{"type":"web_search"}`，保持 `tool_choice=auto`。
- 解析 Responses 流中的终态事件、reasoning、引用与 `web_search_call`，并保存、恢复多轮历史所需的原始 output item。
- 保留函数调用 ID 和原始顺序，避免后续 Responses 请求中出现 `No tool output found for tool call`。
- 将服务端工具调用显示为只读记录，使用云端图标与本地工具区分，不进入 `AITool`、权限确认或本地执行链路。
- Android 支持搜索期间的“正在搜索”状态，并可查看完成后的服务端调用详情。
- Web Chat 支持完成后的 `web_search` 只读记录，严格处理 `action.query` 和 `action.queries`，点击记录可查看完整 raw JSON。
- 408 和 429 保留既有重试与多 Key 轮换行为，其他确定性 4xx 仍立即失败。
- 增加端点路由、旧配置兼容、Responses payload、工具历史、流事件和展示 metadata 的回归测试代码，并补充协议文档。

### 未包含与待跟进 / Out of scope and follow-ups

- 不包含“只允许服务端搜索”模式。当前 `tool_choice=auto`，模型可在服务端 `web_search` 与 Operit 本地工具之间自主选择，也可在同一轮混合使用。
- Web Chat 尚未转发 `SERVER_TOOL_STARTED` / `SERVER_TOOL_COMPLETED` 旁路事件；搜索期间显示通用“正在接收回复”，完成后才显示服务端工具记录。
- 服务端搜索开关目前跟随 Responses provider 配置；使用同一配置的辅助功能请求还需要单独限定到正常 `CHAT` 调用。
- 不主动请求 `web_search_call.action.sources`，不包含完整搜索来源面板或独立引用面板。
- 不包含 Gradle wrapper、构建工具链或其他与功能无关的变更。

## 兼容性与风险 / Compatibility and risks

- 已发布的 DeepSeek `/chat/completions` 配置继续使用原协议；新增配置字段有默认值，不要求迁移旧数据。
- 只有显式使用 `/responses` 端点时才进入 Responses 请求路径，服务端搜索仍可通过开关关闭。
- `web_search_call` 以隐藏 metadata 保存，仅用于 Responses 历史恢复和经过校验的只读展示；复制消息与非 Responses 请求会移除该 metadata。
- 服务端工具记录不会转换为客户端 `<tool>`，不会绕过本地工具权限。
- DeepSeek `web_search` 可能以 `SSRF_BLOCKED` 拒绝部分公开域名；该策略由模型服务端控制，Operit 仅保留并展示服务端结果。

## 关联 Issue / Related issues

Closes #877

Fixes #989

Related: #948, #797, #946

## 验证 / Verification

### 已通过 / Passed

- `git diff --check upstream/development...HEAD`
- `npm --prefix web-chat run typecheck`
- `npm run build:webchat`
- `mise exec java@21.0.2 -- ./gradlew assembleDebug --stacktrace --no-daemon`（`BUILD SUCCESSFUL`）
- Web Chat 生产构建产物已包含 `openai:responses_web_search`、`action.queries` 解析和服务端工具详情弹窗。

Vite 构建仅报告现有的 500 kB chunk 大小警告，构建成功。Android Debug APK 构建仅报告现有的资源值覆盖与 SDK XML 版本警告，构建成功。

### 已运行但被上游问题阻断 / Run but blocked upstream

- `mise exec java@21.0.2 -- ./gradlew :app:testDebugUnitTest --stacktrace --no-daemon` 已运行，但在 `:app:compileDebugUnitTestKotlin` 阶段失败，测试用例尚未开始执行。
- 编译错误位于 `ThinkingQualityMappingTest.kt` 第 19、35、61 行：测试仍传入 `Int`，当前实现已要求字符串选项 ID。相关实现与测试文件在本分支和 `upstream/development` 完全一致，且不在本 PR diff 中，因此判定为上游已有回归，本 PR 未混入无关修复。
- GitHub 已为最新提交创建 [PR Check run #32720130880](https://github.com/AAswordman/Operit/actions/runs/32720130880)，但 fork 工作流停在 `action_required`，尚未启动任何 job；当前身份无上游仓库管理员权限，无法代为批准。

## 证据 / Evidence

- Android 端点选择、搜索开关、搜索状态与服务端调用记录：[#issuecomment-5379170879](https://github.com/AAswordman/Operit/pull/1015#issuecomment-5379170879)
- Web Chat 完成后的服务端工具记录和详情展示：[#issuecomment-5394234660](https://github.com/AAswordman/Operit/pull/1015#issuecomment-5394234660)
- 2026-08-24 运行日志确认 DeepSeek Responses 请求成功执行服务端 `web_search`，返回 `web_search_call` 和批量 `action.queries`；同一轮也可继续调用 Operit 本地工具。

## 检查清单 / Checklist

- [x] 目标分支为 `development`。
- [x] 已记录协议边界、已知限制和未运行项。
- [x] 已提供 Android 和 Web Chat 界面证据。
- [x] Web Chat 类型检查与生产构建通过。
- [x] Android Debug APK 构建通过。
- [ ] Android JVM 测试命令已运行，但被 `upstream/development` 的既有测试源码编译回归阻断。
- [ ] PR Check 已创建但等待上游管理员批准运行，当前尚无 job 结果。

