### PR TITLE
feat(chat): 新增重试控制并修复工具调用渲染

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/AIForegroundService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/AIForegroundService.kt
@@ -1860,9 +1860,10 @@ class AIForegroundService : Service() {
         val wakeListeningEnabledSnapshot = wakeListeningEnabled
         val wakeListeningSuspendedSnapshot = wakeListeningSuspendedForIme || wakeListeningSuspendedForExternalRecording || wakeListeningSuspendedForFloatingFullscreen
         val externalHttpSnapshot = externalHttpStateFlow.value
+        val applicationLabel = applicationInfo.loadLabel(packageManager).toString()
         val title =
             if (isAiBusy) {
-                characterName ?: getString(R.string.service_operit_running)
+                characterName ?: applicationLabel
             } else {
                 if (wakeListeningEnabledSnapshot) {
                     if (wakeListeningSuspendedSnapshot) {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/AIForegroundService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/AIForegroundService.kt
@@ -31,7 +31,9 @@ import androidx.core.app.NotificationCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.graphics.drawable.IconCompat
+import com.ai.assistance.operit.BuildConfig
 import com.ai.assistance.operit.R
+
 import com.ai.assistance.operit.api.speech.PersonalWakeListener
 import com.ai.assistance.operit.api.speech.SpeechPrerollStore
 import com.ai.assistance.operit.api.speech.SpeechService
@@ -1862,7 +1864,9 @@ class AIForegroundService : Service() {
         val externalHttpSnapshot = externalHttpStateFlow.value
         val applicationLabel = applicationInfo.loadLabel(packageManager).toString()
         val title =
-            if (isAiBusy) {
+            if (BuildConfig.DEBUG) {
+                applicationLabel
+            } else if (isAiBusy) {
                 characterName ?: applicationLabel
             } else {
                 if (wakeListeningEnabledSnapshot) {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/ChatRuntimeHolder.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/ChatRuntimeHolder.kt
@@ -120,7 +120,7 @@ class ChatRuntimeHolder private constructor(context: Context) {
                 mainCore.currentTurnToolInvocationCountByChatId,
                 floatingCore.currentTurnToolInvocationCountByChatId,
             ) { mainCounts, floatingCounts ->
-                mainCounts.values.sum() + floatingCounts.values.sum()
+                countCurrentTurnTools(mainCounts) + countCurrentTurnTools(floatingCounts)
             }.collect { count ->
                 _currentSessionToolCount.value = count
             }
@@ -234,6 +234,10 @@ class ChatRuntimeHolder private constructor(context: Context) {
 
         @Volatile
         private var instance: ChatRuntimeHolder? = null
+
+        internal fun countCurrentTurnTools(countMap: Map<String, Int>): Int {
+            return countMap.values.sumOf { it.coerceAtLeast(0) }
+        }
 
         fun getInstance(context: Context): ChatRuntimeHolder {
             return instance ?: synchronized(this) {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/ChatRuntimeHolder.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/ChatRuntimeHolder.kt
@@ -117,24 +117,14 @@ class ChatRuntimeHolder private constructor(context: Context) {
 
         runtimeScope.launch {
             combine(
-                mainCore.activeStreamingChatIds,
                 mainCore.currentTurnToolInvocationCountByChatId,
-                floatingCore.activeStreamingChatIds,
-                floatingCore.currentTurnToolInvocationCountByChatId
-            ) { mainActiveChatIds, mainCounts, floatingActiveChatIds, floatingCounts ->
-                countCurrentTurnToolsForActiveChats(mainActiveChatIds, mainCounts) +
-                    countCurrentTurnToolsForActiveChats(floatingActiveChatIds, floatingCounts)
+                floatingCore.currentTurnToolInvocationCountByChatId,
+            ) { mainCounts, floatingCounts ->
+                mainCounts.values.sum() + floatingCounts.values.sum()
             }.collect { count ->
                 _currentSessionToolCount.value = count
             }
         }
-    }
-
-    private fun countCurrentTurnToolsForActiveChats(
-        activeChatIds: Set<String>,
-        countMap: Map<String, Int>
-    ): Int {
-        return activeChatIds.sumOf { chatId -> countMap[chatId] ?: 0 }
     }
 
     private fun setupCrossSessionSync() {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
@@ -2125,10 +2125,6 @@ class EnhancedAIService private constructor(private val context: Context) {
     ) {
         val startTime = messageTimingNow()
 
-        toolInvocations.forEach { invocation ->
-            onToolInvocation?.invoke(invocation.tool.name)
-        }
-
         if (!isSubTask && toolInvocations.isNotEmpty()) {
             withContext(Dispatchers.Main) {
                 val toolNames = toolInvocations.joinToString(", ") { resolveToolDisplayName(it.tool) }
@@ -2155,6 +2151,7 @@ class EnhancedAIService private constructor(private val context: Context) {
                 callerChatId = chatId,
                 callerCardId = roleCardId,
                 onToolExecutionStarted = { toolName ->
+                    onToolInvocation?.invoke(toolName)
                     if (!isSubTask) {
                         withContext(Dispatchers.Main) {
                             _inputProcessingState.value = InputProcessingState.WaitingToolResult(toolName)

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
@@ -433,7 +433,10 @@ class EnhancedAIService private constructor(private val context: Context) {
         val isConversationActive: AtomicBoolean = AtomicBoolean(true),
         val conversationHistory: MutableList<PromptTurn>,
         val eventChannel: MutableSharedStream<TextStreamEvent>,
+        val toolResultDisplayBudget: ToolExecutionManager.ToolResultDisplayBudget =
+            ToolExecutionManager.ToolResultDisplayBudget(),
         var modelExecutionSnapshot: ModelExecutionSnapshot? = null
+
     )
 
     private val activeExecutionContexts = ConcurrentHashMap<Int, MessageExecutionContext>()
@@ -2161,6 +2164,7 @@ class EnhancedAIService private constructor(private val context: Context) {
                 onDisplayMarkupEmitted = { markup ->
                     context.roundManager.appendContent(markup)
                 },
+                displayBudget = context.toolResultDisplayBudget,
             )
 
             if (allToolResults.isNotEmpty()) {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationMarkupManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationMarkupManager.kt
@@ -51,23 +51,28 @@ class ConversationMarkupManager {
          * @param result The tool execution result
          * @return The formatted tool result message
          */
-        fun formatToolResultForMessage(result: ToolResult): String {
+        fun formatToolResultForMessage(
+            result: ToolResult,
+            maxMessageChars: Int = ToolExecutionLimits.MAX_FINAL_TOOL_RESULT_MESSAGE_CHARS,
+        ): String {
+            val safeMaxMessageChars = maxMessageChars.coerceAtLeast(0)
             return if (result.success) {
                 val (toolPayload, imageLinkPayload) = splitImageLinksForModel(result.result.toString())
                 val toolResultXml =
                     createBoundedToolResultXml(
                         toolName = result.toolName,
                         status = "success",
-                        rawPayload = toolPayload
+                        rawPayload = toolPayload,
+                        maxMessageChars = safeMaxMessageChars,
                     ) { payload ->
                         "<content>$payload</content>"
                     }
 
-                if (imageLinkPayload.isBlank()) {
-                    toolResultXml
-                } else {
-                    "$toolResultXml\n$imageLinkPayload"
-                }
+                appendImageLinksWithinLimit(
+                    toolResultXml = toolResultXml,
+                    imageLinkPayload = imageLinkPayload,
+                    maxMessageChars = safeMaxMessageChars,
+                )
             } else {
                 val errorPayload = buildString {
                     val message = result.error.orEmpty().trim()
@@ -83,7 +88,8 @@ class ConversationMarkupManager {
                 createBoundedToolResultXml(
                     toolName = result.toolName,
                     status = "error",
-                    rawPayload = errorPayload
+                    rawPayload = errorPayload,
+                    maxMessageChars = safeMaxMessageChars,
                 ) { payload ->
                     "<content><error>$payload</error></content>"
                 }
@@ -105,6 +111,29 @@ class ConversationMarkupManager {
                     .joinToString("\n")
 
             return toolPayload to imageLinkPayload
+        }
+
+        private fun appendImageLinksWithinLimit(
+            toolResultXml: String,
+            imageLinkPayload: String,
+            maxMessageChars: Int,
+        ): String {
+            if (imageLinkPayload.isBlank() || toolResultXml.length >= maxMessageChars) {
+                return toolResultXml
+            }
+
+            val bounded = StringBuilder(toolResultXml)
+            for (link in imageLinkPayload.lineSequence()) {
+                if (link.isBlank()) {
+                    continue
+                }
+                val additionalChars = 1 + link.length
+                if (bounded.length + additionalChars > maxMessageChars) {
+                    break
+                }
+                bounded.append('\n').append(link)
+            }
+            return bounded.toString()
         }
 
         fun buildBoundedToolResultMessage(results: List<ToolResult>): String {
@@ -167,6 +196,7 @@ class ConversationMarkupManager {
             toolName: String,
             status: String,
             rawPayload: String,
+            maxMessageChars: Int,
             bodyBuilder: (String) -> String
         ): String {
             val emptyXml =
@@ -176,8 +206,7 @@ class ConversationMarkupManager {
                     content = bodyBuilder("")
                 )
             val maxPayloadChars =
-                (ToolExecutionLimits.MAX_FINAL_TOOL_RESULT_MESSAGE_CHARS - emptyXml.length)
-                    .coerceAtLeast(0)
+                (maxMessageChars - emptyXml.length).coerceAtLeast(0)
             val boundedPayload = truncatePayload(rawPayload, maxPayloadChars)
             return createToolResultXml(
                 toolName = toolName,

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationService.kt
@@ -128,6 +128,7 @@ class ConversationService(
             customRules: String? = null,
             recordTokenUsage: Boolean = true,
     ): String {
+        val progressScopeId = ToolProgressBus.newScopeId()
         try {
             val useEnglish = LocaleUtils.getCurrentLanguage(context).lowercase().startsWith("en")
             val activePromptMetadata = buildActivePromptHookMetadata(context)
@@ -215,9 +216,10 @@ class ConversationService(
             val contentBuilder = StringBuilder()
 
             ToolProgressBus.update(
-                ToolProgressBus.SUMMARY_PROGRESS_TOOL_NAME,
-                0.05f,
-                context.getString(R.string.conversation_summary_preparing)
+                toolName = ToolProgressBus.SUMMARY_PROGRESS_TOOL_NAME,
+                progress = 0.05f,
+                message = context.getString(R.string.conversation_summary_preparing),
+                scopeId = progressScopeId,
             )
 
             data class Stage(
@@ -269,9 +271,10 @@ class ConversationService(
                     if (!matched) break
                     lastStageIndex += 1
                     ToolProgressBus.update(
-                        ToolProgressBus.SUMMARY_PROGRESS_TOOL_NAME,
-                        next.progress,
-                        next.message
+                        toolName = ToolProgressBus.SUMMARY_PROGRESS_TOOL_NAME,
+                        progress = next.progress,
+                        message = next.message,
+                        scopeId = progressScopeId,
                     )
                 }
             }
@@ -292,9 +295,10 @@ class ConversationService(
             }
 
             ToolProgressBus.update(
-                ToolProgressBus.SUMMARY_PROGRESS_TOOL_NAME,
-                1f,
-                context.getString(R.string.conversation_summary_completed)
+                toolName = ToolProgressBus.SUMMARY_PROGRESS_TOOL_NAME,
+                progress = 1f,
+                message = context.getString(R.string.conversation_summary_completed),
+                scopeId = progressScopeId,
             )
 
             // 获取完整的总结内容
@@ -340,6 +344,8 @@ class ConversationService(
             AppLogger.e(TAG, "生成总结时出错", e)
             // return "对话摘要：生成摘要时出错，但对话仍在继续。"
             throw e
+        } finally {
+            ToolProgressBus.clear(scopeId = progressScopeId)
         }
     }
 

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationService.kt
@@ -1151,7 +1151,8 @@ class ConversationService(
 
         val modelParameters =
             multiServiceManager.getModelParametersForFunction(FunctionType.TRANSLATION)
-        val maxRetryAttempts = LlmRetryPolicy.MAX_RETRY_ATTEMPTS
+        val retryPolicy = LlmRetryPolicy.snapshot(context)
+        val maxRetryAttempts = retryPolicy.maxRetryAttempts
         var reportedRetryCount = 0
 
         try {

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
@@ -6,6 +6,7 @@ import com.ai.assistance.operit.util.AppLogger
 import com.ai.assistance.operit.core.tools.AIToolHandler
 import com.ai.assistance.operit.core.tools.AIToolHookDecision
 import com.ai.assistance.operit.core.tools.StringResultData
+import com.ai.assistance.operit.core.tools.ToolExecutionLimits
 import com.ai.assistance.operit.core.tools.ToolExecutor
 import com.ai.assistance.operit.core.tools.climode.CliToolModeSupport
 import com.ai.assistance.operit.core.tools.climode.ToolExposureMode
@@ -15,6 +16,7 @@ import com.ai.assistance.operit.core.tools.packTool.PackageManager
 import com.ai.assistance.operit.util.stream.StreamCollector
 import com.ai.assistance.operit.data.preferences.CharacterCardToolAccessResolver
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.async
@@ -44,6 +46,13 @@ object ToolExecutionManager {
     private const val PACKAGE_CALLER_NAME_PARAM = "__operit_package_caller_name"
     private const val PACKAGE_CHAT_ID_PARAM = "__operit_package_chat_id"
     private const val PACKAGE_CALLER_CARD_ID_PARAM = "__operit_package_caller_card_id"
+    private const val MAX_TOOL_RESULT_DISPLAY_CHARS_PER_TURN = 256 * 1024
+    private const val MAX_TOOL_RESULT_DISPLAY_CHARS_PER_INVOCATION = 16 * 1024
+    private const val MIN_TOOL_RESULT_DISPLAY_CHARS = 1_024
+    private const val COMPACT_RESULT_MESSAGE =
+        "[工具结果已从聊天显示中省略，以避免长任务占用过多内存。]"
+    private const val AGGREGATED_TOOL_RESULT_TRUNCATION_SUFFIX =
+        "\n[工具返回了多个结果，后续内容已截断。]"
     private val toolRuntimeContextThreadLocal = ThreadLocal<ToolRuntimeContext?>()
 
     data class ToolRuntimeContext(
@@ -55,6 +64,175 @@ object ToolExecutionManager {
         val tool: AITool,
         val displayName: String
     )
+
+    private data class OrderedToolInvocation(
+        val index: Int,
+        val invocation: ToolInvocation,
+    )
+    internal data class ToolResultDisplayMarkup(
+
+        val full: String,
+        val compact: String,
+    )
+
+    private fun ToolResult.toCompactDisplayResult(): ToolResult {
+        return if (success) {
+            copy(result = StringResultData(COMPACT_RESULT_MESSAGE))
+        } else {
+            copy(
+                result = StringResultData(""),
+                error = error.orEmpty().take(256).ifBlank { COMPACT_RESULT_MESSAGE },
+            )
+        }
+    }
+
+    private fun formatToolResultDisplayMarkup(
+        result: ToolResult,
+        maxFullMarkupChars: Int,
+    ): ToolResultDisplayMarkup {
+        return ToolResultDisplayMarkup(
+            full =
+                ConversationMarkupManager.formatToolResultForMessage(
+                    result = result,
+                    maxMessageChars = maxFullMarkupChars,
+                ),
+            compact =
+                ConversationMarkupManager.formatToolResultForMessage(
+                    result = result.toCompactDisplayResult(),
+                    maxMessageChars = MIN_TOOL_RESULT_DISPLAY_CHARS,
+                ),
+        )
+    }
+
+    /** Buffers one invocation's display markup until ordered emission is safe. */
+    internal class ToolResultMarkupBuffer {
+        private val markups = mutableListOf<ToolResultDisplayMarkup>()
+        private var retainedMarkupChars = 0
+        private var lastOverflowMarkup: ToolResultDisplayMarkup? = null
+
+        fun record(result: ToolResult) {
+            val remainingChars =
+                MAX_TOOL_RESULT_DISPLAY_CHARS_PER_INVOCATION - retainedMarkupChars
+            if (remainingChars >= MIN_TOOL_RESULT_DISPLAY_CHARS) {
+                val markup =
+                    formatToolResultDisplayMarkup(
+                        result = result,
+                        maxFullMarkupChars = remainingChars,
+                    )
+                markups += markup
+                retainedMarkupChars += markup.full.length
+            } else {
+                // Preserve the latest terminal state even when intermediate events fill the budget.
+                lastOverflowMarkup =
+                    formatToolResultDisplayMarkup(
+                        result = result,
+                        maxFullMarkupChars = MIN_TOOL_RESULT_DISPLAY_CHARS,
+                    )
+            }
+        }
+
+        suspend fun flushTo(
+            collector: StreamCollector<String>,
+            onDisplayMarkupEmitted: suspend (String) -> Unit,
+            displayBudget: ToolResultDisplayBudget,
+            emissionMutex: Mutex? = null,
+        ) {
+            val orderedMarkups =
+                buildList {
+                    addAll(markups)
+                    lastOverflowMarkup?.let(::add)
+                }
+            for (markup in orderedMarkups) {
+                ToolExecutionManager.emitToolResultMarkup(
+                    content = displayBudget.select(markup),
+                    collector = collector,
+                    onDisplayMarkupEmitted = onDisplayMarkupEmitted,
+                    emissionMutex = emissionMutex,
+                )
+            }
+            markups.clear()
+            lastOverflowMarkup = null
+            retainedMarkupChars = 0
+        }
+    }
+    class ToolResultDisplayBudget {
+
+        private val mutex = Mutex()
+        private var remainingChars = MAX_TOOL_RESULT_DISPLAY_CHARS_PER_TURN
+        internal suspend fun select(markup: ToolResultDisplayMarkup): String = mutex.withLock {
+
+            val selected =
+                if (markup.full.length <= remainingChars) {
+                    markup.full
+                } else {
+                    markup.compact
+                }
+            remainingChars = (remainingChars - selected.length).coerceAtLeast(0)
+            selected
+        }
+    }
+
+    /** Emits completed invocation buffers in original invocation order without blocking execution. */
+    internal class OrderedToolResultEmitter(
+        private val collector: StreamCollector<String>,
+        private val onDisplayMarkupEmitted: suspend (String) -> Unit,
+        private val displayBudget: ToolResultDisplayBudget = ToolResultDisplayBudget(),
+    ) {
+        private val mutex = Mutex()
+
+        private val completedBuffers = mutableMapOf<Int, ToolResultMarkupBuffer>()
+        private var nextInvocationIndex = 0
+
+        suspend fun complete(index: Int, buffer: ToolResultMarkupBuffer) {
+            mutex.withLock {
+                completedBuffers[index] = buffer
+                while (true) {
+                    val nextBuffer = completedBuffers.remove(nextInvocationIndex) ?: break
+                    nextBuffer.flushTo(
+                        collector = collector,
+                        onDisplayMarkupEmitted = onDisplayMarkupEmitted,
+                        displayBudget = displayBudget,
+                    )
+                    nextInvocationIndex++
+                }
+            }
+        }
+    }
+
+    private fun appendBoundedToolResult(
+        builder: StringBuilder,
+        result: ToolResult,
+    ) {
+        val nextContent =
+            (if (result.success) {
+                result.result.toString()
+            } else {
+                "Step error: ${result.error ?: "Unknown error"}"
+            }).trim()
+        if (nextContent.isEmpty()) {
+            return
+        }
+
+        val separator = if (builder.isEmpty()) "" else "\n"
+        val remaining =
+            ToolExecutionLimits.MAX_FINAL_TOOL_RESULT_MESSAGE_CHARS - builder.length - separator.length
+        if (remaining <= 0) {
+            return
+        }
+        builder.append(separator)
+        if (nextContent.length <= remaining) {
+            builder.append(nextContent)
+            return
+        }
+
+        val suffix = AGGREGATED_TOOL_RESULT_TRUNCATION_SUFFIX
+        if (remaining <= suffix.length) {
+            builder.append(suffix.take(remaining))
+        } else {
+            builder.append(nextContent.take(remaining - suffix.length).trimEnd())
+            builder.append(suffix)
+        }
+    }
 
     private fun ensureEndsWithNewline(content: String): String {
         return if (content.endsWith("\n")) content else "$content\n"
@@ -542,8 +720,23 @@ object ToolExecutionManager {
         callerCardId: String? = null,
         onToolExecutionStarted: (suspend (String) -> Unit)? = null,
         onDisplayMarkupEmitted: suspend (String) -> Unit = {},
+        displayBudget: ToolResultDisplayBudget = ToolResultDisplayBudget(),
     ): List<ToolResult> = coroutineScope {
-        val resultEmissionMutex = Mutex()
+        val orderedResultEmitter =
+            OrderedToolResultEmitter(
+                collector = collector,
+                onDisplayMarkupEmitted = onDisplayMarkupEmitted,
+                displayBudget = displayBudget,
+            )
+        val orderedInvocations =
+            invocations.mapIndexed { index, invocation ->
+                OrderedToolInvocation(index = index, invocation = invocation)
+            }
+        val resultBuffersByIndex = ConcurrentHashMap<Int, ToolResultMarkupBuffer>()
+        val resultsByIndex = ConcurrentHashMap<Int, ToolResult>()
+
+        fun bufferFor(index: Int): ToolResultMarkupBuffer =
+            resultBuffersByIndex.getOrPut(index) { ToolResultMarkupBuffer() }
         // 默认工具注册现在可能在启动阶段被延后；这里确保在真正执行工具前已完成注册
         // registerDefaultTools() 是幂等且线程安全的，可安全重复调用
         withContext(Dispatchers.Default) {
@@ -567,62 +760,61 @@ object ToolExecutionManager {
                 toolExposureMode = toolExposureMode
             )
 
-        // 1. 顶层工具暴露模式拦截
-        val toolExposurePermittedInvocations = mutableListOf<ToolInvocation>()
-        val toolExposureDeniedResults = mutableListOf<ToolResult>()
-        for (invocation in invocations) {
-            val deniedResult = buildToolExposureDeniedResult(context, invocation, toolExposureMode)
-            if (deniedResult == null) {
-                toolExposurePermittedInvocations.add(invocation)
-            } else {
-                toolExposureDeniedResults.add(deniedResult)
-                toolHandler.notifyToolExecutionResult(invocation.tool, deniedResult)
-                val toolResultStatusContent =
-                    ConversationMarkupManager.formatToolResultForMessage(deniedResult)
-                emitToolResultMarkup(
-                    content = toolResultStatusContent,
-                    collector = collector,
-                    onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                    emissionMutex = resultEmissionMutex,
-                )
-            }
+        // Every parsed invocation enters the same request/finish lifecycle, including denials.
+        orderedInvocations.forEach { orderedInvocation ->
+            toolHandler.notifyToolCallRequested(orderedInvocation.invocation.tool)
         }
 
-        // 2. 角色卡工具权限拦截（优先于权限弹窗与包自动激活）
-        val roleCardPermittedInvocations = mutableListOf<ToolInvocation>()
-        val roleCardDeniedResults = mutableListOf<ToolResult>()
-        for (invocation in toolExposurePermittedInvocations) {
-            val deniedResult = if (roleCardToolAccess?.customEnabled == true &&
-                !isInvocationAllowedForRoleCard(invocation, roleCardToolAccess)
-            ) {
-                buildRoleCardDeniedResult(context, invocation)
+        // 1. 顶层工具暴露模式拦截
+
+        val toolExposurePermittedInvocations = mutableListOf<OrderedToolInvocation>()
+        for (orderedInvocation in orderedInvocations) {
+            val invocation = orderedInvocation.invocation
+            val deniedResult = buildToolExposureDeniedResult(context, invocation, toolExposureMode)
+            if (deniedResult == null) {
+                toolExposurePermittedInvocations.add(orderedInvocation)
             } else {
-                null
+                resultsByIndex[orderedInvocation.index] = deniedResult
+                val resultBuffer = bufferFor(orderedInvocation.index)
+                toolHandler.notifyToolExecutionResult(invocation.tool, deniedResult)
+                toolHandler.notifyToolExecutionFinished(invocation.tool)
+                resultBuffer.record(deniedResult)
+                orderedResultEmitter.complete(orderedInvocation.index, resultBuffer)
             }
+        }
+        // 2. 角色卡工具权限拦截（优先于权限弹窗与包自动激活）
+
+        val roleCardPermittedInvocations = mutableListOf<OrderedToolInvocation>()
+        for (orderedInvocation in toolExposurePermittedInvocations) {
+            val invocation = orderedInvocation.invocation
+            val deniedResult =
+                if (
+                    roleCardToolAccess?.customEnabled == true &&
+                        !isInvocationAllowedForRoleCard(invocation, roleCardToolAccess)
+                ) {
+                    buildRoleCardDeniedResult(context, invocation)
+                } else {
+                    null
+                }
 
             if (deniedResult == null) {
-                roleCardPermittedInvocations.add(invocation)
+                roleCardPermittedInvocations.add(orderedInvocation)
             } else {
-                roleCardDeniedResults.add(deniedResult)
+                resultsByIndex[orderedInvocation.index] = deniedResult
+                val resultBuffer = bufferFor(orderedInvocation.index)
                 toolHandler.notifyToolExecutionResult(invocation.tool, deniedResult)
-                val toolResultStatusContent =
-                    ConversationMarkupManager.formatToolResultForMessage(deniedResult)
-                emitToolResultMarkup(
-                    content = toolResultStatusContent,
-                    collector = collector,
-                    onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                    emissionMutex = resultEmissionMutex,
-                )
+                toolHandler.notifyToolExecutionFinished(invocation.tool)
+                resultBuffer.record(deniedResult)
+                orderedResultEmitter.complete(orderedInvocation.index, resultBuffer)
             }
         }
 
         // 3. Hook 拦截与权限检查
-        val permittedInvocations = mutableListOf<ToolInvocation>()
-        val hookDeniedResults = mutableListOf<ToolResult>()
-        val permissionDeniedResults = mutableListOf<ToolResult>()
-        for (invocation in roleCardPermittedInvocations) {
-            toolHandler.notifyToolCallRequested(invocation.tool)
+        val permittedInvocations = mutableListOf<OrderedToolInvocation>()
+        for (orderedInvocation in roleCardPermittedInvocations) {
+            val invocation = orderedInvocation.invocation
             val interceptionTool = resolveToolTarget(invocation.tool).tool
+
             when (val interception = toolHandler.checkToolInterception(interceptionTool)) {
                 AIToolHookDecision.Allow -> {
                     val (hasPermission, errorResult) =
@@ -630,22 +822,26 @@ object ToolExecutionManager {
                             toolHandler = toolHandler,
                             invocation = invocation,
                             toolExposureMode = toolExposureMode,
-                            callerChatId = callerChatId
+                            callerChatId = callerChatId,
                         )
                     if (hasPermission) {
-                        permittedInvocations.add(invocation)
+                        permittedInvocations.add(orderedInvocation)
                     } else {
-                        errorResult?.let {
-                            permissionDeniedResults.add(it)
-                            val toolResultStatusContent =
-                                ConversationMarkupManager.formatToolResultForMessage(it)
-                            emitToolResultMarkup(
-                                content = toolResultStatusContent,
-                                collector = collector,
-                                onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                                emissionMutex = resultEmissionMutex,
-                            )
-                        }
+                        val deniedResult =
+                            errorResult
+                                ?: ToolResult(
+                                    toolName = resolveDisplayToolName(invocation.tool),
+                                    success = false,
+                                    result = StringResultData(""),
+                                    error = "Tool permission was denied.",
+                                    errorCode = "permission_denied",
+                                )
+                        resultsByIndex[orderedInvocation.index] = deniedResult
+                        val resultBuffer = bufferFor(orderedInvocation.index)
+                        toolHandler.notifyToolExecutionResult(invocation.tool, deniedResult)
+                        toolHandler.notifyToolExecutionFinished(invocation.tool)
+                        resultBuffer.record(deniedResult)
+                        orderedResultEmitter.complete(orderedInvocation.index, resultBuffer)
                     }
                 }
 
@@ -653,35 +849,37 @@ object ToolExecutionManager {
                     val interceptedResult =
                         toolHandler.buildToolInterceptionResult(
                             resolveDisplayToolName(invocation.tool),
-                            interception
+                            interception,
                         )
-                    hookDeniedResults.add(interceptedResult)
+                    resultsByIndex[orderedInvocation.index] = interceptedResult
+                    val resultBuffer = bufferFor(orderedInvocation.index)
                     toolHandler.notifyToolExecutionResult(invocation.tool, interceptedResult)
                     toolHandler.notifyToolExecutionFinished(invocation.tool)
-                    val toolResultStatusContent =
-                        ConversationMarkupManager.formatToolResultForMessage(interceptedResult)
-                    emitToolResultMarkup(
-                        content = toolResultStatusContent,
-                        collector = collector,
-                        onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                        emissionMutex = resultEmissionMutex,
-                    )
+                    resultBuffer.record(interceptedResult)
+                    orderedResultEmitter.complete(orderedInvocation.index, resultBuffer)
                 }
             }
         }
 
         val injectedInvocations =
-            if (callerName.isNullOrBlank() && callerChatId.isNullOrBlank() && callerCardId.isNullOrBlank()) {
+            if (
+                callerName.isNullOrBlank() &&
+                    callerChatId.isNullOrBlank() &&
+                    callerCardId.isNullOrBlank()
+            ) {
                 permittedInvocations
             } else {
                 val jsPackageNames = packageManager.getAvailablePackages().keys
-                permittedInvocations.map { invocation ->
-                    injectPackageCallContext(
-                        invocation = invocation,
-                        jsPackageNames = jsPackageNames,
-                        callerName = callerName,
-                        callerChatId = callerChatId,
-                        callerCardId = callerCardId
+                permittedInvocations.map { orderedInvocation ->
+                    orderedInvocation.copy(
+                        invocation =
+                            injectPackageCallContext(
+                                invocation = orderedInvocation.invocation,
+                                jsPackageNames = jsPackageNames,
+                                callerName = callerName,
+                                callerChatId = callerChatId,
+                                callerCardId = callerCardId,
+                            ),
                     )
                 }
             }
@@ -693,60 +891,49 @@ object ToolExecutionManager {
             "visit_web", "download_file"
         )
         val (parallelInvocations, serialInvocations) = injectedInvocations.partition {
-            parallelizableToolNames.contains(
-                it.tool.name
-            )
+            parallelizableToolNames.contains(it.invocation.tool.name)
         }
 
-        // 5. 执行工具并收集聚合结果
-        val executionResults = ConcurrentHashMap<ToolInvocation, ToolResult>()
+        // 5. 执行工具并缓冲每个调用的显示结果。
 
-        // 启动并行工具
-        val parallelJobs = parallelInvocations.map { invocation ->
+        // 启动并行工具。它们仍然并行执行，但不会按完成顺序直接写入聊天流。
+        val parallelJobs = parallelInvocations.map { orderedInvocation ->
             async {
+                val resultBuffer = bufferFor(orderedInvocation.index)
                 val result =
                     executeAndEmitTool(
-                        invocation = invocation,
+                        invocation = orderedInvocation.invocation,
                         toolHandler = toolHandler,
                         packageManager = packageManager,
-                        collector = collector,
                         runtimeContext = toolRuntimeContext,
                         onToolExecutionStarted = onToolExecutionStarted,
-                        onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                        resultEmissionMutex = resultEmissionMutex,
+                        resultBuffer = resultBuffer,
                     )
-                executionResults[invocation] = result
+                resultsByIndex[orderedInvocation.index] = result
+                orderedResultEmitter.complete(orderedInvocation.index, resultBuffer)
             }
         }
 
-        // 顺序执行串行工具
-        for (invocation in serialInvocations) {
+        // 串行工具保持原始调用顺序；显示结果同样先缓冲。
+        for (orderedInvocation in serialInvocations) {
+            val resultBuffer = bufferFor(orderedInvocation.index)
             val result =
                 executeAndEmitTool(
-                    invocation = invocation,
+                    invocation = orderedInvocation.invocation,
                     toolHandler = toolHandler,
                     packageManager = packageManager,
-                    collector = collector,
                     runtimeContext = toolRuntimeContext,
                     onToolExecutionStarted = onToolExecutionStarted,
-                    onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                    resultEmissionMutex = resultEmissionMutex,
+                    resultBuffer = resultBuffer,
                 )
-            executionResults[invocation] = result
+            resultsByIndex[orderedInvocation.index] = result
+            orderedResultEmitter.complete(orderedInvocation.index, resultBuffer)
         }
 
-        // 等待所有并行任务完成
+        // Wait for execution completion before returning results to the model.
+        // Display emission itself is incremental through orderedResultEmitter.
         parallelJobs.awaitAll()
-
-        // 6. 按原始顺序重新排序结果
-        val orderedAggregated = injectedInvocations.mapNotNull { executionResults[it] }
-
-        // 7. 组合所有结果并返回
-        toolExposureDeniedResults +
-            roleCardDeniedResults +
-            hookDeniedResults +
-            permissionDeniedResults +
-            orderedAggregated
+        orderedInvocations.mapNotNull { resultsByIndex[it.index] }
     }
 
     /**
@@ -756,11 +943,9 @@ object ToolExecutionManager {
         invocation: ToolInvocation,
         toolHandler: AIToolHandler,
         packageManager: PackageManager,
-        collector: StreamCollector<String>,
         runtimeContext: ToolRuntimeContext,
         onToolExecutionStarted: (suspend (String) -> Unit)?,
-        onDisplayMarkupEmitted: suspend (String) -> Unit,
-        resultEmissionMutex: Mutex,
+        resultBuffer: ToolResultMarkupBuffer,
     ): ToolResult {
         val toolName = invocation.tool.name
         val displayToolName = resolveDisplayToolName(invocation.tool)
@@ -772,21 +957,14 @@ object ToolExecutionManager {
                     // 如果仍然为 null，则构建错误消息
                     val errorMessage =
                         buildToolNotAvailableErrorMessage(toolName, packageManager, toolHandler)
-                    val notAvailableContent =
-                        ConversationMarkupManager.createToolNotAvailableError(toolName, errorMessage)
-                    emitToolResultMarkup(
-                        content = notAvailableContent,
-                        collector = collector,
-                        onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                        emissionMutex = resultEmissionMutex,
-                    )
                     val notAvailableResult =
                         ToolResult(
                             toolName = displayToolName,
                             success = false,
                             result = StringResultData(""),
-                            error = errorMessage
+                            error = errorMessage,
                         )
+                    resultBuffer.record(notAvailableResult)
                     toolHandler.notifyToolExecutionResult(invocation.tool, notAvailableResult)
                     return@withContext notAvailableResult
                 }
@@ -794,22 +972,16 @@ object ToolExecutionManager {
                 onToolExecutionStarted?.invoke(displayToolName)
                 toolHandler.notifyToolExecutionStarted(invocation.tool)
 
-                val collectedResults = mutableListOf<ToolResult>()
+                var lastResult: ToolResult? = null
+                val combinedResultBuilder = StringBuilder()
                 executeToolSafely(invocation, executor, toolHandler).collect { result ->
-                    collectedResults.add(result)
-                    // Emit each result to the live stream and persist the same markup for the final chat message.
-                    val toolResultStatusContent =
-                        ConversationMarkupManager.formatToolResultForMessage(result)
-                    emitToolResultMarkup(
-                        content = toolResultStatusContent,
-                        collector = collector,
-                        onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                        emissionMutex = resultEmissionMutex,
-                    )
+                    lastResult = result
+                    appendBoundedToolResult(combinedResultBuilder, result)
+                    resultBuffer.record(result)
                 }
 
                 // 为此调用聚合最终结果
-                if (collectedResults.isEmpty()) {
+                if (lastResult == null) {
                     val emptyResult =
                         ToolResult(
                             toolName = displayToolName,
@@ -817,31 +989,38 @@ object ToolExecutionManager {
                             result = StringResultData(""),
                             error = "The tool execution returned no results."
                         )
-                    emitToolResultMarkup(
-                        content = ConversationMarkupManager.formatToolResultForMessage(emptyResult),
-                        collector = collector,
-                        onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                        emissionMutex = resultEmissionMutex,
-                    )
+                    resultBuffer.record(emptyResult)
                     toolHandler.notifyToolExecutionResult(invocation.tool, emptyResult)
                     return@withContext emptyResult
                 }
 
-                val lastResult = collectedResults.last()
-                val combinedResultString = collectedResults.joinToString("\n") { res ->
-                    (if (res.success) res.result.toString() else "Step error: ${res.error ?: "Unknown error"}").trim()
-                }.trim()
-
+                val finalStepResult = checkNotNull(lastResult)
                 val finalResult =
                     ToolResult(
                         toolName = displayToolName,
-                        success = lastResult.success,
-                        result = StringResultData(combinedResultString),
-                        error = lastResult.error,
-                        errorCode = lastResult.errorCode
+                        success = finalStepResult.success,
+                        result = StringResultData(combinedResultBuilder.toString()),
+                        error = finalStepResult.error,
+                        errorCode = finalStepResult.errorCode,
                     )
                 toolHandler.notifyToolExecutionResult(invocation.tool, finalResult)
                 return@withContext finalResult
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                AppLogger.e(TAG, "Tool execution setup error: ${invocation.tool.name}", error)
+                val unexpectedFailure =
+                    ToolResult(
+                        toolName = displayToolName,
+                        success = false,
+                        result = StringResultData(""),
+                        error = "Tool execution error: ${error.message ?: error.javaClass.simpleName}",
+                        errorCode = "tool_execution_failed",
+                    )
+                resultBuffer.record(unexpectedFailure)
+                toolHandler.notifyToolExecutionError(invocation.tool, error)
+                toolHandler.notifyToolExecutionResult(invocation.tool, unexpectedFailure)
+                return@withContext unexpectedFailure
             } finally {
                 toolHandler.notifyToolExecutionFinished(invocation.tool)
             }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManager.kt
@@ -8,6 +8,7 @@ import com.ai.assistance.operit.core.tools.AIToolHookDecision
 import com.ai.assistance.operit.core.tools.StringResultData
 import com.ai.assistance.operit.core.tools.ToolExecutionLimits
 import com.ai.assistance.operit.core.tools.ToolExecutor
+import com.ai.assistance.operit.core.tools.ToolProgressBus
 import com.ai.assistance.operit.core.tools.climode.CliToolModeSupport
 import com.ai.assistance.operit.core.tools.climode.ToolExposureMode
 import com.ai.assistance.operit.data.model.ToolInvocation
@@ -46,8 +47,8 @@ object ToolExecutionManager {
     private const val PACKAGE_CALLER_NAME_PARAM = "__operit_package_caller_name"
     private const val PACKAGE_CHAT_ID_PARAM = "__operit_package_chat_id"
     private const val PACKAGE_CALLER_CARD_ID_PARAM = "__operit_package_caller_card_id"
-    private const val MAX_TOOL_RESULT_DISPLAY_CHARS_PER_TURN = 256 * 1024
-    private const val MAX_TOOL_RESULT_DISPLAY_CHARS_PER_INVOCATION = 16 * 1024
+    internal const val MAX_TOOL_RESULT_DISPLAY_CHARS_PER_TURN = 16 * 1024 * 1024
+    internal const val MAX_TOOL_RESULT_DISPLAY_CHARS_PER_INVOCATION = 64 * 1024
     private const val MIN_TOOL_RESULT_DISPLAY_CHARS = 1_024
     private const val COMPACT_RESULT_MESSAGE =
         "[工具结果已从聊天显示中省略，以避免长任务占用过多内存。]"
@@ -155,10 +156,11 @@ object ToolExecutionManager {
             retainedMarkupChars = 0
         }
     }
-    class ToolResultDisplayBudget {
-
+    class ToolResultDisplayBudget(
+        initialChars: Int = MAX_TOOL_RESULT_DISPLAY_CHARS_PER_TURN,
+    ) {
         private val mutex = Mutex()
-        private var remainingChars = MAX_TOOL_RESULT_DISPLAY_CHARS_PER_TURN
+        private var remainingChars = initialChars.coerceAtLeast(0)
         internal suspend fun select(markup: ToolResultDisplayMarkup): String = mutex.withLock {
 
             val selected =
@@ -172,7 +174,7 @@ object ToolExecutionManager {
         }
     }
 
-    /** Emits completed invocation buffers in original invocation order without blocking execution. */
+    /** Emits each completed invocation in the order in which it finishes. */
     internal class OrderedToolResultEmitter(
         private val collector: StreamCollector<String>,
         private val onDisplayMarkupEmitted: suspend (String) -> Unit,
@@ -180,21 +182,15 @@ object ToolExecutionManager {
     ) {
         private val mutex = Mutex()
 
-        private val completedBuffers = mutableMapOf<Int, ToolResultMarkupBuffer>()
-        private var nextInvocationIndex = 0
-
         suspend fun complete(index: Int, buffer: ToolResultMarkupBuffer) {
+            // The index still identifies the invocation for callers, but display order follows
+            // completion order to match the release runtime's parallel tool behavior.
             mutex.withLock {
-                completedBuffers[index] = buffer
-                while (true) {
-                    val nextBuffer = completedBuffers.remove(nextInvocationIndex) ?: break
-                    nextBuffer.flushTo(
-                        collector = collector,
-                        onDisplayMarkupEmitted = onDisplayMarkupEmitted,
-                        displayBudget = displayBudget,
-                    )
-                    nextInvocationIndex++
-                }
+                buffer.flushTo(
+                    collector = collector,
+                    onDisplayMarkupEmitted = onDisplayMarkupEmitted,
+                    displayBudget = displayBudget,
+                )
             }
         }
     }
@@ -234,8 +230,9 @@ object ToolExecutionManager {
         }
     }
 
-    private fun ensureEndsWithNewline(content: String): String {
-        return if (content.endsWith("\n")) content else "$content\n"
+    private fun ensureXmlBlockBoundaries(content: String): String {
+        // StreamXmlPlugin recognizes a new XML block reliably only at a line boundary.
+        return "\n${content.trim('\r', '\n')}\n"
     }
 
     internal suspend fun emitToolResultMarkup(
@@ -244,7 +241,7 @@ object ToolExecutionManager {
         onDisplayMarkupEmitted: suspend (String) -> Unit,
         emissionMutex: Mutex? = null,
     ) {
-        val displayContent = ensureEndsWithNewline(content)
+        val displayContent = ensureXmlBlockBoundaries(content)
         suspend fun emitAtomically() {
             onDisplayMarkupEmitted(displayContent)
             collector.emit(displayContent)
@@ -950,79 +947,83 @@ object ToolExecutionManager {
         val toolName = invocation.tool.name
         val displayToolName = resolveDisplayToolName(invocation.tool)
 
-        return withContext(toolRuntimeContextThreadLocal.asContextElement(runtimeContext)) {
-            try {
-                val executor = toolHandler.getToolExecutorOrActivate(toolName)
-                if (executor == null) {
-                    // 如果仍然为 null，则构建错误消息
-                    val errorMessage =
-                        buildToolNotAvailableErrorMessage(toolName, packageManager, toolHandler)
-                    val notAvailableResult =
+        val progressScopeId = ToolProgressBus.newScopeId()
+        return ToolProgressBus.withScope(progressScopeId) {
+            withContext(toolRuntimeContextThreadLocal.asContextElement(runtimeContext)) {
+                try {
+                    val executor = toolHandler.getToolExecutorOrActivate(toolName)
+                    if (executor == null) {
+                        // 如果仍然为 null，则构建错误消息
+                        val errorMessage =
+                            buildToolNotAvailableErrorMessage(toolName, packageManager, toolHandler)
+                        val notAvailableResult =
+                            ToolResult(
+                                toolName = displayToolName,
+                                success = false,
+                                result = StringResultData(""),
+                                error = errorMessage,
+                            )
+                        resultBuffer.record(notAvailableResult)
+                        toolHandler.notifyToolExecutionResult(invocation.tool, notAvailableResult)
+                        return@withContext notAvailableResult
+                    }
+
+                    onToolExecutionStarted?.invoke(displayToolName)
+                    toolHandler.notifyToolExecutionStarted(invocation.tool)
+
+                    var lastResult: ToolResult? = null
+                    val combinedResultBuilder = StringBuilder()
+                    executeToolSafely(invocation, executor, toolHandler).collect { result ->
+                        lastResult = result
+                        appendBoundedToolResult(combinedResultBuilder, result)
+                        resultBuffer.record(result)
+                    }
+
+                    // 为此调用聚合最终结果
+                    if (lastResult == null) {
+                        val emptyResult =
+                            ToolResult(
+                                toolName = displayToolName,
+                                success = false,
+                                result = StringResultData(""),
+                                error = "The tool execution returned no results."
+                            )
+                        resultBuffer.record(emptyResult)
+                        toolHandler.notifyToolExecutionResult(invocation.tool, emptyResult)
+                        return@withContext emptyResult
+                    }
+
+                    val finalStepResult = checkNotNull(lastResult)
+                    val finalResult =
+                        ToolResult(
+                            toolName = displayToolName,
+                            success = finalStepResult.success,
+                            result = StringResultData(combinedResultBuilder.toString()),
+                            error = finalStepResult.error,
+                            errorCode = finalStepResult.errorCode,
+                        )
+                    toolHandler.notifyToolExecutionResult(invocation.tool, finalResult)
+                    return@withContext finalResult
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Exception) {
+                    AppLogger.e(TAG, "Tool execution setup error: ${invocation.tool.name}", error)
+                    val unexpectedFailure =
                         ToolResult(
                             toolName = displayToolName,
                             success = false,
                             result = StringResultData(""),
-                            error = errorMessage,
+                            error = "Tool execution error: ${error.message ?: error.javaClass.simpleName}",
+                            errorCode = "tool_execution_failed",
                         )
-                    resultBuffer.record(notAvailableResult)
-                    toolHandler.notifyToolExecutionResult(invocation.tool, notAvailableResult)
-                    return@withContext notAvailableResult
+                    resultBuffer.record(unexpectedFailure)
+                    toolHandler.notifyToolExecutionError(invocation.tool, error)
+                    toolHandler.notifyToolExecutionResult(invocation.tool, unexpectedFailure)
+                    return@withContext unexpectedFailure
+                } finally {
+                    toolHandler.notifyToolExecutionFinished(invocation.tool)
+                    ToolProgressBus.clear()
                 }
-
-                onToolExecutionStarted?.invoke(displayToolName)
-                toolHandler.notifyToolExecutionStarted(invocation.tool)
-
-                var lastResult: ToolResult? = null
-                val combinedResultBuilder = StringBuilder()
-                executeToolSafely(invocation, executor, toolHandler).collect { result ->
-                    lastResult = result
-                    appendBoundedToolResult(combinedResultBuilder, result)
-                    resultBuffer.record(result)
-                }
-
-                // 为此调用聚合最终结果
-                if (lastResult == null) {
-                    val emptyResult =
-                        ToolResult(
-                            toolName = displayToolName,
-                            success = false,
-                            result = StringResultData(""),
-                            error = "The tool execution returned no results."
-                        )
-                    resultBuffer.record(emptyResult)
-                    toolHandler.notifyToolExecutionResult(invocation.tool, emptyResult)
-                    return@withContext emptyResult
-                }
-
-                val finalStepResult = checkNotNull(lastResult)
-                val finalResult =
-                    ToolResult(
-                        toolName = displayToolName,
-                        success = finalStepResult.success,
-                        result = StringResultData(combinedResultBuilder.toString()),
-                        error = finalStepResult.error,
-                        errorCode = finalStepResult.errorCode,
-                    )
-                toolHandler.notifyToolExecutionResult(invocation.tool, finalResult)
-                return@withContext finalResult
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Exception) {
-                AppLogger.e(TAG, "Tool execution setup error: ${invocation.tool.name}", error)
-                val unexpectedFailure =
-                    ToolResult(
-                        toolName = displayToolName,
-                        success = false,
-                        result = StringResultData(""),
-                        error = "Tool execution error: ${error.message ?: error.javaClass.simpleName}",
-                        errorCode = "tool_execution_failed",
-                    )
-                resultBuffer.record(unexpectedFailure)
-                toolHandler.notifyToolExecutionError(invocation.tool, error)
-                toolHandler.notifyToolExecutionResult(invocation.tool, unexpectedFailure)
-                return@withContext unexpectedFailure
-            } finally {
-                toolHandler.notifyToolExecutionFinished(invocation.tool)
             }
         }
     }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ApiErrorClassifier.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ApiErrorClassifier.kt
@@ -24,7 +24,8 @@ internal enum class OperitNetworkError(
     CONNECTION_RESET(5003, "connection_reset", "Connection reset"),
     CONNECTION_CLOSED(5004, "connection_closed", "Connection closed"),
     TLS_HANDSHAKE_FAILED(5005, "tls_handshake_failed", "TLS handshake failed"),
-    CONNECTION_TIMEOUT(5006, "connection_timeout", "Connection timed out");
+    CONNECTION_TIMEOUT(5006, "connection_timeout", "Connection timed out"),
+    CONNECTION_ABORTED(5007, "connection_aborted", "Connection aborted");
 
     fun toErrorJson(): String =
         org.json.JSONObject()
@@ -197,6 +198,13 @@ internal object ApiErrorClassifier {
                 chain.any { it is SocketException && containsAny(it.message.orEmpty().lowercase(Locale.ROOT), "reset") } ->
                 OperitNetworkError.CONNECTION_RESET
 
+            containsAny(
+                text,
+                "software caused connection abort",
+                "connection aborted",
+                "econnaborted"
+            ) -> OperitNetworkError.CONNECTION_ABORTED
+
             chain.any { it is EOFException } ||
                 containsAny(text, "unexpected end of stream", "unexpected eof", "premature eof", "connection closed", "socket closed") ->
                 OperitNetworkError.CONNECTION_CLOSED
@@ -261,7 +269,8 @@ internal object ApiErrorClassifier {
             "connection_reset",
             "connection_closed",
             "tls_handshake_failed",
-            "connection_timeout"
+            "connection_timeout",
+            "connection_aborted"
         )
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
@@ -1236,13 +1236,14 @@ open class ClaudeProvider(
         context: Context,
         exception: Exception,
         retryCount: Int,
-        maxRetries: Int,
+        retryPolicy: LlmRetryPolicySnapshot,
         enableRetry: Boolean,
         onNonFatalError: suspend (String) -> Unit,
         onRetryState: suspend (RuntimeRetryMetadata) -> Unit = {},
-        onRetryAccepted: suspend () -> Unit,
-        buildRetryMessage: (String, Int) -> String
+        onRetryAccepted: suspend () -> Unit
+
     ): Int {
+        val maxRetries = retryPolicy.maxRetryAttempts
         if (exception is UserCancellationException || exception is CancellationException) {
             throw exception
         }
@@ -1266,6 +1267,10 @@ open class ClaudeProvider(
 
         val newRetryCount = retryCount + 1
         if (newRetryCount > maxRetries) {
+            if (maxRetries == 0) {
+                onNonFatalError(errorText)
+                throw IOException(errorText, exception)
+            }
             AppLogger.e("AIService", "【Claude】$errorText 且达到最大重试次数($maxRetries)", exception)
             throw IOException(
                 context.getString(R.string.openai_error_connection_timeout, maxRetries, errorText),
@@ -1275,7 +1280,7 @@ open class ClaudeProvider(
 
         // A terminal failure must retain its streamed text; only a replacement request discards it.
         onRetryAccepted()
-        val retryDelayMs = LlmRetryPolicy.nextDelayMs(newRetryCount)
+        val retryDelayMs = retryPolicy.nextDelayMs(newRetryCount)
         val classification = ApiErrorClassifier.classify(exception)
         onRetryState(
             RuntimeRetryMetadata(
@@ -1289,9 +1294,6 @@ open class ClaudeProvider(
             )
         )
         AppLogger.w("AIService", "【Claude】$errorText，将在 ${retryDelayMs}ms 后进行第 $newRetryCount 次重试...", exception)
-        if (!shouldSuppressKeyPoolRateLimitNotice(apiKeyProvider, exception, "AIService")) {
-            onNonFatalError(buildRetryMessage(errorText, newRetryCount))
-        }
         delay(retryDelayMs)
         return newRetryCount
     }
@@ -1317,7 +1319,8 @@ open class ClaudeProvider(
         isManuallyCancelled = false
         tokenCacheManager.setOutputTokens(0)
 
-        val maxRetries = LlmRetryPolicy.MAX_RETRY_ATTEMPTS
+        val retryPolicy = LlmRetryPolicy.snapshot(context)
+        val maxRetries = retryPolicy.maxRetryAttempts
         var retryCount = 0
         var lastException: Exception? = null
         val receivedContent = StringBuilder()
@@ -2000,14 +2003,11 @@ open class ClaudeProvider(
                         context = context,
                         exception = e,
                         retryCount = retryCount,
-                        maxRetries = maxRetries,
+                        retryPolicy = retryPolicy,
                         enableRetry = enableRetry,
                         onNonFatalError = onNonFatalError,
                         onRetryState = onRetryState,
                         onRetryAccepted = { emitRollback(requestSavepointId) },
-                        buildRetryMessage = { errorText, retryNumber ->
-                            context.getString(R.string.provider_error_retry_message, errorText, retryNumber)
-                        },
                     )
             } finally {
                 activeCall = null

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
@@ -1054,13 +1054,14 @@ open class GeminiProvider(
         context: Context,
         exception: Exception,
         retryCount: Int,
-        maxRetries: Int,
+        retryPolicy: LlmRetryPolicySnapshot,
         enableRetry: Boolean,
         onNonFatalError: suspend (String) -> Unit,
         onRetryState: suspend (RuntimeRetryMetadata) -> Unit = {},
-        onRetryAccepted: suspend () -> Unit,
-        buildRetryMessage: (String, Int) -> String
+        onRetryAccepted: suspend () -> Unit
+
     ): Int {
+        val maxRetries = retryPolicy.maxRetryAttempts
         if (exception is UserCancellationException || exception is kotlinx.coroutines.CancellationException) {
             throw exception
         }
@@ -1088,6 +1089,10 @@ open class GeminiProvider(
 
         val newRetryCount = retryCount + 1
         if (newRetryCount > maxRetries) {
+            if (maxRetries == 0) {
+                onNonFatalError(errorText)
+                throw IOException(errorText, exception)
+            }
             logError("$errorText 且达到最大重试次数($maxRetries)", exception)
             throw IOException(
                 context.getString(R.string.gemini_error_connection_timeout, maxRetries, errorText),
@@ -1097,7 +1102,7 @@ open class GeminiProvider(
 
         // A terminal failure must retain its streamed text; only a replacement request discards it.
         onRetryAccepted()
-        val retryDelayMs = LlmRetryPolicy.nextDelayMs(newRetryCount)
+        val retryDelayMs = retryPolicy.nextDelayMs(newRetryCount)
         val classification = ApiErrorClassifier.classify(exception)
         onRetryState(
             RuntimeRetryMetadata(
@@ -1111,9 +1116,6 @@ open class GeminiProvider(
             )
         )
         AppLogger.w(TAG, "$errorText，将在 ${retryDelayMs}ms 后进行第 $newRetryCount 次重试...", exception)
-        if (!shouldSuppressKeyPoolRateLimitNotice(apiKeyProvider, exception, TAG)) {
-            onNonFatalError(buildRetryMessage(errorText, newRetryCount))
-        }
         delay(retryDelayMs)
         return newRetryCount
     }
@@ -1151,7 +1153,8 @@ open class GeminiProvider(
 
         AppLogger.d(TAG, "发送消息到Gemini API, 模型: $modelName")
 
-        val maxRetries = LlmRetryPolicy.MAX_RETRY_ATTEMPTS
+        val retryPolicy = LlmRetryPolicy.snapshot(context)
+        val maxRetries = retryPolicy.maxRetryAttempts
         var retryCount = 0
         var lastException: Exception? = null
 
@@ -1263,14 +1266,11 @@ open class GeminiProvider(
                     context = context,
                     exception = e,
                     retryCount = retryCount,
-                    maxRetries = maxRetries,
+                    retryPolicy = retryPolicy,
                     enableRetry = enableRetry,
                     onNonFatalError = onNonFatalError,
                     onRetryState = onRetryState,
                     onRetryAccepted = { emitRollback(requestSavepointId) },
-                    buildRetryMessage = { errorText, retryNumber ->
-                        context.getString(R.string.provider_error_retry_message, errorText, retryNumber)
-                    },
                 )
             }
         }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/LlmRetryPolicy.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/LlmRetryPolicy.kt
@@ -1,5 +1,11 @@
 package com.ai.assistance.operit.api.chat.llmprovider
 
+import android.content.Context
+import com.ai.assistance.operit.data.preferences.DisplayPreferencesManager
+import com.ai.assistance.operit.data.preferences.LlmRetryMode
+import com.ai.assistance.operit.data.preferences.LlmRetrySettings
+import kotlinx.coroutines.flow.first
+
 public data class RuntimeRetryMetadata(
     val retryAttempt: Int,
     val maxRetryAttempts: Int,
@@ -10,16 +16,73 @@ public data class RuntimeRetryMetadata(
     val errorMessage: String? = null
 )
 
+internal data class LlmRetryPolicySnapshot(
+    val maxRetryAttempts: Int,
+    val initialDelayMs: Long,
+    val maxDelayMs: Long
+) {
+    fun nextDelayMs(retryAttempt: Int): Long {
+        val normalizedAttempt = retryAttempt.coerceAtLeast(1)
+        var delayMs = initialDelayMs.coerceIn(1L, maxDelayMs)
+        repeat(normalizedAttempt - 1) {
+            delayMs =
+                if (delayMs >= maxDelayMs / 2L) {
+                    maxDelayMs
+                } else {
+                    (delayMs * 2L).coerceAtMost(maxDelayMs)
+                }
+        }
+        return delayMs
+    }
+
+    fun delayScheduleMs(): List<Long> =
+        (1..maxRetryAttempts).map(::nextDelayMs)
+}
+
 internal object LlmRetryPolicy {
-    const val MAX_RETRY_ATTEMPTS = 5
-    private const val RETRY_BASE_DELAY_MS = 1000L
+    private const val FAST_INITIAL_DELAY_MS = 1_000L
+    private const val FAST_MAX_DELAY_MS = 4_000L
+    private const val STANDARD_INITIAL_DELAY_MS = 1_000L
+    private const val STANDARD_MAX_DELAY_MS = 16_000L
+    private const val STABLE_INITIAL_DELAY_MS = 2_000L
+    private const val STABLE_MAX_DELAY_MS = 30_000L
 
     internal fun isRetryableClientStatus(statusCode: Int): Boolean {
         return statusCode == 408 || statusCode == 429
     }
 
-    fun nextDelayMs(retryAttempt: Int): Long {
-        val normalizedAttempt = retryAttempt.coerceAtLeast(1)
-        return RETRY_BASE_DELAY_MS * (1L shl (normalizedAttempt - 1))
+    suspend fun snapshot(context: Context): LlmRetryPolicySnapshot {
+        val settings =
+            DisplayPreferencesManager.getInstance(context).llmRetrySettings.first()
+        return fromSettings(settings)
+    }
+
+    internal fun fromSettings(settings: LlmRetrySettings): LlmRetryPolicySnapshot {
+        val (initialDelayMs, maxDelayMs) =
+            when (settings.mode) {
+                LlmRetryMode.FAST -> FAST_INITIAL_DELAY_MS to FAST_MAX_DELAY_MS
+                LlmRetryMode.STANDARD -> STANDARD_INITIAL_DELAY_MS to STANDARD_MAX_DELAY_MS
+                LlmRetryMode.STABLE -> STABLE_INITIAL_DELAY_MS to STABLE_MAX_DELAY_MS
+                LlmRetryMode.CUSTOM -> {
+                    val customMaxDelayMs =
+                        settings.customMaxDelaySeconds.coerceAtLeast(1).toLong() * 1_000L
+                    val customInitialDelayMs =
+                        settings.customInitialDelaySeconds
+                            .coerceAtLeast(1)
+                            .toLong()
+                            .times(1_000L)
+                            .coerceAtMost(customMaxDelayMs)
+                    customInitialDelayMs to customMaxDelayMs
+                }
+            }
+        return LlmRetryPolicySnapshot(
+            maxRetryAttempts =
+                settings.maxAttempts.coerceIn(
+                    DisplayPreferencesManager.MIN_LLM_RETRY_ATTEMPTS,
+                    DisplayPreferencesManager.MAX_LLM_RETRY_ATTEMPTS
+                ),
+            initialDelayMs = initialDelayMs,
+            maxDelayMs = maxDelayMs
+        )
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -1677,13 +1677,14 @@ open class OpenAIProvider(
         context: Context,
         exception: Exception,
         retryCount: Int,
-        maxRetries: Int,
+        retryPolicy: LlmRetryPolicySnapshot,
         enableRetry: Boolean,
         onNonFatalError: suspend (String) -> Unit,
         onRetryState: suspend (RuntimeRetryMetadata) -> Unit = {},
-        onRetryAccepted: suspend () -> Unit,
-        buildRetryMessage: (String, Int) -> String
+        onRetryAccepted: suspend () -> Unit
+
     ): Int {
+        val maxRetries = retryPolicy.maxRetryAttempts
         if (exception is UserCancellationException || exception is CancellationException) {
             throw exception
         }
@@ -1704,6 +1705,10 @@ open class OpenAIProvider(
 
         val newRetryCount = retryCount + 1
         if (newRetryCount > maxRetries) {
+            if (maxRetries == 0) {
+                onNonFatalError(errorText)
+                throw IOException(errorText, exception)
+            }
             AppLogger.e("AIService", "【发送消息】$errorText 且达到最大重试次数($maxRetries)", exception)
             throw IOException(
                 context.getString(R.string.openai_error_connection_timeout, maxRetries, errorText),
@@ -1713,7 +1718,7 @@ open class OpenAIProvider(
 
         // A terminal failure must retain its streamed text; only a replacement request discards it.
         onRetryAccepted()
-        val retryDelayMs = LlmRetryPolicy.nextDelayMs(newRetryCount)
+        val retryDelayMs = retryPolicy.nextDelayMs(newRetryCount)
         val classification = ApiErrorClassifier.classify(exception)
         onRetryState(
             RuntimeRetryMetadata(
@@ -1727,9 +1732,6 @@ open class OpenAIProvider(
             )
         )
         AppLogger.w("AIService", "【发送消息】$errorText，将在 ${retryDelayMs}ms 后进行第 $newRetryCount 次重试...", exception)
-        if (!shouldSuppressKeyPoolRateLimitNotice(apiKeyProvider, exception, "AIService")) {
-            onNonFatalError(buildRetryMessage(errorText, newRetryCount))
-        }
         delay(retryDelayMs)
 
         return newRetryCount
@@ -3234,7 +3236,8 @@ open class OpenAIProvider(
                 "【发送消息】开始处理sendMessage请求，历史记录数量: ${chatHistory.size}，最后一条长度: ${chatHistory.lastOrNull()?.content?.length ?: 0}"
             )
 
-            val maxRetries = LlmRetryPolicy.MAX_RETRY_ATTEMPTS
+            val retryPolicy = LlmRetryPolicy.snapshot(context)
+            val maxRetries = retryPolicy.maxRetryAttempts
             var retryCount = 0
             var lastException: Exception? = null
 
@@ -3478,14 +3481,11 @@ open class OpenAIProvider(
                     context = context,
                     exception = e,
                     retryCount = retryCount,
-                    maxRetries = maxRetries,
+                    retryPolicy = retryPolicy,
                     enableRetry = enableRetry,
                     onNonFatalError = onNonFatalError,
                     onRetryState = onRetryState,
                     onRetryAccepted = { emitter.emitRollback(requestSavepointId) },
-                    buildRetryMessage = { errorText, retryNumber ->
-                        "【${context.getString(R.string.openai_retry_with_count, errorText, retryNumber)}】"
-                    },
                 )
             }
             }

--- a/app/src/main/java/com/ai/assistance/operit/core/chat/AIMessageManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/chat/AIMessageManager.kt
@@ -8,6 +8,7 @@ import com.ai.assistance.operit.util.AppLogger
 import com.ai.assistance.operit.api.chat.EnhancedAIService
 import com.ai.assistance.operit.api.chat.enhance.InputProcessor
 import com.ai.assistance.operit.api.chat.llmprovider.MediaLinkParser
+import com.ai.assistance.operit.api.chat.llmprovider.RuntimeRetryMetadata
 import com.ai.assistance.operit.api.chat.llmprovider.MediaLinkBuilder
 import com.ai.assistance.operit.core.chat.hooks.PromptTurn
 import com.ai.assistance.operit.core.chat.hooks.PromptTurnKind
@@ -347,6 +348,7 @@ object AIMessageManager {
         maxTokens: Int,
         tokenUsageThreshold: Double,
         onNonFatalError: suspend (error: String) -> Unit,
+        onRetryState: suspend (retry: RuntimeRetryMetadata) -> Unit = {},
         onTokenLimitExceeded: (suspend () -> Unit)? = null,
         characterName: String? = null,
         avatarUri: String? = null,
@@ -484,8 +486,9 @@ object AIMessageManager {
                     enableMemoryAutoUpdate = enableMemoryAutoUpdate,
                     maxTokens = maxTokens,
                     tokenUsageThreshold = tokenUsageThreshold,
-                    onNonFatalError = onNonFatalError,
-                    onTokenLimitExceeded = onTokenLimitExceeded,
+                     onNonFatalError = onNonFatalError,
+                     onRetryState = onRetryState,
+                     onTokenLimitExceeded = onTokenLimitExceeded,
                     characterName = characterName,
                     avatarUri = avatarUri,
                     roleCardId = roleCardId,

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/ToolProgressBus.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/ToolProgressBus.kt
@@ -1,8 +1,11 @@
 package com.ai.assistance.operit.core.tools
 
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
 
 data class ToolProgressEvent(
     val toolName: String,
@@ -18,6 +21,27 @@ object ToolProgressBus {
     private val _progress = MutableStateFlow<ToolProgressEvent?>(null)
     val progress: StateFlow<ToolProgressEvent?> = _progress.asStateFlow()
 
+    private data class ScopedProgress(
+        val event: ToolProgressEvent,
+        val updateOrder: Long,
+    )
+
+    private val scopeThreadLocal = ThreadLocal<Long?>()
+    private val scopeSequence = AtomicLong(0L)
+    private val updateSequence = AtomicLong(0L)
+    private val lock = Any()
+    private val progressByScope = linkedMapOf<Long?, ScopedProgress>()
+
+    internal fun newScopeId(): Long = scopeSequence.incrementAndGet()
+
+    internal suspend fun <T> withScope(scopeId: Long, block: suspend () -> T): T {
+        return withContext(scopeThreadLocal.asContextElement(scopeId)) {
+            block()
+        }
+    }
+
+    private fun currentScopeId(): Long? = scopeThreadLocal.get()
+
     private fun priorityForTool(toolName: String): Int {
         return when (toolName) {
             SUMMARY_PROGRESS_TOOL_NAME -> 1000
@@ -28,11 +52,29 @@ object ToolProgressBus {
         }
     }
 
-    fun update(toolName: String, progress: Float, message: String = "") {
-        update(toolName = toolName, progress = progress, message = message, priority = priorityForTool(toolName))
+    fun update(
+        toolName: String,
+        progress: Float,
+        message: String = "",
+        scopeId: Long? = currentScopeId(),
+    ) {
+        update(
+            toolName = toolName,
+            progress = progress,
+            message = message,
+            priority = priorityForTool(toolName),
+            scopeId = scopeId,
+        )
     }
 
-    fun update(toolName: String, progress: Float, message: String = "", priority: Int, level: Int = 0) {
+    fun update(
+        toolName: String,
+        progress: Float,
+        message: String = "",
+        priority: Int,
+        level: Int = 0,
+        scopeId: Long? = currentScopeId(),
+    ) {
         val next = ToolProgressEvent(
             toolName = toolName,
             progress = progress,
@@ -40,21 +82,57 @@ object ToolProgressBus {
             priority = priority,
             level = level
         )
-
-        val current = _progress.value
-        val shouldReplace =
-            current == null ||
-                current.toolName == next.toolName ||
-                current.progress >= 1f ||
-                next.priority > current.priority ||
-                (next.priority == current.priority && next.level >= current.level)
-
-        if (shouldReplace) {
-            _progress.value = next
+        synchronized(lock) {
+            val current = progressByScope[scopeId]?.event
+            val shouldReplace =
+                current == null ||
+                    current.toolName == next.toolName ||
+                    current.progress >= 1f ||
+                    next.priority > current.priority ||
+                    (next.priority == current.priority && next.level >= current.level)
+            if (shouldReplace) {
+                progressByScope[scopeId] =
+                    ScopedProgress(
+                        event = next,
+                        updateOrder = updateSequence.incrementAndGet(),
+                    )
+                publishVisibleProgressLocked()
+            }
         }
     }
 
-    fun clear() {
-        _progress.value = null
+    /** Clears only the caller's progress scope and keeps other active scopes visible. */
+    fun clear(scopeId: Long? = currentScopeId()) {
+        synchronized(lock) {
+            if (progressByScope.remove(scopeId) != null) {
+                publishVisibleProgressLocked()
+            }
+        }
+    }
+
+    private fun publishVisibleProgressLocked() {
+        var selected: ScopedProgress? = null
+        progressByScope.values.forEach { candidate ->
+            val current = selected
+            if (
+                current == null ||
+                    candidate.event.priority > current.event.priority ||
+                    (candidate.event.priority == current.event.priority &&
+                        candidate.event.level > current.event.level) ||
+                    (candidate.event.priority == current.event.priority &&
+                        candidate.event.level == current.event.level &&
+                        candidate.updateOrder > current.updateOrder)
+            ) {
+                selected = candidate
+            }
+        }
+        _progress.value = selected?.event
+    }
+
+    internal fun resetForTest() {
+        synchronized(lock) {
+            progressByScope.clear()
+            _progress.value = null
+        }
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/DisplayPreferencesManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/DisplayPreferencesManager.kt
@@ -18,6 +18,26 @@ private val Context.displayPreferencesDataStore: DataStore<Preferences> by prefe
     name = "display_preferences"
 )
 
+enum class LlmRetryMode(val value: String) {
+    FAST("fast"),
+    STANDARD("standard"),
+    STABLE("stable"),
+    CUSTOM("custom");
+
+    companion object {
+        fun fromValue(value: String?): LlmRetryMode {
+            return values().firstOrNull { it.value == value } ?: STANDARD
+        }
+    }
+}
+
+data class LlmRetrySettings(
+    val maxAttempts: Int = 5,
+    val mode: LlmRetryMode = LlmRetryMode.STANDARD,
+    val customInitialDelaySeconds: Int = 1,
+    val customMaxDelaySeconds: Int = 16
+)
+
 /**
  * DisplayPreferencesManager
  * 管理系统显示与行为相关的偏好设置
@@ -26,6 +46,13 @@ private val Context.displayPreferencesDataStore: DataStore<Preferences> by prefe
 class DisplayPreferencesManager private constructor(private val context: Context) {
 
     companion object {
+        const val MIN_LLM_RETRY_ATTEMPTS = 0
+        const val MAX_LLM_RETRY_ATTEMPTS = 10
+        const val DEFAULT_LLM_RETRY_ATTEMPTS = 5
+        const val MIN_LLM_RETRY_DELAY_SECONDS = 1
+        const val MAX_LLM_RETRY_INITIAL_DELAY_SECONDS = 60
+        const val MAX_LLM_RETRY_DELAY_SECONDS = 300
+
         @Volatile
         private var INSTANCE: DisplayPreferencesManager? = null
 
@@ -73,6 +100,12 @@ class DisplayPreferencesManager private constructor(private val context: Context
 
         // 工具折叠设置（多个只读工具 / 多个任意工具 / 全部工具）
         private val KEY_TOOL_COLLAPSE_MODE = stringPreferencesKey("tool_collapse_mode")
+        private val KEY_LLM_RETRY_MAX_ATTEMPTS = intPreferencesKey("llm_retry_max_attempts")
+        private val KEY_LLM_RETRY_MODE = stringPreferencesKey("llm_retry_mode")
+        private val KEY_LLM_RETRY_INITIAL_DELAY_SECONDS =
+            intPreferencesKey("llm_retry_initial_delay_seconds")
+        private val KEY_LLM_RETRY_MAX_DELAY_SECONDS =
+            intPreferencesKey("llm_retry_max_delay_seconds")
     }
 
     /**
@@ -204,6 +237,28 @@ class DisplayPreferencesManager private constructor(private val context: Context
             ToolCollapseMode.fromValue(preferences[KEY_TOOL_COLLAPSE_MODE])
         }
 
+    val llmRetrySettings: Flow<LlmRetrySettings> =
+        context.displayPreferencesDataStore.data.map { preferences ->
+            LlmRetrySettings(
+                maxAttempts =
+                    (preferences[KEY_LLM_RETRY_MAX_ATTEMPTS] ?: DEFAULT_LLM_RETRY_ATTEMPTS)
+                        .coerceIn(MIN_LLM_RETRY_ATTEMPTS, MAX_LLM_RETRY_ATTEMPTS),
+                mode = LlmRetryMode.fromValue(preferences[KEY_LLM_RETRY_MODE]),
+                customInitialDelaySeconds =
+                    (preferences[KEY_LLM_RETRY_INITIAL_DELAY_SECONDS] ?: 1)
+                        .coerceIn(
+                            MIN_LLM_RETRY_DELAY_SECONDS,
+                            MAX_LLM_RETRY_INITIAL_DELAY_SECONDS
+                        ),
+                customMaxDelaySeconds =
+                    (preferences[KEY_LLM_RETRY_MAX_DELAY_SECONDS] ?: 16)
+                        .coerceIn(
+                            MIN_LLM_RETRY_DELAY_SECONDS,
+                            MAX_LLM_RETRY_DELAY_SECONDS
+                        )
+            )
+        }
+
     /**
      * 保存显示设置
      */
@@ -226,7 +281,11 @@ class DisplayPreferencesManager private constructor(private val context: Context
         visitWebWaitSeconds: Int? = null,
         toolPkgHookTimeoutSeconds: Int? = null,
         virtualDisplayBitrateKbps: Int? = null,
-        toolCollapseMode: ToolCollapseMode? = null
+        toolCollapseMode: ToolCollapseMode? = null,
+        llmRetryMaxAttempts: Int? = null,
+        llmRetryMode: LlmRetryMode? = null,
+        llmRetryInitialDelaySeconds: Int? = null,
+        llmRetryMaxDelaySeconds: Int? = null
     ) {
         context.displayPreferencesDataStore.edit { preferences ->
             showFpsCounter?.let { preferences[KEY_SHOW_FPS_COUNTER] = it }
@@ -264,6 +323,22 @@ class DisplayPreferencesManager private constructor(private val context: Context
             }
             virtualDisplayBitrateKbps?.let { preferences[KEY_VIRTUAL_DISPLAY_BITRATE_KBPS] = it }
             toolCollapseMode?.let { preferences[KEY_TOOL_COLLAPSE_MODE] = it.value }
+            llmRetryMaxAttempts?.let {
+                preferences[KEY_LLM_RETRY_MAX_ATTEMPTS] =
+                    it.coerceIn(MIN_LLM_RETRY_ATTEMPTS, MAX_LLM_RETRY_ATTEMPTS)
+            }
+            llmRetryMode?.let { preferences[KEY_LLM_RETRY_MODE] = it.value }
+            llmRetryInitialDelaySeconds?.let {
+                preferences[KEY_LLM_RETRY_INITIAL_DELAY_SECONDS] =
+                    it.coerceIn(
+                        MIN_LLM_RETRY_DELAY_SECONDS,
+                        MAX_LLM_RETRY_INITIAL_DELAY_SECONDS
+                    )
+            }
+            llmRetryMaxDelaySeconds?.let {
+                preferences[KEY_LLM_RETRY_MAX_DELAY_SECONDS] =
+                    it.coerceIn(MIN_LLM_RETRY_DELAY_SECONDS, MAX_LLM_RETRY_DELAY_SECONDS)
+            }
         }
     }
 
@@ -329,9 +404,13 @@ class DisplayPreferencesManager private constructor(private val context: Context
             preferences.remove(KEY_SCREENSHOT_FORMAT)
             preferences.remove(KEY_SCREENSHOT_QUALITY)
             preferences.remove(KEY_SCREENSHOT_SCALE_PERCENT)
+            preferences.remove(KEY_VIRTUAL_DISPLAY_BITRATE_KBPS)
             preferences.remove(KEY_VISIT_WEB_WAIT_SECONDS)
             preferences.remove(KEY_TOOLPKG_HOOK_TIMEOUT_SECONDS)
-            preferences.remove(KEY_VIRTUAL_DISPLAY_BITRATE_KBPS)
+            preferences.remove(KEY_LLM_RETRY_MAX_ATTEMPTS)
+            preferences.remove(KEY_LLM_RETRY_MODE)
+            preferences.remove(KEY_LLM_RETRY_INITIAL_DELAY_SECONDS)
+            preferences.remove(KEY_LLM_RETRY_MAX_DELAY_SECONDS)
             preferences.remove(KEY_TOOL_COLLAPSE_MODE)
         }
     }

--- a/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
@@ -21,7 +21,6 @@ import com.ai.assistance.operit.data.model.InputProcessingState
 import com.ai.assistance.operit.data.model.CharacterCardChatModelBindingMode
 import com.ai.assistance.operit.data.model.CharacterCardMemoryProfileBindingMode
 import com.ai.assistance.operit.data.model.ActivePrompt
-import com.ai.assistance.operit.core.tools.ToolProgressBus
 import com.ai.assistance.operit.ui.features.chat.viewmodel.UiStateDelegate
 import com.ai.assistance.operit.data.preferences.CharacterCardManager
 import com.ai.assistance.operit.data.preferences.CharacterGroupCardManager
@@ -1639,7 +1638,6 @@ class MessageCoordinationDelegate(
         }.onFailure { throwable ->
             AppLogger.w(TAG, "取消 SUMMARY 流失败: ${throwable.message}")
         }
-        ToolProgressBus.clear()
     }
 
     /**

--- a/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
@@ -22,6 +22,7 @@ import com.ai.assistance.operit.data.model.CharacterCardChatModelBindingMode
 import com.ai.assistance.operit.data.model.CharacterCardMemoryProfileBindingMode
 import com.ai.assistance.operit.data.model.ActivePrompt
 import com.ai.assistance.operit.ui.features.chat.viewmodel.UiStateDelegate
+import com.ai.assistance.operit.api.chat.llmprovider.RuntimeRetryMetadata
 import com.ai.assistance.operit.data.preferences.CharacterCardManager
 import com.ai.assistance.operit.data.preferences.CharacterGroupCardManager
 import com.ai.assistance.operit.data.preferences.ActivePromptManager
@@ -100,6 +101,7 @@ class MessageCoordinationDelegate(
     private var currentMemorySpaceIdOverride: String? = null
 
     private var nonFatalErrorCollectorJob: Job? = null
+    private var retryStateCollectorJob: Job? = null
     private val characterCardManager = CharacterCardManager.getInstance(context)
     private val characterGroupCardManager = CharacterGroupCardManager.getInstance(context)
     private val activePromptManager = ActivePromptManager.getInstance(context)
@@ -125,10 +127,31 @@ class MessageCoordinationDelegate(
     }
 
     private fun ensureNonFatalErrorCollectorStarted() {
-        if (nonFatalErrorCollectorJob?.isActive == true) return
-        nonFatalErrorCollectorJob = coroutineScope.launch {
-            messageProcessingDelegate.nonFatalErrorEvent.collect { errorMessage ->
-                uiStateDelegate.showToast(errorMessage)
+        if (nonFatalErrorCollectorJob?.isActive != true) {
+            nonFatalErrorCollectorJob = coroutineScope.launch {
+                messageProcessingDelegate.nonFatalErrorEvent.collect { errorMessage ->
+                    uiStateDelegate.showToast(errorMessage)
+                }
+            }
+        }
+        if (retryStateCollectorJob?.isActive != true) {
+            retryStateCollectorJob = coroutineScope.launch {
+                messageProcessingDelegate.retryStateEvent.collect { retry ->
+                    val errorMessage = retry.errorMessage
+                        ?.takeIf { it.isNotBlank() }
+                        ?: context.getString(R.string.provider_error_network_interrupted)
+                    val waitSeconds =
+                        ((retry.retryAfterMs + 999L) / 1_000L).coerceAtLeast(1L)
+                    uiStateDelegate.showRetryToast(
+                        context.getString(
+                            R.string.provider_error_retry_message,
+                            errorMessage,
+                            retry.retryAttempt,
+                            waitSeconds
+                        ),
+                        retry.retryAfterMs
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/ai/assistance/operit/services/core/MessageProcessingDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/MessageProcessingDelegate.kt
@@ -42,13 +42,13 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import com.ai.assistance.operit.core.tools.ToolProgressBus
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.coroutineContext
@@ -111,9 +111,19 @@ class MessageProcessingDelegate(
                 completedAt = completedAt,
             )
         }
+
+        /** Applies a per-chat update without dropping concurrent updates for other chats. */
+        internal fun <T> updateChatStateMap(
+            state: MutableStateFlow<Map<String, T>>,
+            key: String,
+            transform: (T?) -> T?,
+        ) {
+            state.update { current ->
+                val next = transform(current[key])
+                if (next == null) current - key else current + (key to next)
+            }
+        }
     }
-
-
 
     private fun fallbackConversationTitle(userText: String, attachments: List<AttachmentInfo>): String {
         return attachments.firstOrNull()?.fileName?.trim()?.takeIf { it.isNotBlank() }
@@ -254,7 +264,7 @@ class MessageProcessingDelegate(
 
     private fun runtimeFor(chatId: String?): ChatRuntime {
         val key = chatKey(chatId)
-        return chatRuntimes[key] ?: ChatRuntime().also { chatRuntimes[key] = it }
+        return chatRuntimes.computeIfAbsent(key) { ChatRuntime() }
     }
 
     private fun updateGlobalLoadingState() {
@@ -286,15 +296,10 @@ class MessageProcessingDelegate(
                 return
             }
         }
-        if (state !is EnhancedInputProcessingState.ExecutingTool &&
-            state !is EnhancedInputProcessingState.Summarizing
-        ) {
-            ToolProgressBus.clear()
-        }
-        val key = chatKey(chatId)
-        val map = _inputProcessingStateByChatId.value.toMutableMap()
-        map[key] = state
-        _inputProcessingStateByChatId.value = map
+        updateChatStateMap(
+            state = _inputProcessingStateByChatId,
+            key = chatKey(chatId),
+        ) { state }
     }
 
     fun setSuppressIdleCompletedStateForChat(chatId: String, suppress: Boolean) {
@@ -663,9 +668,10 @@ class MessageProcessingDelegate(
     }
 
     private fun updateUserDraftState(chatId: String, hasDraft: Boolean) {
-        val updated = _userDraftStateByChatId.value.toMutableMap()
-        updated[chatId] = hasDraft
-        _userDraftStateByChatId.value = updated
+        updateChatStateMap(
+            state = _userDraftStateByChatId,
+            key = chatId,
+        ) { hasDraft }
     }
 
     private fun clearUserMessageDraft(chatId: String) {
@@ -697,21 +703,24 @@ class MessageProcessingDelegate(
     }
 
     private fun resetCurrentTurnToolInvocationCount(chatId: String) {
-        val updated = _currentTurnToolInvocationCountByChatId.value.toMutableMap()
-        updated[chatId] = 0
-        _currentTurnToolInvocationCountByChatId.value = updated
+        updateChatStateMap(
+            state = _currentTurnToolInvocationCountByChatId,
+            key = chatId,
+        ) { 0 }
     }
 
     private fun incrementCurrentTurnToolInvocationCount(chatId: String) {
-        val updated = _currentTurnToolInvocationCountByChatId.value.toMutableMap()
-        updated[chatId] = (updated[chatId] ?: 0) + 1
-        _currentTurnToolInvocationCountByChatId.value = updated
+        updateChatStateMap(
+            state = _currentTurnToolInvocationCountByChatId,
+            key = chatId,
+        ) { current -> (current ?: 0) + 1 }
     }
 
     private fun clearCurrentTurnToolInvocationCount(chatId: String) {
-        val updated = _currentTurnToolInvocationCountByChatId.value.toMutableMap()
-        updated.remove(chatId)
-        _currentTurnToolInvocationCountByChatId.value = updated
+        updateChatStateMap(
+            state = _currentTurnToolInvocationCountByChatId,
+            key = chatId,
+        ) { null }
     }
 
     fun sendUserMessage(
@@ -1912,9 +1921,10 @@ class MessageProcessingDelegate(
         turnOptions: ChatTurnOptions = ChatTurnOptions()
     ) {
         if (!chatId.isNullOrBlank()) {
-            val updated = _turnCompleteCounterByChatId.value.toMutableMap()
-            updated[chatId] = (updated[chatId] ?: 0L) + 1L
-            _turnCompleteCounterByChatId.value = updated
+            updateChatStateMap(
+                state = _turnCompleteCounterByChatId,
+                key = chatId,
+            ) { current -> (current ?: 0L) + 1L }
         }
         val nextWindowSize = calculateNextWindowSize?.invoke()
         AppLogger.d(

--- a/app/src/main/java/com/ai/assistance/operit/services/core/MessageProcessingDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/MessageProcessingDelegate.kt
@@ -8,6 +8,7 @@ import com.ai.assistance.operit.R
 import com.ai.assistance.operit.api.chat.EnhancedAIService
 import com.ai.assistance.operit.api.chat.ChatRuntimeSlot
 import com.ai.assistance.operit.api.chat.llmprovider.ApiErrorClassifier
+import com.ai.assistance.operit.api.chat.llmprovider.RuntimeRetryMetadata
 import com.ai.assistance.operit.api.chat.ChatRuntimeStateStore
 import com.ai.assistance.operit.core.chat.AIMessageManager
 import com.ai.assistance.operit.core.chat.logMessageTiming
@@ -192,6 +193,9 @@ class MessageProcessingDelegate(
 
     private val _nonFatalErrorEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val nonFatalErrorEvent = _nonFatalErrorEvent.asSharedFlow()
+
+    private val _retryStateEvent = MutableSharedFlow<RuntimeRetryMetadata>(extraBufferCapacity = 1)
+    val retryStateEvent = _retryStateEvent.asSharedFlow()
 
     /**
      * Publish host-side hook notices through the same stream used by AI retry messages.
@@ -1135,6 +1139,9 @@ class MessageProcessingDelegate(
                     onNonFatalError = { error ->
                         _nonFatalErrorEvent.emit(error)
                     },
+                    onRetryState = { retry ->
+                        _retryStateEvent.emit(retry)
+                    },
                     onTokenLimitExceeded = effectiveOnTokenLimitExceeded,
                     characterName = characterName,
                     avatarUri = avatarUri,
@@ -1537,19 +1544,18 @@ class MessageProcessingDelegate(
                     AppLogger.e(TAG, "发送消息时出错", e)
                     shouldFinalizeInterruptedMessage = true
                     val classification = ApiErrorClassifier.classify(e)
-                    setChatInputProcessingState(
-                        chatId,
-                        EnhancedInputProcessingState.Error(
-                            message = context.getString(R.string.message_send_failed, e.message),
-                            code = classification.code,
-                            errorSource = InputProcessingErrorSource.API,
-                            recoverable = classification.recoverable,
-                            appCode = classification.appCode,
-                            providerCode = classification.providerCode,
-                            httpStatusCode = classification.httpStatusCode,
-                            retryAfterMs = classification.retryAfterMs
-                        )
+                    val terminalErrorState = EnhancedInputProcessingState.Error(
+                        message = context.getString(R.string.message_send_failed, e.message),
+                        code = classification.code,
+                        errorSource = InputProcessingErrorSource.API,
+                        recoverable = classification.recoverable,
+                        appCode = classification.appCode,
+                        providerCode = classification.providerCode,
+                        httpStatusCode = classification.httpStatusCode,
+                        retryAfterMs = classification.retryAfterMs
                     )
+                    finalInputStateAfterSend = terminalErrorState
+                    setChatInputProcessingState(chatId, terminalErrorState)
                     val terminalErrorMessage =
                         context.getString(R.string.message_send_failed, e.message)
                     withContext(Dispatchers.Main) {
@@ -1753,6 +1759,7 @@ class MessageProcessingDelegate(
                     maxTokens = maxTokens,
                     tokenUsageThreshold = tokenUsageThreshold,
                     onNonFatalError = { error -> _nonFatalErrorEvent.emit(error) },
+                    onRetryState = { retry -> _retryStateEvent.emit(retry) },
                     characterName = currentRoleName,
                     roleCardId = roleCardId,
                     currentRoleName = currentRoleName,
@@ -1872,19 +1879,19 @@ class MessageProcessingDelegate(
             } else {
                 AppLogger.e(TAG, "单条重新生成失败", e)
                 val classification = ApiErrorClassifier.classify(e)
-                setChatInputProcessingState(
-                    chatId,
-                    EnhancedInputProcessingState.Error(
-                        message = context.getString(R.string.chat_regenerate_single_failed, e.message ?: ""),
-                        code = classification.code,
-                        errorSource = InputProcessingErrorSource.API,
-                        recoverable = classification.recoverable,
-                        appCode = classification.appCode,
-                        providerCode = classification.providerCode,
-                        httpStatusCode = classification.httpStatusCode,
-                        retryAfterMs = classification.retryAfterMs
-                    )
+                val terminalErrorState = EnhancedInputProcessingState.Error(
+                    message = context.getString(R.string.chat_regenerate_single_failed, e.message ?: ""),
+                    code = classification.code,
+                    errorSource = InputProcessingErrorSource.API,
+                    recoverable = classification.recoverable,
+                    appCode = classification.appCode,
+                    providerCode = classification.providerCode,
+                    httpStatusCode = classification.httpStatusCode,
+                    retryAfterMs = classification.retryAfterMs
                 )
+                terminalState = terminalErrorState
+                setChatInputProcessingState(chatId, terminalErrorState)
+
             }
             exceptionToPropagate = e
         } finally {

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/RenderBatchCoordinator.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/RenderBatchCoordinator.kt
@@ -19,7 +19,6 @@ internal class RenderBatchCoordinator(
     private var requestedRevision = 0L
     private var appliedRevision = 0L
     private var updateJob: Job? = null
-
     fun requestUpdate() {
         requestedRevision++
         if (updateJob?.isActive == true) {
@@ -40,4 +39,17 @@ internal class RenderBatchCoordinator(
                 }
             }
     }
+
+    /** Applies all pending mutations before a stream is replaced or released. */
+    fun flushNow() {
+        updateJob?.cancel()
+        updateJob = null
+
+        while (appliedRevision != requestedRevision) {
+            val revisionToApply = requestedRevision
+            onFlush()
+            appliedRevision = revisionToApply
+        }
+    }
+
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRenderer.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRenderer.kt
@@ -171,7 +171,7 @@ private fun canMergeWithHtmlBreak(node: MarkdownNode?): Boolean {
 private fun replaceRollbackTail(
     nodes: SnapshotStateList<MarkdownNode>,
     rollbackNodes: List<MarkdownNode>,
-    conversionCache: MutableMap<Int, Pair<Int, MarkdownNodeStable>>,
+    conversionCache: MutableMap<Int, StableNodeConversionCacheEntry>,
     xmlNodeStreams: MutableMap<Int, Stream<String>>,
 ) {
     var sharedPrefixSize = 0
@@ -232,6 +232,42 @@ internal fun markdownNodeRenderKey(rendererId: String, nodeId: Long, fallbackInd
     return "node-$rendererId-$identity"
 }
 
+internal data class StableNodeConversionCacheEntry(
+    val nodeId: Long,
+    val contentReference: String,
+    val stableNode: MarkdownNodeStable,
+)
+
+internal fun stableNodeForRender(
+    sourceNode: MarkdownNode,
+    index: Int,
+    conversionCache: MutableMap<Int, StableNodeConversionCacheEntry>,
+): MarkdownNodeStable {
+    // SmartString returns the same immutable instance until the mutable node content changes.
+    val contentReference = sourceNode.content.toString()
+    val cached = conversionCache[index]
+    if (
+        sourceNode.children.isEmpty() &&
+            cached?.nodeId == sourceNode.nodeId &&
+            cached.contentReference === contentReference
+    ) {
+        return cached.stableNode
+    }
+
+    val stableNode = sourceNode.toStableNode()
+    if (sourceNode.children.isEmpty()) {
+        conversionCache[index] =
+            StableNodeConversionCacheEntry(
+                nodeId = sourceNode.nodeId,
+                contentReference = stableNode.content,
+                stableNode = stableNode,
+            )
+    } else {
+        conversionCache.remove(index)
+    }
+    return stableNode
+}
+
 internal fun releaseXmlNodeStream(
     xmlNodeStreams: MutableMap<Int, Stream<String>>,
     nodeIndex: Int,
@@ -247,25 +283,14 @@ internal fun clearXmlNodeStreams(xmlNodeStreams: MutableMap<Int, Stream<String>>
 private fun areRenderNodesSynchronized(
     nodes: SnapshotStateList<MarkdownNode>,
     renderNodes: SnapshotStateList<MarkdownNodeStable>,
-    conversionCache: MutableMap<Int, Pair<Int, MarkdownNodeStable>>,
+    conversionCache: MutableMap<Int, StableNodeConversionCacheEntry>,
 ): Boolean {
     if (nodes.isEmpty() || nodes.size != renderNodes.size) {
         return false
     }
 
     nodes.forEachIndexed { index, sourceNode ->
-        val contentLength = sourceNode.content.length
-        val cached = conversionCache[index]
-        val freshStableNode = sourceNode.toStableNode()
-        val stableNode =
-            if (cached != null && cached.first == contentLength && cached.second == freshStableNode) {
-                cached.second
-            } else {
-                freshStableNode.also {
-                    conversionCache[index] = contentLength to it
-                }
-            }
-
+        val stableNode = stableNodeForRender(sourceNode, index, conversionCache)
         if (renderNodes[index] != stableNode) {
             return false
         }
@@ -369,7 +394,7 @@ class StreamMarkdownRendererState {
     // 节点动画状态映射表
     val nodeAnimationStates = mutableStateMapOf<String, Boolean>()
     // 缓存转换后的稳定节点，避免不必要的对象创建
-    val conversionCache = mutableStateMapOf<Int, Pair<Int, MarkdownNodeStable>>()
+    val conversionCache = mutableStateMapOf<Int, StableNodeConversionCacheEntry>()
     // 保存流式渲染收集的完整内容，用于切换时判断是否需要重新解析
     val collectedContent = SmartString()
     // XML 节点对应的子流（仅流式渲染有效）
@@ -976,7 +1001,9 @@ fun StreamMarkdownRenderer(
             nodes.addAll(cachedNodes)
             renderNodes.clear()
             renderNodes.addAll(cachedNodes.map { it.toStableNode() })
+            conversionCache.clear()
             // 静态内容默认可见，不保留逐节点动画状态
+
             nodeAnimationStates.clear()
             // 移除应用缓存节点相关时间日志
             return@LaunchedEffect
@@ -1187,7 +1214,7 @@ private fun UnifiedMarkdownCanvas(
 internal class BatchNodeUpdater(
         private val nodes: SnapshotStateList<MarkdownNode>,
         private val renderNodes: SnapshotStateList<MarkdownNodeStable>,
-        private val conversionCache: MutableMap<Int, Pair<Int, MarkdownNodeStable>>,
+        private val conversionCache: MutableMap<Int, StableNodeConversionCacheEntry>,
         private val nodeAnimationStates: MutableMap<String, Boolean>,
         private val xmlNodeStreams: MutableMap<Int, Stream<String>>,
         private val rendererId: String,
@@ -1230,7 +1257,7 @@ internal class BatchNodeUpdater(
 private fun synchronizeRenderNodes(
     nodes: SnapshotStateList<MarkdownNode>,
     renderNodes: SnapshotStateList<MarkdownNodeStable>,
-    conversionCache: MutableMap<Int, Pair<Int, MarkdownNodeStable>>,
+    conversionCache: MutableMap<Int, StableNodeConversionCacheEntry>,
     nodeAnimationStates: MutableMap<String, Boolean>,
     xmlNodeStreams: MutableMap<Int, Stream<String>>,
     rendererId: String,
@@ -1240,16 +1267,7 @@ private fun synchronizeRenderNodes(
 
     // 1. 更新现有节点并添加新节点
     nodes.forEachIndexed { i, sourceNode ->
-        val contentLength = sourceNode.content.length
-        val cached = conversionCache[i]
-
-        val stableNode = if (cached != null && cached.first == contentLength) {
-            cached.second
-        } else {
-            sourceNode.toStableNode().also {
-                conversionCache[i] = contentLength to it
-            }
-        }
+        val stableNode = stableNodeForRender(sourceNode, i, conversionCache)
 
         if (i < renderNodes.size) {
             // 如果节点内容发生变化，则更新

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRenderer.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRenderer.kt
@@ -394,7 +394,7 @@ class StreamMarkdownRendererState {
     // 节点动画状态映射表
     val nodeAnimationStates = mutableStateMapOf<String, Boolean>()
     // 缓存转换后的稳定节点，避免不必要的对象创建
-    val conversionCache = mutableStateMapOf<Int, StableNodeConversionCacheEntry>()
+    internal val conversionCache = mutableStateMapOf<Int, StableNodeConversionCacheEntry>()
     // 保存流式渲染收集的完整内容，用于切换时判断是否需要重新解析
     val collectedContent = SmartString()
     // XML 节点对应的子流（仅流式渲染有效）
@@ -688,11 +688,12 @@ fun StreamMarkdownRenderer(
                         }
                     } finally {
                         if (tempBlockType == MarkdownProcessorType.XML_BLOCK) {
-                            // A closed XML block is fully represented by newNode.content. Keeping its
-                            // replay buffer after this point only duplicates completed tool output.
+                            // Publish the complete node before releasing the replay stream. Otherwise a
+                            // following block can trigger recomposition while this node is still stale.
+                            batchUpdater.flushNow()
                             releaseXmlNodeStream(xmlNodeStreams, nodeIndex)
-                            batchUpdater.requestUpdate()
                         }
+
                     }
                 }
 
@@ -1228,6 +1229,8 @@ internal class BatchNodeUpdater(
         )
 
     fun requestUpdate() = coordinator.requestUpdate()
+
+    fun flushNow() = coordinator.flushNow()
 
     fun requestStructuralUpdate(nodeIndex: Int) {
         // Type and child-list mutations can preserve the parent content length.

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -147,6 +149,19 @@ internal fun cleanMessageContentForCopy(content: String): String {
         .let(MediaLinkParser::removeMediaLinks)
         .trim()
 }
+
+/** Preserves structured markup for copying while removing provider protocol metadata. */
+internal fun cleanMessageContentForXmlCopy(content: String): String {
+    return content
+        .let(ChatMarkupRegex::removeGeminiThoughtSignatureMeta)
+        .let(ChatMarkupRegex::removeOpenAiResponsesProtocolMeta)
+        .trim()
+}
+
+internal data class MessageCopyContent(
+    val markdownSource: String,
+    val xmlSource: String,
+)
 
 internal suspend fun buildSelectedMessagesPlainText(
     messages: List<ChatMessage>,
@@ -643,7 +658,7 @@ private fun MessageItem(
     var showMessageInfoDialog by remember { mutableStateOf(false) }
     var showHiddenUserMessageDialog by remember { mutableStateOf(false) }
     var showDeleteMessageConfirmDialog by remember { mutableStateOf(false) }
-    var copyPreviewText by remember { mutableStateOf<String?>(null) }
+    var copyPreviewContent by remember { mutableStateOf<MessageCopyContent?>(null) }
     val context = LocalContext.current
     val messageInteractionSource = remember { MutableInteractionSource() }
 
@@ -782,8 +797,10 @@ private fun MessageItem(
                         )
                     },
                     onClick = {
-                        val cleanContent = cleanMessageContentForCopy(message.content)
-                        copyPreviewText = cleanContent
+                        copyPreviewContent = MessageCopyContent(
+                            markdownSource = cleanMessageContentForCopy(message.content),
+                            xmlSource = cleanMessageContentForXmlCopy(message.content),
+                        )
                         onCopyMessage?.invoke(message)
                         showContextMenu = false
                     },
@@ -1169,19 +1186,25 @@ private fun MessageItem(
             )
         }
 
-        copyPreviewText?.let { previewText ->
+        copyPreviewContent?.let { previewContent ->
             MessageCopyPreviewBottomSheet(
-                text = previewText,
-                onDismiss = { copyPreviewText = null }
+                content = previewContent,
+                onDismiss = { copyPreviewContent = null }
             )
         }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+private enum class MessageCopyMode {
+    PLAIN_TEXT,
+    MARKDOWN_SOURCE,
+    XML_SOURCE,
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 private fun MessageCopyPreviewBottomSheet(
-    text: String,
+    content: MessageCopyContent,
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -1219,23 +1242,26 @@ private fun MessageCopyPreviewBottomSheet(
                 }
             }
         }
-    var showPlainText by remember(text) { mutableStateOf(true) }
-    var plainText by remember(text) { mutableStateOf<String?>(null) }
-    LaunchedEffect(text, context) {
+    var copyMode by remember(content) { mutableStateOf(MessageCopyMode.PLAIN_TEXT) }
+    var plainText by remember(content.markdownSource) { mutableStateOf<String?>(null) }
+    LaunchedEffect(content.markdownSource, context) {
         plainText =
             withContext(Dispatchers.Default) {
-                markdownToPlainTextForCopy(text) { formulas ->
+                markdownToPlainTextForCopy(content.markdownSource) { formulas ->
                     LatexMathMlConverter.convertAll(context, formulas)
                 }
             }
     }
-    val displayedText = if (showPlainText) plainText.orEmpty() else text
-    val copyButtonText =
-        if (showPlainText) {
-            stringResource(R.string.copy_plain_text)
-        } else {
-            stringResource(R.string.copy_markdown_source)
-        }
+    val displayedText = when (copyMode) {
+        MessageCopyMode.PLAIN_TEXT -> plainText.orEmpty()
+        MessageCopyMode.MARKDOWN_SOURCE -> content.markdownSource
+        MessageCopyMode.XML_SOURCE -> content.xmlSource
+    }
+    val copyButtonText = when (copyMode) {
+        MessageCopyMode.PLAIN_TEXT -> stringResource(R.string.copy_plain_text)
+        MessageCopyMode.MARKDOWN_SOURCE -> stringResource(R.string.copy_markdown_source)
+        MessageCopyMode.XML_SOURCE -> stringResource(R.string.copy_xml_source)
+    }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -1252,22 +1278,28 @@ private fun MessageCopyPreviewBottomSheet(
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.padding(bottom = 12.dp)
             )
-            Row(
+            FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.padding(bottom = 12.dp)
             ) {
                 FilterChip(
-                    selected = showPlainText,
-                    onClick = { showPlainText = true },
+                    selected = copyMode == MessageCopyMode.PLAIN_TEXT,
+                    onClick = { copyMode = MessageCopyMode.PLAIN_TEXT },
                     label = { Text(stringResource(R.string.plain_text)) }
                 )
                 FilterChip(
-                    selected = !showPlainText,
-                    onClick = { showPlainText = false },
+                    selected = copyMode == MessageCopyMode.MARKDOWN_SOURCE,
+                    onClick = { copyMode = MessageCopyMode.MARKDOWN_SOURCE },
                     label = { Text(stringResource(R.string.markdown_source)) }
                 )
+                FilterChip(
+                    selected = copyMode == MessageCopyMode.XML_SOURCE,
+                    onClick = { copyMode = MessageCopyMode.XML_SOURCE },
+                    label = { Text(stringResource(R.string.xml_source)) }
+                )
             }
-            if (showPlainText && plainText == null) {
+            if (copyMode == MessageCopyMode.PLAIN_TEXT && plainText == null) {
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
@@ -1300,7 +1332,7 @@ private fun MessageCopyPreviewBottomSheet(
                 horizontalArrangement = Arrangement.End,
             ) {
                 TextButton(
-                    enabled = !showPlainText || plainText != null,
+                    enabled = copyMode != MessageCopyMode.PLAIN_TEXT || plainText != null,
                     onClick = {
                         clipboardManager.setText(AnnotatedString(displayedText))
                         Toast.makeText(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatToastHost.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatToastHost.kt
@@ -53,7 +53,10 @@ fun ChatToastHost(
     LaunchedEffect(event?.id) {
         val activeEvent = event ?: return@LaunchedEffect
         scrollState.scrollTo(0)
-        kotlinx.coroutines.delay(estimateToastDurationMs(activeEvent.message))
+        kotlinx.coroutines.delay(
+            activeEvent.durationMs?.coerceAtLeast(1L)
+                ?: estimateToastDurationMs(activeEvent.message)
+        )
         onDismiss(activeEvent.id)
     }
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/RevisableTextStreamRemember.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/RevisableTextStreamRemember.kt
@@ -7,7 +7,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.ai.assistance.operit.util.stream.MutableSharedStream
+import com.ai.assistance.operit.util.stream.MutableSharedStreamImpl
 import com.ai.assistance.operit.util.stream.Stream
+
 import com.ai.assistance.operit.util.stream.StreamRollbackPrefix
 import com.ai.assistance.operit.util.stream.TextStreamEventCarrier
 import com.ai.assistance.operit.util.stream.TextStreamEventType
@@ -83,9 +85,11 @@ fun rememberRevisableTextStream(sourceStream: Stream<String>?): Stream<String>? 
                 }
             } finally {
                 eventJob.cancelAndJoin()
-                currentOutputStream.resetReplayCache()
-                displayStream = null
+                // Keep the completed replay available until the message switches to static content.
+                // Clearing it here can race the renderer's final frame and leave a tool result blank.
+                (currentOutputStream as? MutableSharedStreamImpl<String>)?.close()
             }
+
         }
     }
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/ThinkToolsXmlNodeGrouper.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/part/ThinkToolsXmlNodeGrouper.kt
@@ -232,6 +232,10 @@ class ThinkToolsXmlNodeGrouper(
         val toolCount = slice.count {
             it.type == MarkdownProcessorType.XML_BLOCK && extractXmlTagName(it.content) == "tool"
         }
+        val thinkingCount = slice.count {
+            it.type == MarkdownProcessorType.XML_BLOCK &&
+                extractXmlTagName(it.content) in setOf("think", "thinking")
+        }
         val searchCount = slice.count {
             it.type == MarkdownProcessorType.XML_BLOCK && extractXmlTagName(it.content) == "search"
         }
@@ -246,7 +250,11 @@ class ThinkToolsXmlNodeGrouper(
                 searchCount > 0 ->
                     stringResource(R.string.thinking_search_group_title)
                 else ->
-                    stringResource(R.string.thinking_tools_group_title_with_count, toolCount)
+                    stringResource(
+                        R.string.thinking_tools_group_title_with_counts,
+                        thinkingCount,
+                        toolCount,
+                    )
             }
 
         val hasLiveXmlStream = slice.indices.any { idx ->

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/bubble/BubbleAiMessageComposable.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/bubble/BubbleAiMessageComposable.kt
@@ -109,6 +109,8 @@ fun BubbleAiMessageComposable(
         } else {
             message.content
         }
+    val shouldRenderStructuredMarkup = renderAiMarkdownAndLatex
+
     val bubbleShowAvatar = themeSnapshot.bubbleShowAvatar
     val bubbleWideLayoutEnabled = themeSnapshot.bubbleWideLayoutEnabled
     val showThinkingProcess = themeSnapshot.showThinkingProcess
@@ -231,8 +233,9 @@ fun BubbleAiMessageComposable(
         }
     }
     val shouldUseExpandedBubbleLayout =
-        renderAiMarkdownAndLatex &&
+        shouldRenderStructuredMarkup &&
             rendererState.renderNodes.any { node -> node.type in ExpandedBubbleLayoutNodeTypes }
+
     val sizeTrackingModifier =
         if (isHidden) {
             Modifier
@@ -379,8 +382,8 @@ fun BubbleAiMessageComposable(
                             .widthIn(max = maxBubbleWidth)
                             .defaultMinSize(minHeight = 44.dp)
                     val renderContent: @Composable () -> Unit = {
-                        key(message.timestamp, renderAiMarkdownAndLatex) {
-                            if (renderAiMarkdownAndLatex) {
+                        key(message.timestamp, shouldRenderStructuredMarkup) {
+                            if (shouldRenderStructuredMarkup) {
                                 val stream = rememberRevisableTextStream(message.contentStream)
                                 if (stream != null) {
                                     val charStream = remember(stream) { stream.toCharStream() }
@@ -599,8 +602,8 @@ fun BubbleAiMessageComposable(
                             .widthIn(max = maxBubbleWidth)
                             .defaultMinSize(minHeight = 44.dp)
                     val renderContent: @Composable () -> Unit = {
-                        key(message.timestamp, renderAiMarkdownAndLatex) {
-                            if (renderAiMarkdownAndLatex) {
+                        key(message.timestamp, shouldRenderStructuredMarkup) {
+                            if (shouldRenderStructuredMarkup) {
                                 val stream = rememberRevisableTextStream(message.contentStream)
                                 if (stream != null) {
                                     val charStream = remember(stream) { stream.toCharStream() }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
@@ -613,7 +613,7 @@ fun AgentChatInputSection(
                             context.getString(R.string.processing_tool_result, inputState.toolName)
                     is InputProcessingState.Retrying ->
                         MaterialTheme.colorScheme.tertiary to
-                            inputState.message.ifBlank { context.getString(R.string.message_processing) }
+                            context.getString(R.string.message_processing)
                     is InputProcessingState.Summarizing -> MaterialTheme.colorScheme.tertiary to inputState.message
                     is InputProcessingState.Receiving -> MaterialTheme.colorScheme.secondary to inputState.message
                     else -> MaterialTheme.colorScheme.primary to ""

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/agent/AgentChatInputSection.kt
@@ -603,21 +603,28 @@ fun AgentChatInputSection(
                     is InputProcessingState.ExecutingTool ->
                         MaterialTheme.colorScheme.secondary to
                             context.getString(R.string.executing_tool, inputState.toolName)
+                    is InputProcessingState.WaitingToolResult ->
+                        MaterialTheme.colorScheme.secondary to
+                            context.getString(R.string.waiting_tool_result, inputState.toolName)
                     is InputProcessingState.ToolProgress -> MaterialTheme.colorScheme.secondary to inputState.message
                     is InputProcessingState.Processing -> MaterialTheme.colorScheme.primary to inputState.message
                     is InputProcessingState.ProcessingToolResult ->
                         MaterialTheme.colorScheme.tertiary.copy(alpha = 0.8f) to
                             context.getString(R.string.processing_tool_result, inputState.toolName)
+                    is InputProcessingState.Retrying ->
+                        MaterialTheme.colorScheme.tertiary to
+                            inputState.message.ifBlank { context.getString(R.string.message_processing) }
                     is InputProcessingState.Summarizing -> MaterialTheme.colorScheme.tertiary to inputState.message
                     is InputProcessingState.Receiving -> MaterialTheme.colorScheme.secondary to inputState.message
                     else -> MaterialTheme.colorScheme.primary to ""
                 }
-
             var message = baseMessage
             var progressValue =
                 when (inputState) {
                     is InputProcessingState.Processing -> 0.3f
                     is InputProcessingState.Connecting -> 0.6f
+                    is InputProcessingState.Retrying -> 0.6f
+                    is InputProcessingState.WaitingToolResult -> 0.8f
                     is InputProcessingState.Summarizing -> 0.05f
                     is InputProcessingState.ToolProgress -> inputState.progress
                     else -> 1f

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatInputSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatInputSection.kt
@@ -378,20 +378,27 @@ fun ClassicChatInputSection(
                 val (progressColor, baseMessage) = when (inputState) {
                     is InputProcessingState.Connecting -> MaterialTheme.colorScheme.tertiary to inputState.message
                     is InputProcessingState.ExecutingTool -> MaterialTheme.colorScheme.secondary to context.getString(R.string.executing_tool, inputState.toolName)
+                    is InputProcessingState.WaitingToolResult ->
+                        MaterialTheme.colorScheme.secondary to
+                            context.getString(R.string.waiting_tool_result, inputState.toolName)
                     is InputProcessingState.ToolProgress -> MaterialTheme.colorScheme.secondary to inputState.message
                     is InputProcessingState.Processing -> MaterialTheme.colorScheme.primary to inputState.message
                     is InputProcessingState.ProcessingToolResult -> MaterialTheme.colorScheme.tertiary.copy(
                         alpha = 0.8f
                     ) to context.getString(R.string.processing_tool_result, inputState.toolName)
+                    is InputProcessingState.Retrying ->
+                        MaterialTheme.colorScheme.tertiary to
+                            inputState.message.ifBlank { context.getString(R.string.message_processing) }
                     is InputProcessingState.Summarizing -> MaterialTheme.colorScheme.tertiary to inputState.message
                     is InputProcessingState.Receiving -> MaterialTheme.colorScheme.secondary to inputState.message
                     else -> MaterialTheme.colorScheme.primary to ""
                 }
-
                 var message = baseMessage
                 var progressValue = when (inputState) {
                     is InputProcessingState.Processing -> 0.3f
                     is InputProcessingState.Connecting -> 0.6f
+                    is InputProcessingState.Retrying -> 0.6f
+                    is InputProcessingState.WaitingToolResult -> 0.8f
                     is InputProcessingState.Summarizing -> 0.05f
                     is InputProcessingState.ToolProgress -> inputState.progress
                     else -> 1f

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatInputSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/style/input/classic/ClassicChatInputSection.kt
@@ -388,7 +388,7 @@ fun ClassicChatInputSection(
                     ) to context.getString(R.string.processing_tool_result, inputState.toolName)
                     is InputProcessingState.Retrying ->
                         MaterialTheme.colorScheme.tertiary to
-                            inputState.message.ifBlank { context.getString(R.string.message_processing) }
+                            context.getString(R.string.message_processing)
                     is InputProcessingState.Summarizing -> MaterialTheme.colorScheme.tertiary to inputState.message
                     is InputProcessingState.Receiving -> MaterialTheme.colorScheme.secondary to inputState.message
                     else -> MaterialTheme.colorScheme.primary to ""

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/UiStateDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/UiStateDelegate.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.asStateFlow
 data class ChatToastEvent(
     val id: Long,
     val message: String,
+    val durationMs: Long? = null,
 )
 
 /** 委托类，负责管理UI状态相关功能 */
@@ -65,6 +66,21 @@ class UiStateDelegate {
             } else {
                 toastQueue.addLast(event)
             }
+        }
+    }
+
+    /** 显示可替换的重试提示；下一次重试状态到来时立即覆盖当前提示。 */
+    fun showRetryToast(message: String, durationMs: Long) {
+        if (message.isBlank()) {
+            return
+        }
+        synchronized(toastLock) {
+            _toastEvent.value =
+                ChatToastEvent(
+                    id = ++nextToastEventId,
+                    message = message,
+                    durationMs = durationMs.coerceAtLeast(1L)
+                )
         }
     }
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerDialogs.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerDialogs.kt
@@ -1,6 +1,9 @@
 package com.ai.assistance.operit.ui.features.packages.screens
 
-import androidx.compose.foundation.ExperimentalFoundationApi
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,16 +15,21 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -35,13 +43,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.core.tools.EnvVar
+import com.ai.assistance.operit.core.tools.ToolPackage
 import com.ai.assistance.operit.core.tools.packTool.PackageManager
 
 @Composable
@@ -84,9 +96,7 @@ fun PackageLoadErrorsDialog(
                     )
                     if (errorInfo.isExternalSource && errorInfo.sourcePath != null) {
                         Spacer(modifier = Modifier.height(8.dp))
-                        OutlinedButton(
-                            onClick = { onDeleteSource(errorInfo.sourcePath) }
-                        ) {
+                        OutlinedButton(onClick = { onDeleteSource(errorInfo.sourcePath) }) {
                             Text(text = stringResource(R.string.package_conflict_delete_source))
                         }
                     }
@@ -102,185 +112,95 @@ fun PackageLoadErrorsDialog(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PackageEnvironmentVariablesDialog(
-    requiredEnvByPackage: Map<String, List<EnvVar>>,
+    toolPackages: List<ToolPackage>,
     currentValues: Map<String, String>,
     onDismiss: () -> Unit,
     onConfirm: (Map<String, String>) -> Unit
 ) {
     val context = LocalContext.current
-
-    val requiredEnvKeys = remember(requiredEnvByPackage) {
-        requiredEnvByPackage.values
-            .flatten()
-            .map { it.name }
-            .toSet()
-            .toList()
-            .sorted()
+    val packageEntries = remember(toolPackages) {
+        toolPackages
+            .filter { it.env.isNotEmpty() }
+            .sortedBy { it.name.lowercase() }
+    }
+    val environmentKeys = remember(packageEntries) {
+        packageEntries.flatMap { it.env }.map { it.name }.distinct()
+    }
+    var editableValues by remember(environmentKeys, currentValues) {
+        mutableStateOf(environmentKeys.associateWith { currentValues[it].orEmpty() })
+    }
+    var expandedPackages by remember(packageEntries) {
+        mutableStateOf(emptySet<String>())
     }
 
-    var editableValues by
-        remember(requiredEnvKeys, currentValues) {
-            mutableStateOf(
-                requiredEnvKeys.associateWith { key: String -> currentValues[key] ?: "" }
-            )
-        }
+    val configuredCount = environmentKeys.count { editableValues[it].isNullOrBlank().not() }
+    val requiredVariables = packageEntries.flatMap { it.env }.filter { it.required }.distinctBy { it.name }
+    val missingRequiredCount = requiredVariables.count { editableValues[it.name].isNullOrBlank() }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(text = stringResource(R.string.pkg_config_env_vars)) },
+        title = {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(text = stringResource(R.string.pkg_config_env_vars))
+                Text(
+                    text = stringResource(R.string.pkg_env_vars_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        },
         text = {
-            if (requiredEnvKeys.isEmpty()) {
+            if (environmentKeys.isEmpty()) {
                 Text(
                     text = stringResource(R.string.pkg_no_env_vars),
                     style = MaterialTheme.typography.bodyMedium
                 )
             } else {
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 400.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    requiredEnvByPackage.forEach { (packageName, envVars) ->
-                        stickyHeader(key = "header:$packageName") {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 4.dp),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Surface(
-                                    modifier = Modifier.size(24.dp),
-                                    shape = CircleShape,
-                                    color = MaterialTheme.colorScheme.primaryContainer
-                                ) {
-                                    Box(contentAlignment = Alignment.Center) {
-                                        Text(
-                                            text = packageName.first().uppercaseChar().toString(),
-                                            style = MaterialTheme.typography.labelSmall,
-                                            fontWeight = FontWeight.Bold,
-                                            color = MaterialTheme.colorScheme.onPrimaryContainer
-                                        )
-                                    }
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    EnvironmentVariablesSummary(
+                        configuredCount = configuredCount,
+                        totalCount = environmentKeys.size,
+                        missingRequiredCount = missingRequiredCount
+                    )
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 460.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        packageEntries.forEach { toolPackage ->
+                            item(key = toolPackage.name) {
+                                val expanded = toolPackage.name in expandedPackages
+                                val configuredForPackage = toolPackage.env.count {
+                                    editableValues[it.name].isNullOrBlank().not()
                                 }
-                                Text(
-                                    text = packageName,
-                                    style = MaterialTheme.typography.labelMedium,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = MaterialTheme.colorScheme.onSurface
+                                val missingRequiredForPackage = toolPackage.env.count {
+                                    it.required && editableValues[it.name].isNullOrBlank()
+                                }
+                                PackageEnvironmentVariablesSection(
+                                    toolPackage = toolPackage,
+                                    values = editableValues,
+                                    expanded = expanded,
+                                    configuredCount = configuredForPackage,
+                                    missingRequiredCount = missingRequiredForPackage,
+                                    context = context,
+                                    onToggleExpanded = {
+                                        expandedPackages = if (expanded) {
+                                            expandedPackages - toolPackage.name
+                                        } else {
+                                            expandedPackages + toolPackage.name
+                                        }
+                                    },
+                                    onValueChange = { name, value ->
+                                        editableValues = editableValues.toMutableMap().apply {
+                                            this[name] = value
+                                        }
+                                    }
                                 )
                             }
-                        }
-
-                        items(
-                            items = envVars,
-                            key = { envVar -> "${packageName}:${envVar.name}" }
-                        ) { envVar ->
-                            Column(modifier = Modifier.fillMaxWidth()) {
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Column(modifier = Modifier.weight(1f)) {
-                                        Row(
-                                            verticalAlignment = Alignment.CenterVertically,
-                                            horizontalArrangement = Arrangement.spacedBy(4.dp)
-                                        ) {
-                                            Text(
-                                                text = envVar.name,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                fontWeight = FontWeight.Medium,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                            if (envVar.required) {
-                                                Surface(
-                                                    modifier = Modifier.size(16.dp),
-                                                    shape = CircleShape,
-                                                    color = MaterialTheme.colorScheme.error
-                                                ) {
-                                                    Box(
-                                                        contentAlignment = Alignment.Center,
-                                                        modifier = Modifier.size(16.dp)
-                                                    ) {
-                                                        Text(
-                                                            text = "!",
-                                                            style = MaterialTheme.typography.labelSmall,
-                                                            fontWeight = FontWeight.Bold,
-                                                            color = MaterialTheme.colorScheme.onError
-                                                        )
-                                                    }
-                                                }
-                                            } else {
-                                                Surface(
-                                                    modifier = Modifier.size(16.dp),
-                                                    shape = CircleShape,
-                                                    color = MaterialTheme.colorScheme.secondaryContainer
-                                                ) {
-                                                    Box(
-                                                        contentAlignment = Alignment.Center,
-                                                        modifier = Modifier.size(16.dp)
-                                                    ) {
-                                                        Icon(
-                                                            imageVector = Icons.Default.Check,
-                                                            contentDescription = "Optional",
-                                                            modifier = Modifier.size(10.dp),
-                                                            tint = MaterialTheme.colorScheme.onSecondaryContainer
-                                                        )
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        val description = envVar.description.resolve(context)
-                                        if (description.isNotBlank()) {
-                                            Text(
-                                                text = description,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                maxLines = 2,
-                                                overflow = TextOverflow.Ellipsis
-                                            )
-                                        }
-                                    }
-                                }
-                                if (envVar.defaultValue != null) {
-                                    Text(
-                                        text = stringResource(R.string.pkg_default, envVar.defaultValue),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.primary,
-                                        modifier = Modifier.padding(start = 8.dp)
-                                    )
-                                }
-                            }
-                            Spacer(modifier = Modifier.height(4.dp))
-                            OutlinedTextField(
-                                value = editableValues[envVar.name] ?: "",
-                                onValueChange = { newValue ->
-                                    editableValues =
-                                        editableValues.toMutableMap().apply {
-                                            this[envVar.name] = newValue
-                                        }
-                                },
-                                singleLine = true,
-                                modifier = Modifier.fillMaxWidth(),
-                                placeholder = {
-                                    Text(
-                                        text =
-                                            if (envVar.required) {
-                                                stringResource(R.string.pkg_input_required)
-                                            } else {
-                                                stringResource(R.string.pkg_input_optional)
-                                            },
-                                        style = MaterialTheme.typography.bodySmall
-                                    )
-                                },
-                                shape = RoundedCornerShape(6.dp),
-                                textStyle = MaterialTheme.typography.bodySmall
-                            )
                         }
                     }
                 }
@@ -297,4 +217,325 @@ fun PackageEnvironmentVariablesDialog(
             }
         }
     )
+}
+
+@Composable
+private fun EnvironmentVariablesSummary(
+    configuredCount: Int,
+    totalCount: Int,
+    missingRequiredCount: Int
+) {
+    val progress = configuredCount.toFloat() / totalCount.toFloat()
+    val complete = configuredCount == totalCount
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f)
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column {
+                    Text(
+                        text = stringResource(R.string.pkg_env_vars_status),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = "$configuredCount / $totalCount",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Text(
+                    text = when {
+                        missingRequiredCount > 0 -> {
+                            stringResource(R.string.pkg_env_vars_missing_required, missingRequiredCount)
+                        }
+                        complete -> stringResource(R.string.pkg_env_vars_complete)
+                        else -> stringResource(R.string.pkg_env_vars_required_complete)
+                    },
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (missingRequiredCount > 0) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.primary
+                    },
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            Spacer(modifier = Modifier.height(9.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(MaterialTheme.colorScheme.surface)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(progress)
+                        .height(6.dp)
+                        .clip(RoundedCornerShape(50))
+                        .background(MaterialTheme.colorScheme.primary)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PackageEnvironmentVariablesSection(
+    toolPackage: ToolPackage,
+    values: Map<String, String>,
+    expanded: Boolean,
+    configuredCount: Int,
+    missingRequiredCount: Int,
+    context: Context,
+    onToggleExpanded: () -> Unit,
+    onValueChange: (String, String) -> Unit
+) {
+    val packageName = toolPackage.name
+    val packageDescription = toolPackage.description.resolve(context).trim()
+    val environmentVariables = toolPackage.env
+    val packageInitial = packageName.firstOrNull()?.uppercaseChar()?.toString().orEmpty()
+    val complete = missingRequiredCount == 0 && configuredCount == environmentVariables.size
+    val status = when {
+        missingRequiredCount > 0 -> stringResource(
+            R.string.pkg_env_vars_missing_required,
+            missingRequiredCount
+        )
+        complete -> stringResource(R.string.pkg_env_vars_complete)
+        else -> stringResource(
+            R.string.pkg_env_vars_configured_count,
+            configuredCount,
+            environmentVariables.size
+        )
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = 1.dp,
+                color = if (expanded) {
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
+                } else {
+                    MaterialTheme.colorScheme.outlineVariant
+                },
+                shape = RoundedCornerShape(10.dp)
+            ),
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surface
+    ) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onToggleExpanded)
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Surface(
+                    modifier = Modifier.size(34.dp),
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primaryContainer
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text(
+                            text = packageInitial,
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.size(10.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = packageName,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (packageDescription.isNotBlank()) {
+                        Text(
+                            text = packageDescription,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    Text(
+                        text = status,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (missingRequiredCount > 0) {
+                            MaterialTheme.colorScheme.error
+                        } else if (complete) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        }
+                    )
+                }
+                Icon(
+                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (expanded) {
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f))
+                Column(
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    environmentVariables.forEach { environmentVariable ->
+                        EnvironmentVariableField(
+                            environmentVariable = environmentVariable,
+                            value = values[environmentVariable.name].orEmpty(),
+                            context = context,
+                            onValueChange = { onValueChange(environmentVariable.name, it) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EnvironmentVariableField(
+    environmentVariable: EnvVar,
+    value: String,
+    context: Context,
+    onValueChange: (String) -> Unit
+) {
+    var isValueVisible by remember(environmentVariable.name) { mutableStateOf(false) }
+    val description = environmentVariable.description.resolve(context).trim()
+    val hasValue = value.isNotBlank()
+    val isSensitive = environmentVariable.name.isSensitiveEnvironmentVariableName()
+
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = environmentVariable.name.toEnvironmentVariableLabel(),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = when {
+                    environmentVariable.required && !hasValue -> {
+                        stringResource(R.string.pkg_env_vars_required)
+                    }
+                    hasValue -> stringResource(R.string.pkg_env_vars_configured)
+                    else -> stringResource(R.string.pkg_env_vars_optional)
+                },
+                style = MaterialTheme.typography.labelSmall,
+                color = when {
+                    environmentVariable.required && !hasValue -> MaterialTheme.colorScheme.error
+                    hasValue -> MaterialTheme.colorScheme.primary
+                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                }
+            )
+        }
+        Text(
+            text = description.ifBlank { stringResource(R.string.pkg_env_vars_missing_description) },
+            style = MaterialTheme.typography.bodySmall,
+            color = if (description.isBlank()) {
+                MaterialTheme.colorScheme.error.copy(alpha = 0.85f)
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis
+        )
+        environmentVariable.defaultValue?.takeIf { it.isNotBlank() }?.let { defaultValue ->
+            Text(
+                text = stringResource(R.string.pkg_default, defaultValue),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            isError = environmentVariable.required && !hasValue,
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = {
+                Text(
+                    text = if (environmentVariable.required) {
+                        stringResource(R.string.pkg_input_required)
+                    } else {
+                        stringResource(R.string.pkg_input_optional)
+                    },
+                    style = MaterialTheme.typography.bodySmall
+                )
+            },
+            trailingIcon = if (isSensitive) {
+                {
+                    IconButton(onClick = { isValueVisible = !isValueVisible }) {
+                        Icon(
+                            imageVector = if (isValueVisible) {
+                                Icons.Default.VisibilityOff
+                            } else {
+                                Icons.Default.Visibility
+                            },
+                            contentDescription = if (isValueVisible) {
+                                stringResource(R.string.pkg_env_vars_hide_value)
+                            } else {
+                                stringResource(R.string.pkg_env_vars_show_value)
+                            }
+                        )
+                    }
+                }
+            } else if (hasValue) {
+                {
+                    Icon(
+                        imageVector = Icons.Default.CheckCircle,
+                        contentDescription = stringResource(R.string.pkg_env_vars_configured),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            } else {
+                null
+            },
+            visualTransformation = if (isSensitive && !isValueVisible) {
+                PasswordVisualTransformation()
+            } else {
+                VisualTransformation.None
+            },
+            shape = RoundedCornerShape(8.dp)
+        )
+    }
+}
+
+private fun String.isSensitiveEnvironmentVariableName(): Boolean {
+    val normalized = lowercase()
+    return listOf("key", "token", "secret", "password", "passwd", "credential").any {
+        normalized.contains(it)
+    }
+}
+
+private fun String.toEnvironmentVariableLabel(): String {
+    val words = substringBeforeLast("_API_KEY", missingDelimiterValue = this)
+        .replace('_', ' ')
+        .lowercase()
+        .replaceFirstChar { it.uppercase() }
+    return when {
+        endsWith("_API_KEY") -> "$words API Key"
+        endsWith("_TOKEN") -> "${substringBeforeLast("_TOKEN").replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() }} Token"
+        endsWith("_URL") -> "${substringBeforeLast("_URL").replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() }} URL"
+        else -> replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() }
+    }
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
@@ -213,7 +213,7 @@ fun PackageManagerScreen(
     var quickPluginSetupRunning by remember { mutableStateOf(false) }
     var quickPluginSetupResult by remember { mutableStateOf<ToolResult?>(null) }
 
-    val requiredEnvByPackage by remember {
+    val environmentPackages by remember {
         derivedStateOf {
             val packagesMap = allAvailablePackages.value
             val imported = importedPackages.value.toSet()
@@ -222,18 +222,15 @@ fun PackageManagerScreen(
                 .mapNotNull { packageName ->
                     packagesMap[packageName]
                 }
+                .filter { toolPackage -> toolPackage.env.isNotEmpty() }
                 .sortedBy { it.name }
-                .associate { toolPackage ->
-                    toolPackage.name to toolPackage.env
-                }
-                .filterValues { envVars -> envVars.isNotEmpty() }
         }
     }
 
     val requiredEnvKeys by remember {
         derivedStateOf {
-            requiredEnvByPackage.values
-                .flatten()
+            environmentPackages
+                .flatMap { it.env }
                 .map { it.name }
                 .toSet()
                 .toList()
@@ -1021,7 +1018,7 @@ fun PackageManagerScreen(
             // Environment Variables Dialog for packages
             if (showEnvDialog) {
                 PackageEnvironmentVariablesDialog(
-                    requiredEnvByPackage = requiredEnvByPackage,
+                    toolPackages = environmentPackages,
                     currentValues = envVariables,
                     onDismiss = { showEnvDialog = false },
                     onConfirm = { updated ->

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/GlobalDisplaySettingsScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/GlobalDisplaySettingsScreen.kt
@@ -29,10 +29,13 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.api.chat.AIForegroundService
+import com.ai.assistance.operit.api.chat.llmprovider.LlmRetryPolicy
 import com.ai.assistance.operit.core.tools.system.AndroidPermissionLevel
 import com.ai.assistance.operit.data.preferences.AndroidPermissionPreferences
 import com.ai.assistance.operit.data.preferences.ApiPreferences
 import com.ai.assistance.operit.data.preferences.DisplayPreferencesManager
+import com.ai.assistance.operit.data.preferences.LlmRetryMode
+import com.ai.assistance.operit.data.preferences.LlmRetrySettings
 import com.ai.assistance.operit.data.preferences.RootCommandExecutionMode
 import com.ai.assistance.operit.data.preferences.ToolCollapseMode
 import com.ai.assistance.operit.data.preferences.UserPreferencesManager
@@ -57,6 +60,7 @@ fun GlobalDisplaySettingsScreen(
     val scrollState = rememberScrollState()
 
     val toolCollapseMode by displayPreferencesManager.toolCollapseMode.collectAsState(initial = ToolCollapseMode.ALL)
+    val llmRetrySettings by displayPreferencesManager.llmRetrySettings.collectAsState(initial = LlmRetrySettings())
     val showFpsCounter by displayPreferencesManager.showFpsCounter.collectAsState(initial = false)
     val enableReplyNotification by displayPreferencesManager.enableReplyNotification.collectAsState(initial = true)
     val enableReplyNotificationSound by displayPreferencesManager.enableReplyNotificationSound.collectAsState(initial = false)
@@ -92,6 +96,9 @@ fun GlobalDisplaySettingsScreen(
     val collapseModeOptions = remember {
         listOf(ToolCollapseMode.READ_ONLY, ToolCollapseMode.ALL, ToolCollapseMode.FULL)
     }
+    val retryModeOptions = remember {
+        listOf(LlmRetryMode.FAST, LlmRetryMode.STANDARD, LlmRetryMode.STABLE, LlmRetryMode.CUSTOM)
+    }
     var collapseModeSliderValue by remember(toolCollapseMode) {
         mutableFloatStateOf(collapseModeOptions.indexOf(toolCollapseMode).coerceAtLeast(0).toFloat())
     }
@@ -113,6 +120,19 @@ fun GlobalDisplaySettingsScreen(
             ToolCollapseMode.ALL -> R.string.tool_collapse_mode_all
             ToolCollapseMode.FULL -> R.string.tool_collapse_mode_full
         }
+    }
+    val retryModeLabelRes: (LlmRetryMode) -> Int = { mode ->
+        when (mode) {
+            LlmRetryMode.FAST -> R.string.llm_retry_mode_fast
+            LlmRetryMode.STANDARD -> R.string.llm_retry_mode_standard
+            LlmRetryMode.STABLE -> R.string.llm_retry_mode_stable
+            LlmRetryMode.CUSTOM -> R.string.llm_retry_mode_custom
+        }
+    }
+    val retryScheduleText = remember(llmRetrySettings) {
+        LlmRetryPolicy.fromSettings(llmRetrySettings)
+            .delayScheduleMs()
+            .joinToString(" -> ") { delayMs -> "${delayMs / 1_000L}s" }
     }
 
     // 自动化状态指示样式（使用与 FloatingChatService 相同的 SharedPreferences）
@@ -246,6 +266,107 @@ fun GlobalDisplaySettingsScreen(
                         )
                     }
                 }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            SectionTitle(
+                text = stringResource(R.string.llm_retry_settings_title),
+                icon = Icons.Default.Refresh
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 4.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(componentBackgroundColor)
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.llm_retry_settings_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    retryModeOptions.forEach { mode ->
+                        FilterChip(
+                            selected = llmRetrySettings.mode == mode,
+                            onClick = {
+                                scope.launch {
+                                    displayPreferencesManager.saveDisplaySettings(llmRetryMode = mode)
+                                }
+                            },
+                            label = { Text(stringResource(retryModeLabelRes(mode))) }
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = if (retryScheduleText.isBlank()) {
+                        stringResource(R.string.llm_retry_schedule_disabled)
+                    } else {
+                        stringResource(R.string.llm_retry_schedule_value, retryScheduleText)
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+
+            EditableNumberSetting(
+                title = stringResource(R.string.llm_retry_max_attempts),
+                subtitle = stringResource(R.string.llm_retry_max_attempts_description),
+                value = llmRetrySettings.maxAttempts.toFloat(),
+                onValueChange = { value ->
+                    scope.launch {
+                        displayPreferencesManager.saveDisplaySettings(
+                            llmRetryMaxAttempts = value.roundToInt()
+                        )
+                    }
+                },
+                valueRange = DisplayPreferencesManager.MIN_LLM_RETRY_ATTEMPTS.toFloat()..
+                    DisplayPreferencesManager.MAX_LLM_RETRY_ATTEMPTS.toFloat(),
+                unitText = stringResource(R.string.llm_retry_attempts_unit),
+                backgroundColor = componentBackgroundColor
+            )
+
+            if (llmRetrySettings.mode == LlmRetryMode.CUSTOM) {
+                EditableNumberSetting(
+                    title = stringResource(R.string.llm_retry_initial_delay),
+                    subtitle = stringResource(R.string.llm_retry_initial_delay_description),
+                    value = llmRetrySettings.customInitialDelaySeconds.toFloat(),
+                    onValueChange = { value ->
+                        scope.launch {
+                            displayPreferencesManager.saveDisplaySettings(
+                                llmRetryInitialDelaySeconds = value.roundToInt()
+                            )
+                        }
+                    },
+                    valueRange = DisplayPreferencesManager.MIN_LLM_RETRY_DELAY_SECONDS.toFloat()..
+                        DisplayPreferencesManager.MAX_LLM_RETRY_INITIAL_DELAY_SECONDS.toFloat(),
+                    unitText = stringResource(R.string.llm_retry_seconds_unit),
+                    backgroundColor = componentBackgroundColor
+                )
+                EditableNumberSetting(
+                    title = stringResource(R.string.llm_retry_max_delay),
+                    subtitle = stringResource(R.string.llm_retry_max_delay_description),
+                    value = llmRetrySettings.customMaxDelaySeconds.toFloat(),
+                    onValueChange = { value ->
+                        scope.launch {
+                            displayPreferencesManager.saveDisplaySettings(
+                                llmRetryMaxDelaySeconds = value.roundToInt()
+                            )
+                        }
+                    },
+                    valueRange = DisplayPreferencesManager.MIN_LLM_RETRY_DELAY_SECONDS.toFloat()..
+                        DisplayPreferencesManager.MAX_LLM_RETRY_DELAY_SECONDS.toFloat(),
+                    unitText = stringResource(R.string.llm_retry_seconds_unit),
+                    backgroundColor = componentBackgroundColor
+                )
             }
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -1013,7 +1134,14 @@ private fun EditableNumberSetting(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 BasicTextField(
                     value = textValue,
-                    onValueChange = { newText -> textValue = newText },
+                    onValueChange = { newText ->
+                        textValue = newText
+                        newText.toFloatOrNull()?.let { enteredValue ->
+                            if (enteredValue in valueRange) {
+                                onValueChange(enteredValue)
+                            }
+                        }
+                    },
                     modifier = Modifier
                         .width(64.dp)
                         .background(

--- a/app/src/main/java/com/ai/assistance/operit/util/ChatMarkupRegex.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/ChatMarkupRegex.kt
@@ -16,6 +16,7 @@ object ChatMarkupRegex {
     private val openingTagNameRegex = Regex("<([A-Za-z][A-Za-z0-9_]*)")
     private val toolStartTagRegex = Regex("<(?:$TOOL_TAG_NAME_REGEX_SOURCE)\\b", RegexOption.IGNORE_CASE)
     private val toolResultStartTagRegex = Regex("<(?:$TOOL_RESULT_TAG_NAME_REGEX_SOURCE)\\b", RegexOption.IGNORE_CASE)
+
     private val metaProviderAttrRegex = Regex("""\bprovider\s*=\s*["']([^"']+)["']""", RegexOption.IGNORE_CASE)
     private val metaBodyRegex = Regex(
         """<meta\b[^>]*>([\s\S]*?)</meta>""",
@@ -226,7 +227,6 @@ object ChatMarkupRegex {
     fun containsAnyToolLikeTag(content: String): Boolean {
         return containsToolTag(content) || containsToolResultTag(content)
     }
-
     fun extractOpeningTagName(xml: String): String? {
         return openingTagNameRegex.find(xml.trim())?.groupValues?.getOrNull(1)
     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -727,8 +727,10 @@
     <!-- Context Menu -->
     <string name="copy_message">Copy Message</string>
     <string name="markdown_source">Markdown source</string>
+    <string name="xml_source">XML source</string>
     <string name="copy_plain_text">Copy plain text</string>
     <string name="copy_markdown_source">Copy Markdown source</string>
+    <string name="copy_xml_source">Copy XML source</string>
     <string name="chat_hidden_user_message_placeholder">Auto-triggered user message (content hidden)</string>
     <string name="chat_hidden_user_message_badge">AUTO</string>
     <string name="info">Info</string>
@@ -5043,6 +5045,7 @@
     <string name="camera_permission_denied_toast">Camera permission denied</string>
     <string name="microphone_permission_denied_toast">Microphone permission denied</string>
     <string name="executing_tool">Executing tool: %1$s</string>
+    <string name="waiting_tool_result">Waiting for tool result: %1$s</string>
     <string name="processing_tool_result">Processing tool result: %1$s</string>
     <string name="input_question_hint">Enter your question...</string>
     <string name="input_question_with_workspace">Enter question, use @ to reference files</string>
@@ -6081,10 +6084,22 @@
     <!-- Package Manager Module -->
     <string name="pkg_manage_env_vars">Manage Environment Variables</string>
     <string name="pkg_config_env_vars">Configure Environment Variables</string>
+    <string name="pkg_env_vars_subtitle">Manage the configuration required by packages and scripts</string>
     <string name="pkg_no_env_vars">The currently imported tool packages have not declared any required environment variables.</string>
     <string name="pkg_default">Default: %1$s</string>
     <string name="pkg_input_required">Input value (required)</string>
     <string name="pkg_input_optional">Input value (optional)</string>
+    <string name="pkg_env_vars_status">Configuration status</string>
+    <string name="pkg_env_vars_configured_count">%1$d / %2$d configured</string>
+    <string name="pkg_env_vars_complete">Configured</string>
+    <string name="pkg_env_vars_required_complete">Required items configured</string>
+    <string name="pkg_env_vars_missing_required">%1$d required remaining</string>
+    <string name="pkg_env_vars_required">Required</string>
+    <string name="pkg_env_vars_optional">Optional</string>
+    <string name="pkg_env_vars_configured">Configured</string>
+    <string name="pkg_env_vars_missing_description">This variable has no usage description.</string>
+    <string name="pkg_env_vars_show_value">Show value</string>
+    <string name="pkg_env_vars_hide_value">Hide value</string>
     <string name="pkg_save">Save</string>
     <string name="pkg_cancel">Cancel</string>
 
@@ -8425,8 +8440,8 @@
     <string name="chat_message_rendering_title">Message rendering</string>
     <string name="chat_message_rendering_ai_markdown_latex">Render Markdown, LaTeX, and XML in AI messages</string>
     <string name="chat_message_rendering_ai_markdown_latex_desc">Display Markdown, LaTeX expressions, and structured XML content such as thinking, tool calls, and results in AI messages as rich content.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Render Markdown, LaTeX, and XML in user messages</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Display Markdown, LaTeX expressions, and structured XML content in user messages as rich content.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Render Markdown and LaTeX in user messages</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Display Markdown and LaTeX expressions in user messages as rich content.</string>
 
     <string name="chat_style_bubble_user_opacity">User bubble opacity: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">AI bubble opacity: %1$d%%</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -5284,6 +5284,8 @@
     <string name="html_content_block">HTML Content</string>
     <string name="mood_tag_block">Mood Tag</string>
     <string name="thinking_tools_group_title_with_count">Thinking &amp; Tool Calls (%1$d)</string>
+    <string name="thinking_tools_group_title_with_counts">Thinking &amp; Tool Calls (%1$d + %2$d)</string>
+
     <string name="tools_group_title_with_count">Tool Calls (%1$d)</string>
     <string name="search_group_title">Search</string>
     <string name="thinking_search_group_title">Thinking and searching</string>
@@ -8421,10 +8423,11 @@
     <string name="thinking_config_preset_add_selected">Add %1$d presets</string>
     <string name="thinking_config_preset_added_count">Added %1$d built-in presets</string>
     <string name="chat_message_rendering_title">Message rendering</string>
-    <string name="chat_message_rendering_ai_markdown_latex">Render Markdown and LaTeX in AI messages</string>
-    <string name="chat_message_rendering_ai_markdown_latex_desc">Display Markdown and LaTeX expressions in AI messages as rich content.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Render Markdown and LaTeX in user messages</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Display Markdown and LaTeX expressions in user messages as rich content.</string>
+    <string name="chat_message_rendering_ai_markdown_latex">Render Markdown, LaTeX, and XML in AI messages</string>
+    <string name="chat_message_rendering_ai_markdown_latex_desc">Display Markdown, LaTeX expressions, and structured XML content such as thinking, tool calls, and results in AI messages as rich content.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Render Markdown, LaTeX, and XML in user messages</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Display Markdown, LaTeX expressions, and structured XML content in user messages as rich content.</string>
+
     <string name="chat_style_bubble_user_opacity">User bubble opacity: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">AI bubble opacity: %1$d%%</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -6664,7 +6664,7 @@
 
     <string name="provider_error_response_empty">API response is empty</string>
     <string name="provider_error_parsing_failed">Failed to parse response</string>
-    <string name="provider_error_retry_message">%1$s, retrying (%2$d)...</string>
+    <string name="provider_error_retry_message">%1, retrying (%2), waiting %3 sec...</string>
     <string name="provider_error_timeout">Connection timeout</string>
     <string name="provider_error_network_interrupted">Network interrupted</string>
     <string name="operit_network_error_format">Failed: Network request failed, status code: %1$d, error: %2$s</string>
@@ -8445,4 +8445,20 @@
 
     <string name="chat_style_bubble_user_opacity">User bubble opacity: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">AI bubble opacity: %1$d%%</string>
+    <string name="llm_retry_settings_title">Request retries</string>
+    <string name="llm_retry_settings_description">Configure automatic retries and wait timing after a model request fails.</string>
+    <string name="llm_retry_mode_fast">Fast</string>
+    <string name="llm_retry_mode_standard">Standard</string>
+    <string name="llm_retry_mode_stable">Stable</string>
+    <string name="llm_retry_mode_custom">Custom</string>
+    <string name="llm_retry_max_attempts">Maximum retry attempts</string>
+    <string name="llm_retry_max_attempts_description">Set to 0 to disable automatic retries. Maximum: 10.</string>
+    <string name="llm_retry_attempts_unit">times</string>
+    <string name="llm_retry_initial_delay">Initial wait</string>
+    <string name="llm_retry_initial_delay_description">Seconds before the first retry; later waits double.</string>
+    <string name="llm_retry_max_delay">Maximum single wait</string>
+    <string name="llm_retry_max_delay_description">A retry wait will never exceed this value.</string>
+    <string name="llm_retry_seconds_unit">sec</string>
+    <string name="llm_retry_schedule_value">Wait sequence: %1$s</string>
+    <string name="llm_retry_schedule_disabled">Automatic retries disabled</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6467,7 +6467,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="gemini_connection_test_failed">Prueba de conexión fallida: %1$s</string>
     <string name="provider_error_response_empty">La respuesta de la API está vacía.</string>
     <string name="provider_error_parsing_failed">Error al analizar la respuesta.</string>
-    <string name="provider_error_retry_message">%1$s, reintento %2$d en curso...</string>
+    <string name="provider_error_retry_message">%1, reintento %2 en curso; esperando %3 s...</string>
     <string name="provider_error_timeout">Tiempo de espera agotado.</string>
     <string name="provider_error_network_interrupted">Conexión de red interrumpida.</string>
     <string name="operit_network_error_format">Error: La solicitud de red falló, código de estado: %1$d, información del error: %2$s</string>
@@ -7650,4 +7650,20 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
 
     <string name="chat_style_bubble_user_opacity">Opacidad de la burbuja del usuario: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opacidad de la burbuja de IA: %1$d%%</string>
+    <string name="llm_retry_settings_title">Reintentos de solicitud</string>
+    <string name="llm_retry_settings_description">Configura los reintentos automáticos y la espera tras un fallo del modelo.</string>
+    <string name="llm_retry_mode_fast">Rápido</string>
+    <string name="llm_retry_mode_standard">Estándar</string>
+    <string name="llm_retry_mode_stable">Estable</string>
+    <string name="llm_retry_mode_custom">Personalizado</string>
+    <string name="llm_retry_max_attempts">Máximo de reintentos</string>
+    <string name="llm_retry_max_attempts_description">Usa 0 para desactivar los reintentos. Máximo: 10.</string>
+    <string name="llm_retry_attempts_unit">veces</string>
+    <string name="llm_retry_initial_delay">Espera inicial</string>
+    <string name="llm_retry_initial_delay_description">Segundos antes del primer reintento; después se duplica.</string>
+    <string name="llm_retry_max_delay">Espera máxima</string>
+    <string name="llm_retry_max_delay_description">Ninguna espera superará este valor.</string>
+    <string name="llm_retry_seconds_unit">s</string>
+    <string name="llm_retry_schedule_value">Secuencia de espera: %1$s</string>
+    <string name="llm_retry_schedule_disabled">Reintentos automáticos desactivados</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4943,6 +4943,8 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="audio_block">Audio</string>
     <string name="video_block">Video</string>
     <string name="thinking_tools_group_title_with_count">Pensamiento y llamadas a herramientas (%1$d)</string>
+    <string name="thinking_tools_group_title_with_counts">Pensamiento y llamadas a herramientas (%1$d + %2$d)</string>
+
     <string name="tools_group_title_with_count">Llamadas a herramientas (%1$d)</string>
 
     <string name="backup_data_overview">Resumen de datos</string>
@@ -7626,10 +7628,11 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="thinking_config_preset_add_selected">Añadir %1$d preajustes</string>
     <string name="thinking_config_preset_added_count">Se añadieron %1$d preajustes integrados</string>
     <string name="chat_message_rendering_title">Renderizado de mensajes</string>
-    <string name="chat_message_rendering_ai_markdown_latex">Renderizar Markdown y LaTeX en los mensajes de IA</string>
-    <string name="chat_message_rendering_ai_markdown_latex_desc">Muestra Markdown y expresiones LaTeX de los mensajes de IA como contenido enriquecido.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Renderizar Markdown y LaTeX en los mensajes del usuario</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Muestra Markdown y expresiones LaTeX de los mensajes del usuario como contenido enriquecido.</string>
+    <string name="chat_message_rendering_ai_markdown_latex">Renderizar Markdown, LaTeX y XML en los mensajes de IA</string>
+    <string name="chat_message_rendering_ai_markdown_latex_desc">Muestra Markdown, expresiones LaTeX y contenido XML estructurado, como razonamientos, llamadas a herramientas y resultados, en los mensajes de IA como contenido enriquecido.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Renderizar Markdown, LaTeX y XML en los mensajes del usuario</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Muestra Markdown, expresiones LaTeX y contenido XML estructurado en los mensajes del usuario como contenido enriquecido.</string>
+
     <string name="chat_style_bubble_user_opacity">Opacidad de la burbuja del usuario: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opacidad de la burbuja de IA: %1$d%%</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1288,8 +1288,10 @@
     <!-- Context Menu -->
     <string name="copy_message">Copiar Mensaje</string>
     <string name="markdown_source">Código fuente Markdown</string>
+    <string name="xml_source">Código fuente XML</string>
     <string name="copy_plain_text">Copiar texto sin formato</string>
     <string name="copy_markdown_source">Copiar código fuente Markdown</string>
+    <string name="copy_xml_source">Copiar código fuente XML</string>
     <string name="read_message">Leer Mensaje</string>
     <string name="pause_reading">Pausar Lectura</string>
     <string name="resume_reading">Continuar Lectura</string>
@@ -4329,6 +4331,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="camera_permission_denied_toast">Permiso de cámara denegado</string>
     <string name="microphone_permission_denied_toast">Permiso de micrófono denegado</string>
     <string name="executing_tool">Ejecutando herramienta: %1$s</string>
+    <string name="waiting_tool_result">Esperando el resultado de la herramienta: %1$s</string>
     <string name="processing_tool_result">Procesando resultado de herramienta: %1$s</string>
     <string name="input_question_hint">Ingrese su pregunta...</string>
     <string name="input_question_with_workspace">Ingrese una pregunta, use @ para referenciar archivos</string>
@@ -5381,10 +5384,22 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="mcp_server_not_installed_cannot_configure">Este plugin no está instalado, no se puede configurar</string>
     <string name="pkg_manage_env_vars">Gestionar variables de entorno</string>
     <string name="pkg_config_env_vars">Configurar variables de entorno</string>
+    <string name="pkg_env_vars_subtitle">Gestiona la configuración necesaria para paquetes y scripts</string>
     <string name="pkg_no_env_vars">El paquete de herramientas importado actualmente no declara variables de entorno necesarias.</string>
     <string name="pkg_default">Predeterminado: %1$s</string>
     <string name="pkg_input_required">Introduce un valor (obligatorio)</string>
     <string name="pkg_input_optional">Introduce un valor (opcional)</string>
+    <string name="pkg_env_vars_status">Estado de configuración</string>
+    <string name="pkg_env_vars_configured_count">%1$d / %2$d configuradas</string>
+    <string name="pkg_env_vars_complete">Configurado</string>
+    <string name="pkg_env_vars_required_complete">Obligatorias configuradas</string>
+    <string name="pkg_env_vars_missing_required">Falta %1$d obligatoria</string>
+    <string name="pkg_env_vars_required">Obligatoria</string>
+    <string name="pkg_env_vars_optional">Opcional</string>
+    <string name="pkg_env_vars_configured">Configurada</string>
+    <string name="pkg_env_vars_missing_description">Esta variable no tiene descripción de uso.</string>
+    <string name="pkg_env_vars_show_value">Mostrar valor</string>
+    <string name="pkg_env_vars_hide_value">Ocultar valor</string>
     <string name="pkg_save">Guardar</string>
     <string name="pkg_cancel">Cancelar</string>
     <string name="pkg_confirm_delete">Confirmar eliminación</string>
@@ -7630,8 +7645,8 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="chat_message_rendering_title">Renderizado de mensajes</string>
     <string name="chat_message_rendering_ai_markdown_latex">Renderizar Markdown, LaTeX y XML en los mensajes de IA</string>
     <string name="chat_message_rendering_ai_markdown_latex_desc">Muestra Markdown, expresiones LaTeX y contenido XML estructurado, como razonamientos, llamadas a herramientas y resultados, en los mensajes de IA como contenido enriquecido.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Renderizar Markdown, LaTeX y XML en los mensajes del usuario</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Muestra Markdown, expresiones LaTeX y contenido XML estructurado en los mensajes del usuario como contenido enriquecido.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Renderizar Markdown y LaTeX en los mensajes del usuario</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Muestra Markdown y expresiones LaTeX en los mensajes del usuario como contenido enriquecido.</string>
 
     <string name="chat_style_bubble_user_opacity">Opacidad de la burbuja del usuario: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opacidad de la burbuja de IA: %1$d%%</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -6057,7 +6057,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="gemini_connection_test_failed">Tes koneksi gagal: %1$s</string>
     <string name="provider_error_response_empty">Respons API kosong</string>
     <string name="provider_error_parsing_failed">Gagal mem-parsing respons</string>
-    <string name="provider_error_retry_message">%1$s, sedang melakukan percobaan ulang ke-%2$d...</string>
+    <string name="provider_error_retry_message">%1, sedang melakukan percobaan ulang ke-%2; menunggu %3 dtk...</string>
     <string name="provider_error_timeout">Koneksi timeout</string>
     <string name="provider_error_network_interrupted">Jaringan terputus</string>
     <string name="operit_network_error_format">Gagal: Permintaan jaringan gagal, kode status: %1$d, informasi kesalahan: %2$s</string>
@@ -7583,4 +7583,20 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
 
     <string name="chat_style_bubble_user_opacity">Opasitas gelembung pengguna: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opasitas gelembung AI: %1$d%%</string>
+    <string name="llm_retry_settings_title">Percobaan ulang permintaan</string>
+    <string name="llm_retry_settings_description">Atur percobaan ulang otomatis dan waktu tunggu setelah permintaan model gagal.</string>
+    <string name="llm_retry_mode_fast">Cepat</string>
+    <string name="llm_retry_mode_standard">Standar</string>
+    <string name="llm_retry_mode_stable">Stabil</string>
+    <string name="llm_retry_mode_custom">Kustom</string>
+    <string name="llm_retry_max_attempts">Maksimum percobaan ulang</string>
+    <string name="llm_retry_max_attempts_description">Atur 0 untuk menonaktifkan. Maksimum: 10.</string>
+    <string name="llm_retry_attempts_unit">kali</string>
+    <string name="llm_retry_initial_delay">Tunggu awal</string>
+    <string name="llm_retry_initial_delay_description">Detik sebelum percobaan pertama; waktu berikutnya berlipat dua.</string>
+    <string name="llm_retry_max_delay">Tunggu maksimum</string>
+    <string name="llm_retry_max_delay_description">Waktu tunggu tidak akan melebihi nilai ini.</string>
+    <string name="llm_retry_seconds_unit">dtk</string>
+    <string name="llm_retry_schedule_value">Urutan tunggu: %1$s</string>
+    <string name="llm_retry_schedule_disabled">Percobaan ulang otomatis dinonaktifkan</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -4746,6 +4746,8 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="html_content_block">Konten HTML</string>
     <string name="mood_tag_block">Tag Emosi</string>
     <string name="thinking_tools_group_title_with_count">Berpikir &amp; Pemanggilan Alat (%1$d)</string>
+    <string name="thinking_tools_group_title_with_counts">Berpikir &amp; Pemanggilan Alat (%1$d + %2$d)</string>
+
     <string name="tools_group_title_with_count">Pemanggilan Alat (%1$d)</string>
     <string name="backup_data_overview">Ikhtisar Data</string>
     <string name="backup_current_profile">Konfigurasi saat ini: %1$s</string>
@@ -7559,10 +7561,11 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="thinking_config_preset_add_selected">Tambahkan %1$d preset</string>
     <string name="thinking_config_preset_added_count">%1$d preset bawaan telah ditambahkan</string>
     <string name="chat_message_rendering_title">Perenderan pesan</string>
-    <string name="chat_message_rendering_ai_markdown_latex">Render Markdown dan LaTeX dalam pesan AI</string>
-    <string name="chat_message_rendering_ai_markdown_latex_desc">Tampilkan Markdown dan ekspresi LaTeX dalam pesan AI sebagai konten kaya.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Render Markdown dan LaTeX dalam pesan pengguna</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Tampilkan Markdown dan ekspresi LaTeX dalam pesan pengguna sebagai konten kaya.</string>
+    <string name="chat_message_rendering_ai_markdown_latex">Render Markdown, LaTeX, dan XML dalam pesan AI</string>
+    <string name="chat_message_rendering_ai_markdown_latex_desc">Tampilkan Markdown, ekspresi LaTeX, dan konten XML terstruktur seperti pemikiran, pemanggilan alat, dan hasil dalam pesan AI sebagai konten kaya.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Render Markdown, LaTeX, dan XML dalam pesan pengguna</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Tampilkan Markdown, ekspresi LaTeX, dan konten XML terstruktur dalam pesan pengguna sebagai konten kaya.</string>
+
     <string name="chat_style_bubble_user_opacity">Opasitas gelembung pengguna: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opasitas gelembung AI: %1$d%%</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1308,8 +1308,10 @@
     <string name="accessibility_wizard_success_message">Selamat! Layanan aksesibilitas telah berhasil dikonfigurasi, sekarang AI dapat menganalisis dan mengoperasikan konten layar.</string>
     <string name="copy_message">Salin Pesan</string>
     <string name="markdown_source">Sumber Markdown</string>
+    <string name="xml_source">Sumber XML</string>
     <string name="copy_plain_text">Salin teks biasa</string>
     <string name="copy_markdown_source">Salin sumber Markdown</string>
+    <string name="copy_xml_source">Salin sumber XML</string>
     <string name="info">Informasi</string>
     <string name="read_message">Bacakan Pesan</string>
     <string name="auto_read_message">Bacakan Otomatis</string>
@@ -4452,6 +4454,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="camera_permission_denied_toast">Izin kamera ditolak</string>
     <string name="microphone_permission_denied_toast">Izin mikrofon ditolak</string>
     <string name="executing_tool">Sedang menjalankan alat: %1$s</string>
+    <string name="waiting_tool_result">Menunggu hasil alat: %1$s</string>
     <string name="processing_tool_result">Sedang memproses hasil alat: %1$s</string>
     <string name="input_question_hint">Silakan masukkan pertanyaan Anda...</string>
 
@@ -5314,10 +5317,22 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="mcp_server_not_installed_cannot_configure">Plugin ini belum terpasang, tidak dapat dikonfigurasi</string>
     <string name="pkg_manage_env_vars">Kelola variabel lingkungan</string>
     <string name="pkg_config_env_vars">Konfigurasi variabel lingkungan</string>
+    <string name="pkg_env_vars_subtitle">Kelola konfigurasi yang diperlukan oleh paket dan skrip</string>
     <string name="pkg_no_env_vars">Paket alat yang diimpor saat ini tidak mendeklarasikan variabel lingkungan yang diperlukan.</string>
     <string name="pkg_default">Bawaan: %1$s</string>
     <string name="pkg_input_required">Masukkan nilai (diperlukan)</string>
     <string name="pkg_input_optional">Masukkan nilai (opsional)</string>
+    <string name="pkg_env_vars_status">Status konfigurasi</string>
+    <string name="pkg_env_vars_configured_count">%1$d / %2$d telah dikonfigurasi</string>
+    <string name="pkg_env_vars_complete">Dikonfigurasi</string>
+    <string name="pkg_env_vars_required_complete">Item wajib telah dikonfigurasi</string>
+    <string name="pkg_env_vars_missing_required">Masih kurang %1$d yang wajib</string>
+    <string name="pkg_env_vars_required">Wajib</string>
+    <string name="pkg_env_vars_optional">Opsional</string>
+    <string name="pkg_env_vars_configured">Dikonfigurasi</string>
+    <string name="pkg_env_vars_missing_description">Variabel ini tidak memiliki deskripsi penggunaan.</string>
+    <string name="pkg_env_vars_show_value">Tampilkan nilai</string>
+    <string name="pkg_env_vars_hide_value">Sembunyikan nilai</string>
     <string name="pkg_save">Simpan</string>
     <string name="pkg_cancel">Batal</string>
     <string name="pkg_confirm_delete">Konfirmasi penghapusan</string>
@@ -7563,8 +7578,8 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="chat_message_rendering_title">Perenderan pesan</string>
     <string name="chat_message_rendering_ai_markdown_latex">Render Markdown, LaTeX, dan XML dalam pesan AI</string>
     <string name="chat_message_rendering_ai_markdown_latex_desc">Tampilkan Markdown, ekspresi LaTeX, dan konten XML terstruktur seperti pemikiran, pemanggilan alat, dan hasil dalam pesan AI sebagai konten kaya.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Render Markdown, LaTeX, dan XML dalam pesan pengguna</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Tampilkan Markdown, ekspresi LaTeX, dan konten XML terstruktur dalam pesan pengguna sebagai konten kaya.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Render Markdown dan LaTeX dalam pesan pengguna</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Tampilkan Markdown dan ekspresi LaTeX dalam pesan pengguna sebagai konten kaya.</string>
 
     <string name="chat_style_bubble_user_opacity">Opasitas gelembung pengguna: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opasitas gelembung AI: %1$d%%</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1441,8 +1441,10 @@
     <string name="accessibility_wizard_success_message">접근성 서비스가 올바르게 구성되었으며 사용할 준비가 되었습니다!</string>
     <string name="copy_message">메시지 복사</string>
     <string name="markdown_source">Markdown 원문</string>
+    <string name="xml_source">XML 원문</string>
     <string name="copy_plain_text">일반 텍스트 복사</string>
     <string name="copy_markdown_source">Markdown 원문 복사</string>
+    <string name="copy_xml_source">XML 원문 복사</string>
     <string name="chat_hidden_user_message_placeholder">자동으로 트리거된 사용자 메시지(콘텐츠 숨김)</string>
     <string name="chat_hidden_user_message_badge">자동</string>
     <string name="info">정보</string>
@@ -4628,6 +4630,7 @@
     <string name="camera_permission_denied_toast">카메라 권한이 거부되었습니다.</string>
     <string name="microphone_permission_denied_toast">마이크 권한이 거부되었습니다.</string>
     <string name="executing_tool">도구 실행 중: %1$s</string>
+    <string name="waiting_tool_result">도구 결과 대기 중: %1$s</string>
     <string name="processing_tool_result">도구 결과 처리 중: %1$s</string>
     <string name="input_question_hint">질문을 입력하세요...</string>
     <string name="input_question_with_workspace">질문을 입력하고 @를 사용하여 파일을 참조하세요.</string>
@@ -5484,10 +5487,22 @@
     <string name="mcp_server_not_installed_cannot_configure">이 플러그인은 설치되지 않았으며 구성할 수 없습니다.</string>
     <string name="pkg_manage_env_vars">환경 변수 관리</string>
     <string name="pkg_config_env_vars">환경 변수 구성</string>
+    <string name="pkg_env_vars_subtitle">패키지와 스크립트에 필요한 구성을 관리합니다</string>
     <string name="pkg_no_env_vars">현재 가져온 도구 패키지에는 필수 환경 변수가 선언되지 않았습니다.</string>
     <string name="pkg_default">기본값: %1$s</string>
     <string name="pkg_input_required">입력값(필수)</string>
     <string name="pkg_input_optional">입력값(선택사항)</string>
+    <string name="pkg_env_vars_status">구성 상태</string>
+    <string name="pkg_env_vars_configured_count">%1$d / %2$d 구성됨</string>
+    <string name="pkg_env_vars_complete">구성 완료</string>
+    <string name="pkg_env_vars_required_complete">필수 항목 구성 완료</string>
+    <string name="pkg_env_vars_missing_required">필수 항목 %1$d개 남음</string>
+    <string name="pkg_env_vars_required">필수</string>
+    <string name="pkg_env_vars_optional">선택</string>
+    <string name="pkg_env_vars_configured">구성됨</string>
+    <string name="pkg_env_vars_missing_description">이 변수에는 사용 설명이 없습니다.</string>
+    <string name="pkg_env_vars_show_value">값 표시</string>
+    <string name="pkg_env_vars_hide_value">값 숨기기</string>
     <string name="pkg_save">저장</string>
     <string name="pkg_cancel">취소</string>
     <string name="pkg_confirm_delete">삭제 확인</string>
@@ -7410,8 +7425,8 @@
     <string name="chat_message_rendering_title">메시지 렌더링</string>
     <string name="chat_message_rendering_ai_markdown_latex">AI 메시지의 Markdown, LaTeX 및 XML 렌더링</string>
     <string name="chat_message_rendering_ai_markdown_latex_desc">AI 메시지의 Markdown, LaTeX 수식 및 사고, 도구 호출, 결과 등의 구조화된 XML 콘텐츠를 서식 있는 콘텐츠로 표시합니다.</string>
-    <string name="chat_message_rendering_user_markdown_latex">사용자 메시지의 Markdown, LaTeX 및 XML 렌더링</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">사용자 메시지의 Markdown, LaTeX 수식 및 구조화된 XML 콘텐츠를 서식 있는 콘텐츠로 표시합니다.</string>
+    <string name="chat_message_rendering_user_markdown_latex">사용자 메시지의 Markdown 및 LaTeX 렌더링</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">사용자 메시지의 Markdown 및 LaTeX 수식을 서식 있는 콘텐츠로 표시합니다.</string>
 
     <string name="chat_style_bubble_user_opacity">사용자 말풍선 투명도: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">AI 말풍선 투명도: %1$d%%</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -6138,7 +6138,7 @@
     <string name="gemini_connection_test_failed">연결 테스트 실패: %1$s</string>
     <string name="provider_error_response_empty">API 응답이 비어 있습니다.</string>
     <string name="provider_error_parsing_failed">응답을 구문 분석하지 못했습니다.</string>
-    <string name="provider_error_retry_message">%1$s, 재시도 중(%2$d)...</string>
+    <string name="provider_error_retry_message">%1, 재시도 중(%2), %3초 대기...</string>
     <string name="provider_error_timeout">연결 시간 초과</string>
     <string name="provider_error_network_interrupted">네트워크 중단됨</string>
     <string name="operit_network_error_format">실패: 네트워크 요청 실패, 상태 코드: %1$d, 오류 정보: %2$s</string>
@@ -7430,4 +7430,20 @@
 
     <string name="chat_style_bubble_user_opacity">사용자 말풍선 투명도: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">AI 말풍선 투명도: %1$d%%</string>
+    <string name="llm_retry_settings_title">요청 재시도</string>
+    <string name="llm_retry_settings_description">모델 요청 실패 후 자동 재시도 횟수와 대기 시간을 설정합니다.</string>
+    <string name="llm_retry_mode_fast">빠르게</string>
+    <string name="llm_retry_mode_standard">표준</string>
+    <string name="llm_retry_mode_stable">안정적</string>
+    <string name="llm_retry_mode_custom">사용자 지정</string>
+    <string name="llm_retry_max_attempts">최대 재시도 횟수</string>
+    <string name="llm_retry_max_attempts_description">0으로 설정하면 자동 재시도를 끕니다. 최대 10회입니다.</string>
+    <string name="llm_retry_attempts_unit">회</string>
+    <string name="llm_retry_initial_delay">첫 대기 시간</string>
+    <string name="llm_retry_initial_delay_description">첫 재시도 전 대기 시간이며 이후에는 2배씩 늘어납니다.</string>
+    <string name="llm_retry_max_delay">최대 단일 대기</string>
+    <string name="llm_retry_max_delay_description">재시도 대기 시간은 이 값을 넘지 않습니다.</string>
+    <string name="llm_retry_seconds_unit">초</string>
+    <string name="llm_retry_schedule_value">대기 순서: %1$s</string>
+    <string name="llm_retry_schedule_disabled">자동 재시도 꺼짐</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -4875,6 +4875,8 @@
     <string name="html_content_block">HTML 콘텐츠</string>
     <string name="mood_tag_block">감정 태그</string>
     <string name="thinking_tools_group_title_with_count">사고 및 도구 호출(%1$d)</string>
+    <string name="thinking_tools_group_title_with_counts">사고 및 도구 호출(%1$d + %2$d)</string>
+
     <string name="tools_group_title_with_count">도구 호출(%1$d)</string>
     <string name="backup_data_overview">데이터 개요</string>
     <string name="backup_current_profile">현재 프로필: %1$s</string>
@@ -7406,10 +7408,11 @@
     <string name="thinking_config_preset_add_selected">프리셋 %1$d개 추가</string>
     <string name="thinking_config_preset_added_count">내장 프리셋 %1$d개를 추가했습니다</string>
     <string name="chat_message_rendering_title">메시지 렌더링</string>
-    <string name="chat_message_rendering_ai_markdown_latex">AI 메시지의 Markdown 및 LaTeX 렌더링</string>
-    <string name="chat_message_rendering_ai_markdown_latex_desc">AI 메시지의 Markdown 및 LaTeX 수식을 서식 있는 콘텐츠로 표시합니다.</string>
-    <string name="chat_message_rendering_user_markdown_latex">사용자 메시지의 Markdown 및 LaTeX 렌더링</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">사용자 메시지의 Markdown 및 LaTeX 수식을 서식 있는 콘텐츠로 표시합니다.</string>
+    <string name="chat_message_rendering_ai_markdown_latex">AI 메시지의 Markdown, LaTeX 및 XML 렌더링</string>
+    <string name="chat_message_rendering_ai_markdown_latex_desc">AI 메시지의 Markdown, LaTeX 수식 및 사고, 도구 호출, 결과 등의 구조화된 XML 콘텐츠를 서식 있는 콘텐츠로 표시합니다.</string>
+    <string name="chat_message_rendering_user_markdown_latex">사용자 메시지의 Markdown, LaTeX 및 XML 렌더링</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">사용자 메시지의 Markdown, LaTeX 수식 및 구조화된 XML 콘텐츠를 서식 있는 콘텐츠로 표시합니다.</string>
+
     <string name="chat_style_bubble_user_opacity">사용자 말풍선 투명도: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">AI 말풍선 투명도: %1$d%%</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -6057,7 +6057,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="gemini_connection_test_failed">Ujian sambungan gagal: %1$s</string>
     <string name="provider_error_response_empty">Respons API kosong</string>
     <string name="provider_error_parsing_failed">Gagal menghuraikan respons</string>
-    <string name="provider_error_retry_message">%1$s, sedang mencuba semula kali ke-%2$d...</string>
+    <string name="provider_error_retry_message">%1, sedang mencuba semula kali ke-%2; menunggu %3 saat...</string>
     <string name="provider_error_timeout">Sambungan tamat masa</string>
     <string name="provider_error_network_interrupted">Rangkaian terputus</string>
     <string name="operit_network_error_format">Gagal: Permintaan rangkaian gagal, kod status: %1$d, maklumat ralat: %2$s</string>
@@ -7580,4 +7580,20 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
 
     <string name="chat_style_bubble_user_opacity">Kelegapan gelembung pengguna: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Kelegapan gelembung AI: %1$d%%</string>
+    <string name="llm_retry_settings_title">Cuba semula permintaan</string>
+    <string name="llm_retry_settings_description">Tetapkan percubaan semula automatik dan masa menunggu selepas permintaan model gagal.</string>
+    <string name="llm_retry_mode_fast">Pantas</string>
+    <string name="llm_retry_mode_standard">Standard</string>
+    <string name="llm_retry_mode_stable">Stabil</string>
+    <string name="llm_retry_mode_custom">Tersuai</string>
+    <string name="llm_retry_max_attempts">Maksimum percubaan semula</string>
+    <string name="llm_retry_max_attempts_description">Tetapkan 0 untuk mematikan. Maksimum: 10.</string>
+    <string name="llm_retry_attempts_unit">kali</string>
+    <string name="llm_retry_initial_delay">Tunggu awal</string>
+    <string name="llm_retry_initial_delay_description">Saat sebelum percubaan pertama; selepas itu masa digandakan.</string>
+    <string name="llm_retry_max_delay">Tunggu maksimum</string>
+    <string name="llm_retry_max_delay_description">Masa menunggu tidak akan melebihi nilai ini.</string>
+    <string name="llm_retry_seconds_unit">saat</string>
+    <string name="llm_retry_schedule_value">Urutan menunggu: %1$s</string>
+    <string name="llm_retry_schedule_disabled">Percubaan semula automatik dimatikan</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -4748,6 +4748,8 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="html_content_block">Kandungan HTML</string>
     <string name="mood_tag_block">Tag emosi</string>
     <string name="thinking_tools_group_title_with_count">Pemikiran &amp; panggilan alat (%1$d)</string>
+    <string name="thinking_tools_group_title_with_counts">Pemikiran &amp; panggilan alat (%1$d + %2$d)</string>
+
     <string name="tools_group_title_with_count">Panggilan alat (%1$d)</string>
     <string name="backup_data_overview">Gambaran keseluruhan data</string>
 
@@ -7556,10 +7558,11 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="thinking_config_preset_add_selected">Tambah %1$d pratetap</string>
     <string name="thinking_config_preset_added_count">%1$d pratetap terbina dalam telah ditambah</string>
     <string name="chat_message_rendering_title">Pemaparan mesej</string>
-    <string name="chat_message_rendering_ai_markdown_latex">Paparkan Markdown dan LaTeX dalam mesej AI</string>
-    <string name="chat_message_rendering_ai_markdown_latex_desc">Paparkan Markdown dan ungkapan LaTeX dalam mesej AI sebagai kandungan berformat.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Paparkan Markdown dan LaTeX dalam mesej pengguna</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Paparkan Markdown dan ungkapan LaTeX dalam mesej pengguna sebagai kandungan berformat.</string>
+    <string name="chat_message_rendering_ai_markdown_latex">Paparkan Markdown, LaTeX dan XML dalam mesej AI</string>
+    <string name="chat_message_rendering_ai_markdown_latex_desc">Paparkan Markdown, ungkapan LaTeX dan kandungan XML berstruktur seperti pemikiran, panggilan alat dan hasil dalam mesej AI sebagai kandungan berformat.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Paparkan Markdown, LaTeX dan XML dalam mesej pengguna</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Paparkan Markdown, ungkapan LaTeX dan kandungan XML berstruktur dalam mesej pengguna sebagai kandungan berformat.</string>
+
     <string name="chat_style_bubble_user_opacity">Kelegapan gelembung pengguna: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Kelegapan gelembung AI: %1$d%%</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1333,8 +1333,10 @@
     <string name="accessibility_wizard_success_message">Tahniah! Perkhidmatan aksesibiliti berjaya dikonfigurasi, kini AI boleh menganalisis dan mengendalikan kandungan skrin.</string>
     <string name="copy_message">Salin Mesej</string>
     <string name="markdown_source">Sumber Markdown</string>
+    <string name="xml_source">Sumber XML</string>
     <string name="copy_plain_text">Salin teks biasa</string>
     <string name="copy_markdown_source">Salin sumber Markdown</string>
+    <string name="copy_xml_source">Salin sumber XML</string>
     <string name="info">Maklumat</string>
     <string name="read_message">Bacakan Mesej</string>
     <string name="auto_read_message">Bacaan Automatik</string>
@@ -4562,6 +4564,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="camera_permission_denied_toast">Kebenaran kamera ditolak</string>
     <string name="microphone_permission_denied_toast">Kebenaran mikrofon ditolak</string>
     <string name="executing_tool">Sedang melaksanakan alat: %1$s</string>
+    <string name="waiting_tool_result">Menunggu hasil alat: %1$s</string>
     <string name="processing_tool_result">Sedang memproses hasil alat: %1$s</string>
     <string name="input_question_hint">Sila masukkan soalan anda...</string>
     <string name="input_question_with_workspace">Masukkan soalan, gunakan @ untuk merujuk fail</string>
@@ -5312,10 +5315,22 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="mcp_server_not_installed_cannot_configure">Plugin ini belum dipasang, tidak boleh dikonfigurasikan</string>
     <string name="pkg_manage_env_vars">Urus Pembolehubah Persekitaran</string>
     <string name="pkg_config_env_vars">Konfigurasi Pembolehubah Persekitaran</string>
+    <string name="pkg_env_vars_subtitle">Urus konfigurasi yang diperlukan oleh pakej dan skrip</string>
     <string name="pkg_no_env_vars">Pakej yang telah diimport semasa tidak mengisytiharkan pembolehubah persekitaran yang diperlukan.</string>
     <string name="pkg_default">Lalai: %1$s</string>
     <string name="pkg_input_required">Masukkan nilai (diperlukan)</string>
     <string name="pkg_input_optional">Masukkan nilai (pilihan)</string>
+    <string name="pkg_env_vars_status">Status konfigurasi</string>
+    <string name="pkg_env_vars_configured_count">%1$d / %2$d telah dikonfigurasi</string>
+    <string name="pkg_env_vars_complete">Dikonfigurasi</string>
+    <string name="pkg_env_vars_required_complete">Item wajib telah dikonfigurasi</string>
+    <string name="pkg_env_vars_missing_required">%1$d wajib masih diperlukan</string>
+    <string name="pkg_env_vars_required">Wajib</string>
+    <string name="pkg_env_vars_optional">Pilihan</string>
+    <string name="pkg_env_vars_configured">Dikonfigurasi</string>
+    <string name="pkg_env_vars_missing_description">Pemboleh ubah ini tiada penerangan penggunaan.</string>
+    <string name="pkg_env_vars_show_value">Tunjukkan nilai</string>
+    <string name="pkg_env_vars_hide_value">Sembunyikan nilai</string>
     <string name="pkg_save">Simpan</string>
     <string name="pkg_cancel">Batal</string>
     <string name="pkg_confirm_delete">Sahkan Padam</string>
@@ -7560,8 +7575,8 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="chat_message_rendering_title">Pemaparan mesej</string>
     <string name="chat_message_rendering_ai_markdown_latex">Paparkan Markdown, LaTeX dan XML dalam mesej AI</string>
     <string name="chat_message_rendering_ai_markdown_latex_desc">Paparkan Markdown, ungkapan LaTeX dan kandungan XML berstruktur seperti pemikiran, panggilan alat dan hasil dalam mesej AI sebagai kandungan berformat.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Paparkan Markdown, LaTeX dan XML dalam mesej pengguna</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Paparkan Markdown, ungkapan LaTeX dan kandungan XML berstruktur dalam mesej pengguna sebagai kandungan berformat.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Paparkan Markdown dan LaTeX dalam mesej pengguna</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Paparkan Markdown dan ungkapan LaTeX dalam mesej pengguna sebagai kandungan berformat.</string>
 
     <string name="chat_style_bubble_user_opacity">Kelegapan gelembung pengguna: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Kelegapan gelembung AI: %1$d%%</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -5728,7 +5728,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="gemini_connection_test_failed">Falha no teste de conexão: %1$s</string>
     <string name="provider_error_response_empty">A resposta da API está vazia</string>
     <string name="provider_error_parsing_failed">Falha ao analisar a resposta</string>
-    <string name="provider_error_retry_message">%1$s, tentando novamente %2$d...</string>
+    <string name="provider_error_retry_message">%1, tentando novamente %2; aguardando %3 s...</string>
     <string name="provider_error_timeout">Tempo limite de conexão</string>
     <string name="provider_error_network_interrupted">Interrupção de rede</string>
     <string name="operit_network_error_format">Falha: A solicitação de rede falhou, código de status: %1$d, informações do erro: %2$s</string>
@@ -7421,4 +7421,20 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
 
     <string name="chat_style_bubble_user_opacity">Opacidade do balão do usuário: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opacidade do balão da IA: %1$d%%</string>
+    <string name="llm_retry_settings_title">Repetir solicitações</string>
+    <string name="llm_retry_settings_description">Configure novas tentativas automáticas e o tempo de espera após uma falha do modelo.</string>
+    <string name="llm_retry_mode_fast">Rápido</string>
+    <string name="llm_retry_mode_standard">Padrão</string>
+    <string name="llm_retry_mode_stable">Estável</string>
+    <string name="llm_retry_mode_custom">Personalizado</string>
+    <string name="llm_retry_max_attempts">Máximo de tentativas</string>
+    <string name="llm_retry_max_attempts_description">Use 0 para desativar. Máximo: 10.</string>
+    <string name="llm_retry_attempts_unit">vezes</string>
+    <string name="llm_retry_initial_delay">Espera inicial</string>
+    <string name="llm_retry_initial_delay_description">Segundos antes da primeira tentativa; depois o tempo dobra.</string>
+    <string name="llm_retry_max_delay">Espera máxima</string>
+    <string name="llm_retry_max_delay_description">Uma espera nunca ultrapassará este valor.</string>
+    <string name="llm_retry_seconds_unit">s</string>
+    <string name="llm_retry_schedule_value">Sequência de espera: %1$s</string>
+    <string name="llm_retry_schedule_disabled">Novas tentativas automáticas desativadas</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1407,8 +1407,10 @@
     <string name="accessibility_wizard_success_message">Parabéns! Os serviços de acessibilidade foram configurados com sucesso e agora a IA pode analisar e manipular o conteúdo da tela.</string>
     <string name="copy_message">Copiar mensagem</string>
     <string name="markdown_source">Código-fonte Markdown</string>
+    <string name="xml_source">Código-fonte XML</string>
     <string name="copy_plain_text">Copiar texto simples</string>
     <string name="copy_markdown_source">Copiar código-fonte Markdown</string>
+    <string name="copy_xml_source">Copiar código-fonte XML</string>
     <string name="info">Informação</string>
     <string name="read_message">Leia mensagens em voz alta</string>
     <string name="auto_read_message">Ler em voz alta automaticamente</string>
@@ -4289,6 +4291,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="camera_permission_denied_toast">Permissão da câmera negada</string>
     <string name="microphone_permission_denied_toast">Permissão de microfone negada</string>
     <string name="executing_tool">Ferramenta de execução: %1$s</string>
+    <string name="waiting_tool_result">Aguardando resultado da ferramenta: %1$s</string>
     <string name="processing_tool_result">Processando resultados da ferramenta: %1$s</string>
     <string name="input_question_hint">Por favor insira sua pergunta...</string>
     <string name="input_question_with_workspace">Insira uma pergunta, usando @ para referenciar o arquivo</string>
@@ -5083,10 +5086,22 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="mcp_server_not_installed_cannot_configure">Este plugin não foi instalado e não pode ser configurado</string>
     <string name="pkg_manage_env_vars">Gerenciar variáveis ​​de ambiente</string>
     <string name="pkg_config_env_vars">Configurar variáveis ​​de ambiente</string>
+    <string name="pkg_env_vars_subtitle">Gerencie a configuração necessária para pacotes e scripts</string>
     <string name="pkg_no_env_vars">O kit de ferramentas importado atualmente não declara as variáveis ​​de ambiente necessárias.</string>
     <string name="pkg_default">Padrão: %1$s</string>
     <string name="pkg_input_required">Insira o valor (obrigatório)</string>
     <string name="pkg_input_optional">Insira o valor (opcional)</string>
+    <string name="pkg_env_vars_status">Status da configuração</string>
+    <string name="pkg_env_vars_configured_count">%1$d / %2$d configuradas</string>
+    <string name="pkg_env_vars_complete">Configurado</string>
+    <string name="pkg_env_vars_required_complete">Itens obrigatórios configurados</string>
+    <string name="pkg_env_vars_missing_required">Falta %1$d obrigatória</string>
+    <string name="pkg_env_vars_required">Obrigatória</string>
+    <string name="pkg_env_vars_optional">Opcional</string>
+    <string name="pkg_env_vars_configured">Configurada</string>
+    <string name="pkg_env_vars_missing_description">Esta variável não tem descrição de uso.</string>
+    <string name="pkg_env_vars_show_value">Mostrar valor</string>
+    <string name="pkg_env_vars_hide_value">Ocultar valor</string>
     <string name="pkg_save">salvar</string>
     <string name="pkg_cancel">Cancelar</string>
     <string name="pkg_confirm_delete">Confirmar exclusão</string>
@@ -7401,8 +7416,8 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="chat_message_rendering_title">Renderização de mensagens</string>
     <string name="chat_message_rendering_ai_markdown_latex">Renderizar Markdown, LaTeX e XML em mensagens de IA</string>
     <string name="chat_message_rendering_ai_markdown_latex_desc">Exibe Markdown, expressões LaTeX e conteúdo XML estruturado, como raciocínio, chamadas de ferramenta e resultados, em mensagens de IA como conteúdo rico.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Renderizar Markdown, LaTeX e XML em mensagens do usuário</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Exibe Markdown, expressões LaTeX e conteúdo XML estruturado em mensagens do usuário como conteúdo rico.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Renderizar Markdown e LaTeX em mensagens do usuário</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Exibe Markdown e expressões LaTeX em mensagens do usuário como conteúdo rico.</string>
 
     <string name="chat_style_bubble_user_opacity">Opacidade do balão do usuário: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opacidade do balão da IA: %1$d%%</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -4489,6 +4489,8 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="html_content_block">Conteúdo HTML</string>
     <string name="mood_tag_block">Tags de emoção</string>
     <string name="thinking_tools_group_title_with_count">Pensamento e chamada de ferramentas (%1$d)</string>
+    <string name="thinking_tools_group_title_with_counts">Pensamento e chamada de ferramentas (%1$d + %2$d)</string>
+
     <string name="tools_group_title_with_count">Chamada de ferramenta (%1$d)</string>
     <string name="backup_data_overview">Visão geral dos dados</string>
     <string name="backup_current_profile">Configuração atual: %1$s</string>
@@ -7397,10 +7399,11 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="thinking_config_preset_add_selected">Adicionar %1$d predefinições</string>
     <string name="thinking_config_preset_added_count">%1$d predefinições integradas foram adicionadas</string>
     <string name="chat_message_rendering_title">Renderização de mensagens</string>
-    <string name="chat_message_rendering_ai_markdown_latex">Renderizar Markdown e LaTeX em mensagens de IA</string>
-    <string name="chat_message_rendering_ai_markdown_latex_desc">Exibe Markdown e expressões LaTeX em mensagens de IA como conteúdo rico.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Renderizar Markdown e LaTeX em mensagens do usuário</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Exibe Markdown e expressões LaTeX em mensagens do usuário como conteúdo rico.</string>
+    <string name="chat_message_rendering_ai_markdown_latex">Renderizar Markdown, LaTeX e XML em mensagens de IA</string>
+    <string name="chat_message_rendering_ai_markdown_latex_desc">Exibe Markdown, expressões LaTeX e conteúdo XML estruturado, como raciocínio, chamadas de ferramenta e resultados, em mensagens de IA como conteúdo rico.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Renderizar Markdown, LaTeX e XML em mensagens do usuário</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Exibe Markdown, expressões LaTeX e conteúdo XML estruturado em mensagens do usuário como conteúdo rico.</string>
+
     <string name="chat_style_bubble_user_opacity">Opacidade do balão do usuário: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opacidade do balão da IA: %1$d%%</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -5582,6 +5582,8 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="html_content_block">HTMLConținut</string>
     <string name="mood_tag_block">Etichete emoționale</string>
     <string name="thinking_tools_group_title_with_count">Reflecție și utilizarea instrumentelor (%1$d)</string>
+    <string name="thinking_tools_group_title_with_counts">Reflecție și utilizarea instrumentelor (%1$d + %2$d)</string>
+
     <string name="tools_group_title_with_count">Apelarea instrumentelor (%1$d)</string>
 
     <!-- 备份设置界面 -->
@@ -8154,10 +8156,11 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="thinking_config_preset_add_selected">Adaugă %1$d presetări</string>
     <string name="thinking_config_preset_added_count">Au fost adăugate %1$d presetări integrate</string>
     <string name="chat_message_rendering_title">Redarea mesajelor</string>
-    <string name="chat_message_rendering_ai_markdown_latex">Redă Markdown și LaTeX în mesajele AI</string>
-    <string name="chat_message_rendering_ai_markdown_latex_desc">Afișează Markdown și expresiile LaTeX din mesajele AI ca conținut formatat.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Redă Markdown și LaTeX în mesajele utilizatorului</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Afișează Markdown și expresiile LaTeX din mesajele utilizatorului ca conținut formatat.</string>
+    <string name="chat_message_rendering_ai_markdown_latex">Redă Markdown, LaTeX și XML în mesajele AI</string>
+    <string name="chat_message_rendering_ai_markdown_latex_desc">Afișează Markdown, expresiile LaTeX și conținut XML structurat, precum raționamente, apeluri de instrumente și rezultate, în mesajele AI ca conținut formatat.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Redă Markdown, LaTeX și XML în mesajele utilizatorului</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Afișează Markdown, expresiile LaTeX și conținut XML structurat în mesajele utilizatorului ca conținut formatat.</string>
+
     <string name="chat_style_bubble_user_opacity">Opacitatea balonului utilizatorului: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opacitatea balonului AI: %1$d%%</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -6986,7 +6986,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
 
     <string name="provider_error_response_empty">APIRăspunsul este gol</string>
     <string name="provider_error_parsing_failed">Eșecul analizării răspunsului</string>
-    <string name="provider_error_retry_message">%1$s, se află la a %2$d A doua încercare...</string>
+    <string name="provider_error_retry_message">%1, reîncercarea %2; se așteaptă %3 s...</string>
     <string name="provider_error_timeout">Timpul de așteptare pentru conectare a expirat</string>
     <string name="provider_error_network_interrupted">Întrerupere a conexiunii la internet</string>
     <string name="operit_network_error_format">Eșec: Solicitarea de rețea a eșuat, cod de stare: %1$d, informații despre eroare: %2$s</string>
@@ -8178,4 +8178,20 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
 
     <string name="chat_style_bubble_user_opacity">Opacitatea balonului utilizatorului: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opacitatea balonului AI: %1$d%%</string>
+    <string name="llm_retry_settings_title">Reîncercări solicitare</string>
+    <string name="llm_retry_settings_description">Configurează reîncercările automate și timpul de așteptare după eșecul modelului.</string>
+    <string name="llm_retry_mode_fast">Rapid</string>
+    <string name="llm_retry_mode_standard">Standard</string>
+    <string name="llm_retry_mode_stable">Stabil</string>
+    <string name="llm_retry_mode_custom">Personalizat</string>
+    <string name="llm_retry_max_attempts">Număr maxim de reîncercări</string>
+    <string name="llm_retry_max_attempts_description">Setează 0 pentru dezactivare. Maxim: 10.</string>
+    <string name="llm_retry_attempts_unit">ori</string>
+    <string name="llm_retry_initial_delay">Așteptare inițială</string>
+    <string name="llm_retry_initial_delay_description">Secunde înainte de prima reîncercare; apoi timpul se dublează.</string>
+    <string name="llm_retry_max_delay">Așteptare maximă</string>
+    <string name="llm_retry_max_delay_description">Așteptarea nu va depăși această valoare.</string>
+    <string name="llm_retry_seconds_unit">s</string>
+    <string name="llm_retry_schedule_value">Secvență de așteptare: %1$s</string>
+    <string name="llm_retry_schedule_disabled">Reîncercările automate sunt dezactivate</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1605,8 +1605,10 @@
     <!-- Context Menu -->
     <string name="copy_message">Copiere mesaj</string>
     <string name="markdown_source">Markdown Codul sursă</string>
+    <string name="xml_source">XML Codul sursă</string>
     <string name="copy_plain_text">Copiere text simplu</string>
     <string name="copy_markdown_source">Copiere Markdown Codul sursă</string>
+    <string name="copy_xml_source">Copiere XML Codul sursă</string>
     <string name="chat_hidden_user_message_placeholder">Mesaj automat către utilizator (conținutul a fost ascuns)</string>
     <string name="chat_hidden_user_message_badge">Declanșare automată</string>
     <string name="info">Informații</string>
@@ -5315,6 +5317,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="camera_permission_denied_toast">Accesul la cameră a fost refuzat</string>
     <string name="microphone_permission_denied_toast">Accesul la microfon a fost refuzat</string>
     <string name="executing_tool">Instrumentul este în curs de execuție: %1$s</string>
+    <string name="waiting_tool_result">Se așteaptă rezultatul instrumentului: %1$s</string>
     <string name="processing_tool_result">Se procesează rezultatele instrumentului: %1$s</string>
     <string name="input_question_hint">Vă rugăm să introduceți întrebarea dumneavoastră...</string>
     <string name="input_question_with_workspace">Introduceți problema, folosind@Fișier de referință</string>
@@ -6248,10 +6251,22 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <!-- Package Manager Module -->
     <string name="pkg_manage_env_vars">Gestionarea variabilelor de mediu</string>
     <string name="pkg_config_env_vars">Configurarea variabilelor de mediu</string>
+    <string name="pkg_env_vars_subtitle">Gestionează configurația necesară pachetelor și scripturilor</string>
     <string name="pkg_no_env_vars">Pachetul importat în prezent nu conține declarațiile privind variabilele de mediu necesare.</string>
     <string name="pkg_default">Implicit: %1$s</string>
     <string name="pkg_input_required">Valoare introdusă (obligatorie)</string>
     <string name="pkg_input_optional">Valoare introdusă (opțional)</string>
+    <string name="pkg_env_vars_status">Stare configurare</string>
+    <string name="pkg_env_vars_configured_count">%1$d / %2$d configurate</string>
+    <string name="pkg_env_vars_complete">Configurat</string>
+    <string name="pkg_env_vars_required_complete">Elementele obligatorii sunt configurate</string>
+    <string name="pkg_env_vars_missing_required">Mai lipsesc %1$d obligatorii</string>
+    <string name="pkg_env_vars_required">Obligatoriu</string>
+    <string name="pkg_env_vars_optional">Opțional</string>
+    <string name="pkg_env_vars_configured">Configurat</string>
+    <string name="pkg_env_vars_missing_description">Această variabilă nu are o descriere de utilizare.</string>
+    <string name="pkg_env_vars_show_value">Arată valoarea</string>
+    <string name="pkg_env_vars_hide_value">Ascunde valoarea</string>
     <string name="pkg_save">Salvare</string>
     <string name="pkg_cancel">Anulare</string>
 
@@ -8158,8 +8173,8 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="chat_message_rendering_title">Redarea mesajelor</string>
     <string name="chat_message_rendering_ai_markdown_latex">Redă Markdown, LaTeX și XML în mesajele AI</string>
     <string name="chat_message_rendering_ai_markdown_latex_desc">Afișează Markdown, expresiile LaTeX și conținut XML structurat, precum raționamente, apeluri de instrumente și rezultate, în mesajele AI ca conținut formatat.</string>
-    <string name="chat_message_rendering_user_markdown_latex">Redă Markdown, LaTeX și XML în mesajele utilizatorului</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">Afișează Markdown, expresiile LaTeX și conținut XML structurat în mesajele utilizatorului ca conținut formatat.</string>
+    <string name="chat_message_rendering_user_markdown_latex">Redă Markdown și LaTeX în mesajele utilizatorului</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">Afișează Markdown și expresiile LaTeX în mesajele utilizatorului ca conținut formatat.</string>
 
     <string name="chat_style_bubble_user_opacity">Opacitatea balonului utilizatorului: %1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">Opacitatea balonului AI: %1$d%%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5839,6 +5839,7 @@
     <string name="html_content_block">HTML内容</string>
     <string name="mood_tag_block">情绪标签</string>
     <string name="thinking_tools_group_title_with_count">思考与工具调用（%1$d）</string>
+    <string name="thinking_tools_group_title_with_counts">思考与工具调用（%1$d + %2$d）</string>
     <string name="tools_group_title_with_count">工具调用（%1$d）</string>
     <string name="search_group_title">搜索</string>
     <string name="thinking_search_group_title">思考并搜索</string>
@@ -8417,10 +8418,11 @@
     <string name="thinking_config_preset_add_selected">添加 %1$d 个预设</string>
     <string name="thinking_config_preset_added_count">已添加 %1$d 个内置预设</string>
     <string name="chat_message_rendering_title">消息渲染</string>
-    <string name="chat_message_rendering_ai_markdown_latex">AI 消息 Markdown 和 LaTeX 渲染</string>
-    <string name="chat_message_rendering_ai_markdown_latex_desc">将 AI 消息中的 Markdown 和 LaTeX 表达式以富文本显示</string>
-    <string name="chat_message_rendering_user_markdown_latex">用户消息 Markdown 和 LaTeX 渲染</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">将用户消息中的 Markdown 和 LaTeX 表达式以富文本显示</string>
+    <string name="chat_message_rendering_ai_markdown_latex">AI 消息 Markdown、LaTeX 和 XML 渲染</string>
+    <string name="chat_message_rendering_ai_markdown_latex_desc">将 AI 消息中的 Markdown、LaTeX 表达式和 XML 结构化内容（如思考、工具调用及结果）以富文本显示</string>
+    <string name="chat_message_rendering_user_markdown_latex">用户消息 Markdown、LaTeX 和 XML 渲染</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">将用户消息中的 Markdown、LaTeX 表达式和 XML 结构化内容以富文本显示</string>
+
     <string name="chat_style_bubble_user_opacity">用户气泡透明度：%1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">AI 气泡透明度：%1$d%%</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1637,8 +1637,10 @@
     <!-- Context Menu -->
     <string name="copy_message">复制消息</string>
     <string name="markdown_source">Markdown 源码</string>
+    <string name="xml_source">XML 源码</string>
     <string name="copy_plain_text">复制纯文本</string>
     <string name="copy_markdown_source">复制 Markdown 源码</string>
+    <string name="copy_xml_source">复制 XML 源码</string>
     <string name="chat_hidden_user_message_placeholder">自动触发用户消息（内容已隐藏）</string>
     <string name="chat_hidden_user_message_badge">自动触发</string>
     <string name="info">信息</string>
@@ -5572,6 +5574,7 @@
     <string name="camera_permission_denied_toast">相机权限被拒绝</string>
     <string name="microphone_permission_denied_toast">麦克风权限被拒绝</string>
     <string name="executing_tool">正在执行工具: %1$s</string>
+    <string name="waiting_tool_result">正在等待工具返回: %1$s</string>
     <string name="processing_tool_result">正在处理工具结果: %1$s</string>
     <string name="input_question_hint">请输入您的问题...</string>
     <string name="input_question_with_workspace">输入问题，使用@来引用文件</string>
@@ -6507,10 +6510,22 @@
     <!-- Package Manager Module -->
     <string name="pkg_manage_env_vars">管理环境变量</string>
     <string name="pkg_config_env_vars">配置环境变量</string>
+    <string name="pkg_env_vars_subtitle">管理插件和脚本运行所需的配置</string>
     <string name="pkg_no_env_vars">当前已导入的工具包没有声明需要的环境变量。</string>
     <string name="pkg_default">默认: %1$s</string>
     <string name="pkg_input_required">输入值（必需）</string>
     <string name="pkg_input_optional">输入值（可选）</string>
+    <string name="pkg_env_vars_status">配置状态</string>
+    <string name="pkg_env_vars_configured_count">已配置 %1$d / %2$d</string>
+    <string name="pkg_env_vars_complete">配置完成</string>
+    <string name="pkg_env_vars_required_complete">必填项已配置</string>
+    <string name="pkg_env_vars_missing_required">还缺 %1$d 项必填</string>
+    <string name="pkg_env_vars_required">必填</string>
+    <string name="pkg_env_vars_optional">可选</string>
+    <string name="pkg_env_vars_configured">已配置</string>
+    <string name="pkg_env_vars_missing_description">此变量未提供用途说明</string>
+    <string name="pkg_env_vars_show_value">显示值</string>
+    <string name="pkg_env_vars_hide_value">隐藏值</string>
     <string name="pkg_save">保存</string>
     <string name="pkg_cancel">取消</string>
 
@@ -8420,8 +8435,8 @@
     <string name="chat_message_rendering_title">消息渲染</string>
     <string name="chat_message_rendering_ai_markdown_latex">AI 消息 Markdown、LaTeX 和 XML 渲染</string>
     <string name="chat_message_rendering_ai_markdown_latex_desc">将 AI 消息中的 Markdown、LaTeX 表达式和 XML 结构化内容（如思考、工具调用及结果）以富文本显示</string>
-    <string name="chat_message_rendering_user_markdown_latex">用户消息 Markdown、LaTeX 和 XML 渲染</string>
-    <string name="chat_message_rendering_user_markdown_latex_desc">将用户消息中的 Markdown、LaTeX 表达式和 XML 结构化内容以富文本显示</string>
+    <string name="chat_message_rendering_user_markdown_latex">用户消息 Markdown 和 LaTeX 渲染</string>
+    <string name="chat_message_rendering_user_markdown_latex_desc">将用户消息中的 Markdown 和 LaTeX 表达式以富文本显示</string>
 
     <string name="chat_style_bubble_user_opacity">用户气泡透明度：%1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">AI 气泡透明度：%1$d%%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7253,7 +7253,7 @@
 
     <string name="provider_error_response_empty">API响应为空</string>
     <string name="provider_error_parsing_failed">解析响应失败</string>
-    <string name="provider_error_retry_message">%1$s，正在进行第 %2$d 次重试...</string>
+    <string name="provider_error_retry_message">%1，正在进行第 %2 次重试，等待 %3 秒...</string>
     <string name="provider_error_timeout">连接超时</string>
     <string name="provider_error_network_interrupted">网络中断</string>
     <string name="operit_network_error_format">失败：网络请求失败，状态码：%1$d，错误信息：%2$s</string>
@@ -8440,4 +8440,20 @@
 
     <string name="chat_style_bubble_user_opacity">用户气泡透明度：%1$d%%</string>
     <string name="chat_style_bubble_ai_opacity">AI 气泡透明度：%1$d%%</string>
+    <string name="llm_retry_settings_title">请求重试</string>
+    <string name="llm_retry_settings_description">配置模型请求失败后的自动重试次数和等待节奏。</string>
+    <string name="llm_retry_mode_fast">快速</string>
+    <string name="llm_retry_mode_standard">标准</string>
+    <string name="llm_retry_mode_stable">稳健</string>
+    <string name="llm_retry_mode_custom">自定义</string>
+    <string name="llm_retry_max_attempts">最大重试次数</string>
+    <string name="llm_retry_max_attempts_description">设为 0 可关闭自动重试，最多 10 次。</string>
+    <string name="llm_retry_attempts_unit">次</string>
+    <string name="llm_retry_initial_delay">首次等待</string>
+    <string name="llm_retry_initial_delay_description">第一次重试前等待的秒数，后续按 2 倍增长。</string>
+    <string name="llm_retry_max_delay">最长单次等待</string>
+    <string name="llm_retry_max_delay_description">每次重试等待时间不会超过此值。</string>
+    <string name="llm_retry_seconds_unit">秒</string>
+    <string name="llm_retry_schedule_value">等待序列：%1$s</string>
+    <string name="llm_retry_schedule_disabled">自动重试已关闭</string>
 </resources>

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/ChatRuntimeHolderTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/ChatRuntimeHolderTest.kt
@@ -1,0 +1,32 @@
+package com.ai.assistance.operit.api.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatRuntimeHolderTest {
+    @Test
+    fun countCurrentTurnTools_includesEveryTrackedTurn() {
+        val counts = mapOf(
+            "main-chat" to 3,
+            "floating-chat" to 4,
+        )
+
+        assertEquals(
+            7,
+            ChatRuntimeHolder.countCurrentTurnTools(counts),
+        )
+    }
+
+    @Test
+    fun countCurrentTurnTools_doesNotAllowNegativeCounts() {
+        val counts = mapOf(
+            "main-chat" to 2,
+            "invalid-chat" to -100,
+        )
+
+        assertEquals(
+            2,
+            ChatRuntimeHolder.countCurrentTurnTools(counts),
+        )
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ConversationMarkupManagerTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ConversationMarkupManagerTest.kt
@@ -1,0 +1,52 @@
+package com.ai.assistance.operit.api.chat.enhance
+
+import com.ai.assistance.operit.core.tools.StringResultData
+import com.ai.assistance.operit.data.model.ToolResult
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConversationMarkupManagerTest {
+    @Test
+    fun requestedMarkupLimitBoundsToolResultPayload() {
+        val markup =
+            ConversationMarkupManager.formatToolResultForMessage(
+                result =
+                    ToolResult(
+                        toolName = "read_file_part",
+                        success = true,
+                        result = StringResultData("x".repeat(4_096)),
+                    ),
+                maxMessageChars = 256,
+            )
+
+        assertTrue(markup.length <= 256)
+        assertTrue(markup.contains("[工具结果过长，已截断]"))
+    }
+
+    @Test
+    fun requestedMarkupLimitAlsoBoundsExtractedImageLinks() {
+        val imageLinks =
+            (1..32).joinToString(separator = "") { index ->
+                buildString {
+                    append(60.toChar())
+                    append("link type=\"image\" id=\"image-")
+                    append(index)
+                    append("\"/")
+                    append(62.toChar())
+                }
+            }
+        val markup =
+            ConversationMarkupManager.formatToolResultForMessage(
+                result =
+                    ToolResult(
+                        toolName = "visit_web",
+                        success = true,
+                        result = StringResultData(imageLinks),
+                    ),
+                maxMessageChars = 256,
+            )
+
+        assertTrue(markup.contains("link type=\"image\""))
+        assertTrue(markup.length <= 256)
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManagerTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManagerTest.kt
@@ -2,6 +2,7 @@ package com.ai.assistance.operit.api.chat.enhance
 
 import com.ai.assistance.operit.core.tools.StringResultData
 import com.ai.assistance.operit.data.model.ToolResult
+import com.ai.assistance.operit.core.tools.ToolProgressBus
 import com.ai.assistance.operit.util.stream.StreamCollector
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -59,7 +60,7 @@ class ToolExecutionManagerTest {
             onDisplayMarkupEmitted = { persisted += it },
         )
 
-        assertEquals(listOf("$markup\n"), persisted)
+        assertEquals(listOf("\n$markup\n"), persisted)
         assertEquals(persisted, live)
     }
 
@@ -97,7 +98,7 @@ class ToolExecutionManagerTest {
     }
 
     @Test
-    fun orderedEmitterDelaysLaterCompletionUntilEarlierInvocationFinishes() = runTest {
+    fun emitterPublishesEachCompletedInvocationImmediately() = runTest {
         val persisted = mutableListOf<String>()
         val live = mutableListOf<String>()
         val emitter =
@@ -128,14 +129,33 @@ class ToolExecutionManagerTest {
         )
 
         emitter.complete(index = 1, buffer = secondBuffer)
-        assertTrue(live.isEmpty())
+        assertEquals(1, live.size)
+        assertTrue(live.single().contains("second result"))
 
         emitter.complete(index = 0, buffer = firstBuffer)
 
         assertEquals(persisted, live)
         assertEquals(2, live.size)
-        assertTrue(live[0].contains("first result"))
-        assertTrue(live[1].contains("second result"))
+        assertTrue(live[1].contains("first result"))
+    }
+
+    @Test
+    fun progressScopesPreventAnOlderToolFromClearingTheCurrentTool() = runTest {
+        ToolProgressBus.resetForTest()
+        val firstScope = ToolProgressBus.newScopeId()
+        val secondScope = ToolProgressBus.newScopeId()
+
+        ToolProgressBus.withScope(firstScope) {
+            ToolProgressBus.update("read_file", 0.4f, "first")
+        }
+        ToolProgressBus.withScope(secondScope) {
+            ToolProgressBus.update("grep_code", 0.5f, "second", priority = 10)
+        }
+        ToolProgressBus.clear(scopeId = firstScope)
+        assertEquals("grep_code", ToolProgressBus.progress.value?.toolName)
+
+        ToolProgressBus.clear(scopeId = secondScope)
+        assertEquals(null, ToolProgressBus.progress.value)
     }
 
     @Test
@@ -162,15 +182,22 @@ class ToolExecutionManagerTest {
         )
 
         assertEquals(1, live.size)
-        assertTrue(live.single().length <= 16 * 1024 + 1)
+        assertTrue(live.single().length <= 64 * 1024 + 2)
         assertTrue(live.single().contains("[工具结果过长，已截断]"))
     }
     @Test
+    fun productionDisplayBudgetSupportsLongAgentTurns() {
+        assertTrue(
+            ToolExecutionManager.MAX_TOOL_RESULT_DISPLAY_CHARS_PER_TURN >=
+                ToolExecutionManager.MAX_TOOL_RESULT_DISPLAY_CHARS_PER_INVOCATION * 256,
+        )
+    }
+
+    @Test
     fun sharedDisplayBudgetCompactsResultsAfterTheConversationLimit() = runTest {
         val live = mutableListOf<String>()
-        val sharedBudget = ToolExecutionManager.ToolResultDisplayBudget()
-
-        repeat(17) { index ->
+        val sharedBudget = ToolExecutionManager.ToolResultDisplayBudget(initialChars = 32 * 1024)
+        repeat(3) { index ->
             val buffer = ToolExecutionManager.ToolResultMarkupBuffer()
             buffer.record(
                 ToolResult(
@@ -190,8 +217,8 @@ class ToolExecutionManagerTest {
                 displayBudget = sharedBudget,
             ).complete(index = 0, buffer = buffer)
         }
-
-        assertEquals(17, live.size)
+        assertEquals(3, live.size)
+        assertTrue(live.take(2).none { it.contains("工具结果已从聊天显示中省略") })
         assertTrue(live.last().contains("[工具结果已从聊天显示中省略，以避免长任务占用过多内存。]"))
     }
 

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManagerTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/enhance/ToolExecutionManagerTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ToolExecutionManagerTest {
@@ -95,7 +96,107 @@ class ToolExecutionManagerTest {
         assertEquals(12, persisted.size)
     }
 
+    @Test
+    fun orderedEmitterDelaysLaterCompletionUntilEarlierInvocationFinishes() = runTest {
+        val persisted = mutableListOf<String>()
+        val live = mutableListOf<String>()
+        val emitter =
+            ToolExecutionManager.OrderedToolResultEmitter(
+                collector =
+                    object : StreamCollector<String> {
+                        override suspend fun emit(value: String) {
+                            live += value
+                        }
+                    },
+                onDisplayMarkupEmitted = { persisted += it },
+            )
+        val firstBuffer = ToolExecutionManager.ToolResultMarkupBuffer()
+        val secondBuffer = ToolExecutionManager.ToolResultMarkupBuffer()
+        firstBuffer.record(
+            ToolResult(
+                toolName = "grep_context",
+                success = true,
+                result = StringResultData("first result"),
+            ),
+        )
+        secondBuffer.record(
+            ToolResult(
+                toolName = "read_file_part",
+                success = true,
+                result = StringResultData("second result"),
+            ),
+        )
+
+        emitter.complete(index = 1, buffer = secondBuffer)
+        assertTrue(live.isEmpty())
+
+        emitter.complete(index = 0, buffer = firstBuffer)
+
+        assertEquals(persisted, live)
+        assertEquals(2, live.size)
+        assertTrue(live[0].contains("first result"))
+        assertTrue(live[1].contains("second result"))
+    }
+
+    @Test
+    fun bufferedToolResultMarkupStaysWithinInvocationDisplayBudget() = runTest {
+        val live = mutableListOf<String>()
+        val buffer = ToolExecutionManager.ToolResultMarkupBuffer()
+        buffer.record(
+            ToolResult(
+                toolName = "read_file",
+                success = true,
+                result = StringResultData("x".repeat(128 * 1024)),
+            ),
+        )
+
+        buffer.flushTo(
+            collector =
+                object : StreamCollector<String> {
+                    override suspend fun emit(value: String) {
+                        live += value
+                    }
+                },
+            onDisplayMarkupEmitted = {},
+            displayBudget = ToolExecutionManager.ToolResultDisplayBudget(),
+        )
+
+        assertEquals(1, live.size)
+        assertTrue(live.single().length <= 16 * 1024 + 1)
+        assertTrue(live.single().contains("[工具结果过长，已截断]"))
+    }
+    @Test
+    fun sharedDisplayBudgetCompactsResultsAfterTheConversationLimit() = runTest {
+        val live = mutableListOf<String>()
+        val sharedBudget = ToolExecutionManager.ToolResultDisplayBudget()
+
+        repeat(17) { index ->
+            val buffer = ToolExecutionManager.ToolResultMarkupBuffer()
+            buffer.record(
+                ToolResult(
+                    toolName = "read_file_$index",
+                    success = true,
+                    result = StringResultData("x".repeat(16 * 1024)),
+                ),
+            )
+            ToolExecutionManager.OrderedToolResultEmitter(
+                collector =
+                    object : StreamCollector<String> {
+                        override suspend fun emit(value: String) {
+                            live += value
+                        }
+                    },
+                onDisplayMarkupEmitted = {},
+                displayBudget = sharedBudget,
+            ).complete(index = 0, buffer = buffer)
+        }
+
+        assertEquals(17, live.size)
+        assertTrue(live.last().contains("[工具结果已从聊天显示中省略，以避免长任务占用过多内存。]"))
+    }
+
     private fun failedResult(error: String, errorCode: String? = null) =
+
         ToolResult(
             toolName = "read_file",
             success = false,

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ApiErrorClassifierTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ApiErrorClassifierTest.kt
@@ -103,7 +103,7 @@ class ApiErrorClassifierTest {
     }
 
     @Test
-    fun classifiesSevenLocalNetworkFailuresWithOperitCodes() {
+    fun classifiesEightLocalNetworkFailuresWithOperitCodes() {
         val cases = listOf(
             UnknownHostException("api.example.com") to OperitNetworkError.DNS_RESOLUTION_FAILED,
             ConnectException("Connection refused") to OperitNetworkError.CONNECTION_REFUSED,
@@ -112,6 +112,7 @@ class ApiErrorClassifierTest {
             EOFException("unexpected end of stream") to OperitNetworkError.CONNECTION_CLOSED,
             SSLHandshakeException("certificate verify failed") to OperitNetworkError.TLS_HANDSHAKE_FAILED,
             SocketTimeoutException("read timed out") to OperitNetworkError.CONNECTION_TIMEOUT,
+            SocketException("Software caused connection abort") to OperitNetworkError.CONNECTION_ABORTED,
         )
 
         cases.forEach { (throwable, expected) ->

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/LlmRetryPolicyTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/LlmRetryPolicyTest.kt
@@ -1,0 +1,70 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import com.ai.assistance.operit.data.preferences.LlmRetryMode
+import com.ai.assistance.operit.data.preferences.LlmRetrySettings
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LlmRetryPolicyTest {
+    @Test
+    fun standardModePreservesExistingRetrySchedule() {
+        val policy =
+            LlmRetryPolicy.fromSettings(
+                LlmRetrySettings(maxAttempts = 5, mode = LlmRetryMode.STANDARD)
+            )
+
+        assertEquals(listOf(1_000L, 2_000L, 4_000L, 8_000L, 16_000L), policy.delayScheduleMs())
+    }
+
+    @Test
+    fun presetModesCapLongRetrySchedules() {
+        val fast =
+            LlmRetryPolicy.fromSettings(
+                LlmRetrySettings(maxAttempts = 6, mode = LlmRetryMode.FAST)
+            )
+        val stable =
+            LlmRetryPolicy.fromSettings(
+                LlmRetrySettings(maxAttempts = 6, mode = LlmRetryMode.STABLE)
+            )
+
+        assertEquals(listOf(1_000L, 2_000L, 4_000L, 4_000L, 4_000L, 4_000L), fast.delayScheduleMs())
+        assertEquals(listOf(2_000L, 4_000L, 8_000L, 16_000L, 30_000L, 30_000L), stable.delayScheduleMs())
+    }
+
+    @Test
+    fun customModeUsesInitialDelayAndMaximumCap() {
+        val policy =
+            LlmRetryPolicy.fromSettings(
+                LlmRetrySettings(
+                    maxAttempts = 6,
+                    mode = LlmRetryMode.CUSTOM,
+                    customInitialDelaySeconds = 3,
+                    customMaxDelaySeconds = 10
+                )
+            )
+
+        assertEquals(listOf(3_000L, 6_000L, 10_000L, 10_000L, 10_000L, 10_000L), policy.delayScheduleMs())
+    }
+
+    @Test
+    fun retryCountAndCustomDelaysAreBounded() {
+        val disabled =
+            LlmRetryPolicy.fromSettings(
+                LlmRetrySettings(maxAttempts = -1, mode = LlmRetryMode.STANDARD)
+            )
+        val bounded =
+            LlmRetryPolicy.fromSettings(
+                LlmRetrySettings(
+                    maxAttempts = 99,
+                    mode = LlmRetryMode.CUSTOM,
+                    customInitialDelaySeconds = 20,
+                    customMaxDelaySeconds = 5
+                )
+            )
+
+        assertEquals(emptyList<Long>(), disabled.delayScheduleMs())
+        assertEquals(10, bounded.maxRetryAttempts)
+        assertEquals(5_000L, bounded.nextDelayMs(1))
+        assertEquals(5_000L, bounded.nextDelayMs(10))
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/services/core/MessageProcessingDelegateTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/services/core/MessageProcessingDelegateTest.kt
@@ -2,6 +2,9 @@ package com.ai.assistance.operit.services.core
 
 import com.ai.assistance.operit.data.model.ChatMessage
 import com.ai.assistance.operit.util.stream.emptyStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -53,5 +56,32 @@ class MessageProcessingDelegateTest {
         assertFalse(MessageProcessingDelegate.shouldPersistInterruptedMessage(""))
         assertFalse(MessageProcessingDelegate.shouldPersistInterruptedMessage("   \n"))
         assertTrue(MessageProcessingDelegate.shouldPersistInterruptedMessage("partial response"))
+    }
+
+    @Test
+    fun updateChatStateMap_preservesConcurrentUpdatesForDifferentChats() {
+        val state = MutableStateFlow<Map<String, Int>>(emptyMap())
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(2)
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            listOf("chat-a", "chat-b").forEach { chatId ->
+                executor.execute {
+                    start.await()
+                    repeat(1_000) {
+                        MessageProcessingDelegate.updateChatStateMap(state, chatId) { current ->
+                            (current ?: 0) + 1
+                        }
+                    }
+                    done.countDown()
+                }
+            }
+            start.countDown()
+            assertTrue(done.await(10, java.util.concurrent.TimeUnit.SECONDS))
+            assertEquals(1_000, state.value["chat-a"])
+            assertEquals(1_000, state.value["chat-b"])
+        } finally {
+            executor.shutdownNow()
+        }
     }
 }

--- a/app/src/test/java/com/ai/assistance/operit/ui/common/markdown/RenderBatchCoordinatorTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/common/markdown/RenderBatchCoordinatorTest.kt
@@ -32,9 +32,26 @@ class RenderBatchCoordinatorTest {
 
         assertEquals(1, flushCount)
     }
+    @Test
+    fun flushNow_appliesPendingUpdateWithoutWaiting() = runTest {
+        var flushCount = 0
+        val coordinator =
+            RenderBatchCoordinator(
+                scope = this,
+                intervalMs = 200,
+                onFlush = { flushCount++ },
+            )
+
+        coordinator.requestUpdate()
+        coordinator.flushNow()
+        advanceUntilIdle()
+
+        assertEquals(1, flushCount)
+    }
 
     @Test
     fun requestDuringFlush_isDrainedBeforeCoordinatorBecomesIdle() = runTest {
+
         var flushCount = 0
         lateinit var coordinator: RenderBatchCoordinator
         coordinator =

--- a/app/src/test/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRendererStateTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/common/markdown/StreamMarkdownRendererStateTest.kt
@@ -1,8 +1,12 @@
 package com.ai.assistance.operit.ui.common.markdown
 
+import com.ai.assistance.operit.util.markdown.MarkdownNode
+import com.ai.assistance.operit.util.markdown.MarkdownProcessorType
 import com.ai.assistance.operit.util.stream.MutableSharedStream
 import com.ai.assistance.operit.util.stream.Stream
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -17,5 +21,26 @@ class StreamMarkdownRendererStateTest {
 
         assertTrue(xmlNodeStreams.isEmpty())
         assertTrue(stream.replayCache.isEmpty())
+    }
+
+    @Test
+    fun `same length replacement does not reuse a stale render node`() {
+        val conversionCache = mutableMapOf<Int, StableNodeConversionCacheEntry>()
+        val thinkingNode = MarkdownNode(
+            type = MarkdownProcessorType.XML_BLOCK,
+            initialContent = "<think>a</think>",
+        )
+        val toolResultNode = MarkdownNode(
+            type = MarkdownProcessorType.XML_BLOCK,
+            initialContent = "<tool>abc</tool>",
+        )
+
+        assertEquals(thinkingNode.content.length, toolResultNode.content.length)
+        val first = stableNodeForRender(thinkingNode, 0, conversionCache)
+        val replacement = stableNodeForRender(toolResultNode, 0, conversionCache)
+
+        assertNotEquals(first.nodeId, replacement.nodeId)
+        assertEquals(toolResultNode.nodeId, replacement.nodeId)
+        assertEquals(toolResultNode.content.toString(), replacement.content)
     }
 }

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/MessageCopyTextTest.kt
@@ -49,6 +49,32 @@ class MessageCopyTextTest {
         assertEquals("answer", cleanMessageContentForCopy(content))
     }
 
+    @Test fun cleanMessageContentForXmlCopy_preservesStructuredTagsAndRemovesProtocolMetadata() {
+        val content =
+            """
+            <meta provider="openai:responses_reasoning">internal reasoning</meta>
+            <think>visible reasoning</think>
+            <tool name="run"><param name="command">pwd</param></tool>
+            <tool_result name="run" status="success"><content>done</content></tool_result>
+            <meta provider="gemini:thought_signature">internal signature</meta>
+            """.trimIndent()
+
+        val expected =
+            """
+            <think>visible reasoning</think>
+            <tool name="run"><param name="command">pwd</param></tool>
+            <tool_result name="run" status="success"><content>done</content></tool_result>
+            """.trimIndent()
+
+        assertEquals(expected, cleanMessageContentForXmlCopy(content))
+    }
+
+    @Test fun cleanMessageContentForXmlCopy_preservesNonProtocolMetadata() {
+        val content = "<meta provider=\"other\">visible</meta><tool name=\"run\">body</tool>"
+
+        assertEquals(content, cleanMessageContentForXmlCopy(content))
+    }
+
     @Test fun buildSelectedMessagesPlainText_usesMessageOrderAndPlainTextConversion() = runTest {
         val chatHistory =
             listOf(

--- a/docs/TODO/chat-runtime-state-api/index.md
+++ b/docs/TODO/chat-runtime-state-api/index.md
@@ -212,7 +212,7 @@ Tool-error recoverability currently follows `InputProcessingState.ToolError` def
 | 字段 / Field | 中文说明 | English description |
 |---|---|---|
 | `message` | 面向公开接口的脱敏错误摘要，最长 300 字符 | Sanitized public error summary, limited to 300 characters |
-| `appCode` | Operit 本地错误码；网络错误当前使用 `5000` 至 `5006` | Operit-local error code; network failures currently use `5000` through `5006` |
+| `appCode` | Operit 本地错误码；网络错误当前使用 `5000` 至 `5007` | Operit-local error code; network failures currently use `5000` through `5007` |
 | `providerCode` | Provider 原始 `error.code` / `error.type`，无法提取时为 `null` | Original provider `error.code` / `error.type`, or `null` when unavailable |
 | `httpStatusCode` | HTTP 状态码，无法识别时为 `null` | HTTP status code, or `null` when unavailable |
 

--- a/docs/doc-src/package-dev/chat.md
+++ b/docs/doc-src/package-dev/chat.md
@@ -93,7 +93,7 @@ getCurrentChatRuntimeState(chatId?: string): Promise<CurrentChatRuntimeStateResu
 - `cancelled`（用户取消当前操作；下一次非终止状态会替换它）
 - `error`
 
-返回值还包含用户交互状态、应用前后台状态、工具名称，以及可选的 `error` 和 `retry` 对象。`error.source` 为 `ai`、`tool`、`api` 或 `system`，`error.code` 是可扩展的归一化字符串；Operit 本地网络错误通过 `error.appCode` 暴露 `5000` 至 `5006` 的应用码，服务商原始 code 和 HTTP 状态位于 `error.providerCode`、`error.httpStatusCode`。`retry` 包含 `attempt`、`maxAttempts` 和 `retryAfterMs`。这个接口不暴露 `main`/`floating` runtime 选择器。
+返回值还包含用户交互状态、应用前后台状态、工具名称，以及可选的 `error` 和 `retry` 对象。`error.source` 为 `ai`、`tool`、`api` 或 `system`，`error.code` 是可扩展的归一化字符串；Operit 本地网络错误通过 `error.appCode` 暴露 `5000` 至 `5007` 的应用码，服务商原始 code 和 HTTP 状态位于 `error.providerCode`、`error.httpStatusCode`。`retry` 包含 `attempt`、`maxAttempts` 和 `retryAfterMs`。这个接口不暴露 `main`/`floating` runtime 选择器。
 
 ### `getGlobalChatRuntimeState()`
 


### PR DESCRIPTION
## 变更说明

本 PR 汇总独立新增功能、环境变量编辑体验优化，以及对 [PR #1066](https://github.com/AAswordman/Operit/pull/1066) 中相关改动的后续修正。

### 背景与动机

- 原有 LLM 重试次数和等待间隔不可配置，无法适配不同 Provider、网络环境和使用场景。
- AI 渲染控制实际覆盖 Markdown、LaTeX 和 XML，但设置文案遗漏 XML，容易造成设置预期与实际行为不一致。
- [PR #1066](https://github.com/AAswordman/Operit/pull/1066) 中的工具调用相关改动在后续使用中仍暴露出长上下文、结果类型和调用计数的稳定性问题。
- 消息复制缺少直接保留 XML 结构的格式。
- 环境变量编辑区连续堆叠时层次不够清晰，字段较多时不利于扫描和填写。

### 改动范围

- 新增可配置的 LLM 重试次数、预设/自定义策略、首次等待时间和最大等待时间；自定义等待按退避策略增长并受最大值限制。
- 修复重试设置保存与反馈同步：合法数值立即保存，Toast 使用实际等待时间并在新错误到来时刷新；重试次数为 `0` 时保留原始错误提示。
- 新增 XML 消息复制选项，保留结构化消息内容。
- 将环境变量编辑区由连续堆叠调整为卡片分组，改善字段层级、扫描和填写体验。
- 补全 AI 渲染控制文案，明确其同时影响 Markdown、LaTeX 和 XML。
- 修正 [PR #1066](https://github.com/AAswordman/Operit/pull/1066) 的工具调用相关问题：
  - 长对话中思考内容和工具调用无法展开；
  - 工具结果被错误渲染为思考内容；
  - 工具调用数量与工具结果数量不一致。
- 调整高流量工具结果限制为每轮 `64 KiB`、整轮对话 `16 MiB`，降低超长结果对渲染和历史重建的影响。

### 兼容性与风险

- 默认重试节奏保持 `1s -> 2s -> 4s -> 8s -> 16s`。
- 用户修改重试设置后，请求次数和等待时间会按新配置执行；最大重试次数设为 `0` 会关闭自动重试，但不会隐藏原始错误。
- 工具结果超过单轮或整轮限制时可能被限制处理。
- 环境变量改动仅调整编辑界面，不改变变量读取、保存或注入行为。

## 关联 Issue

- #1019：本 PR 仅优化环境变量编辑区的界面层级和填写体验，不解决该 Issue 的核心问题，也不会自动关闭该 Issue。

## 关联 PR

- [PR #1066](https://github.com/AAswordman/Operit/pull/1066)：AI 渲染控制文案遗漏与工具调用相关修复的后续处理。

## 验证方式

```text
检查或命令：
- git diff --check
- GitHub Actions Android Build：assembleDebug

环境与变体：
- 本地工作区：/root/Operit-preview-tools
- 远程构建：preview 分支，assembleDebug

结果：
- git diff --check 通过，退出码 0。
- 已触发 Android Build：
  https://github.com/AAswordman/Operit/actions/runs/33582932576
- 远程构建最终结论待补充。
- 未声明本地 Gradle 构建或真机回归已完成。
```

## 证据

- 环境变量编辑区优化前后截图待补充。
- 需要补充重试设置保存、零次重试错误提示、长上下文工具调用和超长工具结果的手动回归结果。

## 检查清单

- [x] 日常开发 PR 的目标分支为 `dev`
- [x] 已执行 `git diff --check`
- [x] 已触发远程 `assembleDebug`
- [x] 已确认远程构建最终结论
- [x] 已完成关键真机/手动回归
- [ ] 已补充环境变量优化前后截图
- [x] 已说明 #1019 仅为关联界面优化，未解决其核心问题