### PR TITLE
fix(openai): send reasoning_effort only to reasoning-capable models

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/collects/ModelThinkingConfigDefaultsCollect.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/collects/ModelThinkingConfigDefaultsCollect.kt
@@ -11,6 +11,26 @@ object ModelThinkingConfigDefaults {
                   {
                     "id": "openai-chat-reasoning-effort",
                     "providers": ["OPENAI", "OPENAI_GENERIC"],
+                    "match": {"modelRegex": ["(?:^|/)(?:o[1-9]|gpt-[5-9]|gpt-oss|codex)"]},
+                    "control": "levels",
+                    "parameterLabel": "reasoning_effort",
+                    "options": [
+                      {"id": "low", "label": "low", "path": "reasoning_effort", "value": "low"},
+                      {"id": "medium", "label": "medium", "path": "reasoning_effort", "value": "medium"},
+                      {"id": "high", "label": "high", "path": "reasoning_effort", "value": "high"},
+                      {"id": "xhigh", "label": "xhigh", "path": "reasoning_effort", "value": "xhigh"},
+                      {"id": "max", "label": "max", "path": "reasoning_effort", "value": "max"}
+                    ]
+                  },
+                  {
+                    "id": "openai-chat-non-reasoning-models",
+                    "providers": ["OPENAI_GENERIC"],
+                    "match": {"modelRegex": ["(?:^|/)(?:chatgpt-|gpt-3|gpt-4)"]},
+                    "control": "unsupported"
+                  },
+                  {
+                    "id": "openai-compatible-chat-reasoning-effort",
+                    "providers": ["OPENAI_GENERIC"],
                     "control": "levels",
                     "parameterLabel": "reasoning_effort",
                     "options": [

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiChatReasoningEffortTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiChatReasoningEffortTest.kt
@@ -1,0 +1,78 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import com.ai.assistance.operit.data.collects.ModelThinkingConfigDefaults
+import com.ai.assistance.operit.data.model.ApiProviderType
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * OpenAI's Chat Completions endpoint rejects reasoning_effort with a 400 on models that
+ * do not reason, so the parameter must only reach the wire for models that accept it.
+ */
+class OpenAiChatReasoningEffortTest {
+    private fun mapping(provider: ApiProviderType, modelName: String): ThinkingQualityMapping =
+        ThinkingQualityMappingRegistry.resolve(
+            providerTypeId = provider.name,
+            modelName = modelName,
+            thinkingConfigurations = ModelThinkingConfigDefaults.forProvider(provider.name)
+        )
+
+    /** Mirrors what OpenAIProvider.createRequestBody sends for a freshly seeded config. */
+    private fun requestBody(
+        provider: ApiProviderType,
+        modelName: String,
+        enableThinking: Boolean
+    ): JSONObject {
+        val thinkingConfigurations = ModelThinkingConfigDefaults.forProvider(provider.name)
+        val requestJson = JSONObject().put("model", modelName).put("stream", true)
+        ThinkingConfigurationApplier.apply(
+            requestJson = requestJson,
+            providerTypeId = provider.name,
+            modelName = modelName,
+            apiEndpoint = "https://api.openai.com/v1/chat/completions",
+            thinkingConfigurations = thinkingConfigurations,
+            enableThinking = enableThinking,
+            // ModelConfigManager seeds a config with the first option its mapping offers.
+            optionId = mapping(provider, modelName).options.firstOrNull()?.id.orEmpty(),
+        )
+        return requestJson
+    }
+
+    @Test
+    fun openAiChatModelsNeverReceiveReasoningEffort() {
+        for (model in listOf("gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-3.5-turbo", "chatgpt-4o-latest")) {
+            assertEquals(model, ThinkingQualityControl.UNSUPPORTED, mapping(ApiProviderType.OPENAI, model).control)
+            assertFalse(model, requestBody(ApiProviderType.OPENAI, model, enableThinking = true).has("reasoning_effort"))
+            assertFalse(model, requestBody(ApiProviderType.OPENAI, model, enableThinking = false).has("reasoning_effort"))
+        }
+    }
+
+    @Test
+    fun openAiReasoningModelsKeepReasoningEffortWhenThinkingIsOn() {
+        for (model in listOf("o3", "o4-mini", "gpt-5-mini", "gpt-5.6-luna", "gpt-oss-120b", "codex-mini-latest")) {
+            assertEquals(model, ThinkingQualityControl.LEVELS, mapping(ApiProviderType.OPENAI, model).control)
+            assertEquals(model, "low", requestBody(ApiProviderType.OPENAI, model, enableThinking = true).getString("reasoning_effort"))
+        }
+    }
+
+    @Test
+    fun openAiReasoningModelsOmitReasoningEffortWhenThinkingIsOff() {
+        assertFalse(requestBody(ApiProviderType.OPENAI, "o3", enableThinking = false).has("reasoning_effort"))
+    }
+
+    @Test
+    fun compatibleEndpointsDropReasoningEffortForOpenAiChatModels() {
+        assertEquals(ThinkingQualityControl.UNSUPPORTED, mapping(ApiProviderType.OPENAI_GENERIC, "gpt-4o").control)
+        assertFalse(requestBody(ApiProviderType.OPENAI_GENERIC, "gpt-4o", enableThinking = true).has("reasoning_effort"))
+    }
+
+    @Test
+    fun compatibleEndpointsKeepReasoningEffortForThirdPartyModels() {
+        for (model in listOf("deepseek-reasoner", "glm-4.6", "qwen3-235b-a22b")) {
+            assertEquals(model, ThinkingQualityControl.LEVELS, mapping(ApiProviderType.OPENAI_GENERIC, model).control)
+            assertEquals(model, "low", requestBody(ApiProviderType.OPENAI_GENERIC, model, enableThinking = true).getString("reasoning_effort"))
+        }
+    }
+}


### PR DESCRIPTION
## 关联 Issue

Fixes #1048

## 问题

`#1048` 报告的现象：接口类型选 OpenAI / OpenAI 兼容时，即使关闭思考模式也会注入 `reasoning_effort`，gpt-4o 等 chat 模型直接被官方端点拒绝：

```
400 Unrecognized request argument supplied: reasoning_effort
```

Issue 里贴的那段 `applyOpenAiChatReasoning()`（关闭思考时写 `"none"`）在 #1024 的重构中已经被删掉了，所以**"关闭思考仍然发送"这一半在当前 dev 上确实已经修好**。

但根因还在：`ModelThinkingConfigDefaults` 里的 `openai-chat-reasoning-effort` 规则**没有 `match` 块**，`ThinkingModelMatcher.isEmpty()` 直接返回 `true`，于是它对 OPENAI / OPENAI_GENERIC 下的**任何模型**都命中。结果是：

- 思考开关打开时，gpt-4o 依然会拿到 `reasoning_effort`，官方端点照样 400；
- 思考深度滑块也会显示在根本不支持推理的模型上（`ClassicChatSettingsBar` / `AgentChatInputSection` 只按 `control == LEVELS` 决定是否渲染）。

在打补丁前用当前 dev（a92a6ffe）的真实源码跑了一遍请求体构造：

```
OPENAI  gpt-4o  thinking=false  control=LEVELS  body={"stream":true,"model":"gpt-4o"}
OPENAI  gpt-4o  thinking=true   control=LEVELS  body={"reasoning_effort":"low","stream":true,"model":"gpt-4o"}
```

## 改动

只动 `ModelThinkingConfigDefaults.DEFAULT_JSON`，沿用仓库既有的"具体规则在前、兜底规则在后"写法（NVIDIA / 智谱都是这个形状）：

1. `openai-chat-reasoning-effort` 加上 `match`，限定到确实接受该参数的 OpenAI 系列：`(?:^|/)(?:o[1-9]|gpt-[5-9]|gpt-oss|codex)`。
2. 新增 `openai-chat-non-reasoning-models`（仅 OPENAI_GENERIC）：`gpt-3` / `gpt-4` / `chatgpt-` 家族标记为 `unsupported` —— 这些模型在任何转发端点上都不支持 `reasoning_effort`。
3. 新增 `openai-compatible-chat-reasoning-effort`（仅 OPENAI_GENERIC）作为兜底，保持第三方兼容端点上 deepseek / glm / qwen 这类模型的行为不变。

官方 OPENAI 用白名单而不是黑名单，是因为两种失败方向代价不对称：漏发一个支持的参数只是走模型默认档位，误发一个不支持的参数是整轮对话 400。

## 验证方式

本机跑不了完整 Gradle 构建（缺 NDK/CMake 等），所以把 `ThinkingQualityMapping.kt` + `ModelThinkingConfigDefaultsCollect.kt` 的真实源码配 `org.json` 和 JUnit 4.13.2 单独编译运行。

新增 `OpenAiChatReasoningEffortTest`，在**请求体层面**断言（而不只是 mapping 层面），并连同现有的 `ThinkingQualityMappingTest` / `OpenCodeThinkingConfigurationTest` 一起跑：

```
JUnit version 4.13.2
....................
OK (20 tests)
```

新增的 5 条用例在未打补丁的 dev 上会失败（`expected:<UNSUPPORTED> but was:<LEVELS>`），确认不是空断言。

补丁后的请求体：

```
OPENAI          gpt-4o     thinking=true   control=UNSUPPORTED  body={"stream":true,"model":"gpt-4o"}
OPENAI          gpt-4.1    thinking=true   control=UNSUPPORTED  body={"stream":true,"model":"gpt-4.1"}
OPENAI          o3         thinking=true   control=LEVELS       body={"reasoning_effort":"low",...}
OPENAI          gpt-5.6-luna thinking=true control=LEVELS       body={"reasoning_effort":"low",...}
OPENAI_GENERIC  gpt-4o     thinking=true   control=UNSUPPORTED  body={"stream":true,"model":"gpt-4o"}
OPENAI_GENERIC  glm-4.6    thinking=true   control=LEVELS       body={"reasoning_effort":"low",...}
```

另外 `ci/script/check_repo_hygiene.py` 和 `check_localizations.py` 均为 `errors=0`。

## 两点想请你确认

1. **老配置不会自动改回来。** `thinkingConfigurations` 是在 DataStore 迁移（version 1 → 2）时写进每个模型配置的，`migratePreferencesFromVersionOne` 只在字段为空/`[]` 时才重新播种。#1024 还没进 release，所以从 1.12.x 升上来的用户会在迁移时拿到修正后的默认值；但已经跑过 dev 包的用户，配置里存的还是旧规则，需要切一次 provider 或手动改 JSON。要不要为此升 version 3 重新播种，我没有擅自动——那会覆盖用户自己改过的规则。
2. **Responses 路由有同形状的问题，我没有一起改。** `openai-responses-reasoning-effort` 同样没有 `match`，而且它的 `disable` 会在关闭思考时写入 `reasoning.effort: "none"`，gpt-4o 走 Responses API 会报 `Unsupported parameter`。这是 issue 之外的面，改法一样但影响到 OPENAI_CODEX / OPENAI_RESPONSES_GENERIC，需要你判断是否要一起收。要的话我另开一个 PR。
