### PR TITLE
fix(chat): strictly pair tool results across providers

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
@@ -407,8 +407,6 @@ open class ClaudeProvider(
         
         val results = mutableListOf<Pair<String, String>>()
         var textContent = content
-        var resultIndex = 0
-        
         matches.forEach { match ->
             val fullContent = match.groupValues[2].trim()
             val contentMatch = ChatMarkupRegex.contentTag.find(fullContent)
@@ -418,11 +416,13 @@ open class ClaudeProvider(
                 fullContent
             }
             
-            results.add(Pair("toolu_result_${resultIndex}", resultContent))
+            val openingTag = match.value.substringBefore('>')
+            val resultName =
+                ChatMarkupRegex.nameAttr.find(openingTag)?.groupValues?.getOrNull(1).orEmpty()
+            results.add(Pair(resultName, resultContent))
             textContent = textContent.replace(match.value, "").trim()
             
-            AppLogger.d("AIService", "解析Claude tool_result #$resultIndex, content length=${resultContent.length}")
-            resultIndex++
+            AppLogger.d("AIService", "解析Claude tool_result $resultName, content length=${resultContent.length}")
         }
         
         return Pair(textContent.trim(), results)
@@ -738,8 +738,8 @@ open class ClaudeProvider(
         val historyWithoutSystem = effectiveHistory.filter { it.kind != PromptTurnKind.SYSTEM }
         var queuedAssistantToolText: String? = null
         var queuedToolUses = JSONArray()
-        val queuedToolUseIds = mutableListOf<String>()
-        val openToolUseIds = mutableListOf<String>()
+        val queuedOpenToolUses = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
+        val openToolUses = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
         var nextToolUseOrdinal = 0
 
         fun generatedToolUseId(ordinal: Int): String {
@@ -772,7 +772,12 @@ open class ClaudeProvider(
                 val toolUseId = generatedToolUseId(nextToolUseOrdinal++)
                 toolUse.put("id", toolUseId)
                 queuedToolUses.put(toolUse)
-                queuedToolUseIds.add(toolUseId)
+                queuedOpenToolUses.add(
+                    StructuredToolCallBridge.OpenToolCall(
+                        toolUseId,
+                        sourceToolUse.optString("name", "").trim()
+                    )
+                )
             }
         }
 
@@ -794,30 +799,30 @@ open class ClaudeProvider(
                 }
             )
 
-            openToolUseIds.addAll(queuedToolUseIds)
+            openToolUses.addAll(queuedOpenToolUses)
             queuedAssistantToolText = null
             queuedToolUses = JSONArray()
-            queuedToolUseIds.clear()
+            queuedOpenToolUses.clear()
         }
 
         fun appendCancelledOpenToolUses(target: JSONArray, reason: String): Boolean {
             emitQueuedToolUsesIfNeeded()
-            if (openToolUseIds.isEmpty()) return false
+            if (openToolUses.isEmpty()) return false
 
             AppLogger.w(
                 "AIService",
-                "发现未完成的tool_use，按取消处理: count=${openToolUseIds.size}, reason=$reason"
+                "发现未完成的tool_use，按取消处理: count=${openToolUses.size}, reason=$reason"
             )
-            for (toolUseId in openToolUseIds) {
+            for (openToolUse in openToolUses) {
                 target.put(
                     JSONObject().apply {
                         put("type", "tool_result")
-                        put("tool_use_id", toolUseId)
+                        put("tool_use_id", openToolUse.id)
                         put("content", "User cancelled")
                     }
                 )
             }
-            openToolUseIds.clear()
+            openToolUses.clear()
             return true
         }
 
@@ -847,7 +852,7 @@ open class ClaudeProvider(
                     PromptTurnKind.ASSISTANT -> {
                         val (textContent, toolUses) = parseXmlToolCalls(content)
                         if (toolUses != null && toolUses.length() > 0) {
-                            if (openToolUseIds.isNotEmpty()) {
+                            if (openToolUses.isNotEmpty()) {
                                 flushOpenToolUsesAsCancelled("assistant_tool_use_before_result")
                             }
                             queueToolUses(textContent, toolUses)
@@ -865,7 +870,7 @@ open class ClaudeProvider(
                     PromptTurnKind.TOOL_CALL -> {
                         val (textContent, toolUses) = parseXmlToolCalls(content)
                         if (toolUses != null && toolUses.length() > 0) {
-                            if (openToolUseIds.isNotEmpty()) {
+                            if (openToolUses.isNotEmpty()) {
                                 flushOpenToolUsesAsCancelled("typed_tool_use_before_result")
                             }
                             queueToolUses(textContent, toolUses)
@@ -904,39 +909,53 @@ open class ClaudeProvider(
                         val (textContent, toolResults) = parseXmlToolResults(content)
                         val resultsList = toolResults ?: emptyList()
 
-                        if (resultsList.isNotEmpty() && openToolUseIds.isNotEmpty()) {
-                            val contentArray = JSONArray()
-                            val validCount = minOf(resultsList.size, openToolUseIds.size)
+                            if (resultsList.isNotEmpty() && openToolUses.isNotEmpty()) {
+                                val contentArray = JSONArray()
+                                val matchedCalls =
+                                    StructuredToolCallBridge.consumeMatchingToolCalls(
+                                        openToolUses,
+                                        resultsList.map { it.first }
+                                    )
+                                val matchedResultIndexes = matchedCalls.mapTo(mutableSetOf()) { it.resultIndex }
 
-                            for (index in 0 until validCount) {
-                                val (_, resultContent) = resultsList[index]
-                                contentArray.put(
-                                    JSONObject().apply {
-                                        put("type", "tool_result")
-                                        put("tool_use_id", openToolUseIds[index])
-                                        put("content", nonEmptyContentText(resultContent))
-                                    }
-                                )
-                                AppLogger.d(
-                                    "AIService",
-                                    "历史XML→ClaudeToolResult: ID=${openToolUseIds[index]}, content length=${resultContent.length}"
-                                )
-                            }
+                                matchedCalls.forEach { matchedCall ->
+                                    val resultContent = resultsList[matchedCall.resultIndex].second
+                                    contentArray.put(
+                                        JSONObject().apply {
+                                            put("type", "tool_result")
+                                            put("tool_use_id", matchedCall.call.id)
+                                            put("content", nonEmptyContentText(resultContent))
+                                        }
+                                    )
+                                    AppLogger.d(
+                                        "AIService",
+                                        "历史XML→ClaudeToolResult: ID=${matchedCall.call.id}, content length=${resultContent.length}"
+                                    )
+                                }
 
-                            repeat(validCount) {
-                                openToolUseIds.removeAt(0)
-                            }
+                                if (matchedCalls.size < resultsList.size) {
+                                    AppLogger.w(
+                                        "AIService",
+                                        "发现未匹配的tool_result: ${resultsList.size - matchedCalls.size}"
+                                    )
+                                }
 
-                            if (resultsList.size > validCount) {
-                                AppLogger.w(
-                                    "AIService",
-                                    "发现多余的tool_result: ${resultsList.size} results vs ${validCount} pending tool_uses"
-                                )
-                            }
+                                appendCancelledOpenToolUses(contentArray, "tool_result_partial_batch")
 
-                            if (textContent.isNotEmpty()) {
-                                appendContentBlocks(contentArray, buildContentArray(textContent))
-                            }
+                                val unmatchedContent =
+                                    resultsList
+                                        .filterIndexed { index, _ -> index !in matchedResultIndexes }
+                                        .joinToString("\n") { result ->
+                                            if (result.second.isBlank()) "[Empty]" else result.second
+                                        }
+                                val userContent =
+                                    listOf(unmatchedContent, textContent)
+                                        .filter { it.isNotBlank() }
+                                        .joinToString("\n")
+
+                                if (userContent.isNotEmpty()) {
+                                    appendContentBlocks(contentArray, buildContentArray(userContent))
+                                }
 
                             messagesArray.put(
                                 JSONObject().apply {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
@@ -223,8 +223,8 @@ class DeepseekProvider(
         var queuedAssistantToolText: String? = null
         var queuedAssistantReasoning: String? = null
         var queuedToolCalls = JSONArray()
-        val queuedToolCallIds = mutableListOf<String>()
-        val openToolCallIds = mutableListOf<String>()
+        val queuedOpenToolCalls = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
+        val openToolCalls = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
         var nextToolCallOrdinal = 0
 
         fun appendQueuedAssistantToolText(text: String) {
@@ -256,7 +256,12 @@ class DeepseekProvider(
                 val callId = generatedToolCallId(nextToolCallOrdinal++)
                 toolCall.put("id", callId)
                 queuedToolCalls.put(toolCall)
-                queuedToolCallIds.add(callId)
+                queuedOpenToolCalls.add(
+                    StructuredToolCallBridge.OpenToolCall(
+                        callId,
+                        StructuredToolCallBridge.toolCallName(toolCall)
+                    )
+                )
             }
         }
 
@@ -276,31 +281,31 @@ class DeepseekProvider(
                 }
             )
 
-            openToolCallIds.addAll(queuedToolCallIds)
+            openToolCalls.addAll(queuedOpenToolCalls)
             queuedAssistantToolText = null
             queuedAssistantReasoning = null
             queuedToolCalls = JSONArray()
-            queuedToolCallIds.clear()
+            queuedOpenToolCalls.clear()
         }
 
         fun flushOpenToolCallsAsCancelled(reason: String) {
             emitQueuedToolCallsIfNeeded()
-            if (openToolCallIds.isEmpty()) return
+            if (openToolCalls.isEmpty()) return
 
             AppLogger.w(
                 "DeepseekProvider",
-                "发现未完成的tool_calls，按取消处理: count=${openToolCallIds.size}, reason=$reason"
+                "发现未完成的tool_calls，按取消处理: count=${openToolCalls.size}, reason=$reason"
             )
-            for (toolCallId in openToolCallIds) {
+            for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
-                        put("tool_call_id", toolCallId)
+                        put("tool_call_id", openToolCall.id)
                         put("content", "User cancelled")
                     }
                 )
             }
-            openToolCallIds.clear()
+            openToolCalls.clear()
         }
 
         if (effectiveHistory.isNotEmpty()) {
@@ -340,7 +345,7 @@ class DeepseekProvider(
                                 }
 
                             if (toolCalls != null && toolCalls.length() > 0) {
-                                if (openToolCallIds.isNotEmpty()) {
+                                if (openToolCalls.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("assistant_tool_call_before_result")
                                 }
                                 queueToolCalls(textContent, toolCalls, reasoningContent)
@@ -371,7 +376,7 @@ class DeepseekProvider(
                                 }
 
                             if (toolCalls != null && toolCalls.length() > 0) {
-                                if (openToolCallIds.isNotEmpty()) {
+                                if (openToolCalls.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("typed_tool_call_before_result")
                                 }
                                 queueToolCalls(textContent, toolCalls)
@@ -397,30 +402,34 @@ class DeepseekProvider(
                             val (textContent, toolResults) = parseXmlToolResults(originalContent)
                             val resultsList = toolResults ?: emptyList()
 
-                            if (resultsList.isNotEmpty() && openToolCallIds.isNotEmpty()) {
-                                val validCount = minOf(resultsList.size, openToolCallIds.size)
+                            if (resultsList.isNotEmpty() && openToolCalls.isNotEmpty()) {
                                 val readableImageSources = mutableListOf<String>()
-                                repeat(validCount) { index ->
-                                    val (_, resultContent) = resultsList[index]
+                                val matchedCalls =
+                                    StructuredToolCallBridge.consumeMatchingToolCalls(
+                                        openToolCalls,
+                                        resultsList.map { it.first }
+                                    )
+                                val matchedResultIndexes = matchedCalls.mapTo(mutableSetOf()) { it.resultIndex }
+                                matchedCalls.forEach { matchedCall ->
+                                    val resultContent = resultsList[matchedCall.resultIndex].second
                                     readableImageSources.add(resultContent)
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "tool")
-                                            put("tool_call_id", openToolCallIds[index])
+                                            put("tool_call_id", matchedCall.call.id)
                                             put("content", buildContentField(context, resultContent, role = "tool"))
                                         }
                                     )
                                 }
-                                repeat(validCount) {
-                                    openToolCallIds.removeAt(0)
-                                }
 
-                                if (resultsList.size > validCount) {
+                                if (matchedCalls.size < resultsList.size) {
                                     AppLogger.w(
                                         "DeepseekProvider",
-                                        "发现多余的tool_result: ${resultsList.size} results vs ${validCount} pending tool_calls"
+                                        "发现未匹配的tool_result: ${resultsList.size - matchedCalls.size}"
                                     )
                                 }
+
+                                flushOpenToolCallsAsCancelled("tool_result_partial_batch")
 
                                 appendReadableImageMessageIfNeeded(
                                     messagesArray,
@@ -428,11 +437,21 @@ class DeepseekProvider(
                                     "tool result"
                                 )
 
-                                if (textContent.isNotEmpty()) {
+                                val unmatchedContent =
+                                    resultsList
+                                        .filterIndexed { index, _ -> index !in matchedResultIndexes }
+                                        .joinToString("\n") { result ->
+                                            if (result.second.isBlank()) "[Empty]" else result.second
+                                        }
+                                val userContent =
+                                    listOf(unmatchedContent, textContent)
+                                        .filter { it.isNotBlank() }
+                                        .joinToString("\n")
+                                if (userContent.isNotEmpty()) {
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "user")
-                                            put("content", buildContentField(context, textContent))
+                                            put("content", buildContentField(context, userContent))
                                         }
                                     )
                                 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
@@ -636,7 +636,7 @@ open class GeminiProvider(
         var queuedAssistantToolText: String? = null
         var queuedAssistantThoughtSignature: String? = null
         val queuedFunctionCalls = mutableListOf<JSONObject>()
-        val openFunctionCallNames = mutableListOf<String>()
+        val openFunctionCalls = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
 
         fun appendParts(target: JSONArray, parts: JSONArray) {
             for (index in 0 until parts.length()) {
@@ -694,7 +694,10 @@ open class GeminiProvider(
             )
 
             queuedFunctionCalls.forEach { functionCall ->
-                openFunctionCallNames.add(functionCall.optString("name", "").trim())
+                val functionName = functionCall.optString("name", "").trim()
+                openFunctionCalls.add(
+                    StructuredToolCallBridge.OpenToolCall(functionName, functionName)
+                )
             }
             queuedAssistantToolText = null
             queuedAssistantThoughtSignature = null
@@ -703,16 +706,16 @@ open class GeminiProvider(
 
         fun appendCancelledOpenFunctionResponses(target: JSONArray, reason: String): Boolean {
             emitQueuedFunctionCallsIfNeeded()
-            if (openFunctionCallNames.isEmpty()) return false
+            if (openFunctionCalls.isEmpty()) return false
 
-            logDebug("发现未完成的Gemini functionCall，按取消处理: count=${openFunctionCallNames.size}, reason=$reason")
-            openFunctionCallNames.forEach { functionName ->
+            logDebug("发现未完成的Gemini functionCall，按取消处理: count=${openFunctionCalls.size}, reason=$reason")
+            openFunctionCalls.forEach { openFunctionCall ->
                 target.put(
                     JSONObject().apply {
                         put(
                             "functionResponse",
                             JSONObject().apply {
-                                put("name", functionName.ifBlank { "cancelled_function" })
+                                put("name", openFunctionCall.name.ifBlank { "cancelled_function" })
                                 put(
                                     "response",
                                     JSONObject().apply {
@@ -724,7 +727,7 @@ open class GeminiProvider(
                     }
                 )
             }
-            openFunctionCallNames.clear()
+            openFunctionCalls.clear()
             return true
         }
 
@@ -753,7 +756,7 @@ open class GeminiProvider(
                     PromptTurnKind.ASSISTANT -> {
                         val functionCallPayload = parseXmlToolCalls(content)
                         if (functionCallPayload.functionCalls.isNotEmpty()) {
-                            if (openFunctionCallNames.isNotEmpty()) {
+                            if (openFunctionCalls.isNotEmpty()) {
                                 flushOpenFunctionCallsAsCancelled("assistant_function_call_before_result")
                             }
                             queueFunctionCalls(
@@ -775,7 +778,7 @@ open class GeminiProvider(
                     PromptTurnKind.TOOL_CALL -> {
                         val functionCallPayload = parseXmlToolCalls(content)
                         if (functionCallPayload.functionCalls.isNotEmpty()) {
-                            if (openFunctionCallNames.isNotEmpty()) {
+                            if (openFunctionCalls.isNotEmpty()) {
                                 flushOpenFunctionCallsAsCancelled("typed_function_call_before_result")
                             }
                             queueFunctionCalls(
@@ -812,13 +815,19 @@ open class GeminiProvider(
                         val (textContent, functionResponses) = parseXmlToolResults(contentWithoutGeminiMeta)
                         val responsesList = functionResponses ?: emptyList()
 
-                        if (responsesList.isNotEmpty() && openFunctionCallNames.isNotEmpty()) {
+                        if (responsesList.isNotEmpty() && openFunctionCalls.isNotEmpty()) {
                             val partsArray = JSONArray()
-                            val validCount = minOf(responsesList.size, openFunctionCallNames.size)
+                            val resultNames = responsesList.map { it.optString("name", "") }
+                            val matchedCalls =
+                                StructuredToolCallBridge.consumeMatchingToolCalls(
+                                    openFunctionCalls,
+                                    resultNames
+                                )
+                            val matchedResultIndexes = matchedCalls.mapTo(mutableSetOf()) { it.resultIndex }
 
-                            repeat(validCount) { index ->
-                                val response = JSONObject(responsesList[index].toString())
-                                val pendingName = openFunctionCallNames[index]
+                            matchedCalls.forEach { matchedCall ->
+                                val response = JSONObject(responsesList[matchedCall.resultIndex].toString())
+                                val pendingName = matchedCall.call.name
                                 if (pendingName.isNotBlank()) {
                                     response.put("name", pendingName)
                                 }
@@ -830,16 +839,27 @@ open class GeminiProvider(
                                 logDebug("历史XML→GeminiFunctionResponse: ${response.optString("name")}")
                             }
 
-                            repeat(validCount) {
-                                openFunctionCallNames.removeAt(0)
+                            if (matchedCalls.size < responsesList.size) {
+                                logDebug("发现未匹配的Gemini functionResponse: ${responsesList.size - matchedCalls.size}")
                             }
 
-                            if (responsesList.size > validCount) {
-                                logDebug("发现多余的Gemini functionResponse: ${responsesList.size} results vs ${validCount} pending functionCalls")
-                            }
+                            appendCancelledOpenFunctionResponses(partsArray, "tool_result_partial_batch")
 
-                            if (textContent.isNotEmpty()) {
-                                appendParts(partsArray, buildPartsArray(textContent))
+                            val unmatchedContent =
+                                responsesList
+                                    .filterIndexed { index, _ -> index !in matchedResultIndexes }
+                                    .joinToString("\n") { response ->
+                                        val name = response.optString("name", "").trim()
+                                        val result =
+                                            response.optJSONObject("response")?.opt("result")?.toString().orEmpty()
+                                        listOf(name, result).filter { it.isNotBlank() }.joinToString(": ")
+                                    }
+                            val userContent =
+                                listOf(unmatchedContent, textContent)
+                                    .filter { it.isNotBlank() }
+                                    .joinToString("\n")
+                            if (userContent.isNotEmpty()) {
+                                appendParts(partsArray, buildPartsArray(userContent))
                             }
 
                             contentsArray.put(

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
@@ -168,8 +168,8 @@ open class KimiProvider(
         var queuedAssistantToolText: String? = null
         var queuedAssistantReasoning: String? = null
         var queuedToolCalls = JSONArray()
-        val queuedToolCallIds = mutableListOf<String>()
-        val openToolCallIds = mutableListOf<String>()
+        val queuedOpenToolCalls = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
+        val openToolCalls = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
         var nextToolCallOrdinal = 0
 
         fun appendQueuedAssistantToolText(text: String) {
@@ -201,7 +201,12 @@ open class KimiProvider(
                 val callId = generatedToolCallId(nextToolCallOrdinal++)
                 toolCall.put("id", callId)
                 queuedToolCalls.put(toolCall)
-                queuedToolCallIds.add(callId)
+                queuedOpenToolCalls.add(
+                    StructuredToolCallBridge.OpenToolCall(
+                        callId,
+                        StructuredToolCallBridge.toolCallName(toolCall)
+                    )
+                )
             }
         }
 
@@ -221,31 +226,31 @@ open class KimiProvider(
                 }
             )
 
-            openToolCallIds.addAll(queuedToolCallIds)
+            openToolCalls.addAll(queuedOpenToolCalls)
             queuedAssistantToolText = null
             queuedAssistantReasoning = null
             queuedToolCalls = JSONArray()
-            queuedToolCallIds.clear()
+            queuedOpenToolCalls.clear()
         }
 
         fun flushOpenToolCallsAsCancelled(reason: String) {
             emitQueuedToolCallsIfNeeded()
-            if (openToolCallIds.isEmpty()) return
+            if (openToolCalls.isEmpty()) return
 
             AppLogger.w(
                 "KimiProvider",
-                "发现未完成的tool_calls，按取消处理: count=${openToolCallIds.size}, reason=$reason"
+                "发现未完成的tool_calls，按取消处理: count=${openToolCalls.size}, reason=$reason"
             )
-            for (toolCallId in openToolCallIds) {
+            for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
-                        put("tool_call_id", toolCallId)
+                        put("tool_call_id", openToolCall.id)
                         put("content", "User cancelled")
                     }
                 )
             }
-            openToolCallIds.clear()
+            openToolCalls.clear()
         }
 
         if (effectiveHistory.isNotEmpty()) {
@@ -285,7 +290,7 @@ open class KimiProvider(
                                 }
 
                             if (toolCalls != null && toolCalls.length() > 0) {
-                                if (openToolCallIds.isNotEmpty()) {
+                                if (openToolCalls.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("assistant_tool_call_before_result")
                                 }
                                 queueToolCalls(textContent, toolCalls, reasoningContent)
@@ -316,7 +321,7 @@ open class KimiProvider(
                                 }
 
                             if (toolCalls != null && toolCalls.length() > 0) {
-                                if (openToolCallIds.isNotEmpty()) {
+                                if (openToolCalls.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("typed_tool_call_before_result")
                                 }
                                 queueToolCalls(textContent, toolCalls)
@@ -342,30 +347,34 @@ open class KimiProvider(
                             val (textContent, toolResults) = parseXmlToolResults(originalContent)
                             val resultsList = toolResults ?: emptyList()
 
-                            if (resultsList.isNotEmpty() && openToolCallIds.isNotEmpty()) {
-                                val validCount = minOf(resultsList.size, openToolCallIds.size)
+                            if (resultsList.isNotEmpty() && openToolCalls.isNotEmpty()) {
                                 val readableImageSources = mutableListOf<String>()
-                                repeat(validCount) { index ->
-                                    val (_, resultContent) = resultsList[index]
+                                val matchedCalls =
+                                    StructuredToolCallBridge.consumeMatchingToolCalls(
+                                        openToolCalls,
+                                        resultsList.map { it.first }
+                                    )
+                                val matchedResultIndexes = matchedCalls.mapTo(mutableSetOf()) { it.resultIndex }
+                                matchedCalls.forEach { matchedCall ->
+                                    val resultContent = resultsList[matchedCall.resultIndex].second
                                     readableImageSources.add(resultContent)
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "tool")
-                                            put("tool_call_id", openToolCallIds[index])
+                                            put("tool_call_id", matchedCall.call.id)
                                             put("content", buildContentField(context, resultContent, role = "tool"))
                                         }
                                     )
                                 }
-                                repeat(validCount) {
-                                    openToolCallIds.removeAt(0)
-                                }
 
-                                if (resultsList.size > validCount) {
+                                if (matchedCalls.size < resultsList.size) {
                                     AppLogger.w(
                                         "KimiProvider",
-                                        "发现多余的tool_result: ${resultsList.size} results vs ${validCount} pending tool_calls"
+                                        "发现未匹配的tool_result: ${resultsList.size - matchedCalls.size}"
                                     )
                                 }
+
+                                flushOpenToolCallsAsCancelled("tool_result_partial_batch")
 
                                 appendReadableImageMessageIfNeeded(
                                     messagesArray,
@@ -373,11 +382,21 @@ open class KimiProvider(
                                     "tool result"
                                 )
 
-                                if (textContent.isNotEmpty()) {
+                                val unmatchedContent =
+                                    resultsList
+                                        .filterIndexed { index, _ -> index !in matchedResultIndexes }
+                                        .joinToString("\n") { result ->
+                                            if (result.second.isBlank()) "[Empty]" else result.second
+                                        }
+                                val userContent =
+                                    listOf(unmatchedContent, textContent)
+                                        .filter { it.isNotBlank() }
+                                        .joinToString("\n")
+                                if (userContent.isNotEmpty()) {
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "user")
-                                            put("content", buildContentField(context, textContent))
+                                            put("content", buildContentField(context, userContent))
                                         }
                                     )
                                 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelConfigConnectionTester.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelConfigConnectionTester.kt
@@ -45,6 +45,29 @@ data class ModelConnectionTestReport(
 }
 
 object ModelConfigConnectionTester {
+    /**
+     * One complete tool-call round trip for the Tool Call probe: the user asks, the assistant calls
+     * the tool, the tool answers.
+     *
+     * The turn kinds matter. The answer has to be a [PromptTurnKind.TOOL_RESULT] turn so that the
+     * provider pairs it with the call instead of reporting the call as never answered, and the
+     * probe has to open with a user turn because gateways that translate the OpenAI payload into
+     * another protocol (Poe onto Anthropic, for instance) reject a conversation that starts with an
+     * assistant message and leave its `tool_result` without a matching `tool_use`.
+     */
+    internal fun buildToolCallProbeHistory(toolName: String): List<PromptTurn> {
+        val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
+        val toolResultTagName = ChatMarkupRegex.generateRandomToolResultTagName()
+        return listOf(
+            "system" to "You are a helpful assistant.",
+            "user" to "Call the $toolName tool with the text \"ping\".",
+            "assistant" to
+                "<$toolTagName name=\"$toolName\"><param name=\"text\">ping</param></$toolTagName>",
+            "tool_result" to
+                "<$toolResultTagName name=\"$toolName\" status=\"success\"><content>pong</content></$toolResultTagName>"
+        ).toPromptTurns()
+    }
+
     suspend fun run(
         context: Context,
         modelConfigManager: ModelConfigManager,
@@ -118,20 +141,9 @@ object ModelConfigConnectionTester {
                         )
 
                     suspend fun runToolCallTest(toolName: String) {
-                        val toolTagName = ChatMarkupRegex.generateRandomToolTagName()
-                        val toolResultTagName = ChatMarkupRegex.generateRandomToolResultTagName()
-                        val testHistory = mutableListOf("system" to "You are a helpful assistant.")
-                        testHistory.add(
-                            "assistant" to
-                                "<$toolTagName name=\"$toolName\"><param name=\"text\">ping</param></$toolTagName>"
-                        )
-                        testHistory.add(
-                            "user" to
-                                "<$toolResultTagName name=\"$toolName\" status=\"success\"><content>pong</content></$toolResultTagName>"
-                        )
                         service.sendMessage(
                             context,
-                            testHistory.toPromptTurns(),
+                            buildToolCallProbeHistory(toolName),
                             parameters,
                             stream = false,
                             availableTools = availableTools,

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -1189,27 +1189,28 @@ open class OpenAIProvider(
 
                             if (resultsList.isNotEmpty() && openToolCalls.isNotEmpty()) {
                                 val readableImageSources = mutableListOf<String>()
-                                val matchedIds =
-                                    StructuredToolCallBridge.consumeMatchingToolCallIds(
+                                val matchedCalls =
+                                    StructuredToolCallBridge.consumeMatchingToolCalls(
                                         openToolCalls,
                                         resultsList.map { it.first }
                                     )
-                                matchedIds.forEachIndexed { index, toolCallId ->
-                                    val resultContent = resultsList[index].second
+                                val matchedResultIndexes = matchedCalls.mapTo(mutableSetOf()) { it.resultIndex }
+                                matchedCalls.forEach { matchedCall ->
+                                    val resultContent = resultsList[matchedCall.resultIndex].second
                                     readableImageSources.add(resultContent)
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "tool")
-                                            put("tool_call_id", toolCallId)
+                                            put("tool_call_id", matchedCall.call.id)
                                             put("content", buildContentField(context, resultContent, role = "tool"))
                                         }
                                     )
                                 }
 
-                                if (resultsList.size > matchedIds.size) {
+                                if (matchedCalls.size < resultsList.size) {
                                     AppLogger.w(
                                         "AIService",
-                                        "发现多余的tool_result: ${resultsList.size} results vs ${matchedIds.size} pending tool_calls"
+                                        "发现未匹配的tool_result: ${resultsList.size - matchedCalls.size}"
                                     )
                                 }
 
@@ -1226,11 +1227,21 @@ open class OpenAIProvider(
                                     )
                                 }
 
-                                if (textContent.isNotEmpty()) {
+                                val unmatchedContent =
+                                    resultsList
+                                        .filterIndexed { index, _ -> index !in matchedResultIndexes }
+                                        .joinToString("\n") { result ->
+                                            if (result.second.isBlank()) "[Empty]" else result.second
+                                        }
+                                val userContent =
+                                    listOf(unmatchedContent, textContent)
+                                        .filter { it.isNotBlank() }
+                                        .joinToString("\n")
+                                if (userContent.isNotEmpty()) {
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "user")
-                                            put("content", buildContentField(context, textContent))
+                                            put("content", buildContentField(context, userContent))
                                         }
                                     )
                                 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -1011,8 +1011,8 @@ open class OpenAIProvider(
 
         var queuedAssistantToolText: String? = null
         var queuedToolCalls = JSONArray()
-        val queuedToolCallIds = mutableListOf<String>()
-        val openToolCallIds = mutableListOf<String>()
+        val queuedOpenToolCalls = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
+        val openToolCalls = mutableListOf<StructuredToolCallBridge.OpenToolCall>()
         var nextToolCallOrdinal = 0
 
         fun appendQueuedAssistantToolText(text: String) {
@@ -1033,7 +1033,12 @@ open class OpenAIProvider(
                 val callId = generatedToolCallId(nextToolCallOrdinal++)
                 toolCall.put("id", callId)
                 queuedToolCalls.put(toolCall)
-                queuedToolCallIds.add(callId)
+                queuedOpenToolCalls.add(
+                    StructuredToolCallBridge.OpenToolCall(
+                        callId,
+                        StructuredToolCallBridge.toolCallName(toolCall)
+                    )
+                )
             }
         }
 
@@ -1049,35 +1054,37 @@ open class OpenAIProvider(
             if (effectiveContent != null) {
                 historyMessage.put("content", buildContentField(context, effectiveContent, role = "assistant"))
             } else {
-                historyMessage.put("content", null)
+                // JSONObject.put(name, null) drops the key; gateways that translate this request to
+                // another protocol need the assistant turn to stay recognizable as `content: null`.
+                historyMessage.put("content", JSONObject.NULL)
             }
             historyMessage.put("tool_calls", queuedToolCalls)
             messagesArray.put(historyMessage)
 
-            openToolCallIds.addAll(queuedToolCallIds)
+            openToolCalls.addAll(queuedOpenToolCalls)
             queuedAssistantToolText = null
             queuedToolCalls = JSONArray()
-            queuedToolCallIds.clear()
+            queuedOpenToolCalls.clear()
         }
 
         fun flushOpenToolCallsAsCancelled(reason: String) {
             emitQueuedToolCallsIfNeeded()
-            if (openToolCallIds.isEmpty()) return
+            if (openToolCalls.isEmpty()) return
 
             AppLogger.w(
                 "AIService",
-                "发现未完成的tool_calls，按取消处理: count=${openToolCallIds.size}, reason=$reason"
+                "发现未完成的tool_calls，按取消处理: count=${openToolCalls.size}, reason=$reason"
             )
-            for (toolCallId in openToolCallIds) {
+            for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
-                        put("tool_call_id", toolCallId)
+                        put("tool_call_id", openToolCall.id)
                         put("content", "User cancelled")
                     }
                 )
             }
-            openToolCallIds.clear()
+            openToolCalls.clear()
         }
 
         // 添加聊天历史
@@ -1118,7 +1125,7 @@ open class OpenAIProvider(
                                 }
 
                             if (toolCalls != null && toolCalls.length() > 0) {
-                                if (openToolCallIds.isNotEmpty()) {
+                                if (openToolCalls.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("assistant_tool_call_before_result")
                                 }
                                 queueToolCalls(textContent, toolCalls)
@@ -1154,7 +1161,7 @@ open class OpenAIProvider(
                                 }
 
                             if (toolCalls != null && toolCalls.length() > 0) {
-                                if (openToolCallIds.isNotEmpty()) {
+                                if (openToolCalls.isNotEmpty()) {
                                     flushOpenToolCallsAsCancelled("typed_tool_call_before_result")
                                 }
                                 queueToolCalls(textContent, toolCalls)
@@ -1180,30 +1187,36 @@ open class OpenAIProvider(
                             val (textContent, toolResults) = parseXmlToolResults(content)
                             val resultsList = toolResults ?: emptyList()
 
-                            if (resultsList.isNotEmpty() && openToolCallIds.isNotEmpty()) {
-                                val validCount = minOf(resultsList.size, openToolCallIds.size)
+                            if (resultsList.isNotEmpty() && openToolCalls.isNotEmpty()) {
                                 val readableImageSources = mutableListOf<String>()
-                                repeat(validCount) { index ->
-                                    val (_, resultContent) = resultsList[index]
+                                val matchedIds =
+                                    StructuredToolCallBridge.consumeMatchingToolCallIds(
+                                        openToolCalls,
+                                        resultsList.map { it.first }
+                                    )
+                                matchedIds.forEachIndexed { index, toolCallId ->
+                                    val resultContent = resultsList[index].second
                                     readableImageSources.add(resultContent)
                                     messagesArray.put(
                                         JSONObject().apply {
                                             put("role", "tool")
-                                            put("tool_call_id", openToolCallIds[index])
+                                            put("tool_call_id", toolCallId)
                                             put("content", buildContentField(context, resultContent, role = "tool"))
                                         }
                                     )
                                 }
-                                repeat(validCount) {
-                                    openToolCallIds.removeAt(0)
-                                }
 
-                                if (resultsList.size > validCount) {
+                                if (resultsList.size > matchedIds.size) {
                                     AppLogger.w(
                                         "AIService",
-                                        "发现多余的tool_result: ${resultsList.size} results vs ${validCount} pending tool_calls"
+                                        "发现多余的tool_result: ${resultsList.size} results vs ${matchedIds.size} pending tool_calls"
                                     )
                                 }
+
+                                // Close the batch before any user message, otherwise the leftover
+                                // calls are answered after it and their `tool` messages no longer
+                                // follow the assistant message that opened them.
+                                flushOpenToolCallsAsCancelled("tool_result_partial_batch")
 
                                 if (!useResponsesApi) {
                                     appendReadableImageMessageIfNeeded(
@@ -1738,7 +1751,7 @@ open class OpenAIProvider(
 
     /**
      * 解析XML格式的tool_result，转换为OpenAI Tool消息格式
-     * @return List<Pair<tool_call_id, result_content>>
+     * @return List<Pair<tool_name, result_content>>，tool_name 用于把结果配回发起它的 tool_call
      */
     fun parseXmlToolResults(content: String): Pair<String, List<Pair<String, String>>?> {
         // 匹配带属性的tool_result标签，例如: <tool_result name="..." status="...">...</tool_result>
@@ -1750,7 +1763,6 @@ open class OpenAIProvider(
 
         val results = mutableListOf<Pair<String, String>>()
         var textContent = content
-        var resultIndex = 0
 
         matches.forEach { match ->
             // 提取<content>标签内的内容，如果有的话
@@ -1762,12 +1774,14 @@ open class OpenAIProvider(
                 fullContent
             }
 
-            // 生成一个tool_call_id（这里需要与之前的call对应，但因为历史记录可能不完整，我们使用索引）
-            results.add(Pair("call_result_${resultIndex}", resultContent))
+            // 保留 name 属性，让结果能配回同名的 tool_call 而不是只按位置对齐
+            val openingTag = match.value.substringBefore('>')
+            val resultName =
+                ChatMarkupRegex.nameAttr.find(openingTag)?.groupValues?.getOrNull(1).orEmpty()
+            results.add(Pair(resultName, resultContent))
 
             // 从文本内容中移除tool_result标签（包括前后的空白符）
             textContent = textContent.replace(match.value, "").trim()
-            resultIndex++
         }
 
         // trim 确保移除所有空白字符

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
@@ -22,6 +22,53 @@ internal object StructuredToolCallBridge {
         val content: String
     )
 
+    /** A tool call that has been sent to the model but has no `tool` message answering it yet. */
+    data class OpenToolCall(val id: String, val name: String)
+
+    /**
+     * The callable tool name behind a queued tool call, unwrapping the `package_proxy` envelope so
+     * that a `pkg:tool` result can still be matched back to the call that produced it.
+     */
+    fun toolCallName(toolCall: JSONObject): String {
+        val function = toolCall.optJSONObject("function") ?: return ""
+        val name = function.optString("name", "")
+        if (name != "package_proxy") {
+            return name
+        }
+        val arguments =
+            kotlin.runCatching { JSONObject(function.optString("arguments", "{}")) }.getOrNull()
+        return arguments?.optString("tool_name", "")?.takeIf { it.isNotBlank() } ?: name
+    }
+
+    /**
+     * Consumes one open tool call per tool result, preferring the call whose tool name matches the
+     * result and falling back to the oldest open call. Tool results are not guaranteed to come back
+     * in call order (denied invocations are hoisted to the front of the result list), so pairing by
+     * position alone can attach a result to the wrong `tool_call_id`.
+     *
+     * @return the matched `tool_call_id` per result, in result order; shorter than [resultToolNames]
+     *   when there are fewer open calls than results.
+     */
+    fun consumeMatchingToolCallIds(
+        openToolCalls: MutableList<OpenToolCall>,
+        resultToolNames: List<String?>
+    ): List<String> {
+        val matched = ArrayList<String>(minOf(openToolCalls.size, resultToolNames.size))
+        for (resultName in resultToolNames) {
+            if (openToolCalls.isEmpty()) {
+                break
+            }
+            val byName =
+                if (resultName.isNullOrBlank()) {
+                    -1
+                } else {
+                    openToolCalls.indexOfFirst { it.name.equals(resultName, ignoreCase = true) }
+                }
+            matched.add(openToolCalls.removeAt(if (byName >= 0) byName else 0).id)
+        }
+        return matched
+    }
+
     fun buildToolsJson(toolPrompts: List<ToolPrompt>?): String? {
         if (toolPrompts.isNullOrEmpty()) {
             return null
@@ -166,8 +213,8 @@ internal object StructuredToolCallBridge {
         val messagesArray = JSONArray()
         var queuedAssistantToolText: String? = null
         var queuedToolCalls = JSONArray()
-        val queuedToolCallIds = mutableListOf<String>()
-        val openToolCallIds = mutableListOf<String>()
+        val queuedOpenToolCalls = mutableListOf<OpenToolCall>()
+        val openToolCalls = mutableListOf<OpenToolCall>()
         var nextToolCallOrdinal = 0
 
         fun appendQueuedAssistantToolText(text: String) {
@@ -188,7 +235,7 @@ internal object StructuredToolCallBridge {
                 val callId = generatedToolCallId(nextToolCallOrdinal++)
                 toolCall.put("id", callId)
                 queuedToolCalls.put(toolCall)
-                queuedToolCallIds.add(callId)
+                queuedOpenToolCalls.add(OpenToolCall(callId, toolCallName(toolCall)))
             }
         }
 
@@ -210,26 +257,26 @@ internal object StructuredToolCallBridge {
                 }
             )
 
-            openToolCallIds.addAll(queuedToolCallIds)
+            openToolCalls.addAll(queuedOpenToolCalls)
             queuedAssistantToolText = null
             queuedToolCalls = JSONArray()
-            queuedToolCallIds.clear()
+            queuedOpenToolCalls.clear()
         }
 
         fun flushOpenToolCallsAsCancelled() {
             emitQueuedToolCallsIfNeeded()
-            if (openToolCallIds.isEmpty()) return
+            if (openToolCalls.isEmpty()) return
 
-            for (toolCallId in openToolCallIds) {
+            for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
-                        put("tool_call_id", toolCallId)
+                        put("tool_call_id", openToolCall.id)
                         put("content", "User cancelled")
                     }
                 )
             }
-            openToolCallIds.clear()
+            openToolCalls.clear()
         }
 
         for (turn in mergedHistory) {
@@ -313,13 +360,14 @@ internal object StructuredToolCallBridge {
                     val (textContent, toolResults) = parseXmlToolResults(content)
                     val resultsList = toolResults ?: emptyList()
 
-                    if (resultsList.isNotEmpty() && openToolCallIds.isNotEmpty()) {
-                        val validCount = minOf(resultsList.size, openToolCallIds.size)
-                        repeat(validCount) { index ->
+                    if (resultsList.isNotEmpty() && openToolCalls.isNotEmpty()) {
+                        val matchedIds =
+                            consumeMatchingToolCallIds(openToolCalls, resultsList.map { it.name })
+                        matchedIds.forEachIndexed { index, toolCallId ->
                             val result = resultsList[index]
                             val toolMessage = JSONObject().apply {
                                 put("role", "tool")
-                                put("tool_call_id", openToolCallIds[index])
+                                put("tool_call_id", toolCallId)
                                 if (!result.name.isNullOrBlank()) {
                                     put("name", result.name)
                                 }
@@ -327,9 +375,9 @@ internal object StructuredToolCallBridge {
                             }
                             messagesArray.put(toolMessage)
                         }
-                        repeat(validCount) {
-                            openToolCallIds.removeAt(0)
-                        }
+                        // Close the batch before any user message, otherwise the leftover calls are
+                        // answered after it and their `tool` messages no longer follow their call.
+                        flushOpenToolCallsAsCancelled()
                         if (textContent.isNotBlank()) {
                             messagesArray.put(
                                 JSONObject().apply {
@@ -695,7 +743,8 @@ internal object StructuredToolCallBridge {
             } else {
                 fullContent
             }
-            val resultName = ChatMarkupRegex.nameAttr.find(match.value)?.groupValues?.getOrNull(1)
+            val openingTag = match.value.substringBefore('>')
+            val resultName = ChatMarkupRegex.nameAttr.find(openingTag)?.groupValues?.getOrNull(1)
             results.add(ToolResultRecord(resultName, resultContent))
             textContent = textContent.replace(match.value, "").trim()
         }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
@@ -4,6 +4,7 @@ import com.ai.assistance.operit.core.chat.hooks.PromptTurn
 import com.ai.assistance.operit.core.chat.hooks.PromptTurnKind
 import com.ai.assistance.operit.data.model.ToolParameterSchema
 import com.ai.assistance.operit.data.model.ToolPrompt
+import com.ai.assistance.operit.util.AppLogger
 import com.ai.assistance.operit.util.ChatMarkupRegex
 import com.ai.assistance.operit.util.ChatUtils
 import kotlin.math.abs
@@ -25,46 +26,49 @@ internal object StructuredToolCallBridge {
     /** A tool call that has been sent to the model but has no `tool` message answering it yet. */
     data class OpenToolCall(val id: String, val name: String)
 
+    data class MatchedToolCall(val resultIndex: Int, val call: OpenToolCall)
+
     /**
      * The callable tool name behind a queued tool call, unwrapping the `package_proxy` envelope so
      * that a `pkg:tool` result can still be matched back to the call that produced it.
      */
     fun toolCallName(toolCall: JSONObject): String {
         val function = toolCall.optJSONObject("function") ?: return ""
-        val name = function.optString("name", "")
+        val name = function.optString("name", "").trim()
         if (name != "package_proxy") {
             return name
         }
-        val arguments =
-            kotlin.runCatching { JSONObject(function.optString("arguments", "{}")) }.getOrNull()
-        return arguments?.optString("tool_name", "")?.takeIf { it.isNotBlank() } ?: name
+
+        return try {
+            JSONObject(function.optString("arguments", "{}"))
+                .optString("tool_name", "")
+                .trim()
+        } catch (e: Exception) {
+            AppLogger.w("StructuredToolCallBridge", "package_proxy arguments are not valid JSON", e)
+            ""
+        }
     }
 
     /**
-     * Consumes one open tool call per tool result, preferring the call whose tool name matches the
-     * result and falling back to the oldest open call. Tool results are not guaranteed to come back
-     * in call order (denied invocations are hoisted to the front of the result list), so pairing by
-     * position alone can attach a result to the wrong `tool_call_id`.
+     * Consumes only the open tool call whose name exactly matches each result. Tool results are not
+     * guaranteed to come back in call order (denied invocations are hoisted to the front of the
+     * result list), so pairing by position alone can attach a result to the wrong call ID.
      *
-     * @return the matched `tool_call_id` per result, in result order; shorter than [resultToolNames]
-     *   when there are fewer open calls than results.
+     * @return matched calls with their source result indexes; unmatched results remain unconsumed.
      */
-    fun consumeMatchingToolCallIds(
+    fun consumeMatchingToolCalls(
         openToolCalls: MutableList<OpenToolCall>,
         resultToolNames: List<String?>
-    ): List<String> {
-        val matched = ArrayList<String>(minOf(openToolCalls.size, resultToolNames.size))
-        for (resultName in resultToolNames) {
-            if (openToolCalls.isEmpty()) {
-                break
+    ): List<MatchedToolCall> {
+        val matched = ArrayList<MatchedToolCall>(minOf(openToolCalls.size, resultToolNames.size))
+        resultToolNames.forEachIndexed { resultIndex, resultName ->
+            val normalizedResultName = resultName?.trim().orEmpty()
+            if (normalizedResultName.isEmpty()) return@forEachIndexed
+
+            val callIndex = openToolCalls.indexOfFirst { it.name == normalizedResultName }
+            if (callIndex >= 0) {
+                matched.add(MatchedToolCall(resultIndex, openToolCalls.removeAt(callIndex)))
             }
-            val byName =
-                if (resultName.isNullOrBlank()) {
-                    -1
-                } else {
-                    openToolCalls.indexOfFirst { it.name.equals(resultName, ignoreCase = true) }
-                }
-            matched.add(openToolCalls.removeAt(if (byName >= 0) byName else 0).id)
         }
         return matched
     }
@@ -361,13 +365,14 @@ internal object StructuredToolCallBridge {
                     val resultsList = toolResults ?: emptyList()
 
                     if (resultsList.isNotEmpty() && openToolCalls.isNotEmpty()) {
-                        val matchedIds =
-                            consumeMatchingToolCallIds(openToolCalls, resultsList.map { it.name })
-                        matchedIds.forEachIndexed { index, toolCallId ->
-                            val result = resultsList[index]
+                        val matchedCalls =
+                            consumeMatchingToolCalls(openToolCalls, resultsList.map { it.name })
+                        val matchedResultIndexes = matchedCalls.mapTo(mutableSetOf()) { it.resultIndex }
+                        matchedCalls.forEach { matchedCall ->
+                            val result = resultsList[matchedCall.resultIndex]
                             val toolMessage = JSONObject().apply {
                                 put("role", "tool")
-                                put("tool_call_id", toolCallId)
+                                put("tool_call_id", matchedCall.call.id)
                                 if (!result.name.isNullOrBlank()) {
                                     put("name", result.name)
                                 }
@@ -375,14 +380,26 @@ internal object StructuredToolCallBridge {
                             }
                             messagesArray.put(toolMessage)
                         }
+                        if (matchedCalls.size < resultsList.size) {
+                            logDebug("发现未匹配的tool_result: ${resultsList.size - matchedCalls.size}")
+                        }
+
                         // Close the batch before any user message, otherwise the leftover calls are
                         // answered after it and their `tool` messages no longer follow their call.
                         flushOpenToolCallsAsCancelled()
-                        if (textContent.isNotBlank()) {
+                        val unmatchedContent =
+                            resultsList
+                                .filterIndexed { index, _ -> index !in matchedResultIndexes }
+                                .joinToString("\n") { nonEmptyContent(it.content) }
+                        val userContent =
+                            listOf(unmatchedContent, textContent)
+                                .filter { it.isNotBlank() }
+                                .joinToString("\n")
+                        if (userContent.isNotBlank()) {
                             messagesArray.put(
                                 JSONObject().apply {
                                     put("role", "user")
-                                    put("content", textContent)
+                                    put("content", userContent)
                                 }
                             )
                         }

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiToolCallHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiToolCallHistoryTest.kt
@@ -1,0 +1,250 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import android.content.Context
+import com.ai.assistance.operit.core.chat.hooks.PromptTurn
+import com.ai.assistance.operit.core.chat.hooks.PromptTurnKind
+import com.ai.assistance.operit.util.AppLogger
+import okhttp3.OkHttpClient
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * Protocol-level regression tests for the OpenAI tool-call history conversion.
+ *
+ * Gateways that translate the OpenAI payload into another protocol (Poe onto Anthropic) enforce
+ * that every `tool` message answers a call opened by the message right before it. See issue #1027.
+ */
+class OpenAiToolCallHistoryTest {
+
+    @Before
+    fun disableAndroidLogging() {
+        AppLogger.enableSystemLog = false
+        AppLogger.enableFileLogging = false
+    }
+
+    @Test
+    fun `connection test tool call probe answers the call it opened`() {
+        val messages =
+            buildMessages(ModelConfigConnectionTester.buildToolCallProbeHistory("echo"))
+
+        assertEquals(
+            listOf("system", "user", "assistant", "tool"),
+            messages.roles()
+        )
+        assertToolResultsFollowTheirCalls(messages)
+        assertEquals(
+            messages.at(2).getJSONArray("tool_calls").getJSONObject(0).getString("id"),
+            messages.at(3).getString("tool_call_id")
+        )
+        assertEquals("pong", messages.at(3).getString("content"))
+    }
+
+    @Test
+    fun `assistant tool call message keeps an explicit null content`() {
+        val messages =
+            buildMessages(ModelConfigConnectionTester.buildToolCallProbeHistory("echo"))
+
+        val assistant = messages.at(2)
+        assertTrue(assistant.has("content"))
+        assertTrue(assistant.isNull("content"))
+    }
+
+    @Test
+    fun `unanswered calls are closed before the trailing tool result text`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.SYSTEM, content = "You are a helpful assistant."),
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Read both files."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("read_file", "path" to "a.txt") +
+                            toolCall("read_file_part", "path" to "b.txt")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("read_file", "alpha") + "\nThe second read was skipped."
+                    )
+                )
+            )
+
+        assertToolResultsFollowTheirCalls(messages)
+        assertEquals(
+            listOf("system", "user", "assistant", "tool", "tool", "user"),
+            messages.roles()
+        )
+        assertEquals("The second read was skipped.", messages.at(5).getString("content"))
+    }
+
+    @Test
+    fun `tool results are paired by tool name when they come back out of order`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Do both."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("list_files", "path" to ".") +
+                            toolCall("calculate", "expression" to "1+1")
+                    ),
+                    // Denied or interrupted invocations are hoisted to the front of the result list,
+                    // so the results do not necessarily arrive in call order.
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("calculate", "2") + toolResult("list_files", "a.txt")
+                    )
+                )
+            )
+
+        assertToolResultsFollowTheirCalls(messages)
+        val toolCalls = messages.at(1).getJSONArray("tool_calls")
+        val listFilesId = toolCalls.getJSONObject(0).getString("id")
+        val calculateId = toolCalls.getJSONObject(1).getString("id")
+
+        assertEquals(calculateId, messages.at(2).getString("tool_call_id"))
+        assertEquals("2", messages.at(2).getString("content"))
+        assertEquals(listFilesId, messages.at(3).getString("tool_call_id"))
+        assertEquals("a.txt", messages.at(3).getString("content"))
+    }
+
+    @Test
+    fun `package tool results are paired through the package proxy envelope`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Draw it."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("qwen_draw:draw", "prompt" to "cat")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("qwen_draw:draw", "done")
+                    )
+                )
+            )
+
+        assertToolResultsFollowTheirCalls(messages)
+        assertEquals(
+            "package_proxy",
+            messages.at(1).getJSONArray("tool_calls").getJSONObject(0)
+                .getJSONObject("function").getString("name")
+        )
+        assertEquals("done", messages.at(2).getString("content"))
+    }
+
+    @Test
+    fun `built-in tool channel sends no tool call protocol fields`() {
+        val history =
+            listOf(
+                PromptTurn(kind = PromptTurnKind.SYSTEM, content = "You are a helpful assistant."),
+                PromptTurn(kind = PromptTurnKind.USER, content = "Use the package."),
+                PromptTurn(
+                    kind = PromptTurnKind.TOOL_CALL,
+                    content = toolCall("use_package", "package_name" to "qwen_draw")
+                ),
+                PromptTurn(
+                    kind = PromptTurnKind.TOOL_RESULT,
+                    content = toolResult("use_package", "activated")
+                )
+            )
+
+        val messages = buildMessages(history, useToolCall = false)
+
+        assertEquals(listOf("system", "user", "assistant", "user"), messages.roles())
+        for (index in 0 until messages.length()) {
+            val message = messages.at(index)
+            assertFalse(message.has("tool_calls"))
+            assertFalse(message.has("tool_call_id"))
+        }
+        assertTrue(messages.at(3).getString("content").contains("activated"))
+    }
+
+    private fun buildMessages(
+        history: List<PromptTurn>,
+        useToolCall: Boolean = true
+    ): JSONArray {
+        val provider =
+            object : OpenAIProvider(
+                apiEndpoint = "https://example.test/v1/chat/completions",
+                apiKeyProvider = SingleApiKeyProvider("test-key"),
+                modelName = "test-model",
+                client = OkHttpClient(),
+                enableToolCall = true
+            ) {
+                fun buildMessages(context: Context): JSONArray =
+                    buildMessagesAndCountTokens(context, history, useToolCall = useToolCall).first
+            }
+        return provider.buildMessages(mock<Context>())
+    }
+
+    private fun toolCall(name: String, vararg params: Pair<String, String>): String {
+        val body = params.joinToString("") { (key, value) ->
+            "<param name=\"$key\">$value</param>"
+        }
+        return "<tool name=\"$name\">$body</tool>"
+    }
+
+    private fun toolResult(name: String, content: String): String =
+        "<tool_result name=\"$name\" status=\"success\"><content>$content</content></tool_result>"
+
+    private fun JSONArray.at(index: Int): JSONObject = getJSONObject(index)
+
+    private fun JSONArray.roles(): List<String> =
+        (0 until length()).map { at(it).getString("role") }
+
+    /**
+     * Mirrors what an Anthropic-backed gateway checks: the conversation may not open with an
+     * assistant turn, every `tool` message must answer a call opened by the message right before
+     * its run, and no other message may cut into that run.
+     */
+    private fun assertToolResultsFollowTheirCalls(messages: JSONArray) {
+        val firstNonSystem = (0 until messages.length())
+            .firstOrNull { messages.at(it).getString("role") != "system" }
+        if (firstNonSystem != null) {
+            assertEquals(
+                "conversation must not open with an assistant turn",
+                "user",
+                messages.at(firstNonSystem).getString("role")
+            )
+        }
+
+        val pendingCallIds = mutableSetOf<String>()
+        for (index in 0 until messages.length()) {
+            val message = messages.at(index)
+            when (message.getString("role")) {
+                "tool" -> {
+                    val toolCallId = message.getString("tool_call_id")
+                    assertTrue(
+                        "message $index answers $toolCallId with no matching tool call before it",
+                        pendingCallIds.remove(toolCallId)
+                    )
+                }
+
+                "assistant" -> {
+                    assertTrue(
+                        "message $index leaves calls $pendingCallIds unanswered",
+                        pendingCallIds.isEmpty()
+                    )
+                    val toolCalls = message.optJSONArray("tool_calls") ?: JSONArray()
+                    for (callIndex in 0 until toolCalls.length()) {
+                        pendingCallIds.add(toolCalls.getJSONObject(callIndex).getString("id"))
+                    }
+                }
+
+                else ->
+                    assertTrue(
+                        "message $index leaves calls $pendingCallIds unanswered",
+                        pendingCallIds.isEmpty()
+                    )
+            }
+        }
+        assertTrue("history ends with unanswered calls $pendingCallIds", pendingCallIds.isEmpty())
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiToolCallHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiToolCallHistoryTest.kt
@@ -7,6 +7,7 @@ import com.ai.assistance.operit.util.AppLogger
 import okhttp3.OkHttpClient
 import org.json.JSONArray
 import org.json.JSONObject
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -22,10 +23,21 @@ import org.mockito.kotlin.mock
  */
 class OpenAiToolCallHistoryTest {
 
+    private var previousSystemLogEnabled = true
+    private var previousFileLogEnabled = true
+
     @Before
     fun disableAndroidLogging() {
+        previousSystemLogEnabled = AppLogger.enableSystemLog
+        previousFileLogEnabled = AppLogger.enableFileLogging
         AppLogger.enableSystemLog = false
         AppLogger.enableFileLogging = false
+    }
+
+    @After
+    fun restoreAndroidLogging() {
+        AppLogger.enableSystemLog = previousSystemLogEnabled
+        AppLogger.enableFileLogging = previousFileLogEnabled
     }
 
     @Test
@@ -137,6 +149,32 @@ class OpenAiToolCallHistoryTest {
                 .getJSONObject("function").getString("name")
         )
         assertEquals("done", messages.at(2).getString("content"))
+    }
+
+    @Test
+    fun `unmatched tool results are preserved as user content without stealing a call id`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Do both."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("first", "value" to "1") +
+                            toolCall("second", "value" to "2")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("missing", "unmatched") + toolResult("first", "ok")
+                    )
+                )
+            )
+
+        val toolCalls = messages.at(1).getJSONArray("tool_calls")
+        assertEquals(toolCalls.getJSONObject(0).getString("id"), messages.at(2).getString("tool_call_id"))
+        assertEquals("ok", messages.at(2).getString("content"))
+        assertEquals(toolCalls.getJSONObject(1).getString("id"), messages.at(3).getString("tool_call_id"))
+        assertEquals("User cancelled", messages.at(3).getString("content"))
+        assertEquals("unmatched", messages.at(4).getString("content"))
     }
 
     @Test

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridgeHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridgeHistoryTest.kt
@@ -1,0 +1,152 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import com.ai.assistance.operit.core.chat.hooks.PromptTurn
+import com.ai.assistance.operit.core.chat.hooks.PromptTurnKind
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Protocol-level regression tests for the structured message builder shared by the local-model
+ * providers. Same invariant as [OpenAiToolCallHistoryTest]: a `tool` message may only answer a call
+ * opened by the message right before its run. See issue #1027.
+ */
+class StructuredToolCallBridgeHistoryTest {
+
+    @Test
+    fun `unanswered calls are closed before the trailing tool result text`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Read both files."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("read_file", "path" to "a.txt") +
+                            toolCall("read_file_part", "path" to "b.txt")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("read_file", "alpha") + "\nThe second read was skipped."
+                    )
+                )
+            )
+
+        assertEquals(listOf("user", "assistant", "tool", "tool", "user"), messages.roles())
+        assertEquals("The second read was skipped.", messages.at(4).getString("content"))
+        assertToolResultsFollowTheirCalls(messages)
+    }
+
+    @Test
+    fun `tool results are paired by tool name when they come back out of order`() {
+        val messages =
+            buildMessages(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Do both."),
+                    PromptTurn(
+                        kind = PromptTurnKind.ASSISTANT,
+                        content = toolCall("list_files", "path" to ".") +
+                            toolCall("calculate", "expression" to "1+1")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("calculate", "2") + toolResult("list_files", "a.txt")
+                    )
+                )
+            )
+
+        val toolCalls = messages.at(1).getJSONArray("tool_calls")
+        assertEquals(
+            toolCalls.getJSONObject(1).getString("id"),
+            messages.at(2).getString("tool_call_id")
+        )
+        assertEquals(
+            toolCalls.getJSONObject(0).getString("id"),
+            messages.at(3).getString("tool_call_id")
+        )
+        assertToolResultsFollowTheirCalls(messages)
+    }
+
+    @Test
+    fun `built-in tool channel compiles tool turns into plain roles`() {
+        val compiled =
+            StructuredToolCallBridge.compileHistoryForProvider(
+                listOf(
+                    PromptTurn(kind = PromptTurnKind.SYSTEM, content = "You are a helpful assistant."),
+                    PromptTurn(kind = PromptTurnKind.USER, content = "Use the package."),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_CALL,
+                        content = toolCall("use_package", "package_name" to "qwen_draw")
+                    ),
+                    PromptTurn(
+                        kind = PromptTurnKind.TOOL_RESULT,
+                        content = toolResult("use_package", "activated")
+                    )
+                ),
+                useToolCall = false
+            )
+
+        assertEquals(
+            listOf(
+                PromptTurnKind.SYSTEM,
+                PromptTurnKind.USER,
+                PromptTurnKind.ASSISTANT,
+                PromptTurnKind.USER
+            ),
+            compiled.map { it.kind }
+        )
+    }
+
+    private fun buildMessages(history: List<PromptTurn>): JSONArray =
+        JSONArray(
+            StructuredToolCallBridge.buildMessagesJson(history, preserveThinkInHistory = false)
+        )
+
+    private fun toolCall(name: String, vararg params: Pair<String, String>): String {
+        val body = params.joinToString("") { (key, value) ->
+            "<param name=\"$key\">$value</param>"
+        }
+        return "<tool name=\"$name\">$body</tool>"
+    }
+
+    private fun toolResult(name: String, content: String): String =
+        "<tool_result name=\"$name\" status=\"success\"><content>$content</content></tool_result>"
+
+    private fun JSONArray.at(index: Int): JSONObject = getJSONObject(index)
+
+    private fun JSONArray.roles(): List<String> =
+        (0 until length()).map { at(it).getString("role") }
+
+    private fun assertToolResultsFollowTheirCalls(messages: JSONArray) {
+        val pendingCallIds = mutableSetOf<String>()
+        for (index in 0 until messages.length()) {
+            val message = messages.at(index)
+            when (message.getString("role")) {
+                "tool" ->
+                    assertTrue(
+                        "message $index answers a call that was never opened before it",
+                        pendingCallIds.remove(message.getString("tool_call_id"))
+                    )
+
+                "assistant" -> {
+                    assertTrue(
+                        "message $index leaves calls $pendingCallIds unanswered",
+                        pendingCallIds.isEmpty()
+                    )
+                    val toolCalls = message.optJSONArray("tool_calls") ?: JSONArray()
+                    for (callIndex in 0 until toolCalls.length()) {
+                        pendingCallIds.add(toolCalls.getJSONObject(callIndex).getString("id"))
+                    }
+                }
+
+                else ->
+                    assertTrue(
+                        "message $index leaves calls $pendingCallIds unanswered",
+                        pendingCallIds.isEmpty()
+                    )
+            }
+        }
+        assertTrue("history ends with unanswered calls $pendingCallIds", pendingCallIds.isEmpty())
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridgeHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridgeHistoryTest.kt
@@ -69,6 +69,25 @@ class StructuredToolCallBridgeHistoryTest {
     }
 
     @Test
+    fun `unmatched result does not consume an unrelated open call`() {
+        val openToolCalls =
+            mutableListOf(
+                StructuredToolCallBridge.OpenToolCall("first-id", "first"),
+                StructuredToolCallBridge.OpenToolCall("second-id", "second")
+            )
+
+        val matched =
+            StructuredToolCallBridge.consumeMatchingToolCalls(
+                openToolCalls,
+                listOf("missing", "first")
+            )
+
+        assertEquals(listOf(1), matched.map { it.resultIndex })
+        assertEquals(listOf("first-id"), matched.map { it.call.id })
+        assertEquals(listOf("second"), openToolCalls.map { it.name })
+    }
+
+    @Test
     fun `built-in tool channel compiles tool turns into plain roles`() {
         val compiled =
             StructuredToolCallBridge.compileHistoryForProvider(


### PR DESCRIPTION
## 变更说明 / Description

本 PR 基于 PR1069，补全工具结果与工具调用的协议配对修复，使乱序、部分结果和无法确认归属的历史记录不会产生错误的调用 ID 绑定。

### 背景与动机 / Context and motivation

PR1069 修复了 OpenAI 历史消息在网关转换时产生孤立 `tool_result` 的问题。本分支进一步覆盖其他原生工具调用 Provider，并避免未识别结果占用无关调用 ID。

### 改动范围 / Changes

- 保留 assistant 工具调用消息的显式 `content: null`，并修正连接探测历史顺序
- 按工具名配对结果，支持 `package_proxy` 的真实工具名解析
- 覆盖 OpenAI、Structured、Claude、Gemini、Kimi 和 DeepSeek 的历史转换路径
- 未匹配结果保留为普通内容，未完成调用在普通用户内容前关闭
- 增加乱序、未匹配结果和日志配置隔离回归测试

### 兼容性与风险 / Compatibility and risks

仅调整工具调用历史转换的协议字段和异常历史处理方式，不改变正常工具执行接口、持久化数据或配置格式。

## 关联 Issue / Related issue

Closes #1027

## 验证方式 / Verification

```text
检查或命令：git diff-tree --check HEAD
环境与变体：静态检查；未运行 Android 构建或测试
结果：git diff-tree --check 通过；按照仓库 AGENTS.md 规则未默认执行构建/测试
```

## 证据 / Evidence

本 PR 为协议历史转换修复，无 UI 变化。

## 检查清单 / Checklist

- [x] 已记录可复现验证和未运行项原因
- [x] 日常开发 PR 的目标分支为 `dev`
- [ ] `Candidate checks` 将在 GitHub PR 创建后运行
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容
- [x] 已提供对应的回归和兼容性证据