### PR TITLE
fix(settings): route background and emoji pickers to the document picker

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/CustomEmojiManagementScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/CustomEmojiManagementScreen.kt
@@ -57,8 +57,11 @@ fun CustomEmojiManagementScreen(
     var showResetDialog by remember { mutableStateOf(false) }
 
     // 图片选择器
+    // ACTION_OPEN_DOCUMENT with EXTRA_ALLOW_MULTIPLE keeps the per-URI grant of
+    // ACTION_GET_CONTENT while routing to the system document picker, whose browse view lists
+    // user-created album folders that some OEM photo pickers hide. See issue #1054.
     val imagePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetMultipleContents()
+        contract = ActivityResultContracts.OpenMultipleDocuments()
     ) { uris: List<Uri> ->
         if (uris.isNotEmpty()) {
             viewModel.addEmojis(selectedCategory, uris)
@@ -76,7 +79,7 @@ fun CustomEmojiManagementScreen(
     Scaffold(
         floatingActionButton = {
             FloatingActionButton(
-                onClick = { imagePickerLauncher.launch("image/*") }
+                onClick = { imagePickerLauncher.launch(arrayOf("image/*")) }
             ) {
                 Icon(Icons.Default.Add, contentDescription = stringResource(R.string.add_emoji))
             }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/theme/ThemeSettingsBackgroundTab.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/theme/ThemeSettingsBackgroundTab.kt
@@ -115,7 +115,7 @@ internal fun ThemeSettingsBackgroundTab(
 internal data class ThemeSettingsBackgroundRuntime(
     val exoPlayer: ExoPlayer,
     val launchImageCrop: (Uri) -> Unit,
-    val mediaPickerLauncher: ManagedActivityResultLauncher<String, Uri?>,
+    val mediaPickerLauncher: ManagedActivityResultLauncher<Array<String>, Uri?>,
 )
 
 @Composable
@@ -308,8 +308,11 @@ internal fun rememberThemeSettingsBackgroundRuntime(
         cropImageLauncher.launch(cropOptions)
     }
 
+    // ACTION_OPEN_DOCUMENT keeps the per-URI grant of ACTION_GET_CONTENT while routing to the
+    // system document picker, whose browse view lists user-created album folders that some OEM
+    // photo pickers hide. See issue #1054.
     val mediaPickerLauncher =
-        rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) {
+        rememberLauncherForActivityResult(contract = ActivityResultContracts.OpenDocument()) {
                 uri: Uri? ->
             if (uri != null) {
                 val isVideo = FileUtils.isVideoFile(context, uri)

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ThemeSettingsBackgroundSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ThemeSettingsBackgroundSection.kt
@@ -73,7 +73,7 @@ internal fun ThemeSettingsBackgroundSection(
     editorSession: ThemeEditorSession,
     exoPlayer: ExoPlayer,
     launchImageCrop: (Uri) -> Unit,
-    mediaPickerLauncher: ManagedActivityResultLauncher<String, Uri?>,
+    mediaPickerLauncher: ManagedActivityResultLauncher<Array<String>, Uri?>,
     scrollState: ScrollState,
     useBackgroundImageInput: Boolean,
     onUseBackgroundImageInputChange: (Boolean) -> Unit,
@@ -390,9 +390,9 @@ internal fun ThemeSettingsBackgroundSection(
                 Button(
                     onClick = {
                         if (backgroundMediaTypeInput == UserPreferencesManager.MEDIA_TYPE_VIDEO) {
-                            mediaPickerLauncher.launch("video/*")
+                            mediaPickerLauncher.launch(arrayOf("video/*"))
                         } else {
-                            mediaPickerLauncher.launch("image/*")
+                            mediaPickerLauncher.launch(arrayOf("image/*"))
                         }
                     },
                     modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Fixes #1054

## 根因

主题背景和「管理自定义表情」两个入口用的是 `ActivityResultContracts.GetContent` / `GetMultipleContents`。反编译 `androidx.activity:activity:1.8.2` 里这几个 contract 的 `createIntent` 可以看到它们构造的 intent：

| Contract | Action | Extras |
| --- | --- | --- |
| `GetContent` | `android.intent.action.GET_CONTENT` | `CATEGORY_OPENABLE` |
| `GetMultipleContents` | `android.intent.action.GET_CONTENT` | `CATEGORY_OPENABLE`, `EXTRA_ALLOW_MULTIPLE` |
| `OpenDocument` | `android.intent.action.OPEN_DOCUMENT` | `EXTRA_MIME_TYPES` |
| `OpenMultipleDocuments` | `android.intent.action.OPEN_DOCUMENT` | `EXTRA_MIME_TYPES`, `EXTRA_ALLOW_MULTIPLE` |

`ACTION_GET_CONTENT` 是一个开放给任意应用响应的动作。部分 OEM 系统会把它拦截到自家相册选择器：在 HyperOS 上交给「安全访问」照片选择器后，其「影集」页只列出收藏、相机、屏幕截图和下载，用户自建相册目录（QQ / 微信 / 抖音等）完全不出现，因此这些图片无法用作主题背景或自定义表情。

`ACTION_OPEN_DOCUMENT` 只能由 DocumentsProvider 响应，会进入系统文档选择器，其「浏览」界面按目录列出共享存储，用户自建相册目录可见。

## 修改范围

只切换这两个入口的 contract，以及随之而来的输入类型（`String` → `Array<String>`）：

- `ThemeSettingsBackgroundTab.kt`：`GetContent` → `OpenDocument`，`ThemeSettingsBackgroundRuntime.mediaPickerLauncher` 的泛型参数同步调整
- `ThemeSettingsBackgroundSection.kt`：形参类型同步调整，两处 `launch("video/*")` / `launch("image/*")` 改为 `launch(arrayOf(...))`
- `CustomEmojiManagementScreen.kt`：`GetMultipleContents` → `OpenMultipleDocuments`，`launch("image/*")` → `launch(arrayOf("image/*"))`

共 3 个文件，+13 / −7，没有其他改动。

## 兼容性

- **隐私语义不变。** 两个 action 都只对用户实际选中的 URI 授予读权限，都不是持久化授权（没有调用 `takePersistableUriPermission`），也都不需要 `READ_MEDIA_IMAGES` / `READ_EXTERNAL_STORAGE`。
- **私有目录复制逻辑不变。** 背景走 `FileUtils.copyFileToInternalStorage`，表情走 `CustomEmojiRepository.addCustomEmoji`，都在选取后立即复制，因此选取后 URI 授权失效也不影响。
- **MIME 过滤不变。** `EXTRA_MIME_TYPES` 传入 `image/*` 或 `video/*`，系统文档选择器按此过滤。
- **裁剪、视频大小检查、错误处理全部未触碰。** 相关辅助函数（`FileUtils.isVideoFile`、`getFileExtension(FromUri)`、`checkVideoSize`、`CustomEmojiRepository.getFileExtension`）读取元数据一律走 `ContentResolver.getType` / `openInputStream` / `openFileDescriptor` / `query(OpenableColumns)`，对 SAF URI 同样有效。
- **minSdk 26**，`ACTION_OPEN_DOCUMENT` 与 `EXTRA_MIME_TYPES` 自 API 19 起可用。
- 代价是只能选到 DocumentsProvider 暴露的内容；仅注册了 `ACTION_GET_CONTENT` 的第三方图库应用不再出现在选择器里。对本 issue 的场景（用户自己存储上的相册目录）覆盖是净增的，issue 报告者也确认了 `ACTION_OPEN_DOCUMENT` 在该设备上可以进入「浏览」。

## 验证结果

本机无法完成整包 Gradle 构建（缺 NDK/CMake 等），因此采用可复现的静态验证：

1. **Intent 路由证据。** 对项目实际依赖的 `activity-1.8.2.aar` 中的 contract 类做 `javap -c`，得到上表中的 action / extras，直接对应根因与修复方向。
2. **泛型类型检查（有对照）。** 把三处改动的泛型流抽成一个最小复现文件，以项目真实依赖（`activity-compose 1.8.2`、`compose-runtime`、`android-36.jar`）为 classpath 用 Kotlin 2.0.21 编译：新写法零错误通过；作为反向对照，把 `launch(arrayOf(...))` 换回 `launch("...")` 后精确报出 3 处 `argument type mismatch: actual type is 'kotlin.String', but 'kotlin.Array<kotlin.String>!' was expected`，与本 PR 改动的 3 个 launch 站点一一对应。
3. **改动文件解析检查。** 对三个改动文件在 base（`upstream/dev`）与改动后各编译一次，比较错误多重集：177 : 177 完全一致，全部为缺失完整 Android/Compose classpath 造成的未解析符号，未引入新错误。
4. **仓库门禁检查。** `check_repo_hygiene.py` / `check_markdown_links.py` / `check_localizations.py` 三项均 `errors=0`。`ci/test` 的 46 个门禁单测在本机有 2 个 `os.symlink` 报错（`WinError 1314`，Windows 符号链接权限），在未改动的工作区同样复现，与本 PR 无关，Linux CI 上不受影响。

真机复验建议：在 HyperOS 设备上进入「设置 → 主题和外观 → 背景 → 选择图片」和「Waifu 模式设置 → 管理自定义表情 → +」，确认打开的是系统文档选择器并可通过「浏览」进入自建相册目录，选中后图片正常落到应用私有目录。

## 附带说明（本 PR 未处理）

`ThemeSettingsChatTab.kt`、`ThemeSettingsBasicTab.kt`、`ModelPromptsSettingsScreen.kt` 里的头像 / 聊天背景 / 提示词图片选择器仍在用 `GetContent`，理论上在同类设备上有相同表现。issue #1054 只报告了上述两个入口，为保持改动聚焦这里没有一并修改；如果希望统一处理，我可以另开 PR。
