### PR TITLE
docs: update development branch references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 ## 变更说明 / Description
 
 <!--
-日常开发 PR 的目标分支默认为 `development`；只有维护者执行稳定发布同步时才使用 `main`。
-For regular development PRs, the target branch is `development`; use `main` only for maintainer-led release synchronization.
+日常开发 PR 的目标分支默认为 `dev`；只有维护者执行稳定发布同步时才使用 `main`。
+For regular development PRs, the target branch is `dev`; use `main` only for maintainer-led release synchronization.
 
 请先用几句话说明这个 PR 为什么存在，以及用户或维护者会得到什么变化。
 Briefly explain why this PR exists and what users or maintainers will gain.
@@ -59,7 +59,7 @@ Use these items for a final self-review. Automated checks do not enforce their e
 -->
 
 - [ ] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
-- [ ] 日常开发 PR 的目标分支为 `development`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `development` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
+- [ ] 日常开发 PR 的目标分支为 `dev`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `dev` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
 - [ ] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
 - [ ] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
 - [ ] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided

--- a/ci/README.md
+++ b/ci/README.md
@@ -20,8 +20,8 @@ workspace = candidate
 本地检查需要显式指定比较边界。在干净的功能分支上运行：
 
 ```bash
-git fetch upstream development
-BASE_SHA="$(git merge-base upstream/development HEAD)"
+git fetch upstream dev
+BASE_SHA="$(git merge-base upstream/dev HEAD)"
 CANDIDATE_SHA="HEAD"
 
 python3 -B -m unittest discover -s ci/test -p 'test_*.py'
@@ -30,7 +30,7 @@ python3 -B ci/script/check_markdown_links.py --base "$BASE_SHA" --candidate "$CA
 python3 -B ci/script/check_localizations.py --base "$BASE_SHA" --candidate "$CANDIDATE_SHA"
 ```
 
-本地分支不是 GitHub merge candidate，因此本地结果用于提交前检查；PR 页面上的 `Candidate checks` 才验证与当前 `development` 合并后的实际树。
+本地分支不是 GitHub merge candidate，因此本地结果用于提交前检查；PR 页面上的 `Candidate checks` 才验证与当前 `dev` 合并后的实际树。
 
 ## PR check lanes
 

--- a/docs/doc-src/dev-core/CONTRIBUTING.md
+++ b/docs/doc-src/dev-core/CONTRIBUTING.md
@@ -41,7 +41,7 @@ cd Operit
 git submodule update --init --recursive terminal
 git remote add upstream https://github.com/AAswordman/Operit.git
 git fetch upstream
-git switch -c fix/short-description upstream/development
+git switch -c fix/short-description upstream/dev
 ```
 
 不要提交 `local.properties`、本地密钥、手动下载的模型和二进制依赖。修改 WebChat 或示例包时，先按照编译指南准备根目录和 `web-chat` 的依赖。
@@ -60,8 +60,8 @@ git switch -c fix/short-description upstream/development
 在仓库根目录可以复现主要的快速检查：
 
 ```bash
-git fetch upstream development
-BASE_SHA="$(git merge-base upstream/development HEAD)"
+git fetch upstream dev
+BASE_SHA="$(git merge-base upstream/dev HEAD)"
 CANDIDATE_SHA="HEAD"
 
 python3 -B -m unittest discover -s ci/test -p 'test_*.py'
@@ -96,7 +96,7 @@ python3 ./tools/example_packages/sync_example_packages.py --no-hot-reload
 
 ## 创建 Pull Request
 
-日常开发的上游 PR 默认目标分支是长期集成分支 `development`，不再使用旧的 `pr-branch` 流程；`main` 仅用于稳定发布和由维护者执行的发布同步。`development` 是仓库维护的目标分支，不属于贡献分支命名规则的约束。新建贡献分支必须使用以下前缀加简短描述：
+日常开发的上游 PR 默认目标分支是长期集成分支 `dev`，不再使用旧的 `pr-branch` 流程；`main` 仅用于稳定发布和由维护者执行的发布同步。`dev` 是仓库维护的目标分支，不属于贡献分支命名规则的约束。新建贡献分支必须使用以下前缀加简短描述：
 
 - `feat/`：新功能
 - `fix/`：问题修复
@@ -111,7 +111,7 @@ python3 ./tools/example_packages/sync_example_packages.py --no-hot-reload
 
 ```bash
 git fetch upstream
-git rebase upstream/development
+git rebase upstream/dev
 git push --set-upstream origin fix/short-description
 ```
 
@@ -141,7 +141,7 @@ ci: add localization checks
 
 PR 会进入 [PR Check workflow](../../../.github/workflows/pr-check.yml)，并保留一个 `Candidate checks`
 聚合技术状态；适用时还会显示独立的 `Android build` 和 `Android JVM tests` job。检查运行在
-GitHub 为 PR 与当前 `development` 生成的 merge candidate 上：
+GitHub 为 PR 与当前 `dev` 生成的 merge candidate 上：
 
 - 快速检查：差异空白、冲突标记、JSON/XML/YAML、Actions、本地 Markdown 链接和门禁单元测试
 - 本地化：按 locale 和资源 key 归责类型、重复项、占位符及 locale 配置错误


### PR DESCRIPTION
将开发文档中的旧集成分支名 development 更新为当前 dev。涉及 PR 模板、CI 本地检查说明和贡献指南，避免贡献者继续基于不存在的分支操作。