### PR TITLE
feat(tablet): add sidebar swipe gestures (#871)

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/main/layout/TabletLayout.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/main/layout/TabletLayout.kt
@@ -3,6 +3,7 @@ package com.ai.assistance.operit.ui.main.layout
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,6 +19,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.ai.assistance.operit.ui.common.NavItem
@@ -96,6 +100,11 @@ fun TabletLayout(
                         label = "sidebarWidth"
                 )
 
+        val density = LocalDensity.current
+        val edgeSwipeWidthPx = with(density) { 24.dp.toPx() }
+        val sidebarSwipeThresholdPx = with(density) { 40.dp.toPx() }
+        val edgeGestureStartLimitPx = edgeSwipeWidthPx + LocalViewConfiguration.current.touchSlop
+
         // 使用Box作为顶层容器，这样可以允许子元素重叠
         Box(modifier = Modifier.fillMaxSize()) {
                 // 计算主内容区域的宽度（屏幕宽度减去侧边栏宽度），轻微调整动画时间
@@ -119,8 +128,56 @@ fun TabletLayout(
                 // 侧边栏区域，使用动画宽度，无圆角以完全遮住背景
                 Surface(
                         modifier =
-                                Modifier.width(animatedSidebarWidth)
+                                        Modifier.width(animatedSidebarWidth)
                                         .fillMaxHeight()
+                                        // 手势绑定在侧栏本身，避免主内容的横向手势被拦截。
+                                        .pointerInput(
+                                                isTabletSidebarExpanded,
+                                                edgeGestureStartLimitPx,
+                                                sidebarSwipeThresholdPx
+                                        ) {
+                                                var totalDragPx = 0f
+                                                var gestureEligible = false
+                                                var gestureHandled = false
+
+                                                detectHorizontalDragGestures(
+                                                        onDragStart = { startOffset ->
+                                                                totalDragPx = 0f
+                                                                gestureHandled = false
+                                                                gestureEligible =
+                                                                        isTabletSidebarExpanded ||
+                                                                                startOffset.x <=
+                                                                                        edgeGestureStartLimitPx
+                                                        },
+                                                        onHorizontalDrag = { _, dragAmount ->
+                                                                if (gestureEligible && !gestureHandled) {
+                                                                        totalDragPx += dragAmount
+                                                                        val shouldToggle =
+                                                                                if (isTabletSidebarExpanded) {
+                                                                                        totalDragPx <=
+                                                                                                -sidebarSwipeThresholdPx
+                                                                                } else {
+                                                                                        totalDragPx >=
+                                                                                                sidebarSwipeThresholdPx
+                                                                                }
+                                                                        if (shouldToggle) {
+                                                                                gestureHandled = true
+                                                                                onToggleSidebar()
+                                                                        }
+                                                                }
+                                                        },
+                                                        onDragEnd = {
+                                                                totalDragPx = 0f
+                                                                gestureEligible = false
+                                                                gestureHandled = false
+                                                        },
+                                                        onDragCancel = {
+                                                                totalDragPx = 0f
+                                                                gestureEligible = false
+                                                                gestureHandled = false
+                                                        }
+                                                )
+                                        }
                                         .waterGlass(
                                                 enabled = drawerAppearance.waterGlassEnabled,
                                                 shape = MaterialTheme.shapes.medium,


### PR DESCRIPTION
## 变更说明 / Description

为平板端侧栏增加边缘滑动呼出和侧栏内反向滑动收纳。

### 背景与动机 / Context and motivation

平板侧栏已经支持按钮切换，但缺少触控设备常用的滑动入口。

### 改动范围 / Changes

- 收起态从左侧边缘右滑呼出侧栏。
- 展开态在侧栏区域左滑收纳侧栏。
- 复用现有展开状态、按钮入口和宽度动画。
- 手机端布局、全局导航状态和遮罩层不在本 PR 范围内。

### 兼容性与风险 / Compatibility and risks

仅改变平板侧栏的触控入口，不改变持久化数据、导航 API 或手机端行为。

## 关联 Issue / Related issue

Closes #871

## 验证方式 / Verification

```text
检查或命令：git diff --check upstream/dev...HEAD
环境与变体：拆分分支未重新运行独立构建；拆分前组合实现曾通过远程 Release 构建
结果：分支差异检查通过；精确合并候选由 GitHub Candidate checks 验证
```

## 证据 / Evidence

拆分前组合实现的远程 Release 构建已通过。