### PR TITLE
fix(tools): honor read_file line ranges

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/config/SystemToolPrompts.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/config/SystemToolPrompts.kt
@@ -113,6 +113,20 @@ object SystemToolPrompts {
                         required = false
                     ),
                     ToolParameterSchema(
+                        name = "start_line",
+                        type = "integer",
+                        description = "optional starting line number, 1-indexed",
+                        required = false,
+                        default = "1"
+                    ),
+                    ToolParameterSchema(
+                        name = "end_line",
+                        type = "integer",
+                        description = "optional ending line number, 1-indexed and inclusive",
+                        required = false,
+                        default = "start_line + 99"
+                    ),
+                    ToolParameterSchema(
                         name = "intent",
                         type = "string",
                         description = "optional, your question about the media/file (used for backend recognition)",
@@ -258,6 +272,20 @@ object SystemToolPrompts {
                         type = "string",
                         description = "可选，执行环境。取值：\"android\"（默认，Android文件系统）| \"linux\"（本地Ubuntu 24终端环境，通过proot实现；路径用Linux格式，如/home/...、/etc/hosts）| \"repo:<仓库名>\"（附加本地储存仓库）",
                         required = false
+                    ),
+                    ToolParameterSchema(
+                        name = "start_line",
+                        type = "integer",
+                        description = "可选，起始行号，从1开始",
+                        required = false,
+                        default = "1"
+                    ),
+                    ToolParameterSchema(
+                        name = "end_line",
+                        type = "integer",
+                        description = "可选，结束行号，从1开始并包括该行",
+                        required = false,
+                        default = "start_line + 99"
                     ),
                     ToolParameterSchema(
                         name = "intent",

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardFileSystemTools.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardFileSystemTools.kt
@@ -1568,6 +1568,11 @@ open class StandardFileSystemTools(protected val context: Context) {
         val path = tool.parameters.find { it.name == "path" }?.value ?: ""
         val environment = tool.parameters.find { it.name == "environment" }?.value
 
+        // Route range-bearing calls through the existing line reader so the range is not silently ignored.
+        if (tool.parameters.any { it.name == "start_line" || it.name == "end_line" }) {
+            return readFilePart(tool)
+        }
+
         // 如果是Linux环境，委托给LinuxFileSystemTools
         if (isLinuxEnvironment(environment)) {
             return linuxTools.readFile(tool)

--- a/app/src/test/java/com/ai/assistance/operit/core/config/SystemToolPromptsReadFileRangeTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/config/SystemToolPromptsReadFileRangeTest.kt
@@ -1,0 +1,22 @@
+package com.ai.assistance.operit.core.config
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SystemToolPromptsReadFileRangeTest {
+
+    @Test
+    fun `read_file exposes line range parameters in both schemas`() {
+        listOf(SystemToolPrompts.fileSystemTools, SystemToolPrompts.fileSystemToolsCn).forEach { category ->
+            val readFile = category.tools.single { it.name == "read_file" }
+            val parameters = requireNotNull(readFile.parametersStructured)
+            val startLine = parameters.single { it.name == "start_line" }
+            val endLine = parameters.single { it.name == "end_line" }
+
+            assertEquals("integer", startLine.type)
+            assertEquals("1", startLine.default)
+            assertEquals("integer", endLine.type)
+            assertEquals("start_line + 99", endLine.default)
+        }
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardFileSystemToolsReadFileTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardFileSystemToolsReadFileTest.kt
@@ -1,0 +1,74 @@
+package com.ai.assistance.operit.core.tools.defaultTool.standard
+
+import android.content.Context
+import com.ai.assistance.operit.core.tools.FileContentData
+import com.ai.assistance.operit.core.tools.FilePartContentData
+import com.ai.assistance.operit.data.model.AITool
+import com.ai.assistance.operit.data.model.ToolParameter
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class StandardFileSystemToolsReadFileTest {
+
+    @Test
+    fun `read_file applies a supplied line range`() = runBlocking {
+        withTextFile("one\ntwo\nthree\nfour") { path ->
+            val result =
+                StandardFileSystemTools(mock<Context>()).readFile(
+                    AITool(
+                        name = "read_file",
+                        parameters =
+                            listOf(
+                                ToolParameter("path", path),
+                                ToolParameter("start_line", "2"),
+                                ToolParameter("end_line", "3")
+                            )
+                    )
+                )
+
+            assertTrue(result.success)
+            assertEquals("read_file", result.toolName)
+            assertEquals("2| two\n3| three", (result.result as FilePartContentData).content)
+        }
+    }
+
+    @Test
+    fun `read_file without a range still reads the regular file content`() = runBlocking {
+        withTextFile("one\ntwo\nthree\nfour") { path ->
+            val result =
+                StandardFileSystemTools(mock<Context>()).readFile(
+                    AITool(
+                        name = "read_file",
+                        parameters = listOf(ToolParameter("path", path))
+                    )
+                )
+
+            assertTrue(result.success)
+            assertEquals("read_file", result.toolName)
+            assertEquals(
+                "1| one\n2| two\n3| three\n4| four",
+                (result.result as FileContentData).content
+            )
+        }
+    }
+
+    private suspend fun withTextFile(content: String, assertion: suspend (String) -> Unit) {
+        val directory = File("build/tmp/read-file-tests").apply { mkdirs() }
+        val file = File.createTempFile("read-file-", ".txt", directory)
+        try {
+            file.writeText(content)
+            assertion(androidAbsolutePath(file))
+        } finally {
+            file.delete()
+        }
+    }
+
+    private fun androidAbsolutePath(file: File): String {
+        val absolutePath = file.absolutePath.replace('\\', '/')
+        return if (File.separatorChar == '\\') absolutePath.substringAfter(':') else absolutePath
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

`read_file` 会静默忽略模型传入的 `start_line` / `end_line`，而名称相近的 `read_file_part` 已具备完整的行范围实现。本 PR 按 issue 的低成本方案 B，让 `read_file` 直接复用现有范围读取逻辑。

### 改动范围 / Changes

- 在中英文 `read_file` schema 中加入可选的 `start_line` / `end_line`，默认语义与 `read_file_part` 保持一致。
- `read_file` 检测到任一范围参数时委托给现有 `readFilePart`；未提供范围时继续走原来的完整读取路径。
- 新增 schema 回归测试，以及范围读取和普通读取的执行回归测试。
- 不包含工具调用通用修复层、参数重写框架或无关重构。

### 兼容性与风险 / Compatibility and risks

这是向后兼容的 schema 增量。未传范围参数的 `read_file` 返回行为不变；传入范围时返回现有 `FilePartContentData` 语义，并继续由 `readFilePart` 处理 Android、Linux 与 SAF 环境。无数据迁移、配置、安全或性能影响。

## 关联 Issue / Related issue

Fixes #862

## 验证方式 / Verification

```text
检查或命令：./gradlew :app:testDebugUnitTest --tests com.ai.assistance.operit.core.config.SystemToolPromptsReadFileRangeTest --tests com.ai.assistance.operit.core.tools.defaultTool.standard.StandardFileSystemToolsReadFileTest -x :app:syncSttModelAssets -x :app:syncMainAssets -I <temporary-init-script>
环境与变体：Windows；Eclipse Temurin 21.0.12；Android debug JVM unit tests
结果：PASS；3 tests，0 failures，0 errors，0 skipped。临时 init script 仅切换依赖镜像，并排除 development 当前无法编译的 ThinkingQualityMappingTest.kt，未提交到分支。

检查或命令：python -B -m unittest discover -s ci/test -p 'test_*.py'
环境与变体：WSL；Python 3.12 venv
结果：PASS；46 tests。

检查或命令：check_repo_hygiene.py / check_markdown_links.py / check_localizations.py，base=upstream/development，candidate=HEAD
环境与变体：Windows；Python 3.14 venv
结果：PASS；hygiene 0 errors/0 warnings；Markdown 0 errors/0 warnings（18 个 base 既有坏链被忽略）；localization 0 errors/0 warnings（4 个候选改动外的既有诊断）。

完整 CI：Fast checks PASS；Android JVM tests 已运行未排除的 :app:testDebugUnitTest，并在 development 未改动的 ThinkingQualityMappingTest.kt:19、35、61 被 Int 传给 String 参数的编译错误处 FAIL（https://github.com/AAswordman/Operit/actions/runs/32692333705）。#1029 的独立分支出现相同错误，确认属于共同基线；本 PR 不修改该无关问题。未改 web-chat，因此未运行其 typecheck。
```

## 证据 / Evidence

JUnit XML 分别记录 schema 测试 1 条、执行测试 2 条，全部通过；执行测试同时断言了 `2..3` 行范围内容与无范围时的完整内容。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 `development`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `development` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided