### PR TITLE
fix: strip media links from assistant history

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
@@ -223,7 +223,7 @@ class DeepseekProvider(
                     put("role", "assistant")
                     put("reasoning_content", queuedAssistantReasoning.orEmpty())
                     if (!queuedAssistantToolText.isNullOrBlank()) {
-                        put("content", buildContentField(context, queuedAssistantToolText!!))
+                        put("content", buildContentField(context, queuedAssistantToolText!!, role = "assistant"))
                     } else {
                         put("content", null)
                     }
@@ -268,7 +268,7 @@ class DeepseekProvider(
                             messagesArray.put(
                                 JSONObject().apply {
                                     put("role", "system")
-                                    put("content", buildContentField(context, originalContent))
+                                    put("content", buildContentField(context, originalContent, role = "system"))
                                 }
                             )
                         }
@@ -305,7 +305,7 @@ class DeepseekProvider(
                                     JSONObject().apply {
                                         put("role", "assistant")
                                         put("reasoning_content", reasoningContent)
-                                        put("content", buildContentField(context, content.ifBlank { "[Empty]" }))
+                                        put("content", buildContentField(context, content.ifBlank { "[Empty]" }, role = "assistant"))
                                     }
                                 )
                             }
@@ -331,7 +331,7 @@ class DeepseekProvider(
                                     JSONObject().apply {
                                         put("role", "assistant")
                                         put("reasoning_content", "")
-                                        put("content", buildContentField(context, originalContent.ifBlank { "[Empty]" }))
+                                        put("content", buildContentField(context, originalContent.ifBlank { "[Empty]" }, role = "assistant"))
                                     }
                                 )
                             }
@@ -396,7 +396,7 @@ class DeepseekProvider(
                             messagesArray.put(
                                 JSONObject().apply {
                                     put("role", "system")
-                                    put("content", buildContentField(context, originalContent))
+                                    put("content", buildContentField(context, originalContent, role = "system"))
                                 }
                             )
                         }
@@ -418,7 +418,7 @@ class DeepseekProvider(
                                 JSONObject().apply {
                                     put("role", "assistant")
                                     put("reasoning_content", reasoningContent)
-                                    put("content", buildContentField(context, content.ifBlank { "[Empty]" }))
+                                    put("content", buildContentField(context, content.ifBlank { "[Empty]" }, role = "assistant"))
                                 }
                             )
                         }
@@ -428,7 +428,7 @@ class DeepseekProvider(
                                 JSONObject().apply {
                                     put("role", "assistant")
                                     put("reasoning_content", "")
-                                    put("content", buildContentField(context, originalContent.ifBlank { "[Empty]" }))
+                                    put("content", buildContentField(context, originalContent.ifBlank { "[Empty]" }, role = "assistant"))
                                 }
                             )
                         }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
@@ -205,7 +205,7 @@ open class KimiProvider(
                     put("role", "assistant")
                     put("reasoning_content", queuedAssistantReasoning.orEmpty())
                     if (!queuedAssistantToolText.isNullOrBlank()) {
-                        put("content", buildContentField(context, queuedAssistantToolText!!))
+                        put("content", buildContentField(context, queuedAssistantToolText!!, role = "assistant"))
                     } else {
                         put("content", null)
                     }
@@ -250,7 +250,7 @@ open class KimiProvider(
                             messagesArray.put(
                                 JSONObject().apply {
                                     put("role", "system")
-                                    put("content", buildContentField(context, originalContent))
+                                    put("content", buildContentField(context, originalContent, role = "system"))
                                 }
                             )
                         }
@@ -287,7 +287,7 @@ open class KimiProvider(
                                     JSONObject().apply {
                                         put("role", "assistant")
                                         put("reasoning_content", reasoningContent)
-                                        put("content", buildContentField(context, content.ifBlank { "[Empty]" }))
+                                        put("content", buildContentField(context, content.ifBlank { "[Empty]" }, role = "assistant"))
                                     }
                                 )
                             }
@@ -313,7 +313,7 @@ open class KimiProvider(
                                     JSONObject().apply {
                                         put("role", "assistant")
                                         put("reasoning_content", "")
-                                        put("content", buildContentField(context, originalContent.ifBlank { "[Empty]" }))
+                                        put("content", buildContentField(context, originalContent.ifBlank { "[Empty]" }, role = "assistant"))
                                     }
                                 )
                             }
@@ -378,7 +378,7 @@ open class KimiProvider(
                             messagesArray.put(
                                 JSONObject().apply {
                                     put("role", "system")
-                                    put("content", buildContentField(context, originalContent))
+                                    put("content", buildContentField(context, originalContent, role = "system"))
                                 }
                             )
                         }
@@ -400,7 +400,7 @@ open class KimiProvider(
                                 JSONObject().apply {
                                     put("role", "assistant")
                                     put("reasoning_content", reasoningContent)
-                                    put("content", buildContentField(context, content.ifBlank { "[Empty]" }))
+                                    put("content", buildContentField(context, content.ifBlank { "[Empty]" }, role = "assistant"))
                                 }
                             )
                         }
@@ -410,7 +410,7 @@ open class KimiProvider(
                                 JSONObject().apply {
                                     put("role", "assistant")
                                     put("reasoning_content", "")
-                                    put("content", buildContentField(context, originalContent.ifBlank { "[Empty]" }))
+                                    put("content", buildContentField(context, originalContent.ifBlank { "[Empty]" }, role = "assistant"))
                                 }
                             )
                         }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/MediaLinkParser.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/MediaLinkParser.kt
@@ -24,184 +24,119 @@ data class MediaLinkTag(
 )
 
 object MediaLinkParser {
-    private val IMAGE_LINK_PATTERN_PLAIN = Regex(
-        """<link\s+type\s*=\s*\\?["']?image\\?["']?\s+id\s*=\s*\\?["']?([^"'\s>]+)\\?["']?\s*>.*?</link>""",
-        RegexOption.DOT_MATCHES_ALL
+    // Match the whole link block while allowing arbitrary attribute order and escaping.
+    private val LINK_PATTERN = Regex(
+        """<link\b(?=[^>]*\btype\s*=\s*\\*["']?(image|audio|video)\\*["']?)(?=[^>]*\bid\s*=\s*\\*["']?([^"'\\\s>]+)\\*["']?)[^>]*(?:/>|>.*?</link>)""",
+        setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE)
     )
 
-    private val IMAGE_LINK_PATTERN_ESCAPED = Regex(
-        """<link\s+type\s*=\s*\\?["']?image\\?["']?\s+id\s*=\s*\\?["']?([^"'\s>]+)\\?["']?\s*>.*?</link>""",
-        RegexOption.DOT_MATCHES_ALL
-    )
+    private fun isMediaType(type: String): Boolean =
+        type.equals("audio", ignoreCase = true) || type.equals("video", ignoreCase = true)
 
-    private val LINK_PATTERN_PLAIN = Regex(
-        """<link\s+type=\"?(audio|video)\"?\s+id=\"?([^\"\s>]+)\"?\s*>.*?</link>""",
-        RegexOption.DOT_MATCHES_ALL
-    )
+    private fun matchesForType(message: String, type: String): Sequence<MatchResult> =
+        LINK_PATTERN.findAll(message).filter {
+            it.groupValues[1].equals(type, ignoreCase = true)
+        }
 
-    private val LINK_PATTERN_ESCAPED = Regex(
-        """<link\s+type=\\\"?(audio|video)\\\"?\s+id=\\\"?([^\"\s>]+)\\\"?\s*>.*?</link>""",
-        RegexOption.DOT_MATCHES_ALL
-    )
+    private fun matchesForMediaType(message: String): Sequence<MatchResult> =
+        LINK_PATTERN.findAll(message).filter { isMediaType(it.groupValues[1]) }
 
     fun extractImageLinks(message: String): List<ImageLink> {
         val imageLinks = mutableListOf<ImageLink>()
         val seenIds = mutableSetOf<String>()
-
-        fun collectFromPattern(pattern: Regex) {
-            pattern.findAll(message).forEach { match ->
-                val id = match.groupValues[1]
-                if (id == "error") {
-                    return@forEach
-                }
-                if (!seenIds.add(id)) {
-                    return@forEach
-                }
-                val imageData = ImagePoolManager.getImage(id) ?: return@forEach
-                imageLinks.add(
-                    ImageLink(
-                        type = "image",
-                        id = id,
-                        base64Data = imageData.base64,
-                        mimeType = imageData.mimeType
-                    )
+        for (match in matchesForType(message, "image")) {
+            val id = match.groupValues[2]
+            if (id == "error" || !seenIds.add(id)) continue
+            val imageData = ImagePoolManager.getImage(id) ?: continue
+            imageLinks.add(
+                ImageLink(
+                    type = "image",
+                    id = id,
+                    base64Data = imageData.base64,
+                    mimeType = imageData.mimeType
                 )
-            }
+            )
         }
-
-        collectFromPattern(IMAGE_LINK_PATTERN_PLAIN)
-        collectFromPattern(IMAGE_LINK_PATTERN_ESCAPED)
-
         return imageLinks
     }
 
     fun extractImageLinkIds(message: String): List<String> {
         val ids = mutableListOf<String>()
         val seenIds = mutableSetOf<String>()
-
-        fun collectFromPattern(pattern: Regex) {
-            pattern.findAll(message).forEach { match ->
-                val id = match.groupValues[1]
-                if (id == "error") {
-                    return@forEach
-                }
-                if (seenIds.add(id)) {
-                    ids.add(id)
-                }
+        for (match in matchesForType(message, "image")) {
+            val id = match.groupValues[2]
+            if (id != "error" && seenIds.add(id)) {
+                ids.add(id)
             }
         }
-
-        collectFromPattern(IMAGE_LINK_PATTERN_PLAIN)
-        collectFromPattern(IMAGE_LINK_PATTERN_ESCAPED)
-
         return ids
     }
 
-    fun removeImageLinks(message: String): String {
-        return message
-            .replace(IMAGE_LINK_PATTERN_PLAIN, "")
-            .replace(IMAGE_LINK_PATTERN_ESCAPED, "")
-    }
+    fun removeImageLinks(message: String): String =
+        LINK_PATTERN.replace(message) { match ->
+            if (match.groupValues[1].equals("image", ignoreCase = true)) "" else match.value
+        }
 
-    fun replaceImageLinks(message: String, replacer: (id: String) -> String): String {
-        var result = message
-        val patterns = listOf(IMAGE_LINK_PATTERN_PLAIN, IMAGE_LINK_PATTERN_ESCAPED)
-        patterns.forEach { pattern ->
-            result = pattern.replace(result) { match ->
-                val id = match.groupValues.getOrNull(1) ?: return@replace ""
+    fun replaceImageLinks(message: String, replacer: (id: String) -> String): String =
+        LINK_PATTERN.replace(message) { match ->
+            if (!match.groupValues[1].equals("image", ignoreCase = true)) {
+                match.value
+            } else {
+                val id = match.groupValues[2]
                 if (id == "error") "" else replacer(id)
             }
         }
-        return result
-    }
 
-    fun hasImageLinks(message: String): Boolean {
-        return IMAGE_LINK_PATTERN_PLAIN.containsMatchIn(message) ||
-            IMAGE_LINK_PATTERN_ESCAPED.containsMatchIn(message)
-    }
+    fun hasImageLinks(message: String): Boolean = matchesForType(message, "image").any()
 
     fun extractMediaLinks(message: String): List<MediaLink> {
         val links = mutableListOf<MediaLink>()
         val seenIds = mutableSetOf<String>()
-
-        fun collectFromPattern(pattern: Regex) {
-            pattern.findAll(message).forEach { match ->
-                val type = match.groupValues[1]
-                val id = match.groupValues[2]
-
-                if (id == "error") {
-                    return@forEach
-                }
-
-                if (!seenIds.add("$type:$id")) {
-                    return@forEach
-                }
-
-                val mediaData = MediaPoolManager.getMedia(id) ?: return@forEach
-
-                val limited = MediaBase64Limiter.limitBase64ForAi(mediaData.base64, mediaData.mimeType)
-                    ?: return@forEach
-                links.add(
-                    MediaLink(
-                        type = type,
-                        id = id,
-                        base64Data = limited.base64,
-                        mimeType = limited.mimeType
-                    )
+        for (match in matchesForMediaType(message)) {
+            val type = match.groupValues[1].lowercase()
+            val id = match.groupValues[2]
+            if (id == "error" || !seenIds.add("$type:$id")) continue
+            val mediaData = MediaPoolManager.getMedia(id) ?: continue
+            val limited = MediaBase64Limiter.limitBase64ForAi(mediaData.base64, mediaData.mimeType) ?: continue
+            links.add(
+                MediaLink(
+                    type = type,
+                    id = id,
+                    base64Data = limited.base64,
+                    mimeType = limited.mimeType
                 )
-            }
+            )
         }
-
-        collectFromPattern(LINK_PATTERN_PLAIN)
-        collectFromPattern(LINK_PATTERN_ESCAPED)
-
         return links
     }
 
     fun extractMediaLinkTags(message: String): List<MediaLinkTag> {
         val tags = mutableListOf<MediaLinkTag>()
         val seenIds = mutableSetOf<String>()
-
-        fun collectFromPattern(pattern: Regex) {
-            pattern.findAll(message).forEach { match ->
-                val type = match.groupValues[1]
-                val id = match.groupValues[2]
-                if (id == "error") {
-                    return@forEach
-                }
-                if (!seenIds.add("$type:$id")) {
-                    return@forEach
-                }
-                tags.add(MediaLinkTag(type = type, id = id))
-            }
+        for (match in matchesForMediaType(message)) {
+            val type = match.groupValues[1].lowercase()
+            val id = match.groupValues[2]
+            if (id == "error" || !seenIds.add("$type:$id")) continue
+            tags.add(MediaLinkTag(type = type, id = id))
         }
-
-        collectFromPattern(LINK_PATTERN_PLAIN)
-        collectFromPattern(LINK_PATTERN_ESCAPED)
-
         return tags
     }
 
-    fun replaceMediaLinks(message: String, replacer: (type: String, id: String) -> String): String {
-        var result = message
-        val patterns = listOf(LINK_PATTERN_PLAIN, LINK_PATTERN_ESCAPED)
-        patterns.forEach { pattern ->
-            result = pattern.replace(result) { match ->
-                val type = match.groupValues.getOrNull(1) ?: return@replace ""
-                val id = match.groupValues.getOrNull(2) ?: return@replace ""
+    fun replaceMediaLinks(message: String, replacer: (type: String, id: String) -> String): String =
+        LINK_PATTERN.replace(message) { match ->
+            val type = match.groupValues[1].lowercase()
+            if (!isMediaType(type)) {
+                match.value
+            } else {
+                val id = match.groupValues[2]
                 if (id == "error") "" else replacer(type, id)
             }
         }
-        return result
-    }
 
-    fun removeMediaLinks(message: String): String {
-        return message
-            .replace(LINK_PATTERN_PLAIN, "")
-            .replace(LINK_PATTERN_ESCAPED, "")
-    }
+    fun removeMediaLinks(message: String): String =
+        LINK_PATTERN.replace(message) { match ->
+            if (isMediaType(match.groupValues[1])) "" else match.value
+        }
 
-    fun hasMediaLinks(message: String): Boolean {
-        return LINK_PATTERN_PLAIN.containsMatchIn(message) || LINK_PATTERN_ESCAPED.containsMatchIn(message)
-    }
+    fun hasMediaLinks(message: String): Boolean = matchesForMediaType(message).any()
 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -834,9 +834,12 @@ open class OpenAIProvider(
     /**
      * 构建content字段（可能是字符串或数组）
      * @param text 要处理的文本内容
+     * @param role API消息角色；只有user/summary允许注入多媒体内容
      * @return 纯文本字符串或包含图片和文本的JSONArray
      */
-    fun buildContentField(context: Context, text: String): Any {
+    fun buildContentField(context: Context, text: String, role: String = "user"): Any {
+        val allowRichContent =
+            role.equals("user", ignoreCase = true) || role.equals("summary", ignoreCase = true)
         val hasImages = MediaLinkParser.hasImageLinks(text)
         val hasMedia = MediaLinkParser.hasMediaLinks(text)
 
@@ -868,7 +871,8 @@ open class OpenAIProvider(
             AppLogger.w("AIService", "检测到图片链接，但当前Provider不支持图片处理，已移除图片。原始文本长度: ${text.length}, 处理后: ${textWithoutLinks.length}")
         }
 
-        val hasAnySupportedRichContent = hasSupportedMedia || (supportsVision && imageLinks.isNotEmpty())
+        val hasAnySupportedRichContent =
+            allowRichContent && (hasSupportedMedia || (supportsVision && imageLinks.isNotEmpty()))
         if (!hasAnySupportedRichContent) {
             if (textWithoutLinks.isNotEmpty()) return textWithoutLinks
 
@@ -990,7 +994,7 @@ open class OpenAIProvider(
                 else -> null
             }
             if (effectiveContent != null) {
-                historyMessage.put("content", buildContentField(context, effectiveContent))
+                historyMessage.put("content", buildContentField(context, effectiveContent, role = "assistant"))
             } else {
                 historyMessage.put("content", null)
             }
@@ -1035,7 +1039,7 @@ open class OpenAIProvider(
                             messagesArray.put(
                                 JSONObject().apply {
                                     put("role", "system")
-                                    put("content", buildContentField(context, content))
+                                    put("content", buildContentField(context, content, role = "system"))
                                 }
                             )
                         }
@@ -1076,7 +1080,7 @@ open class OpenAIProvider(
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "assistant")
-                                        put("content", buildContentField(context, effectiveContent))
+                                        put("content", buildContentField(context, effectiveContent, role = "assistant"))
                                     }
                                 )
                             }
@@ -1102,7 +1106,7 @@ open class OpenAIProvider(
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "assistant")
-                                        put("content", buildContentField(context, effectiveContent))
+                                        put("content", buildContentField(context, effectiveContent, role = "assistant"))
                                     }
                                 )
                             }
@@ -1175,8 +1179,7 @@ open class OpenAIProvider(
                     } else {
                         content
                     }
-
-                    historyMessage.put("content", buildContentField(context, effectiveContent))
+                    historyMessage.put("content", buildContentField(context, effectiveContent, role = role))
                     messagesArray.put(historyMessage)
                 }
             }

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/MediaLinkParserTagOrderTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/MediaLinkParserTagOrderTest.kt
@@ -4,6 +4,20 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class MediaLinkParserTagOrderTest {
+    @Test fun extractImageLinkIds_supportsAttributesInEitherOrder() {
+        val input = "<link id=\"i1\" data=\"unused\" type=\"image\">I</link>"
+        assertEquals(listOf("i1"), MediaLinkParser.extractImageLinkIds(input))
+    }
+
+    @Test fun removeImageLinks_removesMissingPoolEntries() {
+        val input = "before<link type=\"image\" id=\"missing\">I</link>after"
+        assertEquals("beforeafter", MediaLinkParser.removeImageLinks(input))
+    }
+
+    @Test fun removeMediaLinks_supportsEscapedAndReorderedAttributes() {
+        val input = "before<link id=\\\"a1\\\" type=\\\"audio\\\">A</link>after"
+        assertEquals("beforeafter", MediaLinkParser.removeMediaLinks(input))
+    }
 
     @Test fun extractMediaLinkTags_preservesEncounterOrder() {
         val input = "<link type=\"video\" id=\"v1\">V</link><link type=\"audio\" id=\"a1\">A</link>"


### PR DESCRIPTION
## Summary
- strip image/audio/video link tags from assistant history content before sending requests
- only allow rich media content for user and summary messages
- support reordered and escaped media link attributes
- add parser regression coverage for Issue #1021

Fixes #1021