### PR TITLE
fix(chat): show token generation speed (#949)

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ThemePreferenceSnapshot.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ThemePreferenceSnapshot.kt
@@ -111,6 +111,7 @@ data class ThemePreferenceValues(
                     "show_user_name" to true,
                     "show_message_token_stats" to false,
                     "show_message_timing_stats" to false,
+                    "show_message_token_speed" to false,
                     "show_message_timestamp" to false,
                     "show_input_processing_status" to true,
                     "show_chat_floating_dots_animation" to true,
@@ -266,6 +267,7 @@ data class ThemePreferenceSnapshot(
     val showUserName: Boolean get() = values.requiredBoolean("show_user_name")
     val showMessageTokenStats: Boolean get() = values.requiredBoolean("show_message_token_stats")
     val showMessageTimingStats: Boolean get() = values.requiredBoolean("show_message_timing_stats")
+    val showMessageTokenSpeed: Boolean get() = values.requiredBoolean("show_message_token_speed")
     val showMessageTimestamp: Boolean get() = values.requiredBoolean("show_message_timestamp")
     val showInputProcessingStatus: Boolean
         get() = values.requiredBoolean("show_input_processing_status")

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/UserPreferencesManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/UserPreferencesManager.kt
@@ -287,6 +287,7 @@ class UserPreferencesManager private constructor(private val context: Context) {
         private val KEY_SHOW_USER_NAME = booleanPreferencesKey("show_user_name")
         private val KEY_SHOW_MESSAGE_TOKEN_STATS = booleanPreferencesKey("show_message_token_stats")
         private val KEY_SHOW_MESSAGE_TIMING_STATS = booleanPreferencesKey("show_message_timing_stats")
+        private val KEY_SHOW_MESSAGE_TOKEN_SPEED = booleanPreferencesKey("show_message_token_speed")
         private val KEY_SHOW_MESSAGE_TIMESTAMP = booleanPreferencesKey("show_message_timestamp")
         private val KEY_CUSTOM_USER_AVATAR_URI = stringPreferencesKey("custom_user_avatar_uri")
         private val KEY_CUSTOM_AI_AVATAR_URI = stringPreferencesKey("custom_ai_avatar_uri")
@@ -830,7 +831,7 @@ class UserPreferencesManager private constructor(private val context: Context) {
             KEY_SHOW_INPUT_PROCESSING_STATUS, KEY_SHOW_CHAT_FLOATING_DOTS_ANIMATION, USE_CUSTOM_FONT,
             BUBBLE_USER_USE_CUSTOM_FONT, BUBBLE_AI_USE_CUSTOM_FONT, KEY_SHOW_MODEL_PROVIDER,
             KEY_SHOW_MODEL_NAME, KEY_SHOW_ROLE_NAME, KEY_SHOW_USER_NAME,
-            KEY_SHOW_MESSAGE_TOKEN_STATS, KEY_SHOW_MESSAGE_TIMING_STATS,
+            KEY_SHOW_MESSAGE_TOKEN_STATS, KEY_SHOW_MESSAGE_TIMING_STATS, KEY_SHOW_MESSAGE_TOKEN_SPEED,
             KEY_SHOW_MESSAGE_TIMESTAMP
         )
     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
@@ -260,6 +260,7 @@ fun ChatArea(
     val themeSnapshot = LocalThemePreferenceSnapshot.current
     val showMessageTokenStats = themeSnapshot.showMessageTokenStats
     val showMessageTimingStats = themeSnapshot.showMessageTimingStats
+    val showMessageTokenSpeed = themeSnapshot.showMessageTokenSpeed
     val showMessageTimestamp = themeSnapshot.showMessageTimestamp
     var viewportHeightPx by remember { mutableStateOf(0) }
     val messageAnchors = remember(currentChatId) { mutableStateMapOf<Long, ChatScrollMessageAnchor>() }
@@ -459,6 +460,7 @@ fun ChatArea(
                             chatStyle = chatStyle,
                             showMessageTokenStats = showMessageTokenStats,
                             showMessageTimingStats = showMessageTimingStats,
+                            showMessageTokenSpeed = showMessageTokenSpeed,
                             showMessageTimestamp = showMessageTimestamp,
                             cursorUserBubbleLiquidGlass = cursorUserBubbleLiquidGlass,
                             cursorUserBubbleWaterGlass = cursorUserBubbleWaterGlass,
@@ -628,6 +630,7 @@ private fun MessageItem(
     chatStyle: ChatStyle, // 新增参数
     showMessageTokenStats: Boolean = false,
     showMessageTimingStats: Boolean = false,
+    showMessageTokenSpeed: Boolean = false,
     showMessageTimestamp: Boolean = false,
     cursorUserBubbleLiquidGlass: Boolean = false,
     cursorUserBubbleWaterGlass: Boolean = false,
@@ -755,6 +758,7 @@ private fun MessageItem(
                     message.variantCount > 1 ||
                         (showMessageTokenStats && hasDisplayableTokenStats(message)) ||
                         (showMessageTimingStats && hasDisplayableTimingStats(message)) ||
+                        (showMessageTokenSpeed && hasDisplayableTokenSpeedStats(message)) ||
                         (showMessageTimestamp && hasDisplayableMessageTimestamp(message))
                 )
             ) {
@@ -762,6 +766,7 @@ private fun MessageItem(
                     message = message,
                     showMessageTokenStats = showMessageTokenStats,
                     showMessageTimingStats = showMessageTimingStats,
+                    showMessageTokenSpeed = showMessageTokenSpeed,
                     showMessageTimestamp = showMessageTimestamp,
                     onSelectVariant = { targetVariantIndex ->
                         onSwitchMessageVariant?.invoke(index, targetVariantIndex)
@@ -1323,6 +1328,15 @@ private fun hasDisplayableTokenStats(message: ChatMessage): Boolean {
     return message.inputTokens > 0 || message.cachedInputTokens > 0 || message.outputTokens > 0
 }
 
+internal fun calculateMessageTokenSpeed(outputTokens: Long, outputDurationMs: Long): Double? {
+    if (outputTokens <= 0L || outputDurationMs <= 0L) return null
+    return outputTokens.toDouble() * 1000.0 / outputDurationMs.toDouble()
+}
+
+private fun hasDisplayableTokenSpeedStats(message: ChatMessage): Boolean {
+    return calculateMessageTokenSpeed(message.outputTokens, message.outputDurationMs) != null
+}
+
 private fun hasDisplayableTimingStats(message: ChatMessage): Boolean {
     return message.waitDurationMs > 0L || message.outputDurationMs > 0L
 }
@@ -1344,6 +1358,10 @@ private fun formatCompactDuration(durationMs: Long): String {
     }
 }
 
+private fun formatCompactTokenSpeed(tokenSpeed: Double): String {
+    return String.format(Locale.getDefault(), "%.1f", tokenSpeed)
+}
+
 private fun formatCompactTimestamp(completedAt: Long): String {
     if (completedAt <= 0L) return ""
     return SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date(completedAt))
@@ -1354,6 +1372,7 @@ private fun MessageFooterBar(
     message: ChatMessage,
     showMessageTokenStats: Boolean,
     showMessageTimingStats: Boolean,
+    showMessageTokenSpeed: Boolean,
     showMessageTimestamp: Boolean,
     onSelectVariant: (Int) -> Unit,
 ) {
@@ -1380,6 +1399,18 @@ private fun MessageFooterBar(
                 formatCompactDuration(message.waitDurationMs),
                 formatCompactDuration(message.outputDurationMs),
             )
+        }
+    val tokenSpeedSummary =
+        remember(message.outputTokens, message.outputDurationMs) {
+            calculateMessageTokenSpeed(
+                message.outputTokens,
+                message.outputDurationMs,
+            )?.let { tokenSpeed ->
+                context.getString(
+                    R.string.chat_message_token_speed_compact,
+                    formatCompactTokenSpeed(tokenSpeed),
+                )
+            }
         }
     val messageTimeSummary =
         remember(message.completedAt) {
@@ -1455,6 +1486,14 @@ private fun MessageFooterBar(
         if (showMessageTimingStats && hasDisplayableTimingStats(message)) {
             Text(
                 text = timeSummary,
+                style = MaterialTheme.typography.labelSmall,
+                color = statsTextColor,
+            )
+        }
+
+        if (showMessageTokenSpeed && tokenSpeedSummary != null) {
+            Text(
+                text = tokenSpeedSummary,
                 style = MaterialTheme.typography.labelSmall,
                 color = statsTextColor,
             )

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/theme/ThemeSettingsChatTab.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/theme/ThemeSettingsChatTab.kt
@@ -544,6 +544,7 @@ internal fun ThemeSettingsChatTab(
     val showUserNameInput = values.requiredBoolean("show_user_name")
     val showMessageTokenStatsInput = values.requiredBoolean("show_message_token_stats")
     val showMessageTimingStatsInput = values.requiredBoolean("show_message_timing_stats")
+    val showMessageTokenSpeedInput = values.requiredBoolean("show_message_token_speed")
     val showMessageTimestampInput = values.requiredBoolean("show_message_timestamp")
     val showInputProcessingStatusInput = values.requiredBoolean("show_input_processing_status")
     val showChatFloatingDotsAnimationInput =
@@ -661,6 +662,7 @@ internal fun ThemeSettingsChatTab(
         showUserNameInput = showUserNameInput,
         showMessageTokenStatsInput = showMessageTokenStatsInput,
         showMessageTimingStatsInput = showMessageTimingStatsInput,
+        showMessageTokenSpeedInput = showMessageTokenSpeedInput,
         showMessageTimestampInput = showMessageTimestampInput,
         showInputProcessingStatusInput = showInputProcessingStatusInput,
         showChatFloatingDotsAnimationInput = showChatFloatingDotsAnimationInput,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ThemeSettingsCoreSections.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ThemeSettingsCoreSections.kt
@@ -2126,6 +2126,7 @@ internal fun ThemeSettingsDisplayOptionsSection(
     showUserNameInput: Boolean,
     showMessageTokenStatsInput: Boolean,
     showMessageTimingStatsInput: Boolean,
+    showMessageTokenSpeedInput: Boolean,
     showMessageTimestampInput: Boolean,
     showInputProcessingStatusInput: Boolean,
     showChatFloatingDotsAnimationInput: Boolean,
@@ -2277,6 +2278,32 @@ internal fun ThemeSettingsDisplayOptionsSection(
                     checked = showMessageTokenStatsInput,
                     onCheckedChange = {
                         editorSession.setBoolean("show_message_token_stats", it)
+                    },
+                )
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(id = R.string.show_message_token_speed),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = stringResource(id = R.string.show_message_token_speed_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = showMessageTokenSpeedInput,
+                    onCheckedChange = {
+                        editorSession.setBoolean("show_message_token_speed", it)
                     },
                 )
             }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -5173,10 +5173,13 @@
     <string name="show_message_token_stats_description">Show compact token upload, output, and cache info below AI messages</string>
     <string name="show_message_timing_stats">Show Message Timing Summary</string>
     <string name="show_message_timing_stats_description">Show first-token and generation timing below AI messages</string>
+    <string name="show_message_token_speed">Show Message Token Generation Rate</string>
+    <string name="show_message_token_speed_description">Show output token generation rate below AI messages (t/s)</string>
     <string name="show_message_timestamp">Show Message Time</string>
     <string name="show_message_timestamp_description">Show the time of that AI message below it</string>
     <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
     <string name="chat_message_timing_stats_compact">usage: %1$s (first %2$s out %3$s)</string>
+    <string name="chat_message_token_speed_compact">%1$s t/s</string>
     <string name="chat_message_timestamp_compact">time: %1$s</string>
     <string name="global_user_name">Global User Name</string>
     <string name="system_display_settings">System Display Settings</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4846,8 +4846,11 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
 
     <string name="show_message_timing_stats">Mostrar estadísticas de tiempo de mensajes</string>
     <string name="show_message_timing_stats_description">Mostrar el tiempo del primer paquete y el tiempo de generación en la parte inferior de los mensajes de IA</string>
+    <string name="show_message_token_speed">Mostrar velocidad de generación de tokens del mensaje</string>
+    <string name="show_message_token_speed_description">Mostrar la velocidad de generación de tokens de salida debajo de los mensajes de IA (t/s)</string>
     <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (caché: %2$d) ↓ %4$d</string>
     <string name="chat_message_timing_stats_compact">tiempo: %1$s (primer %2$s generar %3$s)</string>
+    <string name="chat_message_token_speed_compact">%1$s t/s</string>
     <string name="global_user_name">Nombre de usuario global</string>
     <string name="system_display_settings">Configuración de pantalla del sistema</string>
     <string name="show_fps_counter_description">Mostrar métricas de rendimiento de FPS en la pantalla</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -6900,8 +6900,11 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="show_message_token_stats_description">Tampilkan informasi ringkas token naik/turun dan cache di bagian bawah pesan AI</string>
     <string name="show_message_timing_stats">Tampilkan statistik waktu pesan</string>
     <string name="show_message_timing_stats_description">Tampilkan waktu paket pertama dan waktu generasi di bagian bawah pesan AI</string>
+    <string name="show_message_token_speed">Tampilkan laju pembuatan token pesan</string>
+    <string name="show_message_token_speed_description">Tampilkan laju pembuatan token keluaran di bawah pesan AI (t/s)</string>
     <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
     <string name="chat_message_timing_stats_compact">waktu: %1$s (pertama %2$s generasi %3$s)</string>
+    <string name="chat_message_token_speed_compact">%1$s t/s</string>
     <string name="software_identity_title">Identitas Perangkat Lunak</string>
     <string name="software_identity_description">Ubah identitas perangkat lunak yang ditampilkan di bagian atas sidebar.</string>
     <string name="software_identity_option_operit">Operit AI</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -4779,10 +4779,13 @@
     <string name="show_message_token_stats_description">AI 메시지 아래에 간략한 token 업로드, 출력 및 캐시 정보를 표시합니다</string>
     <string name="show_message_timing_stats">메시지 타이밍 요약 표시</string>
     <string name="show_message_timing_stats_description">AI 메시지 아래에 첫 토큰 및 생성 소요 시간을 표시합니다</string>
+    <string name="show_message_token_speed">메시지 토큰 생성 속도 표시</string>
+    <string name="show_message_token_speed_description">AI 메시지 아래에 출력 토큰 생성 속도를 표시합니다 (t/s)</string>
     <string name="show_message_timestamp">메시지 시간 표시</string>
     <string name="show_message_timestamp_description">해당 AI 메시지 아래에 시간을 표시합니다.</string>
     <string name="chat_message_token_stats_compact">토큰: %1$d ↑ %3$d (캐시: %2$d) ↓ %4$d</string>
     <string name="chat_message_timing_stats_compact">소요 시간: %1$s(대기 %2$s, 출력 %3$s)</string>
+    <string name="chat_message_token_speed_compact">%1$s t/s</string>
     <string name="chat_message_timestamp_compact">시간: %1$s</string>
     <string name="global_user_name">전역 사용자 이름</string>
     <string name="system_display_settings">시스템 디스플레이 설정</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -6898,8 +6898,11 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="show_message_token_stats_description">Paparkan maklumat ringkas token naik/turun dan cache di bahagian bawah mesej AI</string>
     <string name="show_message_timing_stats">Tunjukkan ringkasan masa mesej</string>
     <string name="show_message_timing_stats_description">Paparkan masa paket pertama dan penjanaan di bahagian bawah mesej AI</string>
+    <string name="show_message_token_speed">Tunjukkan kadar penjanaan token mesej</string>
+    <string name="show_message_token_speed_description">Paparkan kadar penjanaan token output di bawah mesej AI (t/s)</string>
     <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
     <string name="chat_message_timing_stats_compact">masa: %1$s (pertama %2$s jana %3$s)</string>
+    <string name="chat_message_token_speed_compact">%1$s t/s</string>
     <string name="software_identity_title">Identiti Perisian</string>
     <string name="software_identity_description">Tukar identiti perisian yang dipaparkan di bahagian atas bar sisi.</string>
     <string name="software_identity_option_operit">Operit AI</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -6733,8 +6733,11 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="show_message_token_stats_description">Exibe informações concisas de tokens de subida/descida e cache na parte inferior das mensagens da IA.</string>
     <string name="show_message_timing_stats">Mostrar resumo de tempo da mensagem</string>
     <string name="show_message_timing_stats_description">Exibe o tempo do primeiro pacote e o tempo de geração na parte inferior das mensagens da IA.</string>
+    <string name="show_message_token_speed">Mostrar taxa de geração de tokens da mensagem</string>
+    <string name="show_message_token_speed_description">Exibe a taxa de geração de tokens de saída abaixo das mensagens da IA (t/s).</string>
     <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
     <string name="chat_message_timing_stats_compact">tempo: %1$s (primeiro %2$s geração %3$s)</string>
+    <string name="chat_message_token_speed_compact">%1$s t/s</string>
     <string name="software_identity_title">Identidade do software</string>
     <string name="software_identity_description">Altera a identidade do software exibida no topo da barra lateral.</string>
     <string name="software_identity_option_operit">Operit AI</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -5480,10 +5480,13 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="show_message_token_stats_description">în AI În partea de jos a știrii se afișează un mesaj concis token Informații privind traficul de intrare și ieșire și memoria cache</string>
     <string name="show_message_timing_stats">Raport privind durata de afișare a mesajelor</string>
     <string name="show_message_timing_stats_description">în AI În partea de jos a mesajului se afișează primul pachet și timpul necesar pentru generare</string>
+    <string name="show_message_token_speed">Afișează viteza de generare a tokenilor mesajului</string>
+    <string name="show_message_token_speed_description">Afișează viteza de generare a tokenilor de ieșire sub mesajele AI (t/s)</string>
     <string name="show_message_timestamp">Afișează ora mesajului</string>
     <string name="show_message_timestamp_description">în AI În partea de jos a mesajului este afișată ora la care a fost postat mesajul respectiv</string>
     <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
     <string name="chat_message_timing_stats_compact">usage: %1$s (Primul %2$s Generare %3$s)</string>
+    <string name="chat_message_token_speed_compact">%1$s t/s</string>
     <string name="chat_message_timestamp_compact">time: %1$s</string>
     <string name="global_user_name">Numele de utilizator global</string>
     <string name="system_display_settings">Setări de afișare ale sistemului</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5663,10 +5663,13 @@
     <string name="show_message_token_stats_description">在 AI 消息底部显示简洁的 token 上下行与缓存信息</string>
     <string name="show_message_timing_stats">显示消息耗时简报</string>
     <string name="show_message_timing_stats_description">在 AI 消息底部显示首包与生成耗时</string>
+    <string name="show_message_token_speed">显示消息 Token 生成速率</string>
+    <string name="show_message_token_speed_description">在 AI 消息底部显示输出 Token 生成速率（t/s）</string>
     <string name="show_message_timestamp">显示消息时间</string>
     <string name="show_message_timestamp_description">在 AI 消息底部显示该条消息的时间</string>
     <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
     <string name="chat_message_timing_stats_compact">usage: %1$s (首 %2$s 生成 %3$s)</string>
+    <string name="chat_message_token_speed_compact">%1$s t/s</string>
     <string name="chat_message_timestamp_compact">time: %1$s</string>
     <string name="global_user_name">全局用户名字</string>
     <string name="system_display_settings">系统显示设置</string>

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/ChatAreaTokenSpeedTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/ChatAreaTokenSpeedTest.kt
@@ -1,0 +1,24 @@
+package com.ai.assistance.operit.ui.features.chat.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChatAreaTokenSpeedTest {
+    @Test
+    fun calculatesOutputTokensPerSecond() {
+        assertEquals(25.0, calculateMessageTokenSpeed(100L, 4_000L)!!, 0.001)
+    }
+
+    @Test
+    fun returnsNullWhenOutputTokensAreNotPositive() {
+        assertNull(calculateMessageTokenSpeed(0L, 4_000L))
+        assertNull(calculateMessageTokenSpeed(-1L, 4_000L))
+    }
+
+    @Test
+    fun returnsNullWhenOutputDurationIsNotPositive() {
+        assertNull(calculateMessageTokenSpeed(100L, 0L))
+        assertNull(calculateMessageTokenSpeed(100L, -1L))
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

为聊天消息 footer 增加可选的平均输出 token 速率显示，帮助用户观察回复生成速度。

### 背景与动机 / Context and motivation

消息已有输出 token 数和输出耗时数据，但缺少直观的生成速率展示。

### 改动范围 / Changes

- 新增 `show_message_token_speed` 主题偏好，默认关闭。
- 使用现有输出 token 数和输出耗时计算平均 `t/s`。
- 在消息 footer 和主题设置中提供对应显示与开关。
- 增加多语言资源和边界测试。
- 不包含实时流式速率、数据库迁移、Provider 或 WebChat 改动。

### 兼容性与风险 / Compatibility and risks

默认关闭，不改变已有消息数据、Provider 接口或默认 UI 行为。

## 关联 Issue / Related issue

Fixes #949

## 验证方式 / Verification

```text
检查或命令：git diff --check upstream/dev...HEAD
环境与变体：拆分分支未重新运行独立构建；拆分前组合实现曾通过远程 Release 构建
结果：分支差异检查通过；精确合并候选由 GitHub Candidate checks 验证
```

## 证据 / Evidence

拆分前组合实现的远程 Release 构建已通过。