### PR TITLE
fix(chat): keep tool round markup on its own line

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
@@ -1770,8 +1770,9 @@ class EnhancedAIService private constructor(private val context: Context) {
                                         R.string.enhanced_pure_thinking_only_warning
                                 )
                         )
-                context.roundManager.appendContent("\n$pureThinkingWarning")
-                collector.emit(pureThinkingWarning)
+                val pureThinkingWarningDisplayContent = "\n$pureThinkingWarning"
+                context.roundManager.appendContent(pureThinkingWarningDisplayContent)
+                collector.emit(pureThinkingWarningDisplayContent)
                 try {
                     context.conversationHistory.add(
                         PromptTurn(kind = PromptTurnKind.TOOL_RESULT, content = pureThinkingWarning)

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
@@ -54,8 +54,15 @@ object ToolExecutionManager {
         val displayName: String
     )
 
-    private fun ensureEndsWithNewline(content: String): String {
-        return if (content.endsWith("\n")) content else "$content\n"
+    /**
+     * Tool round markup is injected into the assistant stream right after model text that usually
+     * ends mid-line. The XML block detector only opens a block at a line boundary, so markup glued
+     * onto the previous character is rendered as plain model text, and is re-parsed out of history
+     * as assistant text instead of a tool result. Keep every injected block on its own line.
+     */
+    internal fun ensureOwnLine(content: String): String {
+        val withLeadingBreak = if (content.startsWith("\n")) content else "\n$content"
+        return if (withLeadingBreak.endsWith("\n")) withLeadingBreak else "$withLeadingBreak\n"
     }
 
     private fun resolveToolTarget(tool: AITool): ResolvedToolTarget {
@@ -538,7 +545,7 @@ object ToolExecutionManager {
                 toolHandler.notifyToolExecutionResult(invocation.tool, deniedResult)
                 val toolResultStatusContent =
                     ConversationMarkupManager.formatToolResultForMessage(deniedResult)
-                collector.emit(ensureEndsWithNewline(toolResultStatusContent))
+                collector.emit(ensureOwnLine(toolResultStatusContent))
             }
         }
 
@@ -561,7 +568,7 @@ object ToolExecutionManager {
                 toolHandler.notifyToolExecutionResult(invocation.tool, deniedResult)
                 val toolResultStatusContent =
                     ConversationMarkupManager.formatToolResultForMessage(deniedResult)
-                collector.emit(ensureEndsWithNewline(toolResultStatusContent))
+                collector.emit(ensureOwnLine(toolResultStatusContent))
             }
         }
 
@@ -583,7 +590,7 @@ object ToolExecutionManager {
                             permissionDeniedResults.add(it)
                             val toolResultStatusContent =
                                 ConversationMarkupManager.formatToolResultForMessage(it)
-                            collector.emit(ensureEndsWithNewline(toolResultStatusContent))
+                            collector.emit(ensureOwnLine(toolResultStatusContent))
                         }
                     }
                 }
@@ -599,7 +606,7 @@ object ToolExecutionManager {
                     toolHandler.notifyToolExecutionFinished(invocation.tool)
                     val toolResultStatusContent =
                         ConversationMarkupManager.formatToolResultForMessage(interceptedResult)
-                    collector.emit(ensureEndsWithNewline(toolResultStatusContent))
+                    collector.emit(ensureOwnLine(toolResultStatusContent))
                 }
             }
         }
@@ -699,7 +706,7 @@ object ToolExecutionManager {
                         buildToolNotAvailableErrorMessage(toolName, packageManager, toolHandler)
                     val notAvailableContent =
                         ConversationMarkupManager.createToolNotAvailableError(toolName, errorMessage)
-                    collector.emit(ensureEndsWithNewline(notAvailableContent))
+                    collector.emit(ensureOwnLine(notAvailableContent))
                     val notAvailableResult =
                         ToolResult(
                             toolName = displayToolName,
@@ -719,7 +726,7 @@ object ToolExecutionManager {
                     // 实时输出每个结果
                     val toolResultStatusContent =
                         ConversationMarkupManager.formatToolResultForMessage(result)
-                    collector.emit(ensureEndsWithNewline(toolResultStatusContent))
+                    collector.emit(ensureOwnLine(toolResultStatusContent))
                 }
 
                 // 为此调用聚合最终结果

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManagerMarkupTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManagerMarkupTest.kt
@@ -1,0 +1,80 @@
+package com.ai.assistance.operit.api.chat.enhance
+
+import com.ai.assistance.operit.util.ChatMarkupRegex
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for issue #1059: tool round markup was appended to the assistant stream
+ * without a line break, so the XML block detector - which only opens a block at a line boundary -
+ * treated the tool result as plain model text.
+ */
+class ToolExecutionManagerMarkupTest {
+
+    private val toolResultMarkup =
+        "<tool_result_Xy9Z name=\"zhipu_draw\" status=\"success\">" +
+            "<content>{\"filepath\":\"/sdcard/a.png\"}</content></tool_result_Xy9Z>"
+
+    /** Streaming tool call: the provider closes the tool tag without a trailing newline. */
+    private val streamedRound = "先画一张\n<tool_aB12 name=\"zhipu_draw\">\n</tool_aB12>"
+
+    /** Non-streaming tool call: the provider emits the tool XML first, then the model text. */
+    private val nonStreamedRound =
+        "\n<tool_aB12 name=\"zhipu_draw\">\n</tool_aB12>\n画完你自己看"
+
+    @Test
+    fun ensureOwnLine_startsToolResultOnItsOwnLineAfterStreamedToolCall() {
+        val round = streamedRound + ToolExecutionManager.ensureOwnLine(toolResultMarkup)
+
+        assertToolResultOpensAtLineStart(round)
+    }
+
+    @Test
+    fun ensureOwnLine_startsToolResultOnItsOwnLineAfterNonStreamedModelText() {
+        // The model text ends mid-line, which is what let the raw JSON surface as model output.
+        val round = nonStreamedRound + ToolExecutionManager.ensureOwnLine(toolResultMarkup)
+
+        assertToolResultOpensAtLineStart(round)
+    }
+
+    @Test
+    fun ensureOwnLine_keepsAssistantTextEmittedBeforeTheToolCallIntact() {
+        val round = streamedRound + ToolExecutionManager.ensureOwnLine(toolResultMarkup)
+
+        // The text the model produced before calling the tool must survive exactly once.
+        assertEquals(1, occurrencesOf(round, "先画一张"))
+        assertEquals(1, occurrencesOf(round, "<tool_result_Xy9Z"))
+    }
+
+    @Test
+    fun ensureOwnLine_separatesConsecutiveToolResultsOfOneBatch() {
+        val secondResult = toolResultMarkup.replace("Xy9Z", "Qw7K")
+        val round =
+            streamedRound +
+                ToolExecutionManager.ensureOwnLine(toolResultMarkup) +
+                ToolExecutionManager.ensureOwnLine(secondResult)
+
+        assertToolResultOpensAtLineStart(round)
+        assertEquals(2, ChatMarkupRegex.toolResultTag.findAll(round).count())
+        assertTrue(round.contains("</tool_result_Xy9Z>\n\n<tool_result_Qw7K"))
+    }
+
+    @Test
+    fun ensureOwnLine_doesNotStackRedundantBlankLines() {
+        assertEquals("\ndone\n", ToolExecutionManager.ensureOwnLine("\ndone\n"))
+    }
+
+    private fun assertToolResultOpensAtLineStart(round: String) {
+        val openingTagIndex = round.indexOf("<tool_result_")
+        assertTrue("tool result markup missing", openingTagIndex > 0)
+        assertEquals(
+            "tool result markup must open a new line so it is parsed as XML, not as model text",
+            '\n',
+            round[openingTagIndex - 1]
+        )
+    }
+
+    private fun occurrencesOf(haystack: String, needle: String): Int =
+        haystack.split(needle).size - 1
+}


### PR DESCRIPTION
关联 issue：#1059（同时命中 #1057、#929 的现象）

## 问题

工具调用返回后，工具结果的 XML 原文（含 `filepath` / `fileuri` / `markdown` 字段和 `file:///storage/...` 路径）被当成模型正文上屏；分条显示（waifu）模式下还会被按句号拆成多条碎片气泡。同一轮的工具结果卡片也不渲染。

## 根因

`ToolExecutionManager` 把工具结果 markup 追加进 assistant 流时只保证结尾换行（`ensureEndsWithNewline`），不保证开头处于行首。而模型正文通常是**行中结束**的。

`StreamXmlPlugin`（`app/src/main/cpp/streamnative/plugins/StreamXmlPlugin.cpp`）只在以下三种位置才允许开启 XML 块：

```cpp
if (state_ == PluginState::IDLE && !atStartOfLine) {
    const bool allowStart = allowStartAfterEndTag_ || allowStartAfterPunctuation_;
    if (!allowStart) { return finish(handleDefaultCharacter(c)); }
```

即：行首、上一个 XML 结束标签之后、或标点之后。这个插件被两条链路共用：

1. `nativeMarkdownSplitByBlock` —— 消息渲染和 `WaifuMessageProcessor.streamSegments` 的分块来源；
2. `splitByXml` / `NativeXmlSplitter.splitXmlTag` —— `ConversationService.prepareConversationHistory` → `processChatMessageWithTools` 重建历史时用的批量切分。

所以只要工具结果紧贴在一个普通汉字/字母后面，两条链路都会把它判成纯文本。

非流式 + Tool Call API 时必然踩中：`OpenAIProvider` 在非流式分支里**先**发 `convertToolCallsToXml` 的工具 XML，**再**发 `content` 正文，工具结果紧接正文尾部注入，正文结尾是不是标点完全由模型决定。

## 影响

用 NDK 里的 clang 直接编译 `StreamOperators.cpp` + `StreamXmlPlugin.cpp` 跑真实分块，修复前后对比（省略 UTF-8 细节）：

修复前
```
renderable: 醒了\n查完原样汇报<tool_result_Xy9Z name="use_package" ...>{"filepath":"/sdcard/a.png", ...}</tool_result_Xy9Z>\n包激活成功
history:  [TEXT] \n
          [XML ] <tool_aB12 name="use_package">...</tool_aB12>
          [TEXT] \n醒了\n查完原样汇报<tool_result_Xy9Z ...>...包激活成功
```
修复后
```
renderable: 醒了\n查完原样汇报\n\n包激活成功
history:  [TEXT] \n
          [XML ] <tool_aB12 name="use_package">...</tool_aB12>
          [TEXT] \n醒了\n查完原样汇报\n
          [XML ] <tool_result_Xy9Z name="use_package" ...>...
          [TEXT] \n包激活成功
```

渲染侧：修复前 JSON 原文留在可渲染文本里（因此上屏、并在 waifu 模式被拆成碎片气泡），修复后被正常识别为 XML 块、交给工具结果卡片。

历史侧更关键：修复前 `splitXmlTag` 把工具结果**连同它之后的全部正文**并进同一个 TEXT 段，于是 `processChatMessageWithTools` 只产出 `ASSISTANT / TOOL_CALL / ASSISTANT`，没有 `TOOL_RESULT`。这段历史进到 `OpenAIProvider.buildMessagesAndCountTokens` 后，工具调用找不到配对结果，会在下一个 user 边界被 `flushOpenToolCallsAsCancelled` 补成 `{"role":"tool","content":"User cancelled"}`，同时 assistant 消息里塞着工具结果 JSON 原文。也就是说每一轮历史里的工具调用都被回放成「工具被取消 + 助手把整段话连同 JSON 复述了一遍」，token 也被白白重复计费。修复后这一轮正常还原成 `assistant(tool_calls) → tool(result) → assistant`。

## 改动

- `ToolExecutionManager.ensureEndsWithNewline` → `ensureOwnLine`：同时补首尾换行，覆盖 6 处工具结果 / 工具错误 / 权限拒绝 / 工具不可用的注入点。
- `EnhancedAIService`：纯思考告警此前 `roundManager` 拿到的是 `"\n$warning"`、collector 拿到的却是不带换行的版本，两边不一致且同样贴在正文尾部；统一成同一个串。

行为上只多一个换行符：已经处于行首时会多出一个空行，Markdown 渲染会折叠，waifu 分句本来就会丢弃纯空白段。

## 验证方式

无法在本机做完整 Gradle 构建（缺 NDK/CMake、terminal 子模块、ffmpeg jniLibs），所以分三层验证：

1. **原生分块 A/B**：用 `Microsoft Visual Studio BuildTools` 的 cl.exe 编译 `StreamOperators.cpp` + `StreamXmlPlugin.cpp` + `StreamMarkdownPlugin.cpp`，把真实的工具轮内容按流式逐字符喂进 `markdownSessionPush`，并对拼好的持久化消息跑 `splitByXml`，得到上面那组对比。
2. **新增单测** `ToolExecutionManagerMarkupTest`（5 个用例）：覆盖「工具调用前已有正文」「流式工具调用（`</tool_x>` 结尾无换行）」「非流式工具调用（工具 XML 在前、正文在后且不以标点结尾）」「一批多个工具结果」「已带换行不重复叠加」。把测试类分别对新旧实现单独编译运行：新实现 `OK (5 tests)`，旧实现 `Tests run: 5, Failures: 3`。
3. **改动文件类型检查**：kotlinc（Gradle 发行版自带）对改动前后两个文件做错误多重集对比，除了新增一处 `startsWith` 的未解析引用（无项目 classpath 时 stdlib 全部未解析，属预期）之外完全一致。
4. `ci/script/check_localizations.py` 与 `ci/script/check_repo_hygiene.py` 均 `errors=0`。

## 未在本 PR 处理

issue #1059 还提到「工具调用前的多条消息被逐字重放一遍」。上面这条历史链路的破坏（工具调用被回放成 cancelled、助手消息里混进工具结果原文）是让模型养成「工具返回后重述整段」的直接诱因；但复述文本本身是模型在工具轮之后生成的，App 侧的流只发增量、轮次历史里 round-1 与 round-2 的 assistant 内容也各只出现一次，没有找到会机械重放的代码路径。建议先在此修复上复测；若仍复现，需要抓一份工具轮前后的实际请求体再定位。
