### PR TITLE
fix(chat): strip media links from tool history

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
@@ -351,7 +351,7 @@ class DeepseekProvider(
                                         JSONObject().apply {
                                             put("role", "tool")
                                             put("tool_call_id", openToolCallIds[index])
-                                            put("content", resultContent)
+                                            put("content", buildContentField(context, resultContent, role = "tool"))
                                         }
                                     )
                                 }
@@ -370,7 +370,7 @@ class DeepseekProvider(
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "user")
-                                            put("content", buildContentField(context, textContent))
+                                            put("content", buildContentField(context, textContent, role = "tool"))
                                         }
                                     )
                                 }
@@ -385,7 +385,7 @@ class DeepseekProvider(
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "user")
-                                        put("content", buildContentField(context, fallbackContent))
+                                        put("content", buildContentField(context, fallbackContent, role = "tool"))
                                     }
                                 )
                             }
@@ -403,12 +403,20 @@ class DeepseekProvider(
                         }
 
                         PromptTurnKind.USER,
-                        PromptTurnKind.SUMMARY,
-                        PromptTurnKind.TOOL_RESULT -> {
+                        PromptTurnKind.SUMMARY -> {
                             messagesArray.put(
                                 JSONObject().apply {
                                     put("role", "user")
                                     put("content", buildContentField(context, originalContent))
+                                }
+                            )
+                        }
+
+                        PromptTurnKind.TOOL_RESULT -> {
+                            messagesArray.put(
+                                JSONObject().apply {
+                                    put("role", "user")
+                                    put("content", buildContentField(context, originalContent, role = "tool"))
                                 }
                             )
                         }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
@@ -332,7 +332,7 @@ open class KimiProvider(
                                         JSONObject().apply {
                                             put("role", "tool")
                                             put("tool_call_id", openToolCallIds[index])
-                                            put("content", resultContent)
+                                            put("content", buildContentField(context, resultContent, role = "tool"))
                                         }
                                     )
                                 }
@@ -351,7 +351,7 @@ open class KimiProvider(
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "user")
-                                            put("content", buildContentField(context, textContent))
+                                            put("content", buildContentField(context, textContent, role = "tool"))
                                         }
                                     )
                                 }
@@ -366,7 +366,7 @@ open class KimiProvider(
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "user")
-                                        put("content", buildContentField(context, fallbackContent))
+                                        put("content", buildContentField(context, fallbackContent, role = "tool"))
                                     }
                                 )
                             }
@@ -384,12 +384,20 @@ open class KimiProvider(
                         }
 
                         PromptTurnKind.USER,
-                        PromptTurnKind.SUMMARY,
-                        PromptTurnKind.TOOL_RESULT -> {
+                        PromptTurnKind.SUMMARY -> {
                             messagesArray.put(
                                 JSONObject().apply {
                                     put("role", "user")
                                     put("content", buildContentField(context, originalContent))
+                                }
+                            )
+                        }
+
+                        PromptTurnKind.TOOL_RESULT -> {
+                            messagesArray.put(
+                                JSONObject().apply {
+                                    put("role", "user")
+                                    put("content", buildContentField(context, originalContent, role = "tool"))
                                 }
                             )
                         }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -1138,7 +1138,7 @@ open class OpenAIProvider(
                                         JSONObject().apply {
                                             put("role", "tool")
                                             put("tool_call_id", openToolCallIds[index])
-                                            put("content", resultContent)
+                                            put("content", buildContentField(context, resultContent, role = "tool"))
                                         }
                                     )
                                 }
@@ -1157,7 +1157,7 @@ open class OpenAIProvider(
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "user")
-                                            put("content", buildContentField(context, textContent))
+                                            put("content", buildContentField(context, textContent, role = "tool"))
                                         }
                                     )
                                 }
@@ -1172,7 +1172,7 @@ open class OpenAIProvider(
                                 messagesArray.put(
                                     JSONObject().apply {
                                         put("role", "user")
-                                        put("content", buildContentField(context, fallbackContent))
+                                        put("content", buildContentField(context, fallbackContent, role = "tool"))
                                     }
                                 )
                             }
@@ -1192,7 +1192,9 @@ open class OpenAIProvider(
                     } else {
                         content
                     }
-                    historyMessage.put("content", buildContentField(context, effectiveContent, role = role))
+                    // TOOL_RESULT is serialized as user here, but its media links must remain text-only.
+                    val contentRole = if (turn.kind == PromptTurnKind.TOOL_RESULT) "tool" else role
+                    historyMessage.put("content", buildContentField(context, effectiveContent, role = contentRole))
                     messagesArray.put(historyMessage)
                 }
             }

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProviderMediaRoleTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProviderMediaRoleTest.kt
@@ -1,0 +1,166 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import android.content.Context
+import com.ai.assistance.operit.core.chat.hooks.PromptTurn
+import com.ai.assistance.operit.core.chat.hooks.PromptTurnKind
+import com.ai.assistance.operit.data.model.ModelParameter
+import com.ai.assistance.operit.data.model.ToolPrompt
+import com.ai.assistance.operit.util.AppLogger
+import com.ai.assistance.operit.util.ImagePoolManager
+import com.ai.assistance.operit.util.OperitPaths
+import java.io.File
+import java.nio.file.Files
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody
+import okio.Buffer
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class DeepseekProviderMediaRoleTest {
+
+    private lateinit var imagePoolRoot: File
+    private var previousSystemLogEnabled = true
+    private var previousFileLogEnabled = true
+
+    @Before
+    fun setUpImagePool() {
+        previousSystemLogEnabled = AppLogger.enableSystemLog
+        previousFileLogEnabled = AppLogger.enableFileLogging
+        AppLogger.enableSystemLog = false
+        AppLogger.enableFileLogging = false
+
+        imagePoolRoot = Files.createTempDirectory("deepseek-media-role-test").toFile()
+        ImagePoolManager.initialize(imagePoolRoot, preloadNow = false)
+        val poolDirectory = OperitPaths.imagePoolDir(imagePoolRoot)
+        File(poolDirectory, "$IMAGE_ID.dat").writeText(IMAGE_BASE64)
+        File(poolDirectory, "$IMAGE_ID.meta").writeText(
+            """{"mimeType":"image/png","width":1,"height":1}"""
+        )
+    }
+
+    @After
+    fun tearDownImagePool() {
+        ImagePoolManager.clear()
+        imagePoolRoot.deleteRecursively()
+        AppLogger.enableSystemLog = previousSystemLogEnabled
+        AppLogger.enableFileLogging = previousFileLogEnabled
+    }
+
+    @Test
+    fun `DeepSeek injects user images but strips assistant and tool image links`() {
+        val history =
+            listOf(
+                PromptTurn(
+                    PromptTurnKind.USER,
+                    "user text<link type=\"image\" id=\"$IMAGE_ID\">Image</link>"
+                ),
+                PromptTurn(
+                    PromptTurnKind.ASSISTANT,
+                    "assistant text<link id=\"$IMAGE_ID\" type=\"image\">Image</link>"
+                ),
+                PromptTurn(
+                    PromptTurnKind.TOOL_RESULT,
+                    "tool text<link type=\"image\" id=\"missing\">Image</link>"
+                )
+            )
+
+        val request = buildRequestJson(history)
+        val messages = request.getJSONArray("messages")
+
+        val userContent = messages.getJSONObject(0).getJSONArray("content")
+        assertEquals("image_url", userContent.getJSONObject(0).getString("type"))
+        assertEquals(
+            "data:image/png;base64,$IMAGE_BASE64",
+            userContent.getJSONObject(0).getJSONObject("image_url").getString("url")
+        )
+        assertEquals("user text", userContent.getJSONObject(1).getString("text"))
+
+        val assistantMessage = messages.getJSONObject(1)
+        assertEquals("assistant", assistantMessage.getString("role"))
+        assertEquals("assistant text", assistantMessage.getString("content"))
+
+        val toolHistoryMessage = messages.getJSONObject(2)
+        assertEquals("user", toolHistoryMessage.getString("role"))
+        assertEquals("tool text", toolHistoryMessage.getString("content"))
+
+        assertFalse(request.toString().contains("<link"))
+        assertTrue(request.toString().contains("image_url"))
+    }
+
+    @Test
+    fun `DeepSeek strips image links from structured tool results`() {
+        val history =
+            listOf(
+                PromptTurn(
+                    PromptTurnKind.TOOL_CALL,
+                    """<tool name="read_file"><param name="path">/tmp/image.png</param></tool>"""
+                ),
+                PromptTurn(
+                    PromptTurnKind.TOOL_RESULT,
+                    """<tool_result name="read_file"><content>tool text<link type="image" id="missing">Image</link></content></tool_result>"""
+                )
+            )
+
+        val request =
+            buildRequestJson(
+                history = history,
+                enableToolCall = true,
+                availableTools = listOf(ToolPrompt(name = "read_file", description = "Read a file"))
+            )
+        val messages = request.getJSONArray("messages")
+        val toolMessage =
+            (0 until messages.length())
+                .map { messages.getJSONObject(it) }
+                .single { it.getString("role") == "tool" }
+
+        assertEquals("tool text", toolMessage.getString("content"))
+        assertFalse(request.toString().contains("<link"))
+        assertFalse(request.toString().contains("image_url"))
+    }
+
+    private fun buildRequestJson(
+        history: List<PromptTurn>,
+        enableToolCall: Boolean = false,
+        availableTools: List<ToolPrompt>? = null
+    ): JSONObject {
+        val provider =
+            DeepseekProvider(
+                apiEndpoint = "https://example.test/v1/chat/completions",
+                apiKeyProvider = SingleApiKeyProvider("test-key"),
+                modelName = "deepseek-test",
+                client = OkHttpClient(),
+                supportsVision = true,
+                enableToolCall = enableToolCall
+            )
+        val method =
+            DeepseekProvider::class.java.declaredMethods.single {
+                it.name == "createRequestBody" && it.parameterCount == 7
+            }
+        method.isAccessible = true
+        val body =
+            method.invoke(
+                provider,
+                mock<Context>(),
+                history,
+                emptyList<ModelParameter<*>>(),
+                false,
+                false,
+                availableTools,
+                false
+            ) as RequestBody
+        val buffer = Buffer()
+        body.writeTo(buffer)
+        return JSONObject(buffer.readUtf8())
+    }
+
+    private companion object {
+        const val IMAGE_ID = "image-present"
+        const val IMAGE_BASE64 = "aW1hZ2U="
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

### 背景与动机 / Context and motivation

#1022 已在本次开发期间合入 `development`，修复了 assistant 消息注入媒体和 link 属性顺序问题；但 TOOL_RESULT 仍有三个遗漏路径：结构化 tool content 直接写入请求体，附带文本与非结构化结果继续使用默认 user 媒体策略，禁用 Tool Call API 时的 TOOL_RESULT 也会按 user 策略处理。这些路径仍可能把 tool 历史中的图片转换为 `image_url`，或留下原始 `<link>` 标签。

### 改动范围 / Changes

- OpenAI、DeepSeek 与 Kimi 消息构建器统一用 `role = "tool"` 清理结构化 tool result、附带文本和非结构化结果；API 要求的实际消息 role 保持不变。
- 禁用 Tool Call API 时，DeepSeek/Kimi 将 TOOL_RESULT 与 USER/SUMMARY 的媒体策略分开；OpenAI 基类按内部 TOOL_RESULT 类型选择 text-only 策略。
- 新增最终 DeepSeek 请求体回归：覆盖 user 有效图片、assistant 有效图片、图片池缺失 ID、普通 tool 历史，以及结构化 `role=tool` 结果。
- 复用 #1022 已合入的 parser 与 assistant 修复，不重复修改 parser，也不做无关重构。

### 兼容性与风险 / Compatibility and risks

USER/SUMMARY 的有效图片仍生成 `image_url`；assistant 与 tool 历史只保留清理标签后的文本。没有数据格式、持久化配置或公开工具 schema 变化。风险限于 OpenAI-compatible provider 的历史消息序列化，并由最终 JSON 回归覆盖。

## 关联 Issue / Related issue

Fixes #1021

## 验证方式 / Verification

```text
检查或命令：./gradlew :app:testDebugUnitTest --tests com.ai.assistance.operit.api.chat.llmprovider.DeepseekProviderMediaRoleTest --tests com.ai.assistance.operit.api.chat.llmprovider.MediaLinkParserTagOrderTest -x :app:syncSttModelAssets -x :app:syncMainAssets -I <temporary-init-script>
环境与变体：Windows；Eclipse Temurin 21.0.12；Android debug JVM unit tests
结果：PASS；8 tests，0 failures，0 errors，0 skipped。临时 init script 仅切换依赖镜像，并排除 development 当前无法编译的 ThinkingQualityMappingTest.kt，未提交到分支。

检查或命令：python -B -m unittest discover -s ci/test -p 'test_*.py'
环境与变体：WSL；Python 3.12 venv
结果：PASS；46 tests。

检查或命令：check_repo_hygiene.py / check_markdown_links.py / check_localizations.py，base=upstream/development，candidate=HEAD
环境与变体：Windows；Python 3.14 venv
结果：PASS；hygiene 0 errors/0 warnings；Markdown 0 errors/0 warnings（18 个 base 既有坏链被忽略）；localization 0 errors/0 warnings（4 个候选改动外的既有诊断）。

完整 CI：Fast checks PASS；Android JVM tests 已运行未排除的 :app:testDebugUnitTest，并在 development 未改动的 ThinkingQualityMappingTest.kt:19、35、61 被 Int 传给 String 参数的编译错误处 FAIL（https://github.com/AAswordman/Operit/actions/runs/32692358929）。#1028 的独立分支出现相同错误，确认属于共同基线；本 PR 不修改该无关问题。未改 web-chat，因此未运行其 typecheck。
```

## 证据 / Evidence

DeepSeek 请求体测试断言：user 图片仍为 `data:image/png;base64,...`；assistant、普通 TOOL_RESULT 与结构化 tool result 均不含 `<link>`，且只有 user 路径出现 `image_url`。现有 parser 测试同时覆盖属性顺序、转义、缺失图片池 ID 清理与 encounter order。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 `development`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `development` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided