### PR TITLE
fix(chat): refresh model list after config changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 ## 变更说明 / Description
 
 <!--
-日常开发 PR 的目标分支默认为 `development`；只有维护者执行稳定发布同步时才使用 `main`。
-For regular development PRs, the target branch is `development`; use `main` only for maintainer-led release synchronization.
+日常开发 PR 的目标分支默认为 `dev`；只有维护者执行稳定发布同步时才使用 `main`。
+For regular development PRs, the target branch is `dev`; use `main` only for maintainer-led release synchronization.
 
 请先用几句话说明这个 PR 为什么存在，以及用户或维护者会得到什么变化。
 Briefly explain why this PR exists and what users or maintainers will gain.
@@ -59,7 +59,7 @@ Use these items for a final self-review. Automated checks do not enforce their e
 -->
 
 - [ ] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
-- [ ] 日常开发 PR 的目标分支为 `development`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `development` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
+- [ ] 日常开发 PR 的目标分支为 `dev`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `dev` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
 - [ ] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
 - [ ] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
 - [ ] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided

--- a/README.md
+++ b/README.md
@@ -222,16 +222,13 @@
 
 ## Star History
 
-<div align="center">
-  <a href="https://www.star-history.com/?repos=AAswordman%2FOperit&amp;type=date&amp;legend=top-left">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=AAswordman/Operit&amp;type=date&amp;theme=dark&amp;legend=top-left&amp;sealed_token=x2g4HD_vqrg9vWOmPW-1NFSSSJK2LImmWpVQBambbxIE2pHqGHAzid1rnimOClPo9Xjg6oLM4771kAIr_JgdboIOqdJuFVSozXRgW2w2HOOSCBtWbL1w9w">
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=AAswordman/Operit&amp;type=date&amp;legend=top-left&amp;sealed_token=x2g4HD_vqrg9vWOmPW-1NFSSSJK2LImmWpVQBambbxIE2pHqGHAzid1rnimOClPo9Xjg6oLM4771kAIr_JgdboIOqdJuFVSozXRgW2w2HOOSCBtWbL1w9w">
-      <img alt="Star 历史图" src="https://api.star-history.com/chart?repos=AAswordman/Operit&amp;type=date&amp;legend=top-left&amp;sealed_token=x2g4HD_vqrg9vWOmPW-1NFSSSJK2LImmWpVQBambbxIE2pHqGHAzid1rnimOClPo9Xjg6oLM4771kAIr_JgdboIOqdJuFVSozXRgW2w2HOOSCBtWbL1w9w">
-    </picture>
-  </a>
-</div>
-
+<a href="https://www.star-history.com/?repos=AAswordman%2FOperit&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=AAswordman/Operit&type=date&theme=dark&legend=top-left&sealed_token=CtZ-YNyNp2_W0AUVXHyAzBNeMlpGVkDx0RjuJPYdalj2Kvy7HkPBhb-uzKQ8t8jbMDGjRvnjHo7Fi-FtGIv-NaS0gqafGHDjgoGufAgx8yXt3gi8f4vV3aP8KskKramok4_vcKfo8Ii4AohtLRdX13mCJz0ABDqwtmec2SoK0j1kLuPyLz6oH3k4lhY4" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=AAswordman/Operit&type=date&legend=top-left&sealed_token=CtZ-YNyNp2_W0AUVXHyAzBNeMlpGVkDx0RjuJPYdalj2Kvy7HkPBhb-uzKQ8t8jbMDGjRvnjHo7Fi-FtGIv-NaS0gqafGHDjgoGufAgx8yXt3gi8f4vV3aP8KskKramok4_vcKfo8Ii4AohtLRdX13mCJz0ABDqwtmec2SoK0j1kLuPyLz6oH3k4lhY4" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=AAswordman/Operit&type=date&legend=top-left&sealed_token=CtZ-YNyNp2_W0AUVXHyAzBNeMlpGVkDx0RjuJPYdalj2Kvy7HkPBhb-uzKQ8t8jbMDGjRvnjHo7Fi-FtGIv-NaS0gqafGHDjgoGufAgx8yXt3gi8f4vV3aP8KskKramok4_vcKfo8Ii4AohtLRdX13mCJz0ABDqwtmec2SoK0j1kLuPyLz6oH3k4lhY4" />
+ </picture>
+</a>
 ---
 
 <div align="center">

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
@@ -43,7 +43,12 @@ private val Context.modelConfigDataStore: DataStore<Preferences> by
             }
         }
 
-class ModelConfigManager(private val context: Context) {
+class ModelConfigManager(
+        private val context: Context,
+        configDataStore: DataStore<Preferences> = context.modelConfigDataStore
+) {
+
+    private val configDataStore = configDataStore
 
     // 提供context访问器
     val appContext: Context
@@ -203,11 +208,58 @@ class ModelConfigManager(private val context: Context) {
 
     // 获取所有配置ID列表
     val configListFlow: Flow<List<String>> =
-            context.modelConfigDataStore.data.map { preferences ->
+            configDataStore.data.map { preferences ->
                 val configList = preferences[CONFIG_LIST_KEY] ?: ""
                 if (configList.isEmpty()) emptyList()
                 else json.decodeFromString<List<String>>(configList)
             }
+
+    // 所有配置摘要的响应式版本。主界面模型选择器必须持续收集它，才能在配置页
+    // 新增或修改模型后立即更新，而不需要重新进入配置页。
+    val configSummariesFlow: Flow<List<ModelConfigSummary>> =
+            configDataStore.data.map { preferences ->
+                readConfigSummariesFromPrefs(preferences)
+            }
+
+    private fun readConfigListFromPrefs(prefs: Preferences): List<String> {
+        val configList = prefs[CONFIG_LIST_KEY] ?: ""
+        return if (configList.isEmpty()) emptyList()
+        else json.decodeFromString<List<String>>(configList)
+    }
+
+    private fun readConfigSummariesFromPrefs(prefs: Preferences): List<ModelConfigSummary> {
+        return readConfigListFromPrefs(prefs).map { configId ->
+            val configJson = prefs[stringPreferencesKey("config_${configId}")]
+            val config =
+                    if (configJson != null) {
+                        try {
+                            json.decodeFromString<ModelConfigData>(configJson)
+                        } catch (_: Exception) {
+                            fallbackConfigFor(configId)
+                        }
+                    } else {
+                        fallbackConfigFor(configId)
+                    }
+            ModelConfigSummary(
+                    id = config.id,
+                    name = config.name,
+                    modelName = config.modelName,
+                    apiEndpoint = config.apiEndpoint,
+                    apiProviderType = config.apiProviderType,
+                    apiProviderTypeId = config.apiProviderTypeId,
+                    thinkingConfigurations = config.thinkingConfigurations,
+                    thinkingOptionId = config.thinkingOptionId
+            )
+        }
+    }
+
+    private fun fallbackConfigFor(configId: String): ModelConfigData {
+        return if (configId == DEFAULT_CONFIG_ID) {
+            createFreshDefaultConfig()
+        } else {
+            ModelConfigData(id = configId, name = context.getString(R.string.model_config_config_id, configId))
+        }
+    }
 
     // 从原有ApiPreferences创建默认配置
     private fun createFreshDefaultConfig(): ModelConfigData {
@@ -217,7 +269,7 @@ class ModelConfigManager(private val context: Context) {
     // 保存配置
     suspend fun saveModelConfig(config: ModelConfigData) {
         val configKey = stringPreferencesKey("config_${config.id}")
-        context.modelConfigDataStore.edit { preferences ->
+        configDataStore.edit { preferences ->
             preferences[configKey] = json.encodeToString(config)
         }
     }
@@ -225,7 +277,7 @@ class ModelConfigManager(private val context: Context) {
     // 从DataStore加载配置
     private suspend fun loadConfigFromDataStore(configId: String): ModelConfigData? {
         val configKey = stringPreferencesKey("config_${configId}")
-        return context.modelConfigDataStore.data.first().let { preferences ->
+        return configDataStore.data.first().let { preferences ->
             val configJson = preferences[configKey]
             if (configJson != null) {
                 try {
@@ -251,7 +303,7 @@ class ModelConfigManager(private val context: Context) {
     // 将配置保存到DataStore
     private suspend fun saveConfigToDataStore(config: ModelConfigData) {
         val configKey = stringPreferencesKey("config_${config.id}")
-        context.modelConfigDataStore.edit { preferences ->
+        configDataStore.edit { preferences ->
             preferences[configKey] = json.encodeToString(config)
         }
     }
@@ -262,7 +314,7 @@ class ModelConfigManager(private val context: Context) {
     ): ModelConfigData {
         val configKey = stringPreferencesKey("config_${configId}")
         var updated: ModelConfigData? = null
-        context.modelConfigDataStore.edit { preferences ->
+        configDataStore.edit { preferences ->
             val current =
                     run {
                         val configJson = preferences[configKey]
@@ -294,7 +346,7 @@ class ModelConfigManager(private val context: Context) {
 
     // 获取指定ID的配置
     fun getModelConfigFlow(configId: String): Flow<ModelConfigData> {
-        return context.modelConfigDataStore.data.map { preferences ->
+        return configDataStore.data.map { preferences ->
             val config = loadConfigFromDataStore(configId) ?: ModelConfigData(id = configId, name = context.getString(R.string.model_config_config_id, configId))
             config
         }
@@ -318,26 +370,7 @@ class ModelConfigManager(private val context: Context) {
 
     // 获取所有配置的摘要信息
     suspend fun getAllConfigSummaries(): List<ModelConfigSummary> {
-        val configIds = configListFlow.first()
-        val summaries = mutableListOf<ModelConfigSummary>()
-
-        for (id in configIds) {
-            val config = getModelConfigFlow(id).first()
-            summaries.add(
-                    ModelConfigSummary(
-                            id = config.id,
-                            name = config.name,
-                            modelName = config.modelName,
-                            apiEndpoint = config.apiEndpoint,
-                            apiProviderType = config.apiProviderType,
-                            apiProviderTypeId = config.apiProviderTypeId,
-                            thinkingConfigurations = config.thinkingConfigurations,
-                            thinkingOptionId = config.thinkingOptionId
-                    )
-            )
-        }
-
-        return summaries
+        return readConfigSummariesFromPrefs(configDataStore.data.first())
     }
 
     // 创建新配置
@@ -361,7 +394,7 @@ class ModelConfigManager(private val context: Context) {
 
         // 更新配置列表
         configList.add(configId)
-        context.modelConfigDataStore.edit { preferences ->
+        configDataStore.edit { preferences ->
             preferences[CONFIG_LIST_KEY] = json.encodeToString(configList)
         }
 
@@ -389,7 +422,7 @@ class ModelConfigManager(private val context: Context) {
             functionalConfigManager.saveFunctionConfigMappingWithIndex(mappingRepair.mapping)
         }
 
-        context.modelConfigDataStore.edit { preferences ->
+        configDataStore.edit { preferences ->
             // 删除配置记录 - 修复null赋值问题
             preferences.remove(stringPreferencesKey("config_${configId}"))
             // 更新配置列表
@@ -887,7 +920,7 @@ class ModelConfigManager(private val context: Context) {
             
             // 更新配置列表
             if (newCount > 0) {
-                context.modelConfigDataStore.edit { preferences ->
+                configDataStore.edit { preferences ->
                     preferences[CONFIG_LIST_KEY] = json.encodeToString(existingConfigList)
                 }
             }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
@@ -360,7 +360,8 @@ fun AgentChatInputSection(
     val currentModelName by actualViewModel.modelName.collectAsState()
     val configMappingWithIndex by
         functionalConfigManager.functionConfigMappingWithIndexFlow.collectAsState(initial = emptyMap())
-    var configSummaries by remember { mutableStateOf<List<ModelConfigSummary>>(emptyList()) }
+    val configSummaries by
+            modelConfigManager.configSummariesFlow.collectAsState(initial = emptyList())
     val activeProfileId by userPreferencesManager.activeMemorySpaceIdFlow.collectAsState(initial = "default")
     var preferenceProfiles by remember { mutableStateOf<List<MemorySpace>>(emptyList()) }
     val currentConfigMapping =
@@ -385,16 +386,9 @@ fun AgentChatInputSection(
         }
 
     LaunchedEffect(Unit) {
-        configSummaries = modelConfigManager.getAllConfigSummaries()
         val profileIds = userPreferencesManager.memorySpaceListFlow.first()
         preferenceProfiles =
             profileIds.map { profileId -> userPreferencesManager.getMemorySpaceFlow(profileId).first() }
-    }
-
-    LaunchedEffect(showModelSelectorPopup.value) {
-        if (showModelSelectorPopup.value) {
-            configSummaries = modelConfigManager.getAllConfigSummaries()
-        }
     }
 
     val mappedModelName =

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatSettingsBar.kt
@@ -160,8 +160,8 @@ fun ClassicChatSettingsBar(
     val modelConfigManager = remember { ModelConfigManager(context) }
     val configMappingWithIndex by
             functionalConfigManager.functionConfigMappingWithIndexFlow.collectAsState(initial = emptyMap())
-    var configSummaries by remember { mutableStateOf<List<ModelConfigSummary>>(emptyList()) }
-    LaunchedEffect(Unit) { configSummaries = modelConfigManager.getAllConfigSummaries() }
+    val configSummaries by
+            modelConfigManager.configSummariesFlow.collectAsState(initial = emptyList())
     val currentConfigMapping =
             configMappingWithIndex[FunctionType.CHAT] ?: FunctionConfigMapping(FunctionalConfigManager.DEFAULT_CONFIG_ID, 0)
     val isModelSelectionLockedByCharacterCard = !characterCardBoundChatModelConfigId.isNullOrBlank()

--- a/app/src/test/java/com/ai/assistance/operit/data/preferences/ModelConfigSummariesFlowTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/preferences/ModelConfigSummariesFlowTest.kt
@@ -1,0 +1,87 @@
+package com.ai.assistance.operit.data.preferences
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.ai.assistance.operit.data.model.ApiProviderType
+import com.ai.assistance.operit.data.model.ModelConfigData
+import com.ai.assistance.operit.data.model.ModelConfigSummary
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class ModelConfigSummariesFlowTest {
+
+    @Test
+    fun `active config summaries subscription receives created and updated models`() = runBlocking {
+        val preferences = MutableStateFlow<Preferences>(mutablePreferencesOf())
+        val dataStore = TestPreferencesDataStore(preferences)
+        val json = Json { ignoreUnknownKeys = true; isLenient = true }
+        val firstConfigId = "first-config"
+        val thinkingConfigurations = """[{"id":"think-1","label":"Low"}]"""
+        val firstConfig =
+            ModelConfigData(
+                id = firstConfigId,
+                name = "first",
+                modelName = "model-a",
+                apiProviderType = ApiProviderType.OPENAI_GENERIC,
+                thinkingConfigurations = thinkingConfigurations,
+                thinkingOptionId = "think-1",
+            )
+        dataStore.updateData { current ->
+            current.toMutablePreferences().apply {
+                set(stringPreferencesKey("config_$firstConfigId"), json.encodeToString(firstConfig))
+                set(ModelConfigManager.CONFIG_LIST_KEY, json.encodeToString(listOf(firstConfigId)))
+            }
+        }
+
+        val context = Mockito.mock(Context::class.java)
+        val manager = ModelConfigManager(context, dataStore)
+        val emissions = Channel<List<ModelConfigSummary>>(Channel.UNLIMITED)
+        val collector = launch {
+            manager.configSummariesFlow.take(3).collect { emissions.send(it) }
+        }
+
+        val initialSummaries = emissions.receive()
+        assertEquals(listOf(firstConfigId), initialSummaries.map { it.id })
+        assertEquals("model-a", initialSummaries.single().modelName)
+        assertEquals(thinkingConfigurations, initialSummaries.single().thinkingConfigurations)
+        assertEquals("think-1", initialSummaries.single().thinkingOptionId)
+
+        val secondConfigId = manager.createConfig("second")
+        val afterCreateSummaries = emissions.receive()
+        assertEquals(listOf(firstConfigId, secondConfigId), afterCreateSummaries.map { it.id })
+
+        manager.updateConfigBase(firstConfigId, "renamed")
+        val afterUpdateSummaries = emissions.receive()
+        assertEquals("renamed", afterUpdateSummaries.first().name)
+        assertEquals("second", afterUpdateSummaries.last().name)
+        assertEquals(thinkingConfigurations, afterUpdateSummaries.first().thinkingConfigurations)
+        assertEquals("think-1", afterUpdateSummaries.first().thinkingOptionId)
+        collector.join()
+    }
+
+    private class TestPreferencesDataStore(
+        private val preferences: MutableStateFlow<Preferences>
+    ) : DataStore<Preferences> {
+        override val data = preferences.asStateFlow()
+
+        override suspend fun updateData(
+            transform: suspend (Preferences) -> Preferences
+        ): Preferences {
+            val updated = transform(preferences.value)
+            preferences.value = updated
+            return updated
+        }
+    }
+}

--- a/ci/README.md
+++ b/ci/README.md
@@ -20,8 +20,8 @@ workspace = candidate
 本地检查需要显式指定比较边界。在干净的功能分支上运行：
 
 ```bash
-git fetch upstream development
-BASE_SHA="$(git merge-base upstream/development HEAD)"
+git fetch upstream dev
+BASE_SHA="$(git merge-base upstream/dev HEAD)"
 CANDIDATE_SHA="HEAD"
 
 python3 -B -m unittest discover -s ci/test -p 'test_*.py'
@@ -30,7 +30,7 @@ python3 -B ci/script/check_markdown_links.py --base "$BASE_SHA" --candidate "$CA
 python3 -B ci/script/check_localizations.py --base "$BASE_SHA" --candidate "$CANDIDATE_SHA"
 ```
 
-本地分支不是 GitHub merge candidate，因此本地结果用于提交前检查；PR 页面上的 `Candidate checks` 才验证与当前 `development` 合并后的实际树。
+本地分支不是 GitHub merge candidate，因此本地结果用于提交前检查；PR 页面上的 `Candidate checks` 才验证与当前 `dev` 合并后的实际树。
 
 ## PR check lanes
 

--- a/docs/doc-src/dev-core/CONTRIBUTING.md
+++ b/docs/doc-src/dev-core/CONTRIBUTING.md
@@ -41,7 +41,7 @@ cd Operit
 git submodule update --init --recursive terminal
 git remote add upstream https://github.com/AAswordman/Operit.git
 git fetch upstream
-git switch -c fix/short-description upstream/development
+git switch -c fix/short-description upstream/dev
 ```
 
 不要提交 `local.properties`、本地密钥、手动下载的模型和二进制依赖。修改 WebChat 或示例包时，先按照编译指南准备根目录和 `web-chat` 的依赖。
@@ -60,8 +60,8 @@ git switch -c fix/short-description upstream/development
 在仓库根目录可以复现主要的快速检查：
 
 ```bash
-git fetch upstream development
-BASE_SHA="$(git merge-base upstream/development HEAD)"
+git fetch upstream dev
+BASE_SHA="$(git merge-base upstream/dev HEAD)"
 CANDIDATE_SHA="HEAD"
 
 python3 -B -m unittest discover -s ci/test -p 'test_*.py'
@@ -96,7 +96,7 @@ python3 ./tools/example_packages/sync_example_packages.py --no-hot-reload
 
 ## 创建 Pull Request
 
-日常开发的上游 PR 默认目标分支是长期集成分支 `development`，不再使用旧的 `pr-branch` 流程；`main` 仅用于稳定发布和由维护者执行的发布同步。`development` 是仓库维护的目标分支，不属于贡献分支命名规则的约束。新建贡献分支必须使用以下前缀加简短描述：
+日常开发的上游 PR 默认目标分支是长期集成分支 `dev`，不再使用旧的 `pr-branch` 流程；`main` 仅用于稳定发布和由维护者执行的发布同步。`dev` 是仓库维护的目标分支，不属于贡献分支命名规则的约束。新建贡献分支必须使用以下前缀加简短描述：
 
 - `feat/`：新功能
 - `fix/`：问题修复
@@ -111,7 +111,7 @@ python3 ./tools/example_packages/sync_example_packages.py --no-hot-reload
 
 ```bash
 git fetch upstream
-git rebase upstream/development
+git rebase upstream/dev
 git push --set-upstream origin fix/short-description
 ```
 
@@ -141,7 +141,7 @@ ci: add localization checks
 
 PR 会进入 [PR Check workflow](../../../.github/workflows/pr-check.yml)，并保留一个 `Candidate checks`
 聚合技术状态；适用时还会显示独立的 `Android build` 和 `Android JVM tests` job。检查运行在
-GitHub 为 PR 与当前 `development` 生成的 merge candidate 上：
+GitHub 为 PR 与当前 `dev` 生成的 merge candidate 上：
 
 - 快速检查：差异空白、冲突标记、JSON/XML/YAML、Actions、本地 Markdown 链接和门禁单元测试
 - 本地化：按 locale 和资源 key 归责类型、重复项、占位符及 locale 配置错误


### PR DESCRIPTION
## 问题

在「模型与参数配置」中新增模型后返回主界面，新模型不显示；必须再次进入配置页才会刷新。

## 根因

主界面两套模型选择器（Classic 经典输入栏、Agent 输入栏）只在组合时通过一次 getAllConfigSummaries() 读取配置摘要快照。配置页写入 DataStore 后没有推送机制，返回主界面时仍然显示旧列表。

## 修复

- ModelConfigManager 新增响应式 configSummariesFlow：直接映射 configDataStore.data，每次 DataStore 快照变化都会重新解析配置摘要。
- getAllConfigSummaries() 与 Flow 共用同一解析逻辑（缺失/损坏配置回退行为与原实现一致，并保留 	hinkingConfigurations / 	hinkingOptionId 字段）。
- 两个输入栏改为 collectAsState 持续订阅 configSummariesFlow，配置页增改模型后无需重新进入即可看到更新。
- 新增单测 ModelConfigSummariesFlowTest：单一长期订阅按顺序验证「初始 → createConfig → updateConfigBase」三次发射，包含 thinking 字段保留断言。

## 验证

- :app:testDebugUnitTest --tests ModelConfigSummariesFlowTest 通过（1 test / 0 failures）
- 主源码编译通过

## 备注

上游 main/dev 的单元测试源集当前存在既有编译错误（XaiProviderReasoningTest 引用不存在的 XaiReasoningMapper / xaiModelSupportsReasoningEffort），与本 PR 无关，未纳入本次改动。

## 关联 Issue

- [#915](https://github.com/AAswordman/Operit/issues/915) 同族问题（配置变更后运行时仍使用旧快照），但位于后台识别服务路径（IMAGE_RECOGNITION/AUDIO_RECOGNITION），与本 PR 的主界面模型选择器修复相互独立。