### PR TITLE
fix(mcp): register remote MCP tools when discovery succeeds

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/mcp/MCPRepository.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/mcp/MCPRepository.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.runBlocking
 
 /**
  * 统一的MCP仓库管理类
@@ -1095,7 +1094,8 @@ class MCPRepository(private val context: Context) {
     }
 
     /**
-     * Returns the names exposed by a remote MCP service for list presentation.
+     * Returns the names exposed by a remote MCP service for list presentation, and registers
+     * the service with the AI runtime once its tools are known.
      *
      * Remote configuration is persisted independently from the in-memory runtime. This
      * method establishes that runtime boundary from the current metadata before asking
@@ -1108,23 +1108,39 @@ class MCPRepository(private val context: Context) {
             return@withContext emptyList()
         }
 
+        val toolNames = discoverRemoteToolNames(pluginId, metadata)
+
+        // Discovery is also the moment the server proves it is usable, so hand it to the AI
+        // runtime here. Otherwise the management screen lists tools that the AI never sees,
+        // because the only other registration trigger runs once during startup.
+        if (toolNames.isNotEmpty() && !metadata.disabled) {
+            registerToolsForPlugin(pluginId)
+        }
+
+        toolNames
+    }
+
+    private suspend fun discoverRemoteToolNames(
+        pluginId: String,
+        metadata: MCPLocalServer.PluginMetadata
+    ): List<String> {
         val cachedToolNames = mcpLocalServer.getCachedTools(pluginId)
             .orEmpty()
             .map { cachedTool -> cachedTool.name.trim() }
             .filter { toolName -> toolName.isNotEmpty() }
             .distinct()
         if (cachedToolNames.isNotEmpty()) {
-            return@withContext cachedToolNames
+            return cachedToolNames
         }
 
         if (metadata.disabled) {
-            return@withContext emptyList()
+            return emptyList()
         }
 
         val mcpManager = MCPManager.getInstance(context)
         mcpManager.registerRuntime(pluginId, createRuntimeDescriptor(metadata))
         val session = mcpManager.getOrCreateSession(pluginId)
-            ?: return@withContext emptyList()
+            ?: return emptyList()
         val discoveredTools = session.listTools()
             .mapNotNull { tool ->
                 val toolName = tool.name.trim()
@@ -1141,7 +1157,7 @@ class MCPRepository(private val context: Context) {
             mcpLocalServer.cacheServerTools(pluginId, discoveredTools)
         }
 
-        discoveredTools.map { tool -> tool.name }.distinct()
+        return discoveredTools.map { tool -> tool.name }.distinct()
     }
 
     /**
@@ -1171,74 +1187,78 @@ class MCPRepository(private val context: Context) {
         }
 
         AppLogger.d(TAG, "开始为 ${successfulPluginIds.size} 个插件注册工具: ${successfulPluginIds.joinToString()}")
-
-        val mcpManager = MCPManager.getInstance(context)
-        val toolHandler = AIToolHandler.getInstance(context)
-        val mcpToolExecutor = MCPToolExecutor(context, mcpManager)
-
-        successfulPluginIds.forEach { pluginId ->
-            try {
-                AppLogger.d(TAG, "正在为插件 $pluginId 注册工具...")
-
-                val pluginMetadata = mcpLocalServer.getPluginMetadata(pluginId)
-                if (pluginMetadata == null) {
-                    AppLogger.w(TAG, "在MCPLocalServer中找不到插件 $pluginId 的元数据")
-                    return@forEach
-                }
-
-                val runtimeDescriptor = createRuntimeDescriptor(pluginMetadata)
-                val serverConfig = MCPServerConfig(
-                    name = pluginId,
-                    endpoint = when (runtimeDescriptor) {
-                        is McpRuntimeDescriptor.Local -> "mcp://plugin/${runtimeDescriptor.serviceName}"
-                        is McpRuntimeDescriptor.Remote -> runtimeDescriptor.endpoint
-                    },
-                    description = pluginMetadata.description,
-                    capabilities = listOf("tools"),
-                    extraData = emptyMap()
-                )
-                mcpManager.registerServer(pluginId, serverConfig, runtimeDescriptor)
-                AppLogger.d(TAG, "已在MCPManager中注册服务器: $pluginId (类型: ${pluginMetadata.type})")
-
-                // 获取工具信息
-                val toolsToRegister = getToolsForPlugin(pluginId)
-
-                if (toolsToRegister.isEmpty()) {
-                    AppLogger.w(TAG, "插件 $pluginId 没有可注册的工具")
-                    return@forEach
-                }
-
-                // 统一注册工具
-                toolsToRegister.forEach { toolInfo ->
-                    val prefixedToolName = "$pluginId:${toolInfo.name}"
-
-                    if (toolHandler.getToolExecutor(prefixedToolName) != null) {
-                        AppLogger.d(TAG, "工具 $prefixedToolName 已注册，跳过")
-                        return@forEach
-                    }
-
-                    runBlocking {
-                        toolHandler.registerTool(
-                            name = prefixedToolName,
-                            executor = mcpToolExecutor,
-                            descriptionGenerator = { tool ->
-                                val baseDescription = toolInfo.description
-                                val paramsString = if (tool.parameters.isNotEmpty()) {
-                                    "\nParameters: " + tool.parameters.joinToString(", ") { "${it.name}='${it.value}'" }
-                                } else ""
-                                baseDescription + paramsString
-                            }
-                        )
-                    }
-                    AppLogger.i(TAG, "成功注册工具: $prefixedToolName")
-                }
-                AppLogger.d(TAG, "插件 $pluginId 的工具注册完成，共 ${toolsToRegister.size} 个")
-
-            } catch (e: Exception) {
-                AppLogger.e(TAG, "为插件 $pluginId 注册工具时发生异常", e)
-            }
-        }
+        successfulPluginIds.forEach { pluginId -> registerToolsForPlugin(pluginId) }
         AppLogger.d(TAG, "所有插件的工具注册流程完成")
+    }
+
+    /**
+     * 把单个插件接入 AI 运行时：在 MCPManager 中注册服务器（这是 AI 能看到该包的前提），
+     * 并把它的工具注册到 AIToolHandler。
+     *
+     * 注册由多个生命周期节点触发（启动校验、MCP 管理页的远程发现），所以这里必须幂等：
+     * 已注册的工具会被跳过，重复调用不会产生重复注册。
+     */
+    fun registerToolsForPlugin(pluginId: String) {
+        try {
+            AppLogger.d(TAG, "正在为插件 $pluginId 注册工具...")
+
+            val pluginMetadata = mcpLocalServer.getPluginMetadata(pluginId)
+            if (pluginMetadata == null) {
+                AppLogger.w(TAG, "在MCPLocalServer中找不到插件 $pluginId 的元数据")
+                return
+            }
+
+            val mcpManager = MCPManager.getInstance(context)
+            val runtimeDescriptor = createRuntimeDescriptor(pluginMetadata)
+            val serverConfig = MCPServerConfig(
+                name = pluginId,
+                endpoint = when (runtimeDescriptor) {
+                    is McpRuntimeDescriptor.Local -> "mcp://plugin/${runtimeDescriptor.serviceName}"
+                    is McpRuntimeDescriptor.Remote -> runtimeDescriptor.endpoint
+                },
+                description = pluginMetadata.description,
+                capabilities = listOf("tools"),
+                extraData = emptyMap()
+            )
+            mcpManager.registerServer(pluginId, serverConfig, runtimeDescriptor)
+            AppLogger.d(TAG, "已在MCPManager中注册服务器: $pluginId (类型: ${pluginMetadata.type})")
+
+            // 获取工具信息
+            val toolsToRegister = getToolsForPlugin(pluginId)
+
+            if (toolsToRegister.isEmpty()) {
+                AppLogger.w(TAG, "插件 $pluginId 没有可注册的工具")
+                return
+            }
+
+            // 统一注册工具
+            val toolHandler = AIToolHandler.getInstance(context)
+            val mcpToolExecutor = MCPToolExecutor(context, mcpManager)
+            toolsToRegister.forEach { toolInfo ->
+                val prefixedToolName = "$pluginId:${toolInfo.name}"
+
+                if (toolHandler.getToolExecutor(prefixedToolName) != null) {
+                    AppLogger.d(TAG, "工具 $prefixedToolName 已注册，跳过")
+                    return@forEach
+                }
+
+                toolHandler.registerTool(
+                    name = prefixedToolName,
+                    executor = mcpToolExecutor,
+                    descriptionGenerator = { tool ->
+                        val baseDescription = toolInfo.description
+                        val paramsString = if (tool.parameters.isNotEmpty()) {
+                            "\nParameters: " + tool.parameters.joinToString(", ") { "${it.name}='${it.value}'" }
+                        } else ""
+                        baseDescription + paramsString
+                    }
+                )
+                AppLogger.i(TAG, "成功注册工具: $prefixedToolName")
+            }
+            AppLogger.d(TAG, "插件 $pluginId 的工具注册完成，共 ${toolsToRegister.size} 个")
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "为插件 $pluginId 注册工具时发生异常", e)
+        }
     }
 
     /**

--- a/app/src/main/java/com/ai/assistance/operit/data/mcp/plugins/MCPStarter.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/mcp/plugins/MCPStarter.kt
@@ -455,7 +455,12 @@ class MCPStarter(private val context: Context) {
                                     totalPluginsToProcess
                                 )
 
-                                processPlugin(pluginId, serviceName, progressListener)
+                                processPlugin(
+                                    pluginId,
+                                    serviceName,
+                                    mcpRepository,
+                                    progressListener
+                                )
                             }
 
                             synchronized(allVerificationResults) {
@@ -481,7 +486,6 @@ class MCPStarter(private val context: Context) {
 
                 val successfulResults = allVerificationResults.filter { it.isResponding }
                 if (successfulResults.isNotEmpty()) {
-                    registerToolsForVerifiedPlugins(successfulResults)
                     generateMissingDescriptions(successfulResults)
                 }
 
@@ -504,6 +508,7 @@ class MCPStarter(private val context: Context) {
     private suspend fun processPlugin(
         pluginId: String,
         serviceName: String,
+        mcpRepository: MCPRepository,
         progressListener: PluginStartProgressListener
     ): VerificationResult {
         val mcpLocalServer = MCPLocalServer.getInstance(context)
@@ -522,6 +527,11 @@ class MCPStarter(private val context: Context) {
         if (!mcpLocalServer.hasValidToolCache(pluginId)) {
             cacheToolsFromService(pluginId)
         }
+
+        // Register while this plugin is known to be up. Registering the whole batch after the
+        // fan-out means a stalled or failing plugin keeps every other plugin, remote ones
+        // included, out of the AI tool list.
+        mcpRepository.registerToolsForPlugin(pluginId)
 
         return VerificationResult(
             pluginId = pluginId,

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/mcp/McpServerRegistrationTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/mcp/McpServerRegistrationTest.kt
@@ -1,0 +1,100 @@
+package com.ai.assistance.operit.core.tools.mcp
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * Guards the registration surface remote MCP plugins depend on (issue #907).
+ *
+ * Bringing a remote plugin up only installs a runtime descriptor. The AI can reach it only once
+ * the plugin is also registered as a server, because the "Available packages" prompt section and
+ * the package auto-activation path both read [MCPManager.getRegisteredServers].
+ */
+class McpServerRegistrationTest {
+
+    private val context: Context = mock()
+
+    private val remoteDescriptor = McpRuntimeDescriptor.Remote(
+        endpoint = "https://example.invalid/mcp",
+        connectionType = "httpStream",
+        bearerToken = "token",
+        headers = mapOf("X-Client" to "Operit")
+    )
+
+    private fun remoteServerConfig() = MCPServerConfig(
+        name = PLUGIN_ID,
+        endpoint = remoteDescriptor.endpoint,
+        description = "Remote MCP service",
+        capabilities = listOf("tools"),
+        extraData = emptyMap()
+    )
+
+    @Test
+    fun `connecting a remote runtime does not expose the server to the AI`() {
+        val manager = MCPManager(context)
+
+        manager.registerRuntime(PLUGIN_ID, remoteDescriptor)
+
+        assertFalse(manager.isServerRegistered(PLUGIN_ID))
+        assertTrue(manager.getRegisteredServers().isEmpty())
+    }
+
+    @Test
+    fun `registering the server exposes the remote endpoint to the AI`() {
+        val manager = MCPManager(context)
+
+        manager.registerServer(PLUGIN_ID, remoteServerConfig(), remoteDescriptor)
+
+        assertTrue(manager.isServerRegistered(PLUGIN_ID))
+        assertEquals(
+            remoteDescriptor.endpoint,
+            manager.getRegisteredServers().getValue(PLUGIN_ID).endpoint
+        )
+    }
+
+    @Test
+    fun `repeated registration keeps a single server entry`() {
+        val manager = MCPManager(context)
+
+        repeat(3) {
+            manager.registerServer(PLUGIN_ID, remoteServerConfig(), remoteDescriptor.copy())
+        }
+
+        assertEquals(setOf(PLUGIN_ID), manager.getRegisteredServers().keys)
+    }
+
+    @Test
+    fun `descriptors rebuilt from the same metadata compare equal`() {
+        // registerRuntime closes the cached session whenever the incoming descriptor differs from
+        // the previous one. Registration runs from several lifecycle points, so unchanged plugin
+        // metadata has to keep producing an equal descriptor or a live session gets torn down on
+        // every refresh.
+        val rebuilt = McpRuntimeDescriptor.Remote(
+            endpoint = "https://example.invalid/mcp",
+            connectionType = "httpStream",
+            bearerToken = "token",
+            headers = mapOf("X-Client" to "Operit")
+        )
+
+        assertEquals(remoteDescriptor, rebuilt)
+    }
+
+    @Test
+    fun `unregistering a server hides it from the AI again`() {
+        val manager = MCPManager(context)
+        manager.registerServer(PLUGIN_ID, remoteServerConfig(), remoteDescriptor)
+
+        manager.unregisterServer(PLUGIN_ID)
+
+        assertFalse(manager.isServerRegistered(PLUGIN_ID))
+        assertTrue(manager.getRegisteredServers().isEmpty())
+    }
+
+    private companion object {
+        const val PLUGIN_ID = "galatea-garden"
+    }
+}


### PR DESCRIPTION
## 问题

远程 MCP（`type: remote`，`connectionType: httpStream`）握手成功、`server_status.json` 里也写进了 `cachedTools`，但工具从来不出现在 AI 的可调用列表里。

## 根因

一个插件要让 AI 看见，必须进 `MCPManager.serverConfigCache`——`SystemPromptConfig` 的 "Available packages" 段落和 `AIToolHandler.getToolExecutorOrActivate` 的包自动激活都读这里。而写进这个缓存的只有一个地方：`MCPRepository.registerToolsForLoadedPlugins` → `MCPManager.registerServer`。其它所有"把插件跑起来"的路径都只调 `registerRuntime`，连接是通的，但对 AI 不可见。

两条具体的断链：

1. **MCP 管理页有自己的一条发现路径。** `MCPRepository.getRemoteToolNames`（`MCPConfigScreen` 的 `LaunchedEffect` 对每个远程插件都会调）会 `registerRuntime` + `getOrCreateSession` + `listTools` + `cacheServerTools`——绿灯和 `cachedTools` 就是这么来的——然后**什么都不注册**。issue 里"绿灯 + 有缓存 + AI 看不到"的状态正是这条路径的产物。

2. **启动批次的注册在整个扇出之后。** `MCPStarter.startAllDeployedPlugins` 里 `registerToolsForVerifiedPlugins` 排在 `jobs.awaitAll()` 后面，所以只要有一个插件卡住或失败，其它插件（包括已经连上的远程插件）就一起拿不到注册。远程插件的注册被本地插件的部署/bridge 流程绑架了。

## 改动

- `MCPRepository`：把 `registerToolsForLoadedPlugins` 的单插件逻辑拆成幂等的 `registerToolsForPlugin(pluginId)`（已注册的工具跳过），批量版本改成循环调用它。
- `MCPRepository.getRemoteToolNames`：发现（缓存命中或实时握手）拿到工具名之后，对**已启用**的远程插件调一次 `registerToolsForPlugin`。被禁用的服务只用于展示，不注册。
- `MCPStarter`：把注册挪进 `processPlugin`，插件一验证通过就注册，删掉 `awaitAll()` 之后的批量注册。`generateMissingDescriptions` 保持在批次末尾不动。

本地插件的行为没有变化：`processPlugin` 对 local/remote 是同一段代码，注册函数本身也没改逻辑，只是调用时机提前到了每个插件自己完成的那一刻。

## 验证方式

Windows 上跑不了完整 Gradle 构建（缺 NDK/CMake 与 terminal submodule），所以用了三层验证。

**1. 生命周期 A/B（复现 + 修复）。** 用 Python 按签名从 `MCPRepository.kt` 里逐字抠出 `getRemoteToolNames` / `discoverRemoteToolNames` / `registerToolsForLoadedPlugins` / `registerToolsForPlugin` / `getToolsForPlugin` / `createRuntimeDescriptor`，同一个抽取器分别跑 `git show upstream/dev:...` 和本分支，配上 `MCPLocalServer` / `MCPManager` / `AIToolHandler` 的桩（`MCPManager.registerServer` / `registerRuntime` 的语义按真实实现照抄），用 gradle 自带的 kotlinc 编译后运行。

场景 1 = "用户打开 MCP 管理页，远程服务握手成功"：

```
baseline (upstream/dev):
  [screen discovery] aiVisibleServers=[] aiTools=[] cachedTools=[list_games, create_thread]

fixed:
  [screen discovery] aiVisibleServers=[galatea-garden]
                     aiTools=[galatea-garden:list_games, galatea-garden:create_thread]
                     cachedTools=[list_games, create_thread]
```

baseline 那一行就是 issue 描述的状态：工具缓存写进去了，AI 侧空的。另外四个场景在两边都跑：缓存命中的发现、被禁用的服务（两边都不注册，保持隐藏）、重复触发（3 次 `getRemoteToolNames` + 1 次批量注册 → `registerTool` 仍然只调 2 次，服务器条目 1 个，没有因为描述符不等而丢会话）、以及启动批次路径（两边都正常注册，回归保护）。

**2. 新增单测。** `app/src/test/java/.../core/tools/mcp/McpServerRegistrationTest.kt`，锁住 #907 里被混淆的那条边界：只 `registerRuntime` 不等于对 AI 可见；`registerServer` 之后 endpoint 能被取到；重复注册只留一个条目；相同元数据重建出的 `Remote` 描述符相等（`registerRuntime` 靠这个判断才不会在每次刷新时把活着的会话关掉）；`unregisterServer` 能撤回。本地用真实的 `MCPManager` / `McpRuntimeDescriptor` / `MCPServerConfig` 编译运行：`OK (5 tests)`。

**3. 解析检查。** 两个改动文件分别与 `upstream/dev` 版本做 kotlinc 错误多重集 diff（项目符号在孤立编译里本就无法解析，看的是增量）：

- `MCPRepository.kt`：`unresolved reference 'MCPLocalServer'` +1（`discoverRemoteToolNames` 新增的显式参数类型）、`unresolved reference 'disabled'` +1（新增的 `!metadata.disabled`）、`cannot infer type for this parameter` −2（去掉了那个空转的 `runBlocking` 包装）。没有新的错误种类。
- `MCPStarter.kt`：`unresolved reference 'MCPRepository'` +1（`processPlugin` 新增参数类型）、`unresolved reference 'registerToolsForPlugin'` +1。其余完全一致。

`ci/script/check_localizations.py`、`check_repo_hygiene.py`、`check_markdown_links.py` 对 `upstream/dev...HEAD` 均为 `errors=0 warnings=0`。

## 一并发现但没有改的

`startAllDeployedPlugins` 里 `initBridge()` 排在插件扇出之前，且整段在同一个 try 里。只要有本地插件，远程插件就得等本地 bridge / 终端环境先跑完；#907 的关联反馈里贴的启动日志正是"只见到 127.0.0.1:32145 的 bridge 尝试，之后再无任何远程 endpoint 请求"。把远程插件从 bridge 初始化上解耦需要重排这段启动流程，terminal submodule 在我这边没有 checkout，`initializeEnvironment()` 到底会不会抛我无法确认，所以没有动，留给维护者判断。另外 `MCPStarter.startPlugin` / `verifyPlugins` 目前全仓没有调用点，也一并保持原样。
