### PR TITLE
fix(chat): use AppLogger for unmatched tool results

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
@@ -375,7 +375,11 @@ internal object StructuredToolCallBridge {
                             messagesArray.put(toolMessage)
                         }
                         if (matchedCalls.size < resultsList.size) {
-                            logDebug("发现未匹配的tool_result: ${resultsList.size - matchedCalls.size}")
+                            // Keep diagnostics on the module logger; logDebug is not a project API.
+                            AppLogger.d(
+                                "StructuredToolCallBridge",
+                                "发现未匹配的tool_result: ${resultsList.size - matchedCalls.size}"
+                            )
                         }
 
                         flushOpenToolCallsAsCancelled()


### PR DESCRIPTION
## 变更说明 / Description

修复 `StructuredToolCallBridge` 中调用不存在的 `logDebug` 导致的 Kotlin 编译失败。

### 改动范围 / Changes

- 使用项目现有的 `AppLogger.d` 记录未匹配 `tool_result` 的调试信息。
- 未改变工具结果配对或消息构造逻辑。

## 验证方式 / Verification

```text
静态检查：确认 AppLogger.d(String, String) 存在，git diff --check 通过
构建/测试：未重复执行，遵循仓库执行准则
```

Closes #1027