### PR TITLE
refactor(settings): streamline speech services layout

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/SpeechServicesSettingsScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/SpeechServicesSettingsScreen.kt
@@ -28,33 +28,29 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material.icons.automirrored.filled.FormatListBulleted
-import androidx.compose.material.icons.automirrored.filled.VolumeUp
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -70,7 +66,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.unit.dp
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.api.speech.SpeechServiceFactory
@@ -132,6 +127,9 @@ fun SpeechServicesSettingsScreen(
     var ttsProfileError by remember { mutableStateOf<String?>(null) }
     var sttProfileError by remember { mutableStateOf<String?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
+    var selectedTabIndex by remember { mutableStateOf(0) }
+    var ttsCleanerExpanded by remember { mutableStateOf(false) }
+    var ttsHttpAdvancedExpanded by remember { mutableStateOf(false) }
 
     LaunchedEffect(profilePrefs) {
         try {
@@ -411,7 +409,15 @@ fun SpeechServicesSettingsScreen(
                 contentPadding = PaddingValues(bottom = 24.dp),
             ) {
                 item {
-                    SpeechProfilesManagementCard(
+                    SpeechServicesModeTabs(
+                        selectedTabIndex = selectedTabIndex,
+                        onTabSelected = { selectedTabIndex = it },
+                    )
+                }
+
+                item {
+                    SpeechProfileManagementBar(
+                        selectedTabIndex = selectedTabIndex,
                         ttsProfiles = ttsProfiles.map { SpeechProfileOption(it.id, it.name) },
                         sttProfiles = sttProfiles.map { SpeechProfileOption(it.id, it.name) },
                         currentTtsProfileId = currentTtsProfileId,
@@ -457,47 +463,18 @@ fun SpeechServicesSettingsScreen(
                     )
                 }
 
-                item {
+                if (selectedTabIndex == 0) item(key = "tts-settings") {
                 // --- TTS Section ---
                 Card(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(10.dp),
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.surface
                     ),
                     border = BorderStroke(0.7.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
                     elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
                 ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(bottom = 12.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.VolumeUp,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.size(24.dp)
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(
-                                    text = stringResource(R.string.speech_services_tts_title),
-                                    style = MaterialTheme.typography.titleMedium,
-                                    fontWeight = FontWeight.Bold
-                                )
-                            }
-                        }
-                        
-                        Text(
-                            text = stringResource(R.string.speech_services_tts_desc),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(bottom = 16.dp)
-                        )
-
-                        Spacer(modifier = Modifier.height(16.dp))
+                    Column(modifier = Modifier.padding(12.dp)) {
 
                         Text(
                             text = stringResource(R.string.speech_services_service_type),
@@ -568,39 +545,41 @@ fun SpeechServicesSettingsScreen(
                             }
                         }
 
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        Text(
-                            text = stringResource(R.string.speech_services_tts_speech_rate_value, ttsSpeechRateInput),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-
-                        Slider(
-                            value = ttsSpeechRateInput,
-                            onValueChange = { ttsSpeechRateInput = it },
-                            valueRange = 0.5f..2.0f,
-                            steps = 5,
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
-                        )
-
                         Spacer(modifier = Modifier.height(12.dp))
 
-                        Text(
-                            text = stringResource(R.string.speech_services_tts_pitch_value, ttsPitchInput),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource(R.string.speech_services_tts_speech_rate_value, ttsSpeechRateInput),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                                Slider(
+                                    value = ttsSpeechRateInput,
+                                    onValueChange = { ttsSpeechRateInput = it },
+                                    valueRange = 0.5f..2.0f,
+                                    steps = 5,
+                                )
+                            }
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource(R.string.speech_services_tts_pitch_value, ttsPitchInput),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                                Slider(
+                                    value = ttsPitchInput,
+                                    onValueChange = { ttsPitchInput = it },
+                                    valueRange = 0.5f..2.0f,
+                                    steps = 5,
+                                )
+                            }
+                        }
 
-                        Slider(
-                            value = ttsPitchInput,
-                            onValueChange = { ttsPitchInput = it },
-                            valueRange = 0.5f..2.0f,
-                            steps = 5,
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
-                        )
-
-                        Spacer(modifier = Modifier.height(16.dp))
+                        Spacer(modifier = Modifier.height(12.dp))
 
                         AnimatedVisibility(visible = ttsServiceTypeInput == VoiceServiceFactory.VoiceServiceType.SIMPLE_TTS) {
                             Column {
@@ -723,102 +702,124 @@ fun SpeechServicesSettingsScreen(
                             }
                         }
 
-                        // TTS Cleaner Regex List
-                        Text(
-                            text = stringResource(R.string.speech_services_tts_cleaner_title),
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.Medium,
-                            modifier = Modifier.padding(bottom = 4.dp)
-                        )
-                        
-                        Text(
-                            text = stringResource(R.string.speech_services_tts_cleaner_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(bottom = 8.dp)
-                        )
-                        
-                        Column {
-                            ttsCleanerRegexsState.forEachIndexed { index, regex ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { ttsCleanerExpanded = !ttsCleanerExpanded }
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "${stringResource(R.string.speech_services_tts_cleaner_title)} (${ttsCleanerRegexsState.size})",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.Medium,
+                                )
+                                Text(
+                                    text = stringResource(R.string.speech_services_tts_cleaner_desc),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Icon(
+                                imageVector = if (ttsCleanerExpanded) {
+                                    Icons.Default.KeyboardArrowUp
+                                } else {
+                                    Icons.Default.KeyboardArrowDown
+                                },
+                                contentDescription = stringResource(
+                                    if (ttsCleanerExpanded) R.string.collapse else R.string.expand,
+                                ),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+
+                        AnimatedVisibility(visible = ttsCleanerExpanded) {
+                            Column {
+                                ttsCleanerRegexsState.forEachIndexed { index, regex ->
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        OutlinedTextField(
+                                            value = regex,
+                                            onValueChange = { ttsCleanerRegexsState[index] = it },
+                                            placeholder = { Text(stringResource(R.string.speech_services_tts_cleaner_placeholder)) },
+                                            modifier = Modifier.weight(1f),
+                                            singleLine = true,
+                                        )
+                                        IconButton(onClick = { ttsCleanerRegexsState.removeAt(index) }) {
+                                            Icon(
+                                                Icons.Default.Delete,
+                                                contentDescription = stringResource(R.string.speech_services_tts_cleaner_delete),
+                                            )
+                                        }
+                                    }
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                }
+
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
-                                    verticalAlignment = Alignment.CenterVertically
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 ) {
-                                    OutlinedTextField(
-                                        value = regex,
-                                        onValueChange = { ttsCleanerRegexsState[index] = it },
-                                        placeholder = { Text(stringResource(R.string.speech_services_tts_cleaner_placeholder)) },
+                                    TextButton(
+                                        onClick = { ttsCleanerRegexsState.add("") },
                                         modifier = Modifier.weight(1f),
-                                        singleLine = true,
-                                    )
-                                    IconButton(onClick = { ttsCleanerRegexsState.removeAt(index) }) {
-                                        Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.speech_services_tts_cleaner_delete))
+                                    ) {
+                                        Icon(Icons.Default.Add, contentDescription = null)
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                        Text(stringResource(R.string.speech_services_tts_cleaner_add))
                                     }
-                                }
-                                Spacer(modifier = Modifier.height(8.dp))
-                            }
-                            
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                Button(
-                                    onClick = { ttsCleanerRegexsState.add("") },
-                                    modifier = Modifier.weight(1f)
-                                ) {
-                                    Icon(Icons.Default.Add, contentDescription = null)
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    Text(stringResource(R.string.speech_services_tts_cleaner_add))
-                                }
-                                
-                                var showTemplateMenu by remember { mutableStateOf(false) }
-                                OutlinedButton(
-                                    onClick = { showTemplateMenu = true },
-                                    modifier = Modifier.weight(1f)
-                                ) {
-                                    Text(stringResource(R.string.speech_services_tts_cleaner_template))
-                                    Icon(Icons.Default.ArrowDropDown, contentDescription = null)
-                                }
-                                
-                                DropdownMenu(
-                                    expanded = showTemplateMenu,
-                                    onDismissRequest = { showTemplateMenu = false }
-                                ) {
-                                    DropdownMenuItem(
-                                        text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_asterisk)) },
-                                        onClick = {
-                                            ttsCleanerRegexsState.add("\\*[^*]+\\*")
-                                            showTemplateMenu = false
-                                        }
-                                    )
-                                    DropdownMenuItem(
-                                        text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_double_asterisk)) },
-                                        onClick = {
-                                            ttsCleanerRegexsState.add("\\*\\*[^*]+\\*\\*")
-                                            showTemplateMenu = false
-                                        }
-                                    )
-                                    DropdownMenuItem(
-                                        text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_parenthesis)) },
-                                        onClick = {
-                                            ttsCleanerRegexsState.add("\\([^)]+\\)")
-                                            showTemplateMenu = false
-                                        }
-                                    )
-                                    DropdownMenuItem(
-                                        text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_chinese_parenthesis)) },
-                                        onClick = {
-                                            ttsCleanerRegexsState.add("（[^）]+）")
-                                            showTemplateMenu = false
-                                        }
-                                    )
-                                    DropdownMenuItem(
-                                        text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_xml)) },
-                                        onClick = {
-                                            ttsCleanerRegexsState.add("<[^>]+>")
-                                            showTemplateMenu = false
-                                        }
-                                    )
+
+                                    var showTemplateMenu by remember { mutableStateOf(false) }
+                                    TextButton(
+                                        onClick = { showTemplateMenu = true },
+                                        modifier = Modifier.weight(1f),
+                                    ) {
+                                        Text(stringResource(R.string.speech_services_tts_cleaner_template))
+                                        Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+                                    }
+
+                                    DropdownMenu(
+                                        expanded = showTemplateMenu,
+                                        onDismissRequest = { showTemplateMenu = false },
+                                    ) {
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_asterisk)) },
+                                            onClick = {
+                                                ttsCleanerRegexsState.add("\\*[^*]+\\*")
+                                                showTemplateMenu = false
+                                            },
+                                        )
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_double_asterisk)) },
+                                            onClick = {
+                                                ttsCleanerRegexsState.add("\\*\\*[^*]+\\*\\*")
+                                                showTemplateMenu = false
+                                            },
+                                        )
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_parenthesis)) },
+                                            onClick = {
+                                                ttsCleanerRegexsState.add("\\([^)]+\\)")
+                                                showTemplateMenu = false
+                                            },
+                                        )
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_chinese_parenthesis)) },
+                                            onClick = {
+                                                ttsCleanerRegexsState.add("（[^）]+）")
+                                                showTemplateMenu = false
+                                            },
+                                        )
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.speech_services_tts_cleaner_template_xml)) },
+                                            onClick = {
+                                                ttsCleanerRegexsState.add("<[^>]+>")
+                                                showTemplateMenu = false
+                                            },
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -855,11 +856,38 @@ fun SpeechServicesSettingsScreen(
                                     singleLine = true
                                 )
 
-                                Spacer(modifier = Modifier.height(8.dp))
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable { ttsHttpAdvancedExpanded = !ttsHttpAdvancedExpanded }
+                                        .padding(vertical = 8.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.advanced_settings),
+                                        style = MaterialTheme.typography.titleSmall,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                    Icon(
+                                        imageVector = if (ttsHttpAdvancedExpanded) {
+                                            Icons.Default.KeyboardArrowUp
+                                        } else {
+                                            Icons.Default.KeyboardArrowDown
+                                        },
+                                        contentDescription = stringResource(
+                                            if (ttsHttpAdvancedExpanded) R.string.collapse else R.string.expand,
+                                        ),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
 
-                                OutlinedTextField(
-                                    value = ttsHeadersInput,
-                                    onValueChange = { 
+                                AnimatedVisibility(visible = ttsHttpAdvancedExpanded) {
+                                    Column {
+                                        Spacer(modifier = Modifier.height(4.dp))
+
+                                        OutlinedTextField(
+                                            value = ttsHeadersInput,
+                                            onValueChange = {
                                         ttsHeadersInput = it
                                         try {
                                             Json.decodeFromString<Map<String, String>>(it)
@@ -872,12 +900,12 @@ fun SpeechServicesSettingsScreen(
                                             }
                                         }
                                     },
-                                    label = { Text(stringResource(R.string.speech_services_http_headers)) },
-                                    placeholder = { Text(stringResource(R.string.speech_services_http_headers_placeholder)) },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    minLines = 2,
-                                    isError = ttsHeadersJsonError != null
-                                )
+                                            label = { Text(stringResource(R.string.speech_services_http_headers)) },
+                                            placeholder = { Text(stringResource(R.string.speech_services_http_headers_placeholder)) },
+                                            modifier = Modifier.fillMaxWidth(),
+                                            minLines = 2,
+                                            isError = ttsHeadersJsonError != null,
+                                        )
 
                                 if (ttsHeadersJsonError != null) {
                                     Text(
@@ -982,6 +1010,8 @@ fun SpeechServicesSettingsScreen(
                                         style = MaterialTheme.typography.bodySmall,
                                         modifier = Modifier.padding(top = 4.dp)
                                     )
+                                }
+                                    }
                                 }
                             }
                         }
@@ -2074,46 +2104,20 @@ fun SpeechServicesSettingsScreen(
                         }
                     }
                 }
-                
-                Spacer(modifier = Modifier.height(16.dp))
+                }
 
+                if (selectedTabIndex == 1) item(key = "stt-settings") {
                 // --- STT Section ---
                 Card(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(10.dp),
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.surface
                     ),
                     border = BorderStroke(0.7.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
                     elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
                 ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(bottom = 12.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Mic,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(24.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text = stringResource(R.string.speech_services_stt_title),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                        
-                        Text(
-                            text = stringResource(R.string.speech_services_stt_desc),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(bottom = 16.dp)
-                        )
-
-                        Spacer(modifier = Modifier.height(16.dp))
+                    Column(modifier = Modifier.padding(12.dp)) {
 
                         Text(
                             text = stringResource(R.string.speech_services_service_type),
@@ -2268,114 +2272,56 @@ fun SpeechServicesSettingsScreen(
                             }
                         }
                         
-                        Spacer(modifier = Modifier.height(8.dp))
-                        
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Info,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.size(16.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text = stringResource(R.string.speech_services_stt_info),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
                     }
                 }
-                
-                Spacer(modifier = Modifier.height(16.dp))
-                
-                // 信息卡片
-                Card(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f)
-                    )
-                ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(bottom = 12.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Info,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(24.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text = stringResource(R.string.speech_services_info_title),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                        
-                        Column(modifier = Modifier.fillMaxWidth()) {
-                            SettingsInfoRow(
-                                title = stringResource(R.string.speech_services_info_tts_title),
-                                description = stringResource(R.string.speech_services_info_tts_desc)
-                            )
-                            
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = 8.dp),
-                                color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
-                            )
-                            
-                            SettingsInfoRow(
-                                title = stringResource(R.string.speech_services_info_stt_title),
-                                description = stringResource(R.string.speech_services_info_stt_desc)
-                            )
-                        }
-                    }
                 }
-                
-                // 底部区域
-                Spacer(modifier = Modifier.height(16.dp))
-                
-                Card(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
-                    )
-                ) {
-                    Column(
+
+                item {
+                    Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(16.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                            .padding(horizontal = 4.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.Top,
                     ) {
-                        OutlinedButton(
-                            onClick = onNavigateToTextToSpeech,
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.VolumeUp,
-                                contentDescription = null,
-                                modifier = Modifier.size(20.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(stringResource(R.string.speech_services_test_tts))
-                        }
+                        Icon(
+                            imageVector = Icons.Default.Info,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = if (selectedTabIndex == 0) {
+                                stringResource(R.string.speech_services_info_tts_desc)
+                            } else {
+                                stringResource(R.string.speech_services_info_stt_desc)
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
                     }
                 }
-                
-                // 底部空间
-                Spacer(modifier = Modifier.height(32.dp))
+
+                if (selectedTabIndex == 0) item {
+                    OutlinedButton(
+                        onClick = onNavigateToTextToSpeech,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.VolumeUp,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(stringResource(R.string.speech_services_test_tts))
+                    }
+                }
+
+                item {
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
             }
         }
-    }
     }
 
     if (simpleTtsShowVoiceDialog) {
@@ -2559,22 +2505,21 @@ fun SpeechServicesSettingsScreen(
 }
 
 @Composable
-fun SettingsInfoRow(title: String, description: String) {
-    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface
+private fun SpeechServicesModeTabs(
+    selectedTabIndex: Int,
+    onTabSelected: (Int) -> Unit,
+) {
+    TabRow(selectedTabIndex = selectedTabIndex) {
+        Tab(
+            selected = selectedTabIndex == 0,
+            onClick = { onTabSelected(0) },
+            text = { Text(stringResource(R.string.speech_services_info_tts_title)) },
         )
-        
-        Text(
-            text = description,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+        Tab(
+            selected = selectedTabIndex == 1,
+            onClick = { onTabSelected(1) },
+            text = { Text(stringResource(R.string.speech_services_info_stt_title)) },
         )
-        
-        Spacer(modifier = Modifier.height(4.dp))
     }
 }
 
@@ -2584,7 +2529,8 @@ private data class SpeechProfileOption(
 )
 
 @Composable
-private fun SpeechProfilesManagementCard(
+private fun SpeechProfileManagementBar(
+    selectedTabIndex: Int,
     ttsProfiles: List<SpeechProfileOption>,
     sttProfiles: List<SpeechProfileOption>,
     currentTtsProfileId: String,
@@ -2600,66 +2546,28 @@ private fun SpeechProfilesManagementCard(
     onDeleteTts: (String) -> Unit,
     onDeleteStt: (String) -> Unit,
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        border = BorderStroke(
-            0.7.dp,
-            MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
-    ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.FormatListBulleted,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(22.dp),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(R.string.speech_services_settings),
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Medium,
-                    )
-                    Text(
-                        text = stringResource(R.string.speech_services_settings_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-
-            SpeechProfileSelector(
-                title = stringResource(R.string.speech_services_tts_profiles),
-                profiles = ttsProfiles,
-                activeProfileId = currentTtsProfileId,
-                errorMessage = ttsProfileError,
-                onCreate = onCreateTts,
-                onRename = onRenameTts,
-                onSelect = onSelectTts,
-                onDelete = onDeleteTts,
-            )
-
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-
-            SpeechProfileSelector(
-                title = stringResource(R.string.speech_services_stt_profiles),
-                profiles = sttProfiles,
-                activeProfileId = currentSttProfileId,
-                errorMessage = sttProfileError,
-                onCreate = onCreateStt,
-                onRename = onRenameStt,
-                onSelect = onSelectStt,
-                onDelete = onDeleteStt,
-            )
-        }
+    if (selectedTabIndex == 0) {
+        SpeechProfileSelector(
+            title = stringResource(R.string.speech_services_tts_profiles),
+            profiles = ttsProfiles,
+            activeProfileId = currentTtsProfileId,
+            errorMessage = ttsProfileError,
+            onCreate = onCreateTts,
+            onRename = onRenameTts,
+            onSelect = onSelectTts,
+            onDelete = onDeleteTts,
+        )
+    } else {
+        SpeechProfileSelector(
+            title = stringResource(R.string.speech_services_stt_profiles),
+            profiles = sttProfiles,
+            activeProfileId = currentSttProfileId,
+            errorMessage = sttProfileError,
+            onCreate = onCreateStt,
+            onRename = onRenameStt,
+            onSelect = onSelectStt,
+            onDelete = onDeleteStt,
+        )
     }
 }
 
@@ -2689,19 +2597,20 @@ private fun SpeechProfileSelector(
             fontWeight = FontWeight.Medium,
             modifier = Modifier.weight(1f),
         )
-        OutlinedButton(
-            onClick = onCreate,
-            shape = RoundedCornerShape(16.dp),
-            border = BorderStroke(0.8.dp, MaterialTheme.colorScheme.primary),
-            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
-            modifier = Modifier.height(28.dp),
-            colors = ButtonDefaults.outlinedButtonColors(
-                contentColor = MaterialTheme.colorScheme.primary,
-            ),
+        IconButton(onClick = onCreate) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = stringResource(R.string.new_action),
+            )
+        }
+        IconButton(
+            onClick = onRename,
+            enabled = profiles.any { it.id == activeProfileId },
         ) {
-            Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(14.dp))
-            Spacer(modifier = Modifier.width(2.dp))
-            Text(stringResource(R.string.new_action), style = MaterialTheme.typography.labelSmall)
+            Icon(
+                imageVector = Icons.Default.Edit,
+                contentDescription = stringResource(R.string.rename_action),
+            )
         }
     }
     Box(modifier = Modifier.fillMaxWidth()) {
@@ -2716,7 +2625,7 @@ private fun SpeechProfileSelector(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
@@ -2767,21 +2676,6 @@ private fun SpeechProfileSelector(
                     },
                 )
             }
-        }
-    }
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        TextButton(
-            onClick = onRename,
-            enabled = profiles.any { it.id == activeProfileId },
-            contentPadding = PaddingValues(horizontal = 8.dp),
-            modifier = Modifier.height(36.dp),
-        ) {
-            Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(16.dp))
-            Spacer(modifier = Modifier.width(4.dp))
-            Text(stringResource(R.string.rename_action))
         }
     }
     if (errorMessage != null) {

--- a/docs/TODO/speech_services_settings_ui_20260822/01_ui_relayout.md
+++ b/docs/TODO/speech_services_settings_ui_20260822/01_ui_relayout.md
@@ -1,0 +1,23 @@
+# UI 重排细化
+
+## 已发布行为约束
+
+- 不改变 `SpeechServiceProfilesPreferences` 的 JSON、档案 ID、当前档案选择和删除约束。
+- 不改变旧 `SpeechServicesPreferences` 投影，现有 Provider 继续读取相同字段。
+- 不增加第二套保存机制；页面继续使用现有自动保存流程。
+- 不删除任何已存在的 Provider 配置字段。
+
+## 页面结构
+
+1. 页面内 Tab：`TTS` 和 `STT`。
+2. 当前 Tab 的配置档案紧凑管理栏，保留新建、切换、重命名和删除非当前档案。
+3. 当前 Provider 和播放参数集中展示。
+4. 清理正则和 HTTP 请求参数作为可展开区域展示。
+5. TTS Tab 保留测试 TTS，STT Tab 保留对应引擎参数和说明。
+
+## 完成标准
+
+- 切换 Tab 不丢失编辑状态。
+- 切换、创建、重命名、删除档案行为不变。
+- 每种已存在 TTS Provider 仍可访问原有字段。
+- 页面不再同时渲染 TTS 和 STT 两个完整长表单。

--- a/docs/TODO/speech_services_settings_ui_20260822/index.md
+++ b/docs/TODO/speech_services_settings_ui_20260822/index.md
@@ -1,0 +1,27 @@
+---
+feature: speech-services-settings-ui
+status: in-progress
+---
+
+# 语音服务设置页 UI 重排
+
+## 原本状况
+
+已发布版本的语音服务设置页把 TTS、STT、配置档案、供应商参数、清理规则和说明内容连续堆叠在同一条长列表中。TTS 供应商切换后，低频 JSON 参数和常用播放参数没有清晰层级。
+
+## 目标
+
+在不改变已发布配置数据、路由、自动保存和 Provider 参数契约的前提下，将页面压缩为 TTS/STT 分页、单行配置档案管理、紧凑播放参数和可展开的低频设置。
+
+## 作用域
+
+- `SpeechServicesSettingsScreen.kt`：只调整 Compose 页面结构和档案入口展示。
+- `SpeechServicesSettingsPreferences.kt` 及 Provider：不修改数据模型和运行时契约。
+- 保留所有现有 TTS/STT 字段、档案操作和测试入口。
+
+## 结果
+
+- TTS 和 STT 通过页面内 Tab 切换，避免同屏滚动两个完整配置区。
+- 当前 Tab 只显示对应的配置档案入口。
+- 语速和音调合并到同一播放参数区域。
+- TTS 清理规则和 HTTP 低频参数支持折叠。


### PR DESCRIPTION
## 变更说明 / Description

将语音服务设置页重构为更紧凑的 TTS/STT 分 Tab 配置界面，便于在移动端查看和编辑。此 PR 按请求从上游 `main` 独立 cherry-pick 提交，不包含统计或 Provider logo 等其他改动。

### 背景与动机 / Context and motivation

原页面同时渲染 TTS 和 STT 的完整配置，移动端滚动距离较长，档案管理和低频参数占用较多空间。

### 改动范围 / Changes

- 增加 TTS/STT Tab，只渲染当前模式的配置。
- 压缩配置档案栏，保留创建、切换、重命名和删除非当前档案。
- 将语速和音调并排展示。
- 将 TTS 清理正则和 HTTP 高级参数改为可展开区域。
- 保留现有 Provider 字段、自动保存流程和配置档案数据契约。
- 添加对应的 UI 重排 TODO 文档。
- 不包含 Provider 逻辑、统计逻辑或持久化格式重构。

### 兼容性与风险 / Compatibility and risks

- 不改变 `SpeechServiceProfilesPreferences` 的 JSON、档案 ID、当前档案选择和删除约束。
- 保留旧 `SpeechServicesPreferences` 投影，现有 Provider 继续读取相同字段。
- 不新增第二套保存机制，不删除已存在的 Provider 配置字段。
- 主要风险限于 Compose 页面布局和交互状态。

## 关联 Issue / Related issue

N/A：独立 UI 重构提交，未关联 Issue。

## 验证方式 / Verification

```text
检查或命令：git diff --check；远程 Release assembleRelease 构建；手动测试 TTS/STT Tab、档案切换和页面配置
环境与变体：Android Release APK；设备信息未记录
结果：静态检查通过，原始实现提交 2d3a6a71d 的远程 Release 构建通过，用户手动测试通过
```

## 证据 / Evidence

用户已在 Android Release APK 中完成当前 UI 的手动验证。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 目标分支为用户指定的稳定 `main`，并已在上文说明该例外 / The requested stable `main` target is explained above
- [ ] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的 UI 和兼容性验证证据 / Relevant UI and compatibility evidence is provided