### PR TITLE
fix GitHub terminal hangs, stale sessions, and command results

### DIFF
--- a/app/src/main/assets/packages/github.js
+++ b/app/src/main/assets/packages/github.js
@@ -228,6 +228,7 @@
       "parameters": [
         { "name": "command", "description": { "zh": "要执行的命令", "en": "Command to execute." }, "type": "string", "required": true },
         { "name": "session_name", "description": { "zh": "会话名（可选，默认 github_tools_session）", "en": "Session name (optional; default: github_tools_session)." }, "type": "string", "required": false },
+        { "name": "timeout_ms", "description": { "zh": "超时时间（毫秒，默认120000）", "en": "Timeout in milliseconds (default 120000)." }, "type": "number", "required": false },
         { "name": "close", "description": { "zh": "是否执行后关闭会话", "en": "Whether to close the session after execution." }, "type": "boolean", "required": false }
       ]
     },
@@ -802,21 +803,97 @@ async function overwriteLocalFile(params) {
 }
 
 // src/local/terminal.ts
+var DEFAULT_SESSION_NAME = "github_tools_session";
+var DEFAULT_TIMEOUT_MS = 120000;
 var terminalSessionId = null;
+var terminalSessionName = null;
+var sessionCreationPromise = null;
+function normalizeSessionName(sessionName) {
+  var normalized = String(sessionName || "").trim();
+  return normalized || DEFAULT_SESSION_NAME;
+}
+function invalidateSession(sessionId) {
+  if (!sessionId || terminalSessionId === sessionId) {
+    terminalSessionId = null;
+    terminalSessionName = null;
+  }
+}
+async function closeSessionQuietly(sessionId) {
+  if (!sessionId) return;
+  try {
+    await Tools.System.terminal.close(sessionId);
+  } catch (_error) {
+  } finally {
+    invalidateSession(sessionId);
+  }
+}
+function isSessionLifecycleError(error) {
+  var message = String(error && error.message ? error.message : error || "").toLowerCase();
+  var mentionsSession = message.includes("session") || message.includes("pty") || message.includes("\u4f1a\u8bdd");
+  var mentionsLifecycle = message.includes("not exist") || message.includes("does not exist") || message.includes("closed") || message.includes("invalid") || message.includes("unavailable") || message.includes("\u4e0d\u5b58\u5728") || message.includes("\u5173\u95ed") || message.includes("\u5931\u6548") || message.includes("\u4e0d\u53ef\u7528");
+  return mentionsSession && mentionsLifecycle;
+}
+function isTimeoutError(error) {
+  var message = String(error && error.message ? error.message : error || "").toLowerCase();
+  return message.includes("timed out") || message.includes("timeout");
+}
+function normalizeTimeout(timeoutMs) {
+  var value = timeoutMs === void 0 || timeoutMs === null ? DEFAULT_TIMEOUT_MS : Number(timeoutMs);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("timeout_ms must be a positive number");
+  }
+  return Math.floor(value);
+}
 async function getTerminalSession(sessionName) {
-  if (terminalSessionId) return terminalSessionId;
-  const session = await Tools.System.terminal.create(sessionName || "github_tools_session");
-  terminalSessionId = session.sessionId;
-  return terminalSessionId;
+  var normalizedName = normalizeSessionName(sessionName);
+  if (terminalSessionId && terminalSessionName === normalizedName) return terminalSessionId;
+  if (sessionCreationPromise) return sessionCreationPromise;
+  sessionCreationPromise = (async function() {
+    if (terminalSessionId) {
+      await closeSessionQuietly(terminalSessionId);
+    }
+    var session = await Tools.System.terminal.create(normalizedName);
+    if (!session || !session.sessionId) {
+      throw new Error("Terminal session creation returned no sessionId for " + normalizedName);
+    }
+    terminalSessionId = String(session.sessionId);
+    terminalSessionName = normalizedName;
+    return terminalSessionId;
+  })();
+  try {
+    return await sessionCreationPromise;
+  } finally {
+    sessionCreationPromise = null;
+  }
 }
 async function terminalExec(params) {
-  const sessionId = await getTerminalSession(params.session_name);
-  const result = await Tools.System.terminal.exec(sessionId, params.command);
-  if (params.close) {
-    await Tools.System.terminal.close(sessionId);
-    terminalSessionId = null;
+  var sessionName = normalizeSessionName(params.session_name);
+  var timeoutMs = normalizeTimeout(params.timeout_ms);
+  var sessionId = await getTerminalSession(sessionName);
+  try {
+    var result;
+    try {
+      result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
+    } catch (error) {
+      if (isTimeoutError(error)) {
+        await closeSessionQuietly(sessionId);
+        throw error;
+      }
+      if (!isSessionLifecycleError(error)) throw error;
+      invalidateSession(sessionId);
+      sessionId = await getTerminalSession(sessionName);
+      result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
+    }
+    if (result && result.timedOut === true) {
+      await closeSessionQuietly(sessionId);
+      throw new Error("Terminal command timed out after " + timeoutMs + "ms");
+    }
+    return result;
+  } finally {
+    if (params.close) {
+      await closeSessionQuietly(sessionId);
+    }
   }
-  return result;
 }
 
 // src/tools.ts

--- a/app/src/main/assets/packages/github.js
+++ b/app/src/main/assets/packages/github.js
@@ -804,12 +804,12 @@ async function overwriteLocalFile(params) {
 
 // src/local/terminal.ts
 var DEFAULT_SESSION_NAME = "github_tools_session";
-var DEFAULT_TIMEOUT_MS = 120000;
+var DEFAULT_TIMEOUT_MS = 12e4;
 var terminalSessionId = null;
 var terminalSessionName = null;
 var sessionCreationPromise = null;
 function normalizeSessionName(sessionName) {
-  var normalized = String(sessionName || "").trim();
+  const normalized = String(sessionName || "").trim();
   return normalized || DEFAULT_SESSION_NAME;
 }
 function invalidateSession(sessionId) {
@@ -828,33 +828,37 @@ async function closeSessionQuietly(sessionId) {
   }
 }
 function isSessionLifecycleError(error) {
-  var message = String(error && error.message ? error.message : error || "").toLowerCase();
-  var mentionsSession = message.includes("session") || message.includes("pty") || message.includes("\u4f1a\u8bdd");
-  var mentionsLifecycle = message.includes("not exist") || message.includes("does not exist") || message.includes("closed") || message.includes("invalid") || message.includes("unavailable") || message.includes("\u4e0d\u5b58\u5728") || message.includes("\u5173\u95ed") || message.includes("\u5931\u6548") || message.includes("\u4e0d\u53ef\u7528");
+  const message = String(error && error.message ? error.message : error || "").toLowerCase();
+  const mentionsSession = message.includes("session") || message.includes("\u4F1A\u8BDD") || message.includes("pty");
+  const mentionsLifecycle = message.includes("not exist") || message.includes("does not exist") || message.includes("closed") || message.includes("invalid") || message.includes("unavailable") || message.includes("\u4E0D\u5B58\u5728") || message.includes("\u5173\u95ED") || message.includes("\u5931\u6548") || message.includes("\u4E0D\u53EF\u7528");
   return mentionsSession && mentionsLifecycle;
 }
 function isTimeoutError(error) {
-  var message = String(error && error.message ? error.message : error || "").toLowerCase();
-  return message.includes("timed out") || message.includes("timeout");
+  const message = String(error && error.message ? error.message : error || "").toLowerCase();
+  return message.includes("timed out") || message.includes("timeout") || message.includes("\u8D85\u65F6");
 }
 function normalizeTimeout(timeoutMs) {
-  var value = timeoutMs === void 0 || timeoutMs === null ? DEFAULT_TIMEOUT_MS : Number(timeoutMs);
+  const value = timeoutMs === void 0 || timeoutMs === null ? DEFAULT_TIMEOUT_MS : Number(timeoutMs);
   if (!Number.isFinite(value) || value <= 0) {
     throw new Error("timeout_ms must be a positive number");
   }
   return Math.floor(value);
 }
 async function getTerminalSession(sessionName) {
-  var normalizedName = normalizeSessionName(sessionName);
-  if (terminalSessionId && terminalSessionName === normalizedName) return terminalSessionId;
-  if (sessionCreationPromise) return sessionCreationPromise;
-  sessionCreationPromise = (async function() {
+  const normalizedName = normalizeSessionName(sessionName);
+  if (terminalSessionId && terminalSessionName === normalizedName) {
+    return terminalSessionId;
+  }
+  if (sessionCreationPromise) {
+    return sessionCreationPromise;
+  }
+  sessionCreationPromise = (async () => {
     if (terminalSessionId) {
       await closeSessionQuietly(terminalSessionId);
     }
-    var session = await Tools.System.terminal.create(normalizedName);
+    const session = await Tools.System.terminal.create(normalizedName);
     if (!session || !session.sessionId) {
-      throw new Error("Terminal session creation returned no sessionId for " + normalizedName);
+      throw new Error(`Terminal session creation returned no sessionId for ${normalizedName}`);
     }
     terminalSessionId = String(session.sessionId);
     terminalSessionName = normalizedName;
@@ -867,11 +871,11 @@ async function getTerminalSession(sessionName) {
   }
 }
 async function terminalExec(params) {
-  var sessionName = normalizeSessionName(params.session_name);
-  var timeoutMs = normalizeTimeout(params.timeout_ms);
-  var sessionId = await getTerminalSession(sessionName);
+  const sessionName = normalizeSessionName(params.session_name);
+  const timeoutMs = normalizeTimeout(params.timeout_ms);
+  let sessionId = await getTerminalSession(sessionName);
   try {
-    var result;
+    let result;
     try {
       result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
     } catch (error) {
@@ -879,14 +883,16 @@ async function terminalExec(params) {
         await closeSessionQuietly(sessionId);
         throw error;
       }
-      if (!isSessionLifecycleError(error)) throw error;
+      if (!isSessionLifecycleError(error)) {
+        throw error;
+      }
       invalidateSession(sessionId);
       sessionId = await getTerminalSession(sessionName);
       result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
     }
     if (result && result.timedOut === true) {
       await closeSessionQuietly(sessionId);
-      throw new Error("Terminal command timed out after " + timeoutMs + "ms");
+      throw new Error(`Terminal command timed out after ${timeoutMs}ms`);
     }
     return result;
   } finally {

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardTerminalCommandExecutor.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardTerminalCommandExecutor.kt
@@ -126,24 +126,22 @@ class StandardTerminalCommandExecutor(private val context: Context) {
                 if (outputFlow != null) {
                     val events = mutableListOf<String>()
                     var completionOutput: String? = null
-                    var exitCode = 0
+                    var exitCode: Int? = null
                     var hasCompleted = false
                     var didTimeout = false
 
                     try {
-                        withTimeout(timeout) {
-                            outputFlow.collect { event ->
-                                if (event.isCompleted) {
-                                    completionOutput = event.outputChunk
-                                } else if (event.outputChunk.isNotEmpty()) {
-                                    events.add(event.outputChunk)
-                                }
-                                if (event.isCompleted) {
-                                    exitCode = 0
-                                    hasCompleted = true
+                            withTimeout(timeout) {
+                                outputFlow.collect { event ->
+                                    if (event.isCompleted) {
+                                        completionOutput = event.outputChunk
+                                        exitCode = event.exitCode ?: 0
+                                        hasCompleted = true
+                                    } else if (event.outputChunk.isNotEmpty()) {
+                                        events.add(event.outputChunk)
+                                    }
                                 }
                             }
-                        }
                     } catch (e: TimeoutCancellationException) {
                         AppLogger.w(TAG, "Command execution timed out after ${timeout}ms")
                         cancelTimedOutCommand(terminal, sessionId)
@@ -153,11 +151,18 @@ class StandardTerminalCommandExecutor(private val context: Context) {
                     }
 
                     val fullOutput = completionOutput?.takeIf { it.isNotEmpty() } ?: events.joinToString("")
-                    AppLogger.d(TAG, "Command output collected: '$fullOutput', exitCode: $exitCode")
+                    val finalExitCode = exitCode ?: if (didTimeout) -1 else 0
+                    AppLogger.d(TAG, "Command output collected: '$fullOutput', exitCode: $finalExitCode")
                     val errorMessage =
                             when {
-                                didTimeout -> null
+                                didTimeout -> "Command execution timed out after ${timeout}ms"
                                 !hasCompleted -> context.getString(R.string.terminal_error_command_failed)
+                                finalExitCode != 0 ->
+                                    if (finalExitCode == -1 && fullOutput.isNotBlank()) {
+                                        "Command failed: ${fullOutput.takeLast(1000)}"
+                                    } else {
+                                        "Command exited with code $finalExitCode"
+                                    }
                                 else -> null
                             }
 
@@ -167,7 +172,7 @@ class StandardTerminalCommandExecutor(private val context: Context) {
                             result = TerminalCommandResultData(
                                     command = command,
                                     output = fullOutput,
-                                    exitCode = exitCode,
+                                    exitCode = finalExitCode,
                                     sessionId = sessionId,
                                     timedOut = didTimeout
                             ),
@@ -252,7 +257,7 @@ class StandardTerminalCommandExecutor(private val context: Context) {
             val outputFlow = terminal.executeCommandFlow(sessionId, command)
             val events = mutableListOf<String>()
             var completionOutput: String? = null
-            var exitCode = 0
+            var exitCode: Int? = null
             var hasCompleted = false
             var didTimeout = false
             var chunkIndex = 0
@@ -263,7 +268,7 @@ class StandardTerminalCommandExecutor(private val context: Context) {
                     outputFlow.collect { event ->
                         if (event.isCompleted) {
                             completionOutput = event.outputChunk
-                            exitCode = 0
+                            exitCode = event.exitCode ?: 0
                             hasCompleted = true
                             return@collect
                         }
@@ -303,10 +308,17 @@ class StandardTerminalCommandExecutor(private val context: Context) {
             }
 
             val fullOutput = completionOutput?.takeIf { it.isNotEmpty() } ?: events.joinToString("")
+            val finalExitCode = exitCode ?: if (didTimeout) -1 else 0
             val errorMessage =
                 when {
-                    didTimeout -> null
+                    didTimeout -> "Command execution timed out after ${timeout}ms"
                     !hasCompleted -> context.getString(R.string.terminal_error_command_failed)
+                    finalExitCode != 0 ->
+                        if (finalExitCode == -1 && fullOutput.isNotBlank()) {
+                            "Command failed: ${fullOutput.takeLast(1000)}"
+                        } else {
+                            "Command exited with code $finalExitCode"
+                        }
                     else -> null
                 }
 
@@ -318,7 +330,7 @@ class StandardTerminalCommandExecutor(private val context: Context) {
                         TerminalCommandResultData(
                             command = command,
                             output = fullOutput,
-                            exitCode = exitCode,
+                            exitCode = finalExitCode,
                             sessionId = sessionId,
                             timedOut = didTimeout
                         ),

--- a/app/src/main/java/com/ai/assistance/operit/data/stats/ReleasedProviderModelKeyDecoder.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/stats/ReleasedProviderModelKeyDecoder.kt
@@ -1,6 +1,7 @@
 package com.ai.assistance.operit.data.stats
 
 import com.ai.assistance.operit.data.model.ApiProviderType
+import com.ai.assistance.operit.data.model.FunctionType
 
 internal data class ReleasedProviderModelKey(
     val storedProviderModel: String,
@@ -11,11 +12,15 @@ internal data class ReleasedProviderModelKey(
 /** Decodes released `provider:model` keys stored as `provider_model`. */
 internal object ReleasedProviderModelKeyDecoder {
     private val builtInProviderAliases = ApiProviderType.entries.associate { it.name to it.name }
+    private val preProviderFunctionKeys = FunctionType.entries.map { it.name }.toSet() + "FILE_BINDING"
 
     fun decode(
         encoded: String,
         additionalProviderAliases: Map<String, String> = emptyMap(),
     ): ReleasedProviderModelKey {
+        require(encoded !in preProviderFunctionKeys) {
+            "released token key is a pre-provider function key: $encoded"
+        }
         val aliases = buildMap {
             putAll(builtInProviderAliases)
             additionalProviderAliases.forEach { (rawAlias, rawIdentity) ->

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/ArtifactPublishScreen.kt
@@ -728,7 +728,7 @@ fun ArtifactPublishScreen(
             }
         }
 
-        if (selectedType == PublishArtifactType.PACKAGE && packageLogo != null) {
+        if (selectedType == PublishArtifactType.PACKAGE && displayedLogo != null) {
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
@@ -754,7 +754,7 @@ fun ArtifactPublishScreen(
                         Text(
                             text = stringResource(
                                 R.string.artifact_publish_logo_from_package,
-                                packageLogo.fileName
+                                displayedLogo.fileName
                             ),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/XaiProviderReasoningTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/XaiProviderReasoningTest.kt
@@ -2,12 +2,28 @@ package com.ai.assistance.operit.api.chat.llmprovider
 
 import com.ai.assistance.operit.data.collects.ApiProviderConfigs
 import com.ai.assistance.operit.data.model.ApiProviderType
+import com.ai.assistance.operit.util.AppLogger
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 class XaiProviderReasoningTest {
+    private var previousSystemLogEnabled = true
+
+    @Before
+    fun disableAndroidSystemLogForJvmTests() {
+        previousSystemLogEnabled = AppLogger.enableSystemLog
+        AppLogger.enableSystemLog = false
+    }
+
+    @After
+    fun restoreAndroidSystemLog() {
+        AppLogger.enableSystemLog = previousSystemLogEnabled
+    }
+
     @Test
     fun defaultConfigUsesTheOfficialXaiEndpointAndModel() {
         assertEquals(

--- a/examples/github.js
+++ b/examples/github.js
@@ -228,6 +228,7 @@
       "parameters": [
         { "name": "command", "description": { "zh": "要执行的命令", "en": "Command to execute." }, "type": "string", "required": true },
         { "name": "session_name", "description": { "zh": "会话名（可选，默认 github_tools_session）", "en": "Session name (optional; default: github_tools_session)." }, "type": "string", "required": false },
+        { "name": "timeout_ms", "description": { "zh": "超时时间（毫秒，默认120000）", "en": "Timeout in milliseconds (default 120000)." }, "type": "number", "required": false },
         { "name": "close", "description": { "zh": "是否执行后关闭会话", "en": "Whether to close the session after execution." }, "type": "boolean", "required": false }
       ]
     },
@@ -802,21 +803,97 @@ async function overwriteLocalFile(params) {
 }
 
 // src/local/terminal.ts
+var DEFAULT_SESSION_NAME = "github_tools_session";
+var DEFAULT_TIMEOUT_MS = 120000;
 var terminalSessionId = null;
+var terminalSessionName = null;
+var sessionCreationPromise = null;
+function normalizeSessionName(sessionName) {
+  var normalized = String(sessionName || "").trim();
+  return normalized || DEFAULT_SESSION_NAME;
+}
+function invalidateSession(sessionId) {
+  if (!sessionId || terminalSessionId === sessionId) {
+    terminalSessionId = null;
+    terminalSessionName = null;
+  }
+}
+async function closeSessionQuietly(sessionId) {
+  if (!sessionId) return;
+  try {
+    await Tools.System.terminal.close(sessionId);
+  } catch (_error) {
+  } finally {
+    invalidateSession(sessionId);
+  }
+}
+function isSessionLifecycleError(error) {
+  var message = String(error && error.message ? error.message : error || "").toLowerCase();
+  var mentionsSession = message.includes("session") || message.includes("pty") || message.includes("\u4f1a\u8bdd");
+  var mentionsLifecycle = message.includes("not exist") || message.includes("does not exist") || message.includes("closed") || message.includes("invalid") || message.includes("unavailable") || message.includes("\u4e0d\u5b58\u5728") || message.includes("\u5173\u95ed") || message.includes("\u5931\u6548") || message.includes("\u4e0d\u53ef\u7528");
+  return mentionsSession && mentionsLifecycle;
+}
+function isTimeoutError(error) {
+  var message = String(error && error.message ? error.message : error || "").toLowerCase();
+  return message.includes("timed out") || message.includes("timeout");
+}
+function normalizeTimeout(timeoutMs) {
+  var value = timeoutMs === void 0 || timeoutMs === null ? DEFAULT_TIMEOUT_MS : Number(timeoutMs);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("timeout_ms must be a positive number");
+  }
+  return Math.floor(value);
+}
 async function getTerminalSession(sessionName) {
-  if (terminalSessionId) return terminalSessionId;
-  const session = await Tools.System.terminal.create(sessionName || "github_tools_session");
-  terminalSessionId = session.sessionId;
-  return terminalSessionId;
+  var normalizedName = normalizeSessionName(sessionName);
+  if (terminalSessionId && terminalSessionName === normalizedName) return terminalSessionId;
+  if (sessionCreationPromise) return sessionCreationPromise;
+  sessionCreationPromise = (async function() {
+    if (terminalSessionId) {
+      await closeSessionQuietly(terminalSessionId);
+    }
+    var session = await Tools.System.terminal.create(normalizedName);
+    if (!session || !session.sessionId) {
+      throw new Error("Terminal session creation returned no sessionId for " + normalizedName);
+    }
+    terminalSessionId = String(session.sessionId);
+    terminalSessionName = normalizedName;
+    return terminalSessionId;
+  })();
+  try {
+    return await sessionCreationPromise;
+  } finally {
+    sessionCreationPromise = null;
+  }
 }
 async function terminalExec(params) {
-  const sessionId = await getTerminalSession(params.session_name);
-  const result = await Tools.System.terminal.exec(sessionId, params.command);
-  if (params.close) {
-    await Tools.System.terminal.close(sessionId);
-    terminalSessionId = null;
+  var sessionName = normalizeSessionName(params.session_name);
+  var timeoutMs = normalizeTimeout(params.timeout_ms);
+  var sessionId = await getTerminalSession(sessionName);
+  try {
+    var result;
+    try {
+      result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
+    } catch (error) {
+      if (isTimeoutError(error)) {
+        await closeSessionQuietly(sessionId);
+        throw error;
+      }
+      if (!isSessionLifecycleError(error)) throw error;
+      invalidateSession(sessionId);
+      sessionId = await getTerminalSession(sessionName);
+      result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
+    }
+    if (result && result.timedOut === true) {
+      await closeSessionQuietly(sessionId);
+      throw new Error("Terminal command timed out after " + timeoutMs + "ms");
+    }
+    return result;
+  } finally {
+    if (params.close) {
+      await closeSessionQuietly(sessionId);
+    }
   }
-  return result;
 }
 
 // src/tools.ts

--- a/examples/github.js
+++ b/examples/github.js
@@ -804,12 +804,12 @@ async function overwriteLocalFile(params) {
 
 // src/local/terminal.ts
 var DEFAULT_SESSION_NAME = "github_tools_session";
-var DEFAULT_TIMEOUT_MS = 120000;
+var DEFAULT_TIMEOUT_MS = 12e4;
 var terminalSessionId = null;
 var terminalSessionName = null;
 var sessionCreationPromise = null;
 function normalizeSessionName(sessionName) {
-  var normalized = String(sessionName || "").trim();
+  const normalized = String(sessionName || "").trim();
   return normalized || DEFAULT_SESSION_NAME;
 }
 function invalidateSession(sessionId) {
@@ -828,33 +828,37 @@ async function closeSessionQuietly(sessionId) {
   }
 }
 function isSessionLifecycleError(error) {
-  var message = String(error && error.message ? error.message : error || "").toLowerCase();
-  var mentionsSession = message.includes("session") || message.includes("pty") || message.includes("\u4f1a\u8bdd");
-  var mentionsLifecycle = message.includes("not exist") || message.includes("does not exist") || message.includes("closed") || message.includes("invalid") || message.includes("unavailable") || message.includes("\u4e0d\u5b58\u5728") || message.includes("\u5173\u95ed") || message.includes("\u5931\u6548") || message.includes("\u4e0d\u53ef\u7528");
+  const message = String(error && error.message ? error.message : error || "").toLowerCase();
+  const mentionsSession = message.includes("session") || message.includes("\u4F1A\u8BDD") || message.includes("pty");
+  const mentionsLifecycle = message.includes("not exist") || message.includes("does not exist") || message.includes("closed") || message.includes("invalid") || message.includes("unavailable") || message.includes("\u4E0D\u5B58\u5728") || message.includes("\u5173\u95ED") || message.includes("\u5931\u6548") || message.includes("\u4E0D\u53EF\u7528");
   return mentionsSession && mentionsLifecycle;
 }
 function isTimeoutError(error) {
-  var message = String(error && error.message ? error.message : error || "").toLowerCase();
-  return message.includes("timed out") || message.includes("timeout");
+  const message = String(error && error.message ? error.message : error || "").toLowerCase();
+  return message.includes("timed out") || message.includes("timeout") || message.includes("\u8D85\u65F6");
 }
 function normalizeTimeout(timeoutMs) {
-  var value = timeoutMs === void 0 || timeoutMs === null ? DEFAULT_TIMEOUT_MS : Number(timeoutMs);
+  const value = timeoutMs === void 0 || timeoutMs === null ? DEFAULT_TIMEOUT_MS : Number(timeoutMs);
   if (!Number.isFinite(value) || value <= 0) {
     throw new Error("timeout_ms must be a positive number");
   }
   return Math.floor(value);
 }
 async function getTerminalSession(sessionName) {
-  var normalizedName = normalizeSessionName(sessionName);
-  if (terminalSessionId && terminalSessionName === normalizedName) return terminalSessionId;
-  if (sessionCreationPromise) return sessionCreationPromise;
-  sessionCreationPromise = (async function() {
+  const normalizedName = normalizeSessionName(sessionName);
+  if (terminalSessionId && terminalSessionName === normalizedName) {
+    return terminalSessionId;
+  }
+  if (sessionCreationPromise) {
+    return sessionCreationPromise;
+  }
+  sessionCreationPromise = (async () => {
     if (terminalSessionId) {
       await closeSessionQuietly(terminalSessionId);
     }
-    var session = await Tools.System.terminal.create(normalizedName);
+    const session = await Tools.System.terminal.create(normalizedName);
     if (!session || !session.sessionId) {
-      throw new Error("Terminal session creation returned no sessionId for " + normalizedName);
+      throw new Error(`Terminal session creation returned no sessionId for ${normalizedName}`);
     }
     terminalSessionId = String(session.sessionId);
     terminalSessionName = normalizedName;
@@ -867,11 +871,11 @@ async function getTerminalSession(sessionName) {
   }
 }
 async function terminalExec(params) {
-  var sessionName = normalizeSessionName(params.session_name);
-  var timeoutMs = normalizeTimeout(params.timeout_ms);
-  var sessionId = await getTerminalSession(sessionName);
+  const sessionName = normalizeSessionName(params.session_name);
+  const timeoutMs = normalizeTimeout(params.timeout_ms);
+  let sessionId = await getTerminalSession(sessionName);
   try {
-    var result;
+    let result;
     try {
       result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
     } catch (error) {
@@ -879,14 +883,16 @@ async function terminalExec(params) {
         await closeSessionQuietly(sessionId);
         throw error;
       }
-      if (!isSessionLifecycleError(error)) throw error;
+      if (!isSessionLifecycleError(error)) {
+        throw error;
+      }
       invalidateSession(sessionId);
       sessionId = await getTerminalSession(sessionName);
       result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
     }
     if (result && result.timedOut === true) {
       await closeSessionQuietly(sessionId);
-      throw new Error("Terminal command timed out after " + timeoutMs + "ms");
+      throw new Error(`Terminal command timed out after ${timeoutMs}ms`);
     }
     return result;
   } finally {

--- a/examples/github/src/index.ts
+++ b/examples/github/src/index.ts
@@ -228,6 +228,7 @@
       "parameters": [
         { "name": "command", "description": { "zh": "要执行的命令", "en": "Command to execute." }, "type": "string", "required": true },
         { "name": "session_name", "description": { "zh": "会话名（可选，默认 github_tools_session）", "en": "Session name (optional; default: github_tools_session)." }, "type": "string", "required": false },
+        { "name": "timeout_ms", "description": { "zh": "超时时间（毫秒，默认120000）", "en": "Timeout in milliseconds (default 120000)." }, "type": "number", "required": false },
         { "name": "close", "description": { "zh": "是否执行后关闭会话", "en": "Whether to close the session after execution." }, "type": "boolean", "required": false }
       ]
     },

--- a/examples/github/src/local/terminal.ts
+++ b/examples/github/src/local/terminal.ts
@@ -1,18 +1,134 @@
-let terminalSessionId: string | null = null;
+const DEFAULT_SESSION_NAME = 'github_tools_session';
+const DEFAULT_TIMEOUT_MS = 120000;
 
-export async function getTerminalSession(sessionName?: string): Promise<string> {
-    if (terminalSessionId) return terminalSessionId;
-    const session = await Tools.System.terminal.create(sessionName || 'github_tools_session');
-    terminalSessionId = session.sessionId;
-    return terminalSessionId;
+let terminalSessionId: string | null = null;
+let terminalSessionName: string | null = null;
+let sessionCreationPromise: Promise<string> | null = null;
+
+function normalizeSessionName(sessionName?: string): string {
+    const normalized = String(sessionName || '').trim();
+    return normalized || DEFAULT_SESSION_NAME;
 }
 
-export async function terminalExec(params: { command: string; session_name?: string; close?: boolean }): Promise<any> {
-    const sessionId = await getTerminalSession(params.session_name);
-    const result = await Tools.System.terminal.exec(sessionId, params.command);
-    if (params.close) {
-        await Tools.System.terminal.close(sessionId);
+function invalidateSession(sessionId?: string): void {
+    if (!sessionId || terminalSessionId === sessionId) {
         terminalSessionId = null;
+        terminalSessionName = null;
     }
-    return result;
+}
+
+async function closeSessionQuietly(sessionId: string | null): Promise<void> {
+    if (!sessionId) return;
+    try {
+        await Tools.System.terminal.close(sessionId);
+    } catch (_error) {
+        // A dead session is already closed from the tool's perspective.
+    } finally {
+        invalidateSession(sessionId);
+    }
+}
+
+function isSessionLifecycleError(error: any): boolean {
+    const message = String(error && error.message ? error.message : error || '').toLowerCase();
+    const mentionsSession = message.includes('session') || message.includes('会话') || message.includes('pty');
+    const mentionsLifecycle =
+        message.includes('not exist') ||
+        message.includes('does not exist') ||
+        message.includes('closed') ||
+        message.includes('invalid') ||
+        message.includes('unavailable') ||
+        message.includes('不存在') ||
+        message.includes('关闭') ||
+        message.includes('失效') ||
+        message.includes('不可用');
+    return mentionsSession && mentionsLifecycle;
+}
+
+function isTimeoutError(error: any): boolean {
+    const message = String(error && error.message ? error.message : error || '').toLowerCase();
+    return message.includes('timed out') || message.includes('timeout') || message.includes('超时');
+}
+
+function normalizeTimeout(timeoutMs?: number): number {
+    const value = timeoutMs === undefined || timeoutMs === null
+        ? DEFAULT_TIMEOUT_MS
+        : Number(timeoutMs);
+    if (!Number.isFinite(value) || value <= 0) {
+        throw new Error('timeout_ms must be a positive number');
+    }
+    return Math.floor(value);
+}
+
+export async function getTerminalSession(sessionName?: string): Promise<string> {
+    const normalizedName = normalizeSessionName(sessionName);
+    if (terminalSessionId && terminalSessionName === normalizedName) {
+        return terminalSessionId;
+    }
+
+    if (sessionCreationPromise) {
+        return sessionCreationPromise;
+    }
+
+    sessionCreationPromise = (async () => {
+        if (terminalSessionId) {
+            await closeSessionQuietly(terminalSessionId);
+        }
+
+        const session = await Tools.System.terminal.create(normalizedName);
+        if (!session || !session.sessionId) {
+            throw new Error(`Terminal session creation returned no sessionId for ${normalizedName}`);
+        }
+
+        terminalSessionId = String(session.sessionId);
+        terminalSessionName = normalizedName;
+        return terminalSessionId;
+    })();
+
+    try {
+        return await sessionCreationPromise;
+    } finally {
+        sessionCreationPromise = null;
+    }
+}
+
+export async function terminalExec(params: {
+    command: string;
+    session_name?: string;
+    timeout_ms?: number;
+    close?: boolean;
+}): Promise<any> {
+    const sessionName = normalizeSessionName(params.session_name);
+    const timeoutMs = normalizeTimeout(params.timeout_ms);
+    let sessionId = await getTerminalSession(sessionName);
+
+    try {
+        let result: any;
+        try {
+            result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
+        } catch (error) {
+            if (isTimeoutError(error)) {
+                await closeSessionQuietly(sessionId);
+                throw error;
+            }
+            if (!isSessionLifecycleError(error)) {
+                throw error;
+            }
+
+            // The Kotlin layer may have reclaimed the PTY. Recreate once, then retry.
+            invalidateSession(sessionId);
+            sessionId = await getTerminalSession(sessionName);
+            result = await Tools.System.terminal.exec(sessionId, params.command, timeoutMs);
+        }
+
+        if (result && result.timedOut === true) {
+            await closeSessionQuietly(sessionId);
+            throw new Error(`Terminal command timed out after ${timeoutMs}ms`);
+        }
+
+        return result;
+    } finally {
+        if (params.close) {
+            await closeSessionQuietly(sessionId);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the built-in GitHub package terminal path that could fail to return results, remain in an executing state, or keep reusing a dead session.

- Add a 120-second default timeout and expose `timeout_ms` for `terminal_exec`.
- Recreate a terminal session once after a stale-session lifecycle error.
- Clear cached session state on timeout and close failures.
- Keep the generated GitHub package assets synchronized.
- Propagate real command exit codes and report timeout/dispatch failures explicitly.

## Submodule dependency

This PR updates the `terminal` submodule to commit `46358e4`, provided by [OperitTerminalCore#4](https://github.com/AAswordman/OperitTerminalCore/pull/4). The core PR should be merged before, or together with, this submodule pointer update.

## Environment

The fix does not modify the Linux rootfs or PRoot image. The terminal core changes are limited to the PTY/session state machine and POSIX shell command completion protocol.

## Validation

- GitHub wrapper behavior test passed for stale-session recreation, timeout cleanup, and explicit timeout values.
- `node --check` passed for both generated `github.js` assets.
- `git diff --check` passed for the parent repository and terminal submodule.
- Android compilation was attempted with `/root/android-sdk`; the environment's `aidl` executable cannot start because the host lacks the required glibc loader.