### PR TITLE
fix(ui): adapt AutoGLM execution text colors to theme

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/autoglm/AutoGlmToolScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/autoglm/AutoGlmToolScreen.kt
@@ -133,5 +133,6 @@ private fun AutoGlmToolContent(
                     .fillMaxSize()
                     .verticalScroll(logScrollState)
             )
+        }
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/autoglm/AutoGlmToolScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/autoglm/AutoGlmToolScreen.kt
@@ -54,7 +54,7 @@ private fun AutoGlmToolContent(
             OutlinedTextField(
                 value = task,
                 onValueChange = onTaskChange,
-                label = { Text("Enter Task") },
+                label = { Text("Enter Task", color = MaterialTheme.colorScheme.onSurfaceVariant) },
                 modifier = Modifier.fillMaxWidth(),
                 maxLines = 5
             )
@@ -67,7 +67,11 @@ private fun AutoGlmToolContent(
                 verticalAlignment = Alignment.CenterVertically
             )
             {
-                Text(stringResource(R.string.autoglm_virtual_screen))
+                Text(
+                    stringResource(R.string.autoglm_virtual_screen),
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
                 Switch(
                     checked = useVirtualScreen,
                     onCheckedChange = { onUseVirtualScreenChange(it) },
@@ -90,12 +94,23 @@ private fun AutoGlmToolContent(
                     containerColor = if (uiState.isLoading) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
                 )
             ) {
-                Text(if (uiState.isLoading) "Cancel" else "Execute")
+                Text(
+                    if (uiState.isLoading) "Cancel" else "Execute",
+                    color = if (uiState.isLoading) {
+                        MaterialTheme.colorScheme.onError
+                    } else {
+                        MaterialTheme.colorScheme.onPrimary
+                    }
+                )
             }
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Text("Execution Log", style = MaterialTheme.typography.titleMedium)
+            Text(
+                "Execution Log",
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.titleMedium
+            )
 
             Spacer(modifier = Modifier.height(8.dp))
         }
@@ -113,10 +128,10 @@ private fun AutoGlmToolContent(
 
             Text(
                 text = uiState.log,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier
                     .fillMaxSize()
                     .verticalScroll(logScrollState)
             )
-        }
     }
 }


### PR DESCRIPTION
## Summary
- adapt AutoGLM execution screen text colors to the active Material theme
- use theme-aware colors for the task label, virtual screen option, execution log, and action button text
- preserve readable foreground colors for both light and dark themes

## Verification
- `./gradlew :app:compileDebugKotlin --no-daemon --console=plain` passed
- `git diff --check` passed
- no real-device testing performed

## Separate issue
The virtual screen service may fail to start on some devices. That behavior is not changed in this PR because it has not yet been confirmed whether the issue is device-specific or general.