### PR TITLE
fix(opencode): round-trip assistant reasoning_content via OpenCodeChatProvider only

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -127,6 +127,11 @@ open class OpenAIProvider(
     val tokenCacheManager = TokenCacheManager()
 
     protected open val useResponsesApi: Boolean = false
+    // 是否在重建历史时保留 assistant 消息的 reasoning_content 字段。
+    // 部分 OpenAI 兼容上游（如 OpenCode 的 OpenAI Chat 路由，深度对齐 DeepSeek thinking 协议）
+    // 在 model 做过工具调用后，要求后续请求原样回传历史 assistant 消息的 reasoning_content，
+    // 否则上游会返回 400: "The reasoning_content in the thinking mode must be passed back to the API."
+    protected open val preserveAssistantReasoningContent: Boolean = false
 
     // 公开token计数
     override val inputTokenCount: Long
@@ -953,10 +958,18 @@ open class OpenAIProvider(
         val effectiveHistory = providerReadyHistory
 
         var queuedAssistantToolText: String? = null
+        var queuedAssistantReasoning: String? = null
         var queuedToolCalls = JSONArray()
         val queuedToolCallIds = mutableListOf<String>()
         val openToolCallIds = mutableListOf<String>()
         var nextToolCallOrdinal = 0
+
+        // 当开关开启时，从含 think 标签的历史 assistant 消息中提取 reasoning_content。
+        fun extractReasoningFromAssistantContent(rawContent: String): Pair<String, String> {
+            if (!preserveAssistantReasoningContent) return Pair(rawContent, "")
+            val (clean, thinking) = ChatUtils.extractThinkingContent(rawContent)
+            return Pair(clean, thinking)
+        }
 
         fun appendQueuedAssistantToolText(text: String) {
             if (text.isBlank()) return
@@ -968,8 +981,19 @@ open class OpenAIProvider(
                 }
         }
 
-        fun queueToolCalls(textContent: String, toolCalls: JSONArray) {
+        fun appendQueuedAssistantReasoning(reasoningContent: String) {
+            if (!preserveAssistantReasoningContent || reasoningContent.isBlank()) return
+            queuedAssistantReasoning =
+                if (queuedAssistantReasoning.isNullOrBlank()) {
+                    reasoningContent
+                } else {
+                    queuedAssistantReasoning + "\n" + reasoningContent
+                }
+        }
+
+        fun queueToolCalls(textContent: String, toolCalls: JSONArray, reasoningContent: String = "") {
             appendQueuedAssistantToolText(textContent)
+            appendQueuedAssistantReasoning(reasoningContent)
             for (i in 0 until toolCalls.length()) {
                 val sourceToolCall = toolCalls.optJSONObject(i) ?: continue
                 val toolCall = JSONObject(sourceToolCall.toString())
@@ -979,12 +1003,13 @@ open class OpenAIProvider(
                 queuedToolCallIds.add(callId)
             }
         }
-
         fun emitQueuedToolCallsIfNeeded() {
             if (queuedToolCalls.length() == 0) return
-
             val historyMessage = JSONObject()
             historyMessage.put("role", "assistant")
+            if (preserveAssistantReasoningContent) {
+                historyMessage.put("reasoning_content", queuedAssistantReasoning.orEmpty())
+            }
             val effectiveContent = when {
                 !queuedAssistantToolText.isNullOrBlank() -> queuedAssistantToolText
                 else -> null
@@ -996,9 +1021,9 @@ open class OpenAIProvider(
             }
             historyMessage.put("tool_calls", queuedToolCalls)
             messagesArray.put(historyMessage)
-
             openToolCallIds.addAll(queuedToolCallIds)
             queuedAssistantToolText = null
+            queuedAssistantReasoning = null
             queuedToolCalls = JSONArray()
             queuedToolCallIds.clear()
         }
@@ -1052,30 +1077,33 @@ open class OpenAIProvider(
                         }
 
                         PromptTurnKind.ASSISTANT -> {
-                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content)
+                            val (assistantContent, reasoningContent) = extractReasoningFromAssistantContent(content)
+                            val (textContent, parsedToolCalls) = parseXmlToolCalls(assistantContent)
                             val toolCalls =
                                 if (parsedToolCalls != null) {
                                     wrapPackageToolCallsWithProxy(parsedToolCalls)
                                 } else {
                                     null
                                 }
-
                             if (toolCalls != null && toolCalls.length() > 0) {
                                 if (openToolCallIds.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("assistant_tool_call_before_result")
                                 }
-                                queueToolCalls(textContent, toolCalls)
+                                queueToolCalls(textContent, toolCalls, reasoningContent)
                             } else {
                                 flushOpenToolCallsAsCancelled("assistant_boundary")
-                                val effectiveContent = if (content.isBlank()) {
+                                val effectiveContent = if (assistantContent.isBlank()) {
                                     AppLogger.d("AIService", "发现空的assistant消息，填充为[空消息]")
                                     "[Empty]"
                                 } else {
-                                    content
+                                    assistantContent
                                 }
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "assistant")
+                                        if (preserveAssistantReasoningContent) {
+                                            put("reasoning_content", reasoningContent)
+                                        }
                                         put("content", buildContentField(context, effectiveContent))
                                     }
                                 )
@@ -1083,25 +1111,28 @@ open class OpenAIProvider(
                         }
 
                         PromptTurnKind.TOOL_CALL -> {
-                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content)
+                            val (cleanContent, reasoningContent) = extractReasoningFromAssistantContent(content)
+                            val (textContent, parsedToolCalls) = parseXmlToolCalls(cleanContent)
                             val toolCalls =
                                 if (parsedToolCalls != null) {
                                     wrapPackageToolCallsWithProxy(parsedToolCalls)
                                 } else {
                                     null
                                 }
-
                             if (toolCalls != null && toolCalls.length() > 0) {
                                 if (openToolCallIds.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("typed_tool_call_before_result")
                                 }
-                                queueToolCalls(textContent, toolCalls)
+                                queueToolCalls(textContent, toolCalls, reasoningContent)
                             } else {
                                 flushOpenToolCallsAsCancelled("typed_tool_call_without_payload")
-                                val effectiveContent = if (content.isBlank()) "[Empty]" else content
+                                val effectiveContent = if (cleanContent.isBlank()) "[Empty]" else cleanContent
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "assistant")
+                                        if (preserveAssistantReasoningContent) {
+                                            put("reasoning_content", reasoningContent)
+                                        }
                                         put("content", buildContentField(context, effectiveContent))
                                     }
                                 )
@@ -1167,16 +1198,26 @@ open class OpenAIProvider(
                     // 不启用Tool Call API时，保持原样
                     val historyMessage = JSONObject()
                     historyMessage.put("role", role)
-
                     // 检查assistant角色的空消息
-                    val effectiveContent = if (role == "assistant" && content.isBlank()) {
-                        AppLogger.d("AIService", "发现空的assistant消息，填充为[空消息]")
-                        "[Empty]"
+                    if (role == "assistant" && preserveAssistantReasoningContent) {
+                        val (cleanContent, reasoningContent) = extractReasoningFromAssistantContent(content)
+                        val effectiveContent = if (cleanContent.isBlank()) {
+                            AppLogger.d("AIService", "发现空的assistant消息，填充为[空消息]")
+                            "[Empty]"
+                        } else {
+                            cleanContent
+                        }
+                        historyMessage.put("reasoning_content", reasoningContent)
+                        historyMessage.put("content", buildContentField(context, effectiveContent))
                     } else {
-                        content
+                        val effectiveContent = if (role == "assistant" && content.isBlank()) {
+                            AppLogger.d("AIService", "发现空的assistant消息，填充为[空消息]")
+                            "[Empty]"
+                        } else {
+                            content
+                        }
+                        historyMessage.put("content", buildContentField(context, effectiveContent))
                     }
-
-                    historyMessage.put("content", buildContentField(context, effectiveContent))
                     messagesArray.put(historyMessage)
                 }
             }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -127,11 +127,6 @@ open class OpenAIProvider(
     val tokenCacheManager = TokenCacheManager()
 
     protected open val useResponsesApi: Boolean = false
-    // 是否在重建历史时保留 assistant 消息的 reasoning_content 字段。
-    // 部分 OpenAI 兼容上游（如 OpenCode 的 OpenAI Chat 路由，深度对齐 DeepSeek thinking 协议）
-    // 在 model 做过工具调用后，要求后续请求原样回传历史 assistant 消息的 reasoning_content，
-    // 否则上游会返回 400: "The reasoning_content in the thinking mode must be passed back to the API."
-    protected open val preserveAssistantReasoningContent: Boolean = false
 
     // 公开token计数
     override val inputTokenCount: Long
@@ -958,18 +953,10 @@ open class OpenAIProvider(
         val effectiveHistory = providerReadyHistory
 
         var queuedAssistantToolText: String? = null
-        var queuedAssistantReasoning: String? = null
         var queuedToolCalls = JSONArray()
         val queuedToolCallIds = mutableListOf<String>()
         val openToolCallIds = mutableListOf<String>()
         var nextToolCallOrdinal = 0
-
-        // 当开关开启时，从含 think 标签的历史 assistant 消息中提取 reasoning_content。
-        fun extractReasoningFromAssistantContent(rawContent: String): Pair<String, String> {
-            if (!preserveAssistantReasoningContent) return Pair(rawContent, "")
-            val (clean, thinking) = ChatUtils.extractThinkingContent(rawContent)
-            return Pair(clean, thinking)
-        }
 
         fun appendQueuedAssistantToolText(text: String) {
             if (text.isBlank()) return
@@ -981,19 +968,8 @@ open class OpenAIProvider(
                 }
         }
 
-        fun appendQueuedAssistantReasoning(reasoningContent: String) {
-            if (!preserveAssistantReasoningContent || reasoningContent.isBlank()) return
-            queuedAssistantReasoning =
-                if (queuedAssistantReasoning.isNullOrBlank()) {
-                    reasoningContent
-                } else {
-                    queuedAssistantReasoning + "\n" + reasoningContent
-                }
-        }
-
-        fun queueToolCalls(textContent: String, toolCalls: JSONArray, reasoningContent: String = "") {
+        fun queueToolCalls(textContent: String, toolCalls: JSONArray) {
             appendQueuedAssistantToolText(textContent)
-            appendQueuedAssistantReasoning(reasoningContent)
             for (i in 0 until toolCalls.length()) {
                 val sourceToolCall = toolCalls.optJSONObject(i) ?: continue
                 val toolCall = JSONObject(sourceToolCall.toString())
@@ -1003,13 +979,12 @@ open class OpenAIProvider(
                 queuedToolCallIds.add(callId)
             }
         }
+
         fun emitQueuedToolCallsIfNeeded() {
             if (queuedToolCalls.length() == 0) return
+
             val historyMessage = JSONObject()
             historyMessage.put("role", "assistant")
-            if (preserveAssistantReasoningContent) {
-                historyMessage.put("reasoning_content", queuedAssistantReasoning.orEmpty())
-            }
             val effectiveContent = when {
                 !queuedAssistantToolText.isNullOrBlank() -> queuedAssistantToolText
                 else -> null
@@ -1021,9 +996,9 @@ open class OpenAIProvider(
             }
             historyMessage.put("tool_calls", queuedToolCalls)
             messagesArray.put(historyMessage)
+
             openToolCallIds.addAll(queuedToolCallIds)
             queuedAssistantToolText = null
-            queuedAssistantReasoning = null
             queuedToolCalls = JSONArray()
             queuedToolCallIds.clear()
         }
@@ -1077,33 +1052,30 @@ open class OpenAIProvider(
                         }
 
                         PromptTurnKind.ASSISTANT -> {
-                            val (assistantContent, reasoningContent) = extractReasoningFromAssistantContent(content)
-                            val (textContent, parsedToolCalls) = parseXmlToolCalls(assistantContent)
+                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content)
                             val toolCalls =
                                 if (parsedToolCalls != null) {
                                     wrapPackageToolCallsWithProxy(parsedToolCalls)
                                 } else {
                                     null
                                 }
+
                             if (toolCalls != null && toolCalls.length() > 0) {
                                 if (openToolCallIds.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("assistant_tool_call_before_result")
                                 }
-                                queueToolCalls(textContent, toolCalls, reasoningContent)
+                                queueToolCalls(textContent, toolCalls)
                             } else {
                                 flushOpenToolCallsAsCancelled("assistant_boundary")
-                                val effectiveContent = if (assistantContent.isBlank()) {
+                                val effectiveContent = if (content.isBlank()) {
                                     AppLogger.d("AIService", "发现空的assistant消息，填充为[空消息]")
                                     "[Empty]"
                                 } else {
-                                    assistantContent
+                                    content
                                 }
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "assistant")
-                                        if (preserveAssistantReasoningContent) {
-                                            put("reasoning_content", reasoningContent)
-                                        }
                                         put("content", buildContentField(context, effectiveContent))
                                     }
                                 )
@@ -1111,28 +1083,25 @@ open class OpenAIProvider(
                         }
 
                         PromptTurnKind.TOOL_CALL -> {
-                            val (cleanContent, reasoningContent) = extractReasoningFromAssistantContent(content)
-                            val (textContent, parsedToolCalls) = parseXmlToolCalls(cleanContent)
+                            val (textContent, parsedToolCalls) = parseXmlToolCalls(content)
                             val toolCalls =
                                 if (parsedToolCalls != null) {
                                     wrapPackageToolCallsWithProxy(parsedToolCalls)
                                 } else {
                                     null
                                 }
+
                             if (toolCalls != null && toolCalls.length() > 0) {
                                 if (openToolCallIds.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("typed_tool_call_before_result")
                                 }
-                                queueToolCalls(textContent, toolCalls, reasoningContent)
+                                queueToolCalls(textContent, toolCalls)
                             } else {
                                 flushOpenToolCallsAsCancelled("typed_tool_call_without_payload")
-                                val effectiveContent = if (cleanContent.isBlank()) "[Empty]" else cleanContent
+                                val effectiveContent = if (content.isBlank()) "[Empty]" else content
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "assistant")
-                                        if (preserveAssistantReasoningContent) {
-                                            put("reasoning_content", reasoningContent)
-                                        }
                                         put("content", buildContentField(context, effectiveContent))
                                     }
                                 )
@@ -1198,26 +1167,16 @@ open class OpenAIProvider(
                     // 不启用Tool Call API时，保持原样
                     val historyMessage = JSONObject()
                     historyMessage.put("role", role)
+
                     // 检查assistant角色的空消息
-                    if (role == "assistant" && preserveAssistantReasoningContent) {
-                        val (cleanContent, reasoningContent) = extractReasoningFromAssistantContent(content)
-                        val effectiveContent = if (cleanContent.isBlank()) {
-                            AppLogger.d("AIService", "发现空的assistant消息，填充为[空消息]")
-                            "[Empty]"
-                        } else {
-                            cleanContent
-                        }
-                        historyMessage.put("reasoning_content", reasoningContent)
-                        historyMessage.put("content", buildContentField(context, effectiveContent))
+                    val effectiveContent = if (role == "assistant" && content.isBlank()) {
+                        AppLogger.d("AIService", "发现空的assistant消息，填充为[空消息]")
+                        "[Empty]"
                     } else {
-                        val effectiveContent = if (role == "assistant" && content.isBlank()) {
-                            AppLogger.d("AIService", "发现空的assistant消息，填充为[空消息]")
-                            "[Empty]"
-                        } else {
-                            content
-                        }
-                        historyMessage.put("content", buildContentField(context, effectiveContent))
+                        content
                     }
+
+                    historyMessage.put("content", buildContentField(context, effectiveContent))
                     messagesArray.put(historyMessage)
                 }
             }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenCodeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenCodeProvider.kt
@@ -201,6 +201,12 @@ internal class OpenCodeChatProvider(
     supportsVideo = supportsVideo,
     enableToolCall = enableToolCall
 ) {
+    // OpenCode 的 OpenAI Chat 路由直接向后端透传 think 历史（即使 Operit 未显式开启
+    // thinking，OpenCode 也可能按模型能力输出推理）。为保证后续请求不因缺失
+    // reasoning_content 而被上游拒绝（400），此路由必须回传历史 assistant 消息的
+    // reasoning_content。这是对 DeepSeek thinking 协议的必要补全。
+    override val preserveAssistantReasoningContent: Boolean = true
+
     override fun createRequestBody(
         context: Context,
         chatHistory: List<PromptTurn>,
@@ -216,7 +222,9 @@ internal class OpenCodeChatProvider(
             modelParameters = modelParameters,
             stream = stream,
             availableTools = availableTools,
-            preserveThinkInHistory = preserveThinkInHistory
+            // OpenCode 的 OpenAI Chat 路由必须保留 think 历史，才能从历史中提取
+            // reasoning_content 并原样回传（上游要求），否则后续请求会被 400 拒绝。
+            preserveThinkInHistory = true
         )
     )
 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenCodeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenCodeProvider.kt
@@ -201,12 +201,18 @@ internal class OpenCodeChatProvider(
     supportsVideo = supportsVideo,
     enableToolCall = enableToolCall
 ) {
-    // OpenCode 的 OpenAI Chat 路由直接向后端透传 think 历史（即使 Operit 未显式开启
-    // thinking，OpenCode 也可能按模型能力输出推理）。为保证后续请求不因缺失
-    // reasoning_content 而被上游拒绝（400），此路由必须回传历史 assistant 消息的
-    // reasoning_content。这是对 DeepSeek thinking 协议的必要补全。
-    override val preserveAssistantReasoningContent: Boolean = true
-
+    // OpenCode 的 OpenAI Chat 路由会向后端透传 DeepSeek 风格 thinking 输出
+    // （即使 Operit 未显式开启 thinking，OpenCode 也可能按模型能力自行开启）。
+    // 该协议要求历史 assistant 消息必须原样回传 reasoning_content，否则
+    // 在模型完成工具调用后的下一轮请求会返回 400：
+    //   "The reasoning_content in the thinking mode must be passed back to the API."
+    //
+    // 以下重写将 reasoning_content 的提取与回传完全收敛在 OpenCodeChatProvider 内部：
+    //   1) 强制 preserveThinkInHistory = true，让父类 buildMessagesAndCountTokens
+    //      保留历史 assistant 消息中的 <think> 内容；
+    //   2) 覆盖 customizeFinalRequestObject，在 messagesArray 后处理阶段对
+    //      assistant 消息做 think -> reasoning_content 的拆分与回填。
+    // 该实现不动通用 OpenAIProvider，不影响其它 OpenAI 兼容 provider 的行为。
     override fun createRequestBody(
         context: Context,
         chatHistory: List<PromptTurn>,
@@ -222,11 +228,47 @@ internal class OpenCodeChatProvider(
             modelParameters = modelParameters,
             stream = stream,
             availableTools = availableTools,
-            // OpenCode 的 OpenAI Chat 路由必须保留 think 历史，才能从历史中提取
-            // reasoning_content 并原样回传（上游要求），否则后续请求会被 400 拒绝。
             preserveThinkInHistory = true
         )
     )
+
+    override fun customizeFinalRequestObject(
+        requestObject: JSONObject,
+        messagesArray: JSONArray,
+        toolsJson: String?
+    ) {
+        if (messagesArray.length() == 0) return
+        for (i in 0 until messagesArray.length()) {
+            val message = messagesArray.optJSONObject(i) ?: continue
+            if (message.optString("role") != "assistant") continue
+            extractReasoningContentIntoMessage(context, message)
+        }
+    }
+
+    /**
+     * 对单个 assistant 消息提取 <think>...</think> 内容，写入 reasoning_content 字段，
+     * 并将清理后的内容写回 content 字段。
+     *
+     * 仅处理纯文本 content（多模态 JSONArray 形态跳过，避免改动既有
+     * 多模态构造逻辑；该路径在 OpenCodeChatProvider 实际请求中极少触发）。
+     */
+    private fun extractReasoningContentIntoMessage(context: Context, message: JSONObject) {
+        val rawContent = message.opt("content") ?: return
+        val textContent: String = when (rawContent) {
+            is String -> rawContent
+            else -> return
+        }
+        if (!textContent.contains("<think", ignoreCase = false) &&
+            !textContent.contains("<thinking", ignoreCase = false)
+        ) {
+            return
+        }
+        val (cleanContent, reasoning) = ChatUtils.extractThinkingContent(textContent)
+        // 总是写入 reasoning_content（即使为空，OpenAI Chat 路由上游在历史不含
+        // 该字段时也会拒绝；写空字符串与未写含义不同）。
+        message.put("reasoning_content", reasoning)
+        message.put("content", buildContentField(context, cleanContent))
+    }
 }
 
 /** OpenCode's OpenAI Responses route. */


### PR DESCRIPTION
## 背景/问题

在 Console Go / OpenCode（含 `opencode-go`）中配置使用 OpenAI Chat 协议（`/chat/completions`）的推理模型（DeepSeek 系、走 DeepSeek thinking 协议的模型）时，模型完成**工具调用**后，后续轮次的请求会报 `400`：

> `The reasoning_content in the thinking mode must be passed back to the API.`

根因：`OpenCodeProvider` 的 `OpenCodeChatProvider`（继承自 `OpenAIProvider`）在重建历史时，**没有回传历史 assistant 消息的 `reasoning_content` 字段**。OpenCode 上游会按模型能力自行开启 thinking 输出推理内容（即使 Operit 未显式开启 thinking），并要求后续请求原样回传该字段，否则拒绝请求。

## 方案二选一的选择

按 maintainer 反馈，本方案采用 **option 2**——`reasoning_content` 的提取与回传完全收敛在 `OpenCodeChatProvider` 内部，**不动通用 `OpenAIProvider`**：

1. `OpenCodeChatProvider.createRequestBody`：调用父类 `createRequestBodyInternal` 时强制 `preserveThinkInHistory = true`，让父类 `buildMessagesAndCountTokens` 保留历史 assistant 消息中的 `<think>` 内容。
2. `OpenCodeChatProvider` 覆盖父类的扩展点 `customizeFinalRequestObject(requestObject, messagesArray, toolsJson)`：遍历 `messagesArray`，对每个 `role == "assistant"` 的消息调用 `extractReasoningContentIntoMessage`：
   - 用 `ChatUtils.extractThinkingContent` 提取 `<think>...</think>` 内容；
   - 写入 `reasoning_content` 字段；
   - 用清理后的 content 重新调用 `buildContentField` 写回 `content` 字段。
3. 多模态 `JSONArray` content 形态保守跳过，避免改动既有路径（该路径在 OpenCodeChatProvider 实际请求中极少触发，且维护者已要求边界清晰）。

## 不影响其他 Provider

- 通用 `OpenAIProvider` 的代码、字段、行为**完全未变**（PR 中该文件 diff 已撤销）。
- `DeepseekProvider` 等其它 provider 不受影响。
- 仅 `OpenCodeChatProvider`（OpenAI Chat 路由）启用 reasoning_content 回传。

## 变更文件

- `app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenCodeProvider.kt`（+51 / -1）

## Token 计数注意（已知轻微偏差）

`buildMessagesAndCountTokens` 的 token 统计会包含 think 历史内容（因为强制 `preserveThinkInHistory = true`），实际发送的请求体不含 think 文本（被拆分到 `reasoning_content` 字段）。这与 `DeepseekProvider` 既有行为一致，仅影响 token 统计数字，不影响请求正确性。
