### PR TITLE
fix(chat): keep every tool_result paired with its tool call

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelConfigConnectionTester.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelConfigConnectionTester.kt
@@ -45,6 +45,29 @@ data class ModelConnectionTestReport(
 }
 
 object ModelConfigConnectionTester {
+    /**
+     * One complete tool-call round trip for the Tool Call probe: the user asks, the assistant calls
+     * the tool, the tool answers.
+     *
+     * The turn kinds matter. The answer has to be a [PromptTurnKind.TOOL_RESULT] turn so that the
+     * provider pairs it with the call instead of reporting the call as never answered, and the
+     * probe has to open with a user turn because gateways that translate the OpenAI payload into
+     * another protocol (Poe onto Anthropic, for instance) reject a conversation that starts with an
+     * assistant message and leave its `tool_result` without a matching `tool_use`.
+     */
+    internal fun buildToolCallProbeHistory(toolName: String): List<PromptTurn> {
+        val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
+        val toolResultTagName = ChatMarkupRegex.generateRandomToolResultTagName()
+        return listOf(
+            "system" to "You are a helpful assistant.",
+            "user" to "Call the $toolName tool with the text \"ping\".",
+            "assistant" to
+                "<$toolTagName name=\"$toolName\"><param name=\"text\">ping</param></$toolTagName>",
+            "tool_result" to
+                "<$toolResultTagName name=\"$toolName\" status=\"success\"><content>pong</content></$toolResultTagName>"
+        ).toPromptTurns()
+    }
+
     suspend fun run(
         context: Context,
         modelConfigManager: ModelConfigManager,
@@ -118,20 +141,9 @@ object ModelConfigConnectionTester {
                         )
 
                     suspend fun runToolCallTest(toolName: String) {
-                        val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-                        val toolResultTagName = ChatMarkupRegex.generateRandomToolResultTagName()
-                        val testHistory = mutableListOf("system" to "You are a helpful assistant.")
-                        testHistory.add(
-                            "assistant" to
-                                "<$toolTagName name=\"$toolName\"><param name=\"text\">ping</param></$toolTagName>"
-                        )
-                        testHistory.add(
-                            "user" to
-                                "<$toolResultTagName name=\"$toolName\" status=\"success\"><content>pong</content></$toolResultTagName>"
-                        )
                         service.sendMessage(
                             context,
-                            testHistory.toPromptTurns(),
+                            buildToolCallProbeHistory(toolName),
                             parameters,
                             stream = false,
                             availableTools = availableTools,

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -1011,8 +1011,8 @@ open class OpenAIProvider(
 
         var queuedAssistantToolText: String? = null
         var queuedToolCalls = JSONArray()
-        val queuedToolCallIds = mutableListOf<String>()
-        val openToolCallIds = mutableListOf<String>()
+        val queuedOpenToolCalls = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
+        val openToolCalls = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
         var nextToolCallOrdinal = 0
 
         fun appendQueuedAssistantToolText(text: String) {
@@ -1033,7 +1033,12 @@ open class OpenAIProvider(
                 val callId = generatedToolCallId(nextToolCallOrdinal++)
                 toolCall.put("id", callId)
                 queuedToolCalls.put(toolCall)
-                queuedToolCallIds.add(callId)
+                queuedOpenToolCalls.add(
+                    StructuredToolCallBridge.OpenToolCall(
+                        callId,
+                        StructuredToolCallBridge.toolCallName(toolCall)
+                    )
+                )
             }
         }
 
@@ -1049,35 +1054,37 @@ open class OpenAIProvider(
             if (effectiveContent != null) {
                 historyMessage.put("content", buildContentField(context, effectiveContent, role = "assistant"))
             } else {
-                historyMessage.put("content", null)
+                // JSONObject.put(name, null) drops the key; gateways that translate this request to
+                // another protocol need the assistant turn to stay recognizable as `content: null`.
+                historyMessage.put("content", JSONObject.NULL)
             }
             historyMessage.put("tool_calls", queuedToolCalls)
             messagesArray.put(historyMessage)
 
-            openToolCallIds.addAll(queuedToolCallIds)
+            openToolCalls.addAll(queuedOpenToolCalls)
             queuedAssistantToolText = null
             queuedToolCalls = JSONArray()
-            queuedToolCallIds.clear()
+            queuedOpenToolCalls.clear()
         }
 
         fun flushOpenToolCallsAsCancelled(reason: String) {
             emitQueuedToolCallsIfNeeded()
-            if (openToolCallIds.isEmpty()) return
+            if (openToolCalls.isEmpty()) return
 
             AppLogger.w(
                 "AIService",
-                "发现未完成的tool_calls，按取消处理: count=${openToolCallIds.size}, reason=$reason"
+                "发现未完成的tool_calls，按取消处理: count=${openToolCalls.size}, reason=$reason"
             )
-            for (toolCallId in openToolCallIds) {
+            for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
-                        put("tool_call_id", toolCallId)
+                        put("tool_call_id", openToolCall.id)
                         put("content", "User cancelled")
                     }
                 )
             }
-            openToolCallIds.clear()
+            openToolCalls.clear()
         }
 
         // 添加聊天历史
@@ -1118,7 +1125,7 @@ open class OpenAIProvider(
                                 }
 
                             if (toolCalls != null && toolCalls.length() > 0) {
-                                if (openToolCallIds.isNotEmpty()) {
+                                if (openToolCalls.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("assistant_tool_call_before_result")
                                 }
                                 queueToolCalls(textContent, toolCalls)
@@ -1154,7 +1161,7 @@ open class OpenAIProvider(
                                 }
 
                             if (toolCalls != null && toolCalls.length() > 0) {
-                                if (openToolCallIds.isNotEmpty()) {
+                                if (openToolCalls.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("typed_tool_call_before_result")
                                 }
                                 queueToolCalls(textContent, toolCalls)
@@ -1180,30 +1187,36 @@ open class OpenAIProvider(
                             val (textContent, toolResults) = parseXmlToolResults(content)
                             val resultsList = toolResults ?: emptyList()
 
-                            if (resultsList.isNotEmpty() && openToolCallIds.isNotEmpty()) {
-                                val validCount = minOf(resultsList.size, openToolCallIds.size)
+                            if (resultsList.isNotEmpty() && openToolCalls.isNotEmpty()) {
                                 val readableImageSources = mutableListOf<String>()
-                                repeat(validCount) { index ->
-                                    val (_, resultContent) = resultsList[index]
+                                val matchedIds =
+                                    StructuredToolCallBridge.consumeMatchingToolCallIds(
+                                        openToolCalls,
+                                        resultsList.map { it.first }
+                                    )
+                                matchedIds.forEachIndexed { index, toolCallId ->
+                                    val resultContent = resultsList[index].second
                                     readableImageSources.add(resultContent)
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "tool")
-                                            put("tool_call_id", openToolCallIds[index])
+                                            put("tool_call_id", toolCallId)
                                             put("content", buildContentField(context, resultContent, role = "tool"))
                                         }
                                     )
                                 }
-                                repeat(validCount) {
-                                    openToolCallIds.removeAt(0)
-                                }
 
-                                if (resultsList.size > validCount) {
+                                if (resultsList.size > matchedIds.size) {
                                     AppLogger.w(
                                         "AIService",
-                                        "发现多余的tool_result: ${resultsList.size} results vs ${validCount} pending tool_calls"
+                                        "发现多余的tool_result: ${resultsList.size} results vs ${matchedIds.size} pending tool_calls"
                                     )
                                 }
+
+                                // Close the batch before any user message, otherwise the leftover
+                                // calls are answered after it and their `tool` messages no longer
+                                // follow the assistant message that opened them.
+                                flushOpenToolCallsAsCancelled("tool_result_partial_batch")
 
                                 if (!useResponsesApi) {
                                     appendReadableImageMessageIfNeeded(
@@ -1738,7 +1751,7 @@ open class OpenAIProvider(
 
     /**
      * 解析XML格式的tool_result，转换为OpenAI Tool消息格式
-     * @return List<Pair<tool_call_id, result_content>>
+     * @return List<Pair<tool_name, result_content>>，tool_name 用于把结果配回发起它的 tool_call
      */
     fun parseXmlToolResults(content: String): Pair<String, List<Pair<String, String>>?> {
         // 匹配带属性的tool_result标签，例如: <tool_result name="..." status="...">...</tool_result>
@@ -1750,7 +1763,6 @@ open class OpenAIProvider(
 
         val results = mutableListOf<Pair<String, String>>()
         var textContent = content
-        var resultIndex = 0
 
         matches.forEach { match ->
             // 提取<content>标签内的内容，如果有的话
@@ -1762,12 +1774,14 @@ open class OpenAIProvider(
                 fullContent
             }
 
-            // 生成一个tool_call_id（这里需要与之前的call对应，但因为历史记录可能不完整，我们使用索引）
-            results.add(Pair("call_result_${resultIndex}", resultContent))
+            // 保留 name 属性，让结果能配回同名的 tool_call 而不是只按位置对齐
+            val openingTag = match.value.substringBefore('>')
+            val resultName =
+                ChatMarkupRegex.nameAttr.find(openingTag)?.groupValues?.getOrNull(1).orEmpty()
+            results.add(Pair(resultName, resultContent))
 
             // 从文本内容中移除tool_result标签（包括前后的空白符）
             textContent = textContent.replace(match.value, "").trim()
-            resultIndex++
         }
 
         // trim 确保移除所有空白字符

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
@@ -22,6 +22,53 @@ internal object StructuredToolCallBridge {
         val content: String
     )
 
+    /** A tool call that has been sent to the model but has no `tool` message answering it yet. */
+    data class OpenToolCall(val id: String, val name: String)
+
+    /**
+     * The callable tool name behind a queued tool call, unwrapping the `package_proxy` envelope so
+     * that a `pkg:tool` result can still be matched back to the call that produced it.
+     */
+    fun toolCallName(toolCall: JSONObject): String {
+        val function = toolCall.optJSONObject("function") ?: return ""
+        val name = function.optString("name", "")
+        if (name != "package_proxy") {
+            return name
+        }
+        val arguments =
+            kotlin.runCatching { JSONObject(function.optString("arguments", "{}")) }.getOrNull()
+        return arguments?.optString("tool_name", "")?.takeIf { it.isNotBlank() } ?: name
+    }
+
+    /**
+     * Consumes one open tool call per tool result, preferring the call whose tool name matches the
+     * result and falling back to the oldest open call. Tool results are not guaranteed to come back
+     * in call order (denied invocations are hoisted to the front of the result list), so pairing by
+     * position alone can attach a result to the wrong `tool_call_id`.
+     *
+     * @return the matched `tool_call_id` per result, in result order; shorter than [resultToolNames]
+     *   when there are fewer open calls than results.
+     */
+    fun consumeMatchingToolCallIds(
+        openToolCalls: MutableList<OpenToolCall>,
+        resultToolNames: List<String?>
+    ): List<String> {
+        val matched = ArrayList<String>(minOf(openToolCalls.size, resultToolNames.size))
+        for (resultName in resultToolNames) {
+            if (openToolCalls.isEmpty()) {
+                break
+            }
+            val byName =
+                if (resultName.isNullOrBlank()) {
+                    -1
+                } else {
+                    openToolCalls.indexOfFirst { it.name.equals(resultName, ignoreCase = true) }
+                }
+            matched.add(openToolCalls.removeAt(if (byName >= 0) byName else 0).id)
+        }
+        return matched
+    }
+
     fun buildToolsJson(toolPrompts: List<ToolPrompt>?): String? {
         if (toolPrompts.isNullOrEmpty()) {
             return null
@@ -166,8 +213,8 @@ internal object StructuredToolCallBridge {
         val messagesArray = JSONArray()
         var queuedAssistantToolText: String? = null
         var queuedToolCalls = JSONArray()
-        val queuedToolCallIds = mutableListOf<String>()
-        val openToolCallIds = mutableListOf<String>()
+        val queuedOpenToolCalls = mutableListOf<OpenToolCall>()
+        val openToolCalls = mutableListOf<OpenToolCall>()
         var nextToolCallOrdinal = 0
 
         fun appendQueuedAssistantToolText(text: String) {
@@ -188,7 +235,7 @@ internal object StructuredToolCallBridge {
                 val callId = generatedToolCallId(nextToolCallOrdinal++)
                 toolCall.put("id", callId)
                 queuedToolCalls.put(toolCall)
-                queuedToolCallIds.add(callId)
+                queuedOpenToolCalls.add(OpenToolCall(callId, toolCallName(toolCall)))
             }
         }
 
@@ -210,26 +257,26 @@ internal object StructuredToolCallBridge {
                 }
             )
 
-            openToolCallIds.addAll(queuedToolCallIds)
+            openToolCalls.addAll(queuedOpenToolCalls)
             queuedAssistantToolText = null
             queuedToolCalls = JSONArray()
-            queuedToolCallIds.clear()
+            queuedOpenToolCalls.clear()
         }
 
         fun flushOpenToolCallsAsCancelled() {
             emitQueuedToolCallsIfNeeded()
-            if (openToolCallIds.isEmpty()) return
+            if (openToolCalls.isEmpty()) return
 
-            for (toolCallId in openToolCallIds) {
+            for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
-                        put("tool_call_id", toolCallId)
+                        put("tool_call_id", openToolCall.id)
                         put("content", "User cancelled")
                     }
                 )
             }
-            openToolCallIds.clear()
+            openToolCalls.clear()
         }
 
         for (turn in mergedHistory) {
@@ -313,13 +360,14 @@ internal object StructuredToolCallBridge {
                     val (textContent, toolResults) = parseXmlToolResults(content)
                     val resultsList = toolResults ?: emptyList()
 
-                    if (resultsList.isNotEmpty() && openToolCallIds.isNotEmpty()) {
-                        val validCount = minOf(resultsList.size, openToolCallIds.size)
-                        repeat(validCount) { index ->
+                    if (resultsList.isNotEmpty() && openToolCalls.isNotEmpty()) {
+                        val matchedIds =
+                            consumeMatchingToolCallIds(openToolCalls, resultsList.map { it.name })
+                        matchedIds.forEachIndexed { index, toolCallId ->
                             val result = resultsList[index]
                             val toolMessage = JSONObject().apply {
                                 put("role", "tool")
-                                put("tool_call_id", openToolCallIds[index])
+                                put("tool_call_id", toolCallId)
                                 if (!result.name.isNullOrBlank()) {
                                     put("name", result.name)
                                 }
@@ -327,9 +375,9 @@ internal object StructuredToolCallBridge {
                             }
                             messagesArray.put(toolMessage)
                         }
-                        repeat(validCount) {
-                            openToolCallIds.removeAt(0)
-                        }
+                        // Close the batch before any user message, otherwise the leftover calls are
+                        // answered after it and their `tool` messages no longer follow their call.
+                        flushOpenToolCallsAsCancelled()
                         if (textContent.isNotBlank()) {
                             messagesArray.put(
                                 JSONObject().apply {
@@ -695,7 +743,8 @@ internal object StructuredToolCallBridge {
             } else {
                 fullContent
             }
-            val resultName = ChatMarkupRegex.nameAttr.find(match.value)?.groupValues?.getOrNull(1)
+            val openingTag = match.value.substringBefore('>')
+            val resultName = ChatMarkupRegex.nameAttr.find(openingTag)?.groupValues?.getOrNull(1)
             results.add(ToolResultRecord(resultName, resultContent))
             textContent = textContent.replace(match.value, "").trim()
         }

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiToolCallHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiToolCallHistoryTest.kt
@@ -1,0 +1,250 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import android.content.Context
+import com.ai.assistance.operit.core.chat.hooks.PromptTurn
+import com.ai.assistance.operit.core.chat.hooks.PromptTurnKind
+import com.ai.assistance.operit.util.AppLogger
+import okhttp3.OkHttpClient
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * Protocol-level regression tests for the OpenAI tool-call history conversion.
+ *
+ * Gateways that translate the OpenAI payload into another protocol (Poe onto Anthropic) enforce
+ * that every `tool` message answers a call opened by the message right before it. See issue #1027.
+ */
+class OpenAiToolCallHistoryTest {
+
+    @Before
+    fun disableAndroidLogging() {
+        AppLogger.enableSystemLog = false
+        AppLogger.enableFileLogging = false
+    }
+
+    @Test
+    fun `connection test tool call probe answers the call it opened`() {
+        val messages =
+            buildMessages(ModelConfigConnectionTester.buildToolCallProbeHistory("echo"))
+
+        assertEquals(
+            listOf("system", "user", "assistant", "tool"),
+            messages.roles()
+        )
+        assertToolResultsFollowTheirCalls(messages)
+        assertEquals(
+            messages.at(2).getJSONArray("tool_calls").getJSONObject(0).getString("id"),
+            messages.at(3).getString("tool_call_id")
+        )
+        assertEquals("pong", messages.at(3).getString("content"))
+    }
+
+    @Test
+    fun `assistant tool call message keeps an explicit null content`() {
+        val messages =
+            buildMessages(ModelConfigConnectionTester.buildToolCallProbeHistory("echo"))
+
+        val assistant = messages.at(2)
+        assertTrue(assistant.has("content"))
+        assertTrue(assistant.isNull("content"))
+    }
+
+    @Test
+    fun `unanswered calls are closed before the trailing tool result text`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.SYSTEM, content = "You are a helpful assistant."),
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Read both files."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("read_file", "path" to "a.txt") +
+                            toolCall("read_file_part", "path" to "b.txt")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("read_file", "alpha") + "\nThe second read was skipped."
+                    )
+                )
+            )
+
+        assertToolResultsFollowTheirCalls(messages)
+        assertEquals(
+            listOf("system", "user", "assistant", "tool", "tool", "user"),
+            messages.roles()
+        )
+        assertEquals("The second read was skipped.", messages.at(5).getString("content"))
+    }
+
+    @Test
+    fun `tool results are paired by tool name when they come back out of order`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Do both."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("list_files", "path" to ".") +
+                            toolCall("calculate", "expression" to "1+1")
+                    ),
+                    // Denied or interrupted invocations are hoisted to the front of the result list,
+                    // so the results do not necessarily arrive in call order.
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("calculate", "2") + toolResult("list_files", "a.txt")
+                    )
+                )
+            )
+
+        assertToolResultsFollowTheirCalls(messages)
+        val toolCalls = messages.at(1).getJSONArray("tool_calls")
+        val listFilesId = toolCalls.getJSONObject(0).getString("id")
+        val calculateId = toolCalls.getJSONObject(1).getString("id")
+
+        assertEquals(calculateId, messages.at(2).getString("tool_call_id"))
+        assertEquals("2", messages.at(2).getString("content"))
+        assertEquals(listFilesId, messages.at(3).getString("tool_call_id"))
+        assertEquals("a.txt", messages.at(3).getString("content"))
+    }
+
+    @Test
+    fun `package tool results are paired through the package proxy envelope`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Draw it."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("qwen_draw:draw", "prompt" to "cat")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("qwen_draw:draw", "done")
+                    )
+                )
+            )
+
+        assertToolResultsFollowTheirCalls(messages)
+        assertEquals(
+            "package_proxy",
+            messages.at(1).getJSONArray("tool_calls").getJSONObject(0)
+                .getJSONObject("function").getString("name")
+        )
+        assertEquals("done", messages.at(2).getString("content"))
+    }
+
+    @Test
+    fun `built-in tool channel sends no tool call protocol fields`() {
+        val history =
+            listOf(
+                PromptTurn(kind = PromptTurnKind.SYSTEM, content = "You are a helpful assistant."),
+                PromptTurn(kind = PromptTurnKind.USER, content = "Use the package."),
+                PromptTurn(
+                    kind = PromptTurnKind.TOOL_CALL,
+                    content = toolCall("use_package", "package_name" to "qwen_draw")
+                ),
+                PromptTurn(
+                    kind = PromptTurnKind.TOOL_RESULT,
+                    content = toolResult("use_package", "activated")
+                )
+            )
+
+        val messages = buildMessages(history, useToolCall = false)
+
+        assertEquals(listOf("system", "user", "assistant", "user"), messages.roles())
+        for (index in 0 until messages.length()) {
+            val message = messages.at(index)
+            assertFalse(message.has("tool_calls"))
+            assertFalse(message.has("tool_call_id"))
+        }
+        assertTrue(messages.at(3).getString("content").contains("activated"))
+    }
+
+    private fun buildMessages(
+        history: List<PromptTurn>,
+        useToolCall: Boolean = true
+    ): JSONArray {
+        val provider =
+            object : OpenAIProvider(
+                apiEndpoint = "https://example.test/v1/chat/completions",
+                apiKeyProvider = SingleApiKeyProvider("test-key"),
+                modelName = "test-model",
+                client = OkHttpClient(),
+                enableToolCall = true
+            ) {
+                fun buildMessages(context: Context): JSONArray =
+                    buildMessagesAndCountTokens(context, history, useToolCall = useToolCall).first
+            }
+        return provider.buildMessages(mock<Context>())
+    }
+
+    private fun toolCall(name: String, vararg params: Pair<String, String>): String {
+        val body = params.joinToString("") { (key, value) ->
+            "<param name=\"$key\">$value</param>"
+        }
+        return "<tool name=\"$name\">$body</tool>"
+    }
+
+    private fun toolResult(name: String, content: String): String =
+        "<tool_result name=\"$name\" status=\"success\"><content>$content</content></tool_result>"
+
+    private fun JSONArray.at(index: Int): JSONObject = getJSONObject(index)
+
+    private fun JSONArray.roles(): List<String> =
+        (0 until length()).map { at(it).getString("role") }
+
+    /**
+     * Mirrors what an Anthropic-backed gateway checks: the conversation may not open with an
+     * assistant turn, every `tool` message must answer a call opened by the message right before
+     * its run, and no other message may cut into that run.
+     */
+    private fun assertToolResultsFollowTheirCalls(messages: JSONArray) {
+        val firstNonSystem = (0 until messages.length())
+            .firstOrNull { messages.at(it).getString("role") != "system" }
+        if (firstNonSystem != null) {
+            assertEquals(
+                "conversation must not open with an assistant turn",
+                "user",
+                messages.at(firstNonSystem).getString("role")
+            )
+        }
+
+        val pendingCallIds = mutableSetOf<String>()
+        for (index in 0 until messages.length()) {
+            val message = messages.at(index)
+            when (message.getString("role")) {
+                "tool" -> {
+                    val toolCallId = message.getString("tool_call_id")
+                    assertTrue(
+                        "message $index answers $toolCallId with no matching tool call before it",
+                        pendingCallIds.remove(toolCallId)
+                    )
+                }
+
+                "assistant" -> {
+                    assertTrue(
+                        "message $index leaves calls $pendingCallIds unanswered",
+                        pendingCallIds.isEmpty()
+                    )
+                    val toolCalls = message.optJSONArray("tool_calls") ?: JSONArray()
+                    for (callIndex in 0 until toolCalls.length()) {
+                        pendingCallIds.add(toolCalls.getJSONObject(callIndex).getString("id"))
+                    }
+                }
+
+                else ->
+                    assertTrue(
+                        "message $index leaves calls $pendingCallIds unanswered",
+                        pendingCallIds.isEmpty()
+                    )
+            }
+        }
+        assertTrue("history ends with unanswered calls $pendingCallIds", pendingCallIds.isEmpty())
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridgeHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridgeHistoryTest.kt
@@ -1,0 +1,152 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import com.ai.assistance.operit.core.chat.hooks.PromptTurn
+import com.ai.assistance.operit.core.chat.hooks.PromptTurnKind
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Protocol-level regression tests for the structured message builder shared by the local-model
+ * providers. Same invariant as [OpenAiToolCallHistoryTest]: a `tool` message may only answer a call
+ * opened by the message right before its run. See issue #1027.
+ */
+class StructuredToolCallBridgeHistoryTest {
+
+    @Test
+    fun `unanswered calls are closed before the trailing tool result text`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Read both files."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("read_file", "path" to "a.txt") +
+                            toolCall("read_file_part", "path" to "b.txt")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("read_file", "alpha") + "\nThe second read was skipped."
+                    )
+                )
+            )
+
+        assertEquals(listOf("user", "assistant", "tool", "tool", "user"), messages.roles())
+        assertEquals("The second read was skipped.", messages.at(4).getString("content"))
+        assertToolResultsFollowTheirCalls(messages)
+    }
+
+    @Test
+    fun `tool results are paired by tool name when they come back out of order`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Do both."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("list_files", "path" to ".") +
+                            toolCall("calculate", "expression" to "1+1")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("calculate", "2") + toolResult("list_files", "a.txt")
+                    )
+                )
+            )
+
+        val toolCalls = messages.at(1).getJSONArray("tool_calls")
+        assertEquals(
+            toolCalls.getJSONObject(1).getString("id"),
+            messages.at(2).getString("tool_call_id")
+        )
+        assertEquals(
+            toolCalls.getJSONObject(0).getString("id"),
+            messages.at(3).getString("tool_call_id")
+        )
+        assertToolResultsFollowTheirCalls(messages)
+    }
+
+    @Test
+    fun `built-in tool channel compiles tool turns into plain roles`() {
+        val compiled =
+            StructuredToolCallBridge.compileHistoryForProvider(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.SYSTEM, content = "You are a helpful assistant."),
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Use the package."),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_CALL,
+                        content = toolCall("use_package", "package_name" to "qwen_draw")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("use_package", "activated")
+                    )
+                ),
+                useToolCall = false
+            )
+
+        assertEquals(
+            listOf(
+                PromptTurnKind.SYSTEM,
+                PromptTurnKind.USER,
+                PromptTurnKind.ASSISTANT,
+                PromptTurnKind.USER
+            ),
+            compiled.map { it.kind }
+        )
+    }
+
+    private fun buildMessages(history: List<PromptTurn>): JSONArray =
+        JSONArray(
+            StructuredToolCallBridge.buildMessagesJson(history, preserveThinkInHistory = false)
+        )
+
+    private fun toolCall(name: String, vararg params: Pair<String, String>): String {
+        val body = params.joinToString("") { (key, value) ->
+            "<param name=\"$key\">$value</param>"
+        }
+        return "<tool name=\"$name\">$body</tool>"
+    }
+
+    private fun toolResult(name: String, content: String): String =
+        "<tool_result name=\"$name\" status=\"success\"><content>$content</content></tool_result>"
+
+    private fun JSONArray.at(index: Int): JSONObject = getJSONObject(index)
+
+    private fun JSONArray.roles(): List<String> =
+        (0 until length()).map { at(it).getString("role") }
+
+    private fun assertToolResultsFollowTheirCalls(messages: JSONArray) {
+        val pendingCallIds = mutableSetOf<String>()
+        for (index in 0 until messages.length()) {
+            val message = messages.at(index)
+            when (message.getString("role")) {
+                "tool" ->
+                    assertTrue(
+                        "message $index answers a call that was never opened before it",
+                        pendingCallIds.remove(message.getString("tool_call_id"))
+                    )
+
+                "assistant" -> {
+                    assertTrue(
+                        "message $index leaves calls $pendingCallIds unanswered",
+                        pendingCallIds.isEmpty()
+                    )
+                    val toolCalls = message.optJSONArray("tool_calls") ?: JSONArray()
+                    for (callIndex in 0 until toolCalls.length()) {
+                        pendingCallIds.add(toolCalls.getJSONObject(callIndex).getString("id"))
+                    }
+                }
+
+                else ->
+                    assertTrue(
+                        "message $index leaves calls $pendingCallIds unanswered",
+                        pendingCallIds.isEmpty()
+                    )
+            }
+        }
+        assertTrue("history ends with unanswered calls $pendingCallIds", pendingCallIds.isEmpty())
+    }
+}


### PR DESCRIPTION
## 关联 Issue

Fixes #1027

## 问题

Issue 里的截图是**「模型与参数配置 → 测试连接 → Tool Call」**那一项失败，不是普通对话：

```
400 {"error": {"message": "messages.0.content.0: unexpected `tool_use_id` found in
`tool_result` blocks: daxkrp0vn. Each `tool_result` block must have a corresponding
`tool_use` block in the previous message.", "type": "invalid_request_error"}}
```

`daxkrp0vn` 不是随机串，它就是 `OpenAIProvider.generatedToolCallId(0)` 的输出（`stableIdHashPart("tool_call:0")` 走 `sanitizeToolCallId`），也就是**这次请求里的第一个 tool call**。

顺着这条线查 `ModelConfigConnectionTester`：Tool Call 探针拼的历史是

```
system    "You are a helpful assistant."
assistant "<tool_… name=\"echo\">…</tool_…>"
user      "<tool_result_… name=\"echo\" status=\"success\"><content>pong</content></tool_result_…>"
```

结果那条 tool_result 被当成 `user` 轮，`OpenAIProvider` 根本不会把它和调用配对。用当前 dev（`ed57021c`）的真实源码跑一遍请求体构造，发出去的是：

```json
[
  {"role": "system",    "content": "You are a helpful assistant."},
  {"role": "assistant", "tool_calls": [{"id": "daxkrp0vn", "type": "function",
                                        "function": {"name": "echo", "arguments": "{\"text\":\"ping\"}"}}]},
  {"role": "tool",      "tool_call_id": "daxkrp0vn", "content": "User cancelled"},
  {"role": "user",      "content": "<tool_result_Zw name=\"echo\" status=\"success\">…</tool_result_Zw>"}
]
```

三个问题一次凑齐：

1. 探针**没有 user 轮**，第一条非 system 消息是 assistant。Poe 这类把 OpenAI 报文转成 Anthropic 协议的网关会把 system 提到顶层字段、并拒绝以 assistant 开头的对话，assistant 那条一掉，`tool` 消息就变成 `messages.0.content.0`，`tool_use_id` 自然没有前置 `tool_use` —— 和报错逐字对应。
2. 探针测的其实是**「工具调用未完成 → 按取消处理」**那条分支（`content` 是 `"User cancelled"`），真正的工具返回被当成普通文本又贴了一遍，等于这个探针从来没验证过一次完整的工具往返。
3. assistant 那条**连 `content` 字段都没有**：`JSONObject.put(name, null)` 在 org.json 里是「删除该键」，不是写 null。

再往下查，真实对话里也有两处会产出同样的孤儿 `tool_result`（只是没有 Anthropic 网关那么严格的端点不会报错）：

- `PromptTurnKind.TOOL_RESULT` 分支里，当**结果数少于调用数**时，剩下的调用要等到下一个边界才被补成 "User cancelled"，而 `appendReadableImageMessageIfNeeded` 和 `textContent` 的 user 消息在那之前就已经插进去了 → 消息序列变成 `assistant(tool_calls[a,b]) → tool(a) → user(…) → tool(b)`。结果数少于调用数是常态：`ToolExecutionManager` 会并行/串行执行多个调用，`ConversationMarkupManager.buildBoundedToolResultMessage` 超长时会直接 `break` 丢掉后面的结果。
- 结果和调用是**按下标配对**的，可 `ToolExecutionManager.executeInvocations` 的返回值是 `toolExposureDeniedResults + roleCardDeniedResults + hookDeniedResults + permissionDeniedResults + orderedAggregated` —— 被拦截的调用会被提到最前面，下标顺序 ≠ 调用顺序，于是 `tool_call_id` 会配到别人的结果上。

## 改动

`ModelConfigConnectionTester`

- 探针历史抽成 `buildToolCallProbeHistory()`：`system → user → assistant(工具调用) → tool_result`，用 `tool_result` 角色让它走真正的配对路径。

`OpenAIProvider`

- `openToolCallIds: List<String>` 换成 `openToolCalls: List<OpenToolCall>`（id + 工具名）。
- `parseXmlToolResults` 现在保留 tool_result 标签上的 `name`（原来第一个元素是没人用的假 id `call_result_N`），返回类型不变，`DeepseekProvider` / `KimiProvider` 的 `val (_, resultContent) = …` 不受影响。
- 结果**先按工具名配回同名调用**，没有名字才退回顺序；`package_proxy` 信封会被拆开取回原始的 `pkg:tool` 名字。
- 匹配完立刻 `flushOpenToolCallsAsCancelled("tool_result_partial_batch")` 关掉这一批，**再**追加图片 / 文本 user 消息。
- assistant 工具调用消息写 `JSONObject.NULL`，和 `StructuredToolCallBridge` 保持一致。

`StructuredToolCallBridge`（Llama / MNN 走这条）

- 新增共享的 `OpenToolCall` / `toolCallName()` / `consumeMatchingToolCallIds()`，两边用同一套配对逻辑，不再各写一份。
- `buildStructuredMessages` 同样改成按名字配对、先关批次再追加 user 文本。

`enable_tool_call = false`（Operit 内置工具通道）这条路径同样纳入了回归测试：`compileHistoryForProvider(useToolCall = false)` 把 TOOL_CALL / TOOL_RESULT 压回 ASSISTANT / USER，请求体里不会出现任何 `tool_calls` / `tool_call_id`，这一点现在有断言守着。

## 验证方式

本机跑不了完整 Gradle 构建（缺 NDK/CMake 等），所以把 `OpenAIProvider` 里负责消息组装的成员（`buildMessagesAndCountTokens`、`parseXmlToolCalls/Results`、`wrapPackageToolCallsWithProxy`、`buildContentField`、id 生成那几个）按大括号配平**原样抽出来**，配 `StructuredToolCallBridge` / `PromptTurn` / `ChatMarkupRegex` / `ChatUtils` 的真实源码 + `org.json` + JUnit 4.13.2 单独编译运行——跑的是仓库里的真实代码，不是手抄版。

新增两个测试文件，共 9 个用例：

- `OpenAiToolCallHistoryTest`（6 个）：连接测试探针的消息序列、assistant 的显式 `content: null`、结果少于调用时的收尾顺序、乱序结果按名字配对、`package_proxy` 包工具配对、`enable_tool_call=false` 不产出任何 tool call 字段。
- `StructuredToolCallBridgeHistoryTest`（3 个）：bridge 上的同类断言 + 内置通道的角色压平。

两个文件都带一个 `assertToolResultsFollowTheirCalls` 断言，直接照抄 Anthropic 网关的校验口径：对话不能以 assistant 开头、每条 `tool` 消息只能回答它前面那条 assistant 打开的调用、中间不许插别的消息。

改完后：

```
OK (6 tests)   OpenAiToolCallHistoryTest
OK (3 tests)   StructuredToolCallBridgeHistoryTest
```

同样的测试跑在 `upstream/dev` 的代码上（探针历史也换回旧写法），9 个里挂 6 个，其中头一条就是本 issue 的报文：

```
1) connection test tool call probe answers the call it opened
   expected:<[system, user, assistant, tool]> but was:<[system, assistant, tool, user]>
2) unanswered calls are closed before the trailing tool result text
   AssertionError: message 4 leaves calls [daxkro1vn] unanswered
3) tool results are paired by tool name when they come back out of order
   ComparisonFailure: expected:<daxkr[o1]vn> but was:<daxkr[p0]vn>
4) assistant tool call message keeps an explicit null content
```

另外跑了 CI 也会跑的两个脚本，均 `errors=0 warnings=0`：`check_localizations.py`、`check_repo_hygiene.py`。

## 留给维护者判断的两点

- `DeepseekProvider` 和 `KimiProvider` 各自抄了一份同样的 TOOL_RESULT 组装循环，上面第 4、5 两个缺陷它们也有。这次没动它们：DeepSeek / Kimi 的端点不是 Anthropic 协议，不会因此 400，而且改动面会翻一倍。要一起收的话我可以补一个 PR。
- Issue 里第二个现象「关掉原生 tool call 后 `use_package` 成功、但调包内工具报 not available」没有日志或截图，本次没有复现到。那条路径不经过 `tool_call_id`（`enable_tool_call=false` 时请求体里根本没有工具调用协议字段），所以和本 PR 修的 400 不是同一个成因。需要的话请报告者补一下具体包名和 `ToolExecutionManager` 给出的完整错误文案 —— `buildToolNotAvailableErrorMessage` 会区分「包不存在 / 包没激活 / 工具不在包里 / advice-only」，那句文案能直接定位。
