### PR TITLE
fix(chat): prevent OpenAI Responses metadata leaking into message content

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -1534,6 +1534,18 @@ open class OpenAIProvider(
             receivedContent.append(tag)
         }
 
+        /**
+         * Provider protocol metadata must sit on its own line: the native XML block
+         * splitter only starts a new XML region at line start, after a closing tag, or after
+         * punctuation. Without this separator the meta tag degrades into plain text when it
+         * directly follows regular content or mid-JSON tool arguments.
+         */
+        suspend fun emitMetadataTag(tag: String) {
+            emitTag("\n")
+            emitTag(tag)
+            emitTag("\n")
+        }
+
         suspend fun emitSavepoint(id: String) {
             savepointLengths[id] = receivedContent.length
             eventChannel.emit(TextStreamEvent(TextStreamEventType.SAVEPOINT, id))
@@ -2354,7 +2366,7 @@ open class OpenAIProvider(
             return
         }
         closeReasoningModeIfOpen(state, emitter)
-        emitter.emitTag(metadataTag)
+        emitter.emitMetadataTag(metadataTag)
     }
 
     private suspend fun emitResponsesOutputItemMetadataFromResponse(
@@ -2642,7 +2654,7 @@ open class OpenAIProvider(
                         )
                         closeReasoningModeIfOpen(state, emitter)
                         OpenAIResponsesPayloadAdapter.createReasoningMetadataTag(item)?.let { metadataTag ->
-                            emitter.emitTag(metadataTag)
+                            emitter.emitMetadataTag(metadataTag)
                         }
                     }
                     return
@@ -3269,10 +3281,10 @@ open class OpenAIProvider(
                                         }
                                     }
                                     parsed.reasoningMetadataTags.forEach { metadataTag ->
-                                        emitter.emitTag(metadataTag)
+                                        emitter.emitMetadataTag(metadataTag)
                                     }
                                     parsed.outputItemMetadataTags.forEach { metadataTag ->
-                                        emitter.emitTag(metadataTag)
+                                        emitter.emitMetadataTag(metadataTag)
                                     }
                                     emitResponsesWebSearchDisplayFromResponse(
                                         context,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/bubble/BubbleAiMessageComposable.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/bubble/BubbleAiMessageComposable.kt
@@ -62,6 +62,7 @@ import com.ai.assistance.operit.ui.theme.resolveConfiguredFontFamily
 import com.ai.assistance.operit.ui.theme.waterGlass
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import com.ai.assistance.operit.util.ChatMarkupRegex
 
 private val ExpandedBubbleLayoutNodeTypes =
     setOf(
@@ -100,6 +101,12 @@ fun BubbleAiMessageComposable(
     val displayPreferencesManager = remember { DisplayPreferencesManager.getInstance(context) }
     val characterCardManager = remember { CharacterCardManager.getInstance(context) }
     val themeSnapshot = LocalThemePreferenceSnapshot.current
+    val displayContent =
+        if (message.contentStream == null) {
+            ChatMarkupRegex.removeOpenAiResponsesProtocolMeta(message.content)
+        } else {
+            message.content
+        }
     val bubbleShowAvatar = themeSnapshot.bubbleShowAvatar
     val bubbleWideLayoutEnabled = themeSnapshot.bubbleWideLayoutEnabled
     val showThinkingProcess = themeSnapshot.showThinkingProcess
@@ -213,10 +220,10 @@ fun BubbleAiMessageComposable(
         animationSpec = tween(durationMillis = 300)
     )
 
-    val imageUrl = remember(message.content, message.contentStream) {
+    val imageUrl = remember(displayContent, message.contentStream) {
         if (message.contentStream == null) {
             val regex = """^\s*!\[[^\]]*\]\(([^)]+)\)\s*$""".toRegex()
-            regex.find(message.content)?.groups?.get(1)?.value
+            regex.find(displayContent)?.groups?.get(1)?.value
         } else {
             null
         }
@@ -393,7 +400,7 @@ fun BubbleAiMessageComposable(
                                 )
                             } else {
                                 StreamMarkdownRenderer(
-                                    content = message.content,
+                                    content = displayContent,
                                     textColor = textColor,
                                     backgroundColor = backgroundColor,
                                     onLinkClick = rememberedOnLinkClick,
@@ -599,10 +606,8 @@ fun BubbleAiMessageComposable(
                                     fillMaxWidth = shouldUseExpandedBubbleLayout,
                                 )
                             } else {
-                                // 对于已完成的静态消息，使用 content 参数的渲染器以支持Markdown
-                                // 共享相同的state，避免重新计算nodes等状态
                                 StreamMarkdownRenderer(
-                                    content = message.content,
+                                    content = displayContent,
                                     textColor = textColor,
                                     backgroundColor = backgroundColor,
                                     onLinkClick = rememberedOnLinkClick,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/cursor/AiMessageComposable.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/cursor/AiMessageComposable.kt
@@ -23,6 +23,7 @@ import com.ai.assistance.operit.ui.features.chat.components.rememberRevisableTex
 import com.ai.assistance.operit.ui.features.chat.components.part.CustomXmlRenderer
 import com.ai.assistance.operit.ui.features.chat.components.part.ThinkToolsXmlNodeGrouper
 import com.ai.assistance.operit.ui.features.chat.components.LinkPreviewDialog
+import com.ai.assistance.operit.util.ChatMarkupRegex
 import com.ai.assistance.operit.util.markdown.toCharStream
 import com.ai.assistance.operit.util.stream.Stream
 import com.ai.assistance.operit.data.preferences.DisplayPreferencesManager
@@ -56,6 +57,12 @@ fun AiMessageComposable(
     val context = LocalContext.current
     val displayPreferencesManager = remember { DisplayPreferencesManager.getInstance(context) }
     val themeSnapshot = LocalThemePreferenceSnapshot.current
+    val displayContent =
+        if (message.contentStream == null) {
+            ChatMarkupRegex.removeOpenAiResponsesProtocolMeta(message.content)
+        } else {
+            message.content
+        }
     val showThinkingProcess = themeSnapshot.showThinkingProcess
     val showStatusTags = themeSnapshot.showStatusTags
     val effectiveShowThinkingProcess = if (forceShowThinkingProcess) true else showThinkingProcess
@@ -197,7 +204,7 @@ fun AiMessageComposable(
                 // 对于已完成的静态消息，使用新的字符串渲染器以提高性能
                 // 共享相同的state，避免重新计算nodes等状态
                 StreamMarkdownRenderer(
-                    content = message.content,
+                    content = displayContent,
                     textColor = textColor,
                     backgroundColor = backgroundColor,
                     onLinkClick = rememberedOnLinkClick,


### PR DESCRIPTION
## 变更说明

本 PR 修复 OpenAI Responses API 在工具调用和推理交替输出时，协议 Meta 标签偶尔泄漏到AI消息正文的问题。

该问题不会影响请求继续执行，但会在聊天界面中显示类似 `<meta provider="openai:responses-reasoning">...</meta>` 的内部协议内容，影响阅读体验。修复后，新的 Responses 元数据会被稳定识别为隐藏标签，历史消息中已经保存的协议 Meta 也不会再显示在正文中。

### 背景与动机

在 OpenAI Responses API 的工具调用场景中，模型的推理元数据需要暂时保存在消息流和聊天历史中，用于后续请求继续传递推理状态。

原有实现会直接发射这些协议 Meta 标签。当 Meta 标签紧贴普通文本、工具参数 JSON 或其他流式内容时，原生 XML 分块器可能无法识别新的 XML 区块，并将 Meta 标签当作普通文本交给界面渲染，最终导致协议内容显示在聊天正文中。

该问题在连续工具调用、代码修改和长时间任务中更容易出现。

### 改动范围

- 在 OpenAI Responses 元数据的四个发射位置增加前后换行，使 Meta 标签独立成行，确保原生 XML 分块器能够稳定识别并隐藏。
- 在气泡样式和 Cursor 样式的静态消息渲染前，移除已经保存到历史消息中的 OpenAI Responses 协议 Meta。
- 使用清理后的消息内容进行独立图片消息识别，避免协议 Meta 影响既有的图片判断。
- 复用现有的 `ChatMarkupRegex` 清理逻辑，不新增数据库字段或新的协议格式。

### 兼容性与风险

- 不改变 OpenAI Responses API 的请求和响应格式。
- 不改变 `reasoning_id` 或加密推理内容的保存和传递逻辑，协议 Meta 仍会保留在内部消息数据中。
- 不改变用户的模型配置、聊天配置或数据格式。
- 仅改变协议 Meta 的流式边界和界面显示方式。
- 已有历史消息在重新渲染时会自动隐藏协议 Meta。
- 对普通文本、Markdown、工具调用和图片消息的正常显示逻辑没有预期影响。
- 新增的换行仅用于帮助内部流式解析器识别协议边界，隐藏标签本身不会显示给用户。

## 关联 Issue

N/A。目前没有单独关联的 Issue，问题来源于实际使用 OpenAI Responses API 进行连续工具调用和长时间任务时的现场反馈。

## 验证方式

```text
检查或命令：
- git diff --check
- Android Build #73
- Android Tests #32
- 使用包含本修复的调试版本进行真机长时间任务测试

环境与变体：
- Android 真机
- 调试版本
- gpt-5.6-terra 模型
- 连续运行约一小时的实际复杂任务

结果：
- git diff --check 通过。
- Android Build #73 通过。
- Android Tests #32 通过。
- 真机长时间任务测试持续约一小时，期间未再发现 OpenAI Responses Meta 标签出现在消息正文中。
- 未观察到工具调用、推理内容或普通 Markdown 消息显示异常。