### PR TITLE
fix(waifu): keep block LaTeX renderable in Waifu mode

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/util/WaifuMessageProcessor.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/WaifuMessageProcessor.kt
@@ -122,11 +122,20 @@ object WaifuMessageProcessor {
 
                 MarkdownProcessorType.CODE_BLOCK,
                 MarkdownProcessorType.TABLE,
-                MarkdownProcessorType.BLOCK_LATEX,
                 MarkdownProcessorType.IMAGE -> {
                     val blockBuilder = StringBuilder()
                     blockGroup.stream.collect { blockBuilder.append(it) }
                     appendRenderableText(blockBuilder.toString())
+                }
+
+                MarkdownProcessorType.BLOCK_LATEX -> {
+                    val blockBuilder = StringBuilder()
+                    blockGroup.stream.collect { blockBuilder.append(it) }
+                    // The `$$…$$` block plugin strips its delimiters; the paren/bracket variant
+                    // keeps them. Re-attach `$$` when missing so the accumulated buffer still
+                    // parses as BLOCK_LATEX on the second pass and the chat bubble renderer
+                    // recognizes the segment as a LaTeX block.
+                    appendRenderableText(ensureBlockLatexDelimiters(blockBuilder.toString()))
                 }
 
                 else -> {
@@ -138,6 +147,36 @@ object WaifuMessageProcessor {
         }
 
         session.collectFinalSegments(renderableBuffer.toString()).forEach { emit(it) }
+    }
+
+    /**
+     * Ensure a BLOCK_LATEX body carries a recognized block delimiter pair.
+     *
+     * `StreamMarkdownBlockLaTeXPlugin` strips the `$$…$$` delimiters from its output while
+     * `StreamMarkdownBlockBracketLaTeXPlugin` keeps `\[…\]`. In Waifu mode the block content
+     * is flattened back into a raw string buffer that is later re-parsed by the same block
+     * splitter and, ultimately, rendered by `StreamMarkdownRenderer`. Without delimiters the
+     * body is indistinguishable from plain text and the LaTeX renderer never fires. This
+     * helper re-attaches `$$` around the body when neither `$$…$$` nor `\[…\]` is present.
+     * Leading and trailing whitespace are preserved so the block still nests correctly inside
+     * the surrounding buffer.
+     */
+    internal fun ensureBlockLatexDelimiters(rawContent: String): String {
+        if (rawContent.isEmpty()) return rawContent
+        val start = rawContent.indexOfFirst { !it.isWhitespace() }
+        if (start < 0) return rawContent
+        val end = rawContent.indexOfLast { !it.isWhitespace() } + 1
+        val body = rawContent.substring(start, end)
+        val hasBracketDelims = body.length >= 4 && body.startsWith("\\[") && body.endsWith("\\]")
+        val hasDollarDelims = body.length >= 4 && body.startsWith("$$") && body.endsWith("$$")
+        if (hasBracketDelims || hasDollarDelims) {
+            return rawContent
+        }
+        // A lone delimiter marker has no interior to wrap; leave it untouched.
+        if (body == "$$" || body == "\\[" || body == "\\]") {
+            return rawContent
+        }
+        return rawContent.substring(0, start) + "$$" + body + "$$" + rawContent.substring(end)
     }
 
     internal fun calculateTypingDelayMs(
@@ -842,13 +881,23 @@ object WaifuMessageProcessor {
                     val isProtected =
                         when (blockType) {
                             MarkdownProcessorType.CODE_BLOCK,
-                            MarkdownProcessorType.TABLE -> true
+                            MarkdownProcessorType.TABLE,
+                            MarkdownProcessorType.BLOCK_LATEX -> true
                             else -> false
+                        }
+
+                    // BLOCK_LATEX from `$$…$$` reaches us stripped of delimiters. Re-attach
+                    // them so the emitted segment renders as LaTeX in the chat bubble.
+                    val normalizedBlock =
+                        if (blockType == MarkdownProcessorType.BLOCK_LATEX) {
+                            ensureBlockLatexDelimiters(block)
+                        } else {
+                            block
                         }
 
                     segments.add(
                         Segment(
-                            content = block,
+                            content = normalizedBlock,
                             isProtected = isProtected,
                             blockType = blockType,
                         )

--- a/app/src/test/java/com/ai/assistance/operit/util/WaifuMessageProcessorTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/util/WaifuMessageProcessorTest.kt
@@ -1,6 +1,11 @@
 package com.ai.assistance.operit.util
 
+import com.ai.assistance.operit.util.stream.Stream
+import com.ai.assistance.operit.util.stream.stream
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeNoException
 import org.junit.Test
 
 class WaifuMessageProcessorTest {
@@ -49,6 +54,152 @@ class WaifuMessageProcessorTest {
                 charDelayMs = 0,
                 isFirstSegment = false,
             )
+        )
+    }
+
+    @Test
+    fun ensureBlockLatexDelimiters_wrapsDollarWhenMissing() {
+        val body = "\\colorbox{pink}{\\text{早该说这句}}"
+        assertEquals(
+            "$$" + body + "$$",
+            WaifuMessageProcessor.ensureBlockLatexDelimiters(body)
+        )
+    }
+
+    @Test
+    fun ensureBlockLatexDelimiters_preservesExistingDollarDelimiters() {
+        val already = "\$\$x^2 + y^2 = z^2\$\$"
+        assertEquals(already, WaifuMessageProcessor.ensureBlockLatexDelimiters(already))
+    }
+
+    @Test
+    fun ensureBlockLatexDelimiters_preservesBracketDelimiters() {
+        val already = "\\[E = mc^2\\]"
+        assertEquals(already, WaifuMessageProcessor.ensureBlockLatexDelimiters(already))
+    }
+
+    @Test
+    fun ensureBlockLatexDelimiters_keepsOuterWhitespace() {
+        val body = "\\frac{1}{2}"
+        assertEquals(
+            "\n$$" + body + "$$\n",
+            WaifuMessageProcessor.ensureBlockLatexDelimiters("\n" + body + "\n")
+        )
+    }
+
+    @Test
+    fun ensureBlockLatexDelimiters_returnsBlankInputUnchanged() {
+        assertEquals("", WaifuMessageProcessor.ensureBlockLatexDelimiters(""))
+        assertEquals("   \n", WaifuMessageProcessor.ensureBlockLatexDelimiters("   \n"))
+    }
+
+    @Test
+    fun ensureBlockLatexDelimiters_doesNotDoubleWrapEmptyBody() {
+        // A stray `$$` on its own should not become `$$$$$$`.
+        assertEquals("$$", WaifuMessageProcessor.ensureBlockLatexDelimiters("$$"))
+    }
+
+    // ---- Integration tests below run the native block splitter and need libstreamnative.so.
+    // ---- They skip cleanly when the native library is unavailable on the host JVM,
+    // ---- e.g. plain JVM unit tests without the Android jniLibs on java.library.path.
+
+    private fun requireNativeStreamSplitter() {
+        try {
+            System.loadLibrary("streamnative")
+        } catch (e: UnsatisfiedLinkError) {
+            assumeNoException(e)
+        }
+    }
+
+    @Test
+    fun splitMessageBySentences_preservesDollarBlockLatex() {
+        requireNativeStreamSplitter()
+        val content = "早该说这句：$$\\colorbox{pink}{\\text{早该说这句}}$$ 就这样。"
+        val segments = WaifuMessageProcessor.splitMessageBySentences(content)
+        val latexSegment = segments.singleOrNull { it.contains("colorbox") }
+            ?: error("Expected exactly one segment containing the LaTeX body, got $segments")
+        assertTrue(
+            "LaTeX segment must keep the `$$` delimiters so the chat bubble renders it as LaTeX: $latexSegment",
+            latexSegment.startsWith("$$") && latexSegment.endsWith("$$")
+        )
+        assertTrue(
+            "LaTeX body must not be split by sentence rules: $latexSegment",
+            latexSegment.contains("\\colorbox{pink}{\\text{早该说这句}}")
+        )
+    }
+
+    @Test
+    fun splitMessageBySentences_preservesBracketBlockLatex() {
+        requireNativeStreamSplitter()
+        val content = "看这里：\\[\\colorbox{pink}{\\text{早该说这句}}\\] 就这样。"
+        val segments = WaifuMessageProcessor.splitMessageBySentences(content)
+        val latexSegment = segments.singleOrNull { it.contains("colorbox") }
+            ?: error("Expected exactly one segment containing the LaTeX body, got $segments")
+        assertTrue(
+            "Bracket-delimited LaTeX must survive intact: $latexSegment",
+            latexSegment.startsWith("\\[") && latexSegment.endsWith("\\]")
+        )
+    }
+
+    @Test
+    fun splitMessageBySentences_doesNotSplitBlockLatexInterior() {
+        requireNativeStreamSplitter()
+        // A period inside the LaTeX body previously chopped the block in two.
+        val content = "结果：\$\$x = 1.5 \\cdot y\$\$"
+        val segments = WaifuMessageProcessor.splitMessageBySentences(content)
+        val latexSegment = segments.singleOrNull { it.contains("cdot") }
+            ?: error("Expected exactly one segment containing the LaTeX body, got $segments")
+        assertEquals("\$\$x = 1.5 \\cdot y\$\$", latexSegment)
+    }
+
+    @Test
+    fun splitMessageBySentences_keepsOrderAroundBlockLatex() {
+        requireNativeStreamSplitter()
+        val content = "开头。\$\$a+b\$\$ 结尾。"
+        val segments = WaifuMessageProcessor.splitMessageBySentences(content)
+        assertEquals(listOf("开头。", "\$\$a+b\$\$", "结尾。"), segments)
+    }
+
+    @Test
+    fun streamSegments_preservesDollarBlockLatexAcrossChunks() = runBlocking {
+        requireNativeStreamSplitter()
+        // Split the LaTeX block across many small chunks to simulate model streaming.
+        val fullText = "早该说这句：$$\\colorbox{pink}{\\text{早该说这句}}$$ 就这样。"
+        val chunks = fullText.chunked(3)
+        val chunkStream: Stream<String> = stream {
+            chunks.forEach { emit(it) }
+        }
+        val collected = mutableListOf<String>()
+        WaifuMessageProcessor.streamSegments(chunkStream).collect { collected.add(it) }
+
+        val latexSegment = collected.singleOrNull { it.contains("colorbox") }
+            ?: error("Expected exactly one segment containing the LaTeX body, got $collected")
+        assertTrue(
+            "Streamed LaTeX must be wrapped in `$$` for the bubble renderer: $latexSegment",
+            latexSegment.startsWith("$$") && latexSegment.endsWith("$$")
+        )
+        assertTrue(
+            "Streamed LaTeX body must remain in one segment: $latexSegment",
+            latexSegment.contains("\\colorbox{pink}{\\text{早该说这句}}")
+        )
+    }
+
+    @Test
+    fun streamSegments_preservesBracketBlockLatexAcrossChunks() = runBlocking {
+        requireNativeStreamSplitter()
+        val fullText = "开头：\\[a^2 + b^2 = c^2\\] 结尾。"
+        val chunks = fullText.chunked(4)
+        val chunkStream: Stream<String> = stream {
+            chunks.forEach { emit(it) }
+        }
+        val collected = mutableListOf<String>()
+        WaifuMessageProcessor.streamSegments(chunkStream).collect { collected.add(it) }
+
+        val latexSegment = collected.singleOrNull { it.contains("a^2") }
+            ?: error("Expected exactly one segment containing the LaTeX body, got $collected")
+        assertTrue(
+            "Bracket-delimited LaTeX must survive streaming intact: $latexSegment",
+            latexSegment.startsWith("\\[") && latexSegment.endsWith("\\]")
         )
     }
 }


### PR DESCRIPTION
Fixes #852.

## What was broken

Reporter's screenshots show `\colorbox{…}\text{…}` and similar LaTeX bodies rendered as raw text once **Waifu mode** is on. In normal chat mode the same replies render correctly.

## Why (single-sentence root cause)

Waifu mode flattens each streamed block back into a raw string and re-parses that buffer through the same block splitter to figure out sentence boundaries — but `StreamMarkdownBlockLaTeXPlugin` is configured with `includeDelimiters=false`, so on the second pass a `$$…$$` body has no delimiters and looks like plain text; the paren/bracket variant keeps its delimiters but is not marked protected in `splitIntoSegments`, so sentence rules and `cleanContentForWaifu` can still chop it up.

## Trace

1. Model streams `早该说这句：$$\colorbox{pink}{\text{早该说这句}}$$ 就这样。`.
2. `WaifuMessageProcessor.streamSegments` calls `sourceStream.nativeMarkdownSplitByBlock()`. The block plugin fires on `$$…$$` and emits a `BLOCK_LATEX` group whose body is just `\colorbox{pink}{\text{早该说这句}}` (delimiters stripped).
3. `streamSegments` collects the block atomically and calls `appendRenderableText(body)`, which appends the delimiterless body to `renderableBuffer`.
4. `StreamingSession.collectStableSegments` re-runs `splitMessageBySentencesInternal` on the accumulated buffer, which re-parses via `nativeMarkdownSplitByBlock`. The body without delimiters is now `PLAIN_TEXT`.
5. As `PLAIN_TEXT` it goes through `cleanContentForWaifu` + `splitPlainTextIntoSentences` and finally becomes one or more String segments.
6. Each segment is turned into `ChatMessage(sender="ai", content=segment, contentStream=null)`. `BubbleAiMessageComposable` renders it via `StreamMarkdownRenderer(content=…)`. That renderer only recognizes LaTeX when the delimiters are present — so the reader sees the raw macro.

The `\[…\]` variant (`StreamMarkdownBlockBracketLaTeXPlugin(includeDelimiters=true)`) keeps its delimiters through the first splitter and its second-pass re-parse, but `splitIntoSegments` doesn't mark `BLOCK_LATEX` as `isProtected`, so the segment still runs through `cleanContentForWaifu` and sentence splitting and can be damaged (e.g. a period inside the body chops the block; unmatched `_` pairs get italicized away).

## Fix

Fix at the atomic-block boundary that Waifu mode already treats specially:

- `WaifuMessageProcessor.streamSegments`: when a `BLOCK_LATEX` block arrives, re-attach `$$` to its body before appending to `renderableBuffer` when neither `$$…$$` nor `\[…\]` is already present. The second pass now still sees the block as a block.
- `WaifuMessageProcessor.splitIntoSegments`: mark `BLOCK_LATEX` as a protected segment alongside `CODE_BLOCK`/`TABLE`, and normalize its body the same way. This makes the batch `splitMessageBySentences` path emit a single, renderable LaTeX segment, and stops `cleanContentForWaifu` from touching the block.

Deliberately **not** doing:

- No special-casing of `\colorbox` / `\textcolor` / any specific macro — the fix is at the block-type layer.
- No changes to the C++ splitter or to `MarkdownProcessorType`. Both would ripple into every consumer of `nativeMarkdownSplitByBlock`.
- No change to inline `$…$` / `\(…\)` — inline LaTeX is not part of the block splitter and this issue is about block LaTeX. Inline LaTeX in simple sentences already survives.

## Tests

Extends `WaifuMessageProcessorTest` (JVM):

- Pure-Kotlin tests for the new `ensureBlockLatexDelimiters` helper (wrap missing `$$`, preserve existing `$$…$$` / `\[…\]`, preserve outer whitespace, leave lone `$$` alone, wrap short bodies).
- Integration tests against `WaifuMessageProcessor.splitMessageBySentences` and `WaifuMessageProcessor.streamSegments` covering:
    - `$$\colorbox{pink}{\text{早该说这句}}$$` sandwiched between two sentences — LaTeX segment kept with `$$` and body intact.
    - `\[\colorbox{pink}{\text{早该说这句}}\]` variant — segment kept with `\[…\]`.
    - `$$x = 1.5 \cdot y$$` — period inside body no longer chops the block.
    - `$$a+b$$` between two sentences — the three-segment order is preserved.
    - Streamed chunk-by-chunk versions of both `$$…$$` and `\[…\]`, chunk size 3 / 4, to simulate model streaming — the LaTeX still lands in a single wrapped segment.

The integration tests use `Assume.assumeNoException` around `System.loadLibrary(\"streamnative\")` so they skip cleanly on a JVM host without the Android jniLibs on `java.library.path`; when the library is available they run end-to-end.

## Verification

- `ci/script/check_repo_hygiene.py` — `errors=0 warnings=0`, 2 files checked.
- `ci/script/check_localizations.py` — `errors=0 warnings=0` (no string-resource changes).
- `ci/script/check_markdown_links.py` — `errors=0 warnings=0`.
- Pure helper logic executed via a standalone kotlinc harness that mirrors `ensureBlockLatexDelimiters` — 10/10 assertions pass.
- Parse-check on `WaifuMessageProcessor.kt` vs `upstream/dev` (per `operit-local-kotlin-check`): +5 error lines, all of them the expected project-symbol references (`MarkdownProcessorType`, `stream`, `it`, `appendRenderableText`) from the new `BLOCK_LATEX` branch. No unrelated regressions.