### PR TITLE
feat(tokenstats): add monthly/yearly activity views and re-anchor ranges to today

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/dao/TokenUsageDao.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/dao/TokenUsageDao.kt
@@ -32,6 +32,12 @@ data class TokenUsageActivityDayRow(
     val tokens: Long,
 )
 
+data class TokenUsageActivityHourRow(
+    val localDate: String,
+    val localHour: Int,
+    val tokens: Long,
+)
+
 @Dao
 abstract class TokenUsageDao {
 
@@ -189,4 +195,35 @@ abstract class TokenUsageDao {
         providerModels: List<String>,
         allModels: Boolean,
     ): List<TokenUsageActivityDayRow>
+
+    @Query(
+        """
+        SELECT
+            strftime('%Y-%m-%d', occurredAtMs / 1000, 'unixepoch', 'localtime') AS localDate,
+            CAST(strftime('%H', occurredAtMs / 1000, 'unixepoch', 'localtime') AS INTEGER) AS localHour,
+            COALESCE(SUM(
+                COALESCE(
+                    totalInputTokens,
+                    CASE
+                        WHEN uncachedInputTokens IS NOT NULL
+                            AND cachedInputTokens IS NOT NULL
+                            AND cacheWriteTokens IS NOT NULL
+                        THEN uncachedInputTokens + cachedInputTokens + cacheWriteTokens
+                    END,
+                    0
+                ) + COALESCE(outputTokens, 0)
+            ), 0) AS tokens
+        FROM token_usage_records
+        WHERE occurredAtMs >= :startMs AND occurredAtMs < :endMs
+            AND (:allModels OR (provider || ':' || model) IN (:providerModels))
+        GROUP BY localDate, localHour, configId, provider, model
+        ORDER BY localDate, localHour, provider, model, configId
+        """
+    )
+    abstract suspend fun getActivityHoursInRange(
+        startMs: Long,
+        endMs: Long,
+        providerModels: List<String>,
+        allModels: Boolean,
+    ): List<TokenUsageActivityHourRow>
 }

--- a/app/src/main/java/com/ai/assistance/operit/data/stats/TokenActivityModels.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/stats/TokenActivityModels.kt
@@ -1,11 +1,11 @@
 package com.ai.assistance.operit.data.stats
 
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import kotlin.math.ceil
-
-enum class TokenActivityViewMode { DAILY, WEEKLY, CUMULATIVE }
+enum class TokenActivityViewMode { DAILY, WEEKLY, MONTHLY, YEARLY, CUMULATIVE }
 
 internal data class TokenActivitySnapshot(
     val zone: ZoneId,
@@ -15,6 +15,20 @@ internal data class TokenActivitySnapshot(
 data class TokenActivityDay(val date: LocalDate, val tokens: Long, val level: Int)
 
 data class TokenActivityWeek(
+    val startDate: LocalDate,
+    val tokens: Long,
+    val level: Int,
+    val barHeight: Int,
+)
+
+data class TokenActivityMonth(
+    val startDate: LocalDate,
+    val tokens: Long,
+    val level: Int,
+    val barHeight: Int,
+)
+
+data class TokenActivityYear(
     val startDate: LocalDate,
     val tokens: Long,
     val level: Int,
@@ -31,12 +45,14 @@ data class TokenActivityStats(
 data class TokenActivityRangeData(
     val daily: List<TokenActivityDay>,
     val weekly: List<TokenActivityWeek>,
+    val monthly: List<TokenActivityMonth>,
+    val yearly: List<TokenActivityYear>,
     val cumulative: List<TokenActivityDay>,
     val stats: TokenActivityStats,
 )
 
 object TokenActivityAggregator {
-    /** Builds all three activity views from the same explicit calendar range. */
+    /** Builds all activity views from the same explicit calendar range. */
     internal fun rangeData(
         snapshot: TokenActivitySnapshot,
         range: TokenStatsTimeRange,
@@ -67,26 +83,61 @@ object TokenActivityAggregator {
         val cumulativeLevels = QuantileLevels.from(cumulativeRaw.map(TokenActivityDay::tokens))
         val cumulative = cumulativeRaw.map { it.copy(level = cumulativeLevels.level(it.tokens)) }
 
-        val firstWeek = start.minusDays((start.dayOfWeek.value % 7).toLong())
-        val lastWeek = end.minusDays((end.dayOfWeek.value % 7).toLong())
-        val weekCount = ChronoUnit.WEEKS.between(firstWeek, lastWeek).toInt() + 1
+        // Rolling 7-day buckets aligned to the range start: a week runs from the
+        // range's first day, matching the mode policy that ends the window today
+        // and starts seven days earlier. The final bucket may be shorter when the
+        // range is not an exact multiple of seven days.
+        val weekCount = ((dayCount + 6) / 7).coerceAtLeast(1)
         val weekTotals = LongArray(weekCount)
         raw.forEach { day ->
-            val weekStart = day.date.minusDays((day.date.dayOfWeek.value % 7).toLong())
-            val index = ChronoUnit.WEEKS.between(firstWeek, weekStart).toInt()
+            val index = (ChronoUnit.DAYS.between(start, day.date).toInt() / 7)
+                .coerceIn(0, weekCount - 1)
             weekTotals[index] = TokenCostCalculator.saturatedAdd(weekTotals[index], day.tokens)
         }
         val weekLevels = QuantileLevels.from(weekTotals.toList())
         val heights = barHeights(weekTotals.toList())
         val weekly = List(weekCount) { index ->
             TokenActivityWeek(
-                startDate = firstWeek.plusWeeks(index.toLong()),
+                startDate = start.plusDays(index.toLong() * 7L),
                 tokens = weekTotals[index],
                 level = weekLevels.level(weekTotals[index]),
                 barHeight = heights[index],
             )
         }
-        return TokenActivityRangeData(daily, weekly, cumulative, stats(raw))
+
+        val monthTotals = linkedMapOf<YearMonth, Long>()
+        raw.forEach { day ->
+            val key = YearMonth.from(day.date)
+            monthTotals[key] = TokenCostCalculator.saturatedAdd(monthTotals[key] ?: 0L, day.tokens)
+        }
+        val monthLevels = QuantileLevels.from(monthTotals.values.toList())
+        val monthHeights = barHeights(monthTotals.values.toList())
+        val monthly = monthTotals.entries.mapIndexed { index, (yearMonth, tokens) ->
+            TokenActivityMonth(
+                startDate = yearMonth.atDay(1),
+                tokens = tokens,
+                level = monthLevels.level(tokens),
+                barHeight = monthHeights[index],
+            )
+        }
+
+        val yearTotals = linkedMapOf<Int, Long>()
+        raw.forEach { day ->
+            val key = day.date.year
+            yearTotals[key] = TokenCostCalculator.saturatedAdd(yearTotals[key] ?: 0L, day.tokens)
+        }
+        val yearLevels = QuantileLevels.from(yearTotals.values.toList())
+        val yearHeights = barHeights(yearTotals.values.toList())
+        val yearly = yearTotals.entries.mapIndexed { index, (year, tokens) ->
+            TokenActivityYear(
+                startDate = LocalDate.of(year, 1, 1),
+                tokens = tokens,
+                level = yearLevels.level(tokens),
+                barHeight = yearHeights[index],
+            )
+        }
+
+        return TokenActivityRangeData(daily, weekly, monthly, yearly, cumulative, stats(raw))
     }
 
     private fun stats(days: List<TokenActivityDay>): TokenActivityStats {

--- a/app/src/main/java/com/ai/assistance/operit/data/stats/TokenActivityModels.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/stats/TokenActivityModels.kt
@@ -1,6 +1,7 @@
 package com.ai.assistance.operit.data.stats
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
@@ -10,6 +11,7 @@ enum class TokenActivityViewMode { DAILY, WEEKLY, MONTHLY, YEARLY, CUMULATIVE }
 internal data class TokenActivitySnapshot(
     val zone: ZoneId,
     val dayTotals: Map<LocalDate, Long>,
+    val hourTotals: Map<LocalDateTime, Long> = emptyMap(),
 )
 
 data class TokenActivityDay(val date: LocalDate, val tokens: Long, val level: Int)
@@ -35,6 +37,14 @@ data class TokenActivityYear(
     val barHeight: Int,
 )
 
+data class TokenActivityHour(
+    val startDate: LocalDate,
+    val hour: Int,
+    val tokens: Long,
+    val level: Int,
+    val barHeight: Int,
+)
+
 data class TokenActivityStats(
     val totalTokens: Long = 0L,
     val peakTokens: Long = 0L,
@@ -47,6 +57,7 @@ data class TokenActivityRangeData(
     val weekly: List<TokenActivityWeek>,
     val monthly: List<TokenActivityMonth>,
     val yearly: List<TokenActivityYear>,
+    val hourly: List<TokenActivityHour>,
     val cumulative: List<TokenActivityDay>,
     val stats: TokenActivityStats,
 )
@@ -59,11 +70,12 @@ object TokenActivityAggregator {
     ): TokenActivityRangeData {
         val start = java.time.Instant.ofEpochMilli(range.startMs).atZone(snapshot.zone).toLocalDate()
         val end = java.time.Instant.ofEpochMilli(range.endMs - 1L).atZone(snapshot.zone).toLocalDate()
-        return rangeData(snapshot.dayTotals, start, end)
+        return rangeData(snapshot.dayTotals, snapshot.hourTotals, start, end)
     }
 
     private fun rangeData(
         dayTotals: Map<LocalDate, Long>,
+        hourTotals: Map<LocalDateTime, Long>,
         start: LocalDate,
         end: LocalDate,
     ): TokenActivityRangeData {
@@ -137,7 +149,38 @@ object TokenActivityAggregator {
             )
         }
 
-        return TokenActivityRangeData(daily, weekly, monthly, yearly, cumulative, stats(raw))
+        // Hourly buckets are only meaningful for single-day views (24 bars). Keep the
+        // range short to avoid wasteful computation for weekly/monthly/yearly ranges.
+        val hourly = if (dayCount <= 2 && hourTotals.isNotEmpty()) {
+            val hourEntries = buildList {
+                var current = start.atStartOfDay()
+                val endExclusive = end.plusDays(1L).atStartOfDay()
+                while (current < endExclusive) {
+                    add(
+                        TokenActivityHour(
+                            startDate = current.toLocalDate(),
+                            hour = current.hour,
+                            tokens = hourTotals[current] ?: 0L,
+                            level = 0,
+                            barHeight = 0,
+                        )
+                    )
+                    current = current.plusHours(1L)
+                }
+            }
+            val hourLevels = QuantileLevels.from(hourEntries.map(TokenActivityHour::tokens))
+            val hourHeights = barHeights(hourEntries.map(TokenActivityHour::tokens))
+            hourEntries.mapIndexed { index, entry ->
+                entry.copy(
+                    level = hourLevels.level(entry.tokens),
+                    barHeight = hourHeights[index],
+                )
+            }
+        } else {
+            emptyList()
+        }
+
+        return TokenActivityRangeData(daily, weekly, monthly, yearly, hourly, cumulative, stats(raw))
     }
 
     private fun stats(days: List<TokenActivityDay>): TokenActivityStats {

--- a/app/src/main/java/com/ai/assistance/operit/data/stats/TokenStatsQueryService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/stats/TokenStatsQueryService.kt
@@ -3,6 +3,7 @@ package com.ai.assistance.operit.data.stats
 import android.content.Context
 import com.ai.assistance.operit.data.collects.PricingCurrency
 import com.ai.assistance.operit.data.dao.TokenUsageActivityDayRow
+import com.ai.assistance.operit.data.dao.TokenUsageActivityHourRow
 import com.ai.assistance.operit.data.dao.TokenUsageModelAggregateRow
 import com.ai.assistance.operit.data.model.TokenStatsModelEntity
 import com.ai.assistance.operit.data.model.normalizeProviderModel
@@ -107,12 +108,24 @@ object TokenStatsQueryService {
                 providerModels = params.providerModels.queryValues(),
                 allModels = params.providerModels == null,
             )
+            val hours = dao.getActivityHoursInRange(
+                startMs = range.startMs,
+                endMs = range.endMs,
+                providerModels = params.providerModels.queryValues(),
+                allModels = params.providerModels == null,
+            )
             TokenActivitySnapshot(
                 zone = zone,
                 dayTotals =
                     days.groupBy(TokenUsageActivityDayRow::localDate).mapValues { (_, rows) ->
                         rows.fold(0L) { total, row -> TokenCostCalculator.saturatedAdd(total, row.tokens) }
                     }.mapKeys { (date, _) -> LocalDate.parse(date) },
+                hourTotals =
+                    hours.groupBy { it.localDate to it.localHour }.mapValues { (_, rows) ->
+                        rows.fold(0L) { total, row -> TokenCostCalculator.saturatedAdd(total, row.tokens) }
+                    }.mapKeys { (key, _) ->
+                        LocalDate.parse(key.first).atTime(key.second, 0)
+                    },
             )
         }
     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/ActivityDateRangePolicy.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/ActivityDateRangePolicy.kt
@@ -4,29 +4,45 @@ import com.ai.assistance.operit.data.stats.TokenActivityViewMode
 import com.ai.assistance.operit.data.stats.TokenStatsTimeRange
 import com.ai.assistance.operit.data.stats.TokenStatsTimeRanges
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.ZoneId
+
 internal fun activityRangeForMode(
     mode: TokenActivityViewMode,
     anchorDate: LocalDate,
     historyStartDate: LocalDate?,
     zone: ZoneId,
 ): TokenStatsTimeRange? {
-    val startDate = when (mode) {
-        TokenActivityViewMode.DAILY -> anchorDate
-        // Rolling 7-day window anchored at today: the future has not happened yet,
-        // so the window reaches backwards from the anchor instead of forwards.
-        TokenActivityViewMode.WEEKLY -> anchorDate.minusDays(7L)
-        // Rolling one-month window. minusMonths clamps month-end dates automatically
-        // (e.g. Mar 31 -> Feb 28/29), so no hard-coded month-length rules are needed.
-        TokenActivityViewMode.MONTHLY -> anchorDate.minusMonths(1L)
-        // Rolling one-year window. minusYears clamps leap days automatically
-        // (e.g. Feb 29 -> Feb 28 in a non-leap year).
-        TokenActivityViewMode.YEARLY -> anchorDate.minusYears(1L)
-        TokenActivityViewMode.CUMULATIVE -> historyStartDate ?: return null
+    // Each periodic mode covers the most recent complete period, because future
+    // time has not happened yet and cannot be counted. Weekly aligns to the same
+    // weekday as today (e.g. today Saturday -> last Saturday through yesterday,
+    // exactly seven days); monthly covers the previous natural month; yearly
+    // covers the trailing twelve natural months (this month last year through
+    // last month).
+    val (startDate, inclusiveEndDate) = when (mode) {
+        TokenActivityViewMode.DAILY -> anchorDate to anchorDate
+        TokenActivityViewMode.WEEKLY -> {
+            val start = anchorDate.minusDays(7L)
+            start to anchorDate.minusDays(1L)
+        }
+        TokenActivityViewMode.MONTHLY -> {
+            val previousMonth = YearMonth.from(anchorDate).minusMonths(1L)
+            previousMonth.atDay(1) to previousMonth.atEndOfMonth()
+        }
+        TokenActivityViewMode.YEARLY -> {
+            val currentMonth = YearMonth.from(anchorDate)
+            val startMonth = currentMonth.minusMonths(12L)
+            val endMonth = currentMonth.minusMonths(1L)
+            startMonth.atDay(1) to endMonth.atEndOfMonth()
+        }
+        TokenActivityViewMode.CUMULATIVE -> {
+            val start = historyStartDate ?: return null
+            start to anchorDate
+        }
     }
-    if (startDate.isAfter(anchorDate)) return null
+    if (startDate.isAfter(inclusiveEndDate)) return null
     return TokenStatsTimeRanges.customRange(
         startDate.atStartOfDay(zone).toInstant().toEpochMilli(),
-        anchorDate.plusDays(1L).atStartOfDay(zone).toInstant().toEpochMilli(),
+        inclusiveEndDate.plusDays(1L).atStartOfDay(zone).toInstant().toEpochMilli(),
     )
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/ActivityDateRangePolicy.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/ActivityDateRangePolicy.kt
@@ -3,15 +3,8 @@ package com.ai.assistance.operit.ui.features.tokenstats
 import com.ai.assistance.operit.data.stats.TokenActivityViewMode
 import com.ai.assistance.operit.data.stats.TokenStatsTimeRange
 import com.ai.assistance.operit.data.stats.TokenStatsTimeRanges
-import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-
-internal fun activityRangeAnchorDate(
-    range: TokenStatsTimeRange,
-    zone: ZoneId,
-): LocalDate = Instant.ofEpochMilli(range.endMs - 1L).atZone(zone).toLocalDate()
-
 internal fun activityRangeForMode(
     mode: TokenActivityViewMode,
     anchorDate: LocalDate,
@@ -20,10 +13,15 @@ internal fun activityRangeForMode(
 ): TokenStatsTimeRange? {
     val startDate = when (mode) {
         TokenActivityViewMode.DAILY -> anchorDate
-        TokenActivityViewMode.WEEKLY -> {
-            // Keep the range aligned with TokenActivityAggregator's Sunday-first weeks.
-            anchorDate.minusDays((anchorDate.dayOfWeek.value % 7).toLong())
-        }
+        // Rolling 7-day window anchored at today: the future has not happened yet,
+        // so the window reaches backwards from the anchor instead of forwards.
+        TokenActivityViewMode.WEEKLY -> anchorDate.minusDays(7L)
+        // Rolling one-month window. minusMonths clamps month-end dates automatically
+        // (e.g. Mar 31 -> Feb 28/29), so no hard-coded month-length rules are needed.
+        TokenActivityViewMode.MONTHLY -> anchorDate.minusMonths(1L)
+        // Rolling one-year window. minusYears clamps leap days automatically
+        // (e.g. Feb 29 -> Feb 28 in a non-leap year).
+        TokenActivityViewMode.YEARLY -> anchorDate.minusYears(1L)
         TokenActivityViewMode.CUMULATIVE -> historyStartDate ?: return null
     }
     if (startDate.isAfter(anchorDate)) return null

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/ActivityDateRangePolicy.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/ActivityDateRangePolicy.kt
@@ -4,7 +4,6 @@ import com.ai.assistance.operit.data.stats.TokenActivityViewMode
 import com.ai.assistance.operit.data.stats.TokenStatsTimeRange
 import com.ai.assistance.operit.data.stats.TokenStatsTimeRanges
 import java.time.LocalDate
-import java.time.YearMonth
 import java.time.ZoneId
 
 internal fun activityRangeForMode(
@@ -14,13 +13,12 @@ internal fun activityRangeForMode(
     zone: ZoneId,
 ): TokenStatsTimeRange? {
     // Each periodic mode covers the most recent complete period, because future
-    // time has not happened yet and cannot be counted. Weekly and monthly mirror
-    // each other: weekly runs from the same weekday last week through yesterday
-    // (exactly seven days); monthly runs from the same day last month through
-    // yesterday, so its length equals the previous month's day count (a 28-day
-    // February yields four week bars, any longer month yields five). Yearly
-    // covers the trailing twelve natural months (this month last year through
-    // last month).
+    // time has not happened yet and cannot be counted. Weekly, monthly and yearly
+    // mirror each other: weekly runs from the same weekday last week through
+    // yesterday (exactly seven days); monthly runs from the same day last month
+    // through yesterday, so its length equals the previous month's day count (a
+    // 28-day February yields four week bars, any longer month yields five);
+    // yearly runs from the same day last year through yesterday.
     val (startDate, inclusiveEndDate) = when (mode) {
         TokenActivityViewMode.DAILY -> anchorDate to anchorDate
         TokenActivityViewMode.WEEKLY -> {
@@ -33,10 +31,10 @@ internal fun activityRangeForMode(
             start to anchorDate.minusDays(1L)
         }
         TokenActivityViewMode.YEARLY -> {
-            val currentMonth = YearMonth.from(anchorDate)
-            val startMonth = currentMonth.minusMonths(12L)
-            val endMonth = currentMonth.minusMonths(1L)
-            startMonth.atDay(1) to endMonth.atEndOfMonth()
+            // Rolling year mirroring weekly/monthly: same day last year through
+            // yesterday. minusYears clamps leap days (e.g. Feb 29 -> Feb 28).
+            val start = anchorDate.minusYears(1L)
+            start to anchorDate.minusDays(1L)
         }
         TokenActivityViewMode.CUMULATIVE -> {
             val start = historyStartDate ?: return null

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/ActivityDateRangePolicy.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/ActivityDateRangePolicy.kt
@@ -14,9 +14,11 @@ internal fun activityRangeForMode(
     zone: ZoneId,
 ): TokenStatsTimeRange? {
     // Each periodic mode covers the most recent complete period, because future
-    // time has not happened yet and cannot be counted. Weekly aligns to the same
-    // weekday as today (e.g. today Saturday -> last Saturday through yesterday,
-    // exactly seven days); monthly covers the previous natural month; yearly
+    // time has not happened yet and cannot be counted. Weekly and monthly mirror
+    // each other: weekly runs from the same weekday last week through yesterday
+    // (exactly seven days); monthly runs from the same day last month through
+    // yesterday, so its length equals the previous month's day count (a 28-day
+    // February yields four week bars, any longer month yields five). Yearly
     // covers the trailing twelve natural months (this month last year through
     // last month).
     val (startDate, inclusiveEndDate) = when (mode) {
@@ -26,8 +28,9 @@ internal fun activityRangeForMode(
             start to anchorDate.minusDays(1L)
         }
         TokenActivityViewMode.MONTHLY -> {
-            val previousMonth = YearMonth.from(anchorDate).minusMonths(1L)
-            previousMonth.atDay(1) to previousMonth.atEndOfMonth()
+            // minusMonths clamps month-end dates (e.g. Mar 31 -> Feb 28/29).
+            val start = anchorDate.minusMonths(1L)
+            start to anchorDate.minusDays(1L)
         }
         TokenActivityViewMode.YEARLY -> {
             val currentMonth = YearMonth.from(anchorDate)

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
@@ -69,11 +69,10 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
- * 活跃记录卡（信息架构重构版，设计规范 §6.5）：
- * - 标题行右侧展示当前连续 / 最长连续胶囊（数据来自 activity.stats）；
- * - 热力图左侧固定星期标签（一~日），与网格同步滚动方向无关；
- * - 热力色阶 = 未激活灰格 + 主色 5 档透明度阶；
- * - 视图模式（每日/每周/累计）由页面顶部三段式选择器驱动，本卡只负责呈现。
+ * 活跃记录区（信息架构重构版，设计规范 §6.5）：
+ * - 主卡按模式展示柱状图/折线图：每日=24 小时柱、每周=7 天柱、每月=周柱、
+ *   每年=月柱、累计=折线；
+ * - 独立的“活跃日历”热力图卡固定在下方，展示最近一年的日历网格，与模式解耦。
  */
 @Composable
 internal fun TokenActivitySection(
@@ -83,34 +82,65 @@ internal fun TokenActivitySection(
     val locale = LocalConfiguration.current.locales[0]
     val stats = state.rangeData?.stats
 
+    Column(verticalArrangement = Arrangement.spacedBy(TokenStatsSpacing.section)) {
+        TokenStatsCard(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.padding(TokenStatsSpacing.card),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                TokenStatsCardTitle(stringResource(R.string.token_activity_title)) {
+                    stats?.let {
+                        TokenStatsPill(
+                            stringResource(R.string.token_activity_current_streak_badge, it.currentStreak)
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        TokenStatsPill(
+                            stringResource(R.string.token_activity_longest_streak_badge, it.longestStreak)
+                        )
+                    }
+                }
+                Crossfade(
+                    targetState = state.viewMode,
+                    animationSpec = tween(150),
+                    label = "token_activity_chart",
+                ) { mode ->
+                    TokenActivityVisualization(
+                        state = state.copy(viewMode = mode),
+                        locale = locale,
+                        tokenDisplayUnit = tokenDisplayUnit,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+        state.heatmap?.let { heatmap ->
+            TokenActivityHeatmapCard(
+                data = heatmap,
+                locale = locale,
+                tokenDisplayUnit = tokenDisplayUnit,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TokenActivityHeatmapCard(
+    data: com.ai.assistance.operit.data.stats.TokenActivityRangeData,
+    locale: Locale,
+    tokenDisplayUnit: TokenStatsDisplayUnit,
+) {
     TokenStatsCard(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.padding(TokenStatsSpacing.card),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            TokenStatsCardTitle(stringResource(R.string.token_activity_title)) {
-                stats?.let {
-                    TokenStatsPill(
-                        stringResource(R.string.token_activity_current_streak_badge, it.currentStreak)
-                    )
-                    Spacer(Modifier.width(6.dp))
-                    TokenStatsPill(
-                        stringResource(R.string.token_activity_longest_streak_badge, it.longestStreak)
-                    )
-                }
-            }
-            Crossfade(
-                targetState = state.viewMode,
-                animationSpec = tween(150),
-                label = "token_activity_heatmap",
-            ) { mode ->
-                TokenActivityVisualization(
-                    state = state.copy(viewMode = mode),
-                    locale = locale,
-                    tokenDisplayUnit = tokenDisplayUnit,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
+            TokenStatsCardTitle(stringResource(R.string.token_activity_calendar))
+            TokenActivityDailyHeatmap(
+                data = data,
+                locale = locale,
+                tokenDisplayUnit = tokenDisplayUnit,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }
@@ -129,24 +159,21 @@ private fun TokenActivityVisualization(
         return
     }
     when (state.viewMode) {
-        TokenActivityViewMode.DAILY -> TokenActivityDailyHeatmap(state, locale, tokenDisplayUnit, modifier)
-        TokenActivityViewMode.WEEKLY -> TokenActivityWeeklyChart(state, locale, tokenDisplayUnit, modifier)
-        TokenActivityViewMode.MONTHLY -> TokenActivityMonthlyChart(state, locale, tokenDisplayUnit, modifier)
-        TokenActivityViewMode.YEARLY -> TokenActivityYearlyChart(state, locale, tokenDisplayUnit, modifier)
+        TokenActivityViewMode.DAILY -> TokenActivityHourlyChart(state, locale, tokenDisplayUnit, modifier)
+        TokenActivityViewMode.WEEKLY -> TokenActivityDailyBarChart(state, locale, tokenDisplayUnit, modifier)
+        TokenActivityViewMode.MONTHLY -> TokenActivityWeeklyChart(state, locale, tokenDisplayUnit, modifier)
+        TokenActivityViewMode.YEARLY -> TokenActivityMonthlyChart(state, locale, tokenDisplayUnit, modifier)
         TokenActivityViewMode.CUMULATIVE -> TokenActivityCumulativeChart(state, locale, tokenDisplayUnit, modifier)
     }
 }
 
 @Composable
 private fun TokenActivityDailyHeatmap(
-    state: TokenActivityUiState,
+    data: com.ai.assistance.operit.data.stats.TokenActivityRangeData,
     locale: Locale,
     tokenDisplayUnit: TokenStatsDisplayUnit,
     modifier: Modifier = Modifier,
 ) {
-    val data = state.rangeData
-    checkNotNull(data)
-
     val days = data.daily
     val firstDate = days.firstOrNull()?.date
     // 网格和左侧标签都按周一到周日排列；此前沿用周日首列偏移，导致标签与日期错行。
@@ -193,16 +220,16 @@ private fun TokenActivityDailyHeatmap(
             }
         }
         val width = (block + gap) * columns - gap
-        var selectedDay by remember(days, state.viewMode) {
+        var selectedDay by remember(days, data) {
             mutableStateOf<TokenActivityDay?>(null)
         }
-        var indicatorDay by remember(grid, state.viewMode) {
+        var indicatorDay by remember(grid, data) {
             mutableStateOf<TokenActivityDay?>(null)
         }
-        var indicatorColumn by remember(grid, state.viewMode) {
+        var indicatorColumn by remember(grid, data) {
             mutableIntStateOf(-1)
         }
-        var indicatorRow by remember(grid, state.viewMode) {
+        var indicatorRow by remember(grid, data) {
             mutableIntStateOf(-1)
         }
         val monthLabels = remember(grid, locale) {
@@ -233,7 +260,7 @@ private fun TokenActivityDailyHeatmap(
             }
         }
 
-        LaunchedEffect(columns, days, state.viewMode) {
+        LaunchedEffect(columns, days, data) {
             snapshotFlow { scroll.maxValue }.first { it > 0 }
             scroll.scrollTo(scroll.maxValue)
         }
@@ -477,6 +504,64 @@ private fun TokenActivityDailyHeatmap(
         }
     }
 }
+}
+
+@Composable
+private fun TokenActivityHourlyChart(
+    state: TokenActivityUiState,
+    locale: Locale,
+    tokenDisplayUnit: TokenStatsDisplayUnit,
+    modifier: Modifier = Modifier,
+) {
+    val data = checkNotNull(state.rangeData)
+    val points = data.hourly.map { entry ->
+        TokenActivitySeriesPoint(
+            startDate = entry.startDate,
+            endDate = entry.startDate,
+            tokens = entry.tokens,
+            hour = entry.hour,
+        )
+    }
+    TokenActivityTimeSeriesChart(
+        points = points,
+        style = TokenActivitySeriesStyle.BAR,
+        locale = locale,
+        modifier = modifier,
+        tapHint = stringResource(R.string.token_activity_chart_tap_hint),
+    ) { point ->
+        stringResource(
+            R.string.token_activity_hour_detail,
+            point.startDate.format(localizedDateFormatter(locale)),
+            point.hour ?: 0,
+            formatTokenCount(point.tokens, tokenDisplayUnit),
+        )
+    }
+}
+
+@Composable
+private fun TokenActivityDailyBarChart(
+    state: TokenActivityUiState,
+    locale: Locale,
+    tokenDisplayUnit: TokenStatsDisplayUnit,
+    modifier: Modifier = Modifier,
+) {
+    val data = checkNotNull(state.rangeData)
+    val points = data.daily.map { day ->
+        TokenActivitySeriesPoint(day.date, day.date, day.tokens)
+    }
+    TokenActivityTimeSeriesChart(
+        points = points,
+        style = TokenActivitySeriesStyle.BAR,
+        locale = locale,
+        modifier = modifier,
+        tapHint = stringResource(R.string.token_activity_chart_tap_hint),
+    ) { point ->
+        stringResource(
+            R.string.token_activity_day_detail,
+            point.startDate.format(localizedDateFormatter(locale)),
+            formatTokenCount(point.tokens, tokenDisplayUnit),
+        )
+    }
 }
 
 @Composable
@@ -742,6 +827,7 @@ private data class TokenActivitySeriesPoint(
     val startDate: java.time.LocalDate,
     val endDate: java.time.LocalDate,
     val tokens: Long,
+    val hour: Int? = null,
 )
 
 private enum class TokenActivitySeriesStyle { BAR, LINE }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
@@ -703,14 +703,6 @@ private fun TokenActivityTimeSeriesChart(
 ) {
     val density = LocalDensity.current
     val scroll = rememberScrollState()
-    val pointWidth = if (style == TokenActivitySeriesStyle.BAR) 18.dp else 14.dp
-    val chartWidth = (pointWidth * points.size).coerceAtLeast(280.dp)
-    val plotHeight = 124.dp
-    val labelHeight = 24.dp
-    val canvasHeight = plotHeight + labelHeight
-    val stepPx = with(density) { pointWidth.toPx() }
-    val plotHeightPx = with(density) { plotHeight.toPx() }
-    val maxTokens = points.maxOfOrNull(TokenActivitySeriesPoint::tokens)?.coerceAtLeast(1L) ?: 1L
     val palette = LocalTokenStatsColors.current
     val primary = palette.chartAccent
     val grid = palette.chartGrid
@@ -722,13 +714,39 @@ private fun TokenActivityTimeSeriesChart(
             isAntiAlias = true
         }
     }
-    val monthLabels = remember(points, locale) {
-        val formatter = DateTimeFormatter.ofPattern("MMM", locale)
+    val monthFormatter = remember(locale) { DateTimeFormatter.ofPattern("MMM", locale) }
+    val monthLabelTexts = remember(points, locale) {
+        points.map { monthFormatter.format(it.startDate) }.distinct()
+    }
+    // When month labels are dense (the twelve-month yearly chart is the densest
+    // case), widen the bar spacing so every label stays readable without any
+    // label being skipped or overlapping. Sparse-label charts keep the base width.
+    val pointWidth = if (style == TokenActivitySeriesStyle.BAR) {
+        val base = 18.dp
+        if (monthLabelTexts.size >= 4) {
+            with(density) {
+                val widestPx = monthLabelTexts.maxOf { labelPaint.measureText(it) }
+                maxOf(base, ((widestPx / density.density) + 12f).dp)
+            }
+        } else {
+            base
+        }
+    } else {
+        14.dp
+    }
+    val chartWidth = (pointWidth * points.size).coerceAtLeast(280.dp)
+    val plotHeight = 124.dp
+    val labelHeight = 24.dp
+    val canvasHeight = plotHeight + labelHeight
+    val stepPx = with(density) { pointWidth.toPx() }
+    val plotHeightPx = with(density) { plotHeight.toPx() }
+    val maxTokens = points.maxOfOrNull(TokenActivitySeriesPoint::tokens)?.coerceAtLeast(1L) ?: 1L
+    val monthLabels = remember(points, monthFormatter) {
         buildList {
             var previousMonth = -1
             points.forEachIndexed { index, point ->
                 if (index == 0 || point.startDate.monthValue != previousMonth) {
-                    add(TokenActivityMonthLabel(index, formatter.format(point.startDate)))
+                    add(TokenActivityMonthLabel(index, monthFormatter.format(point.startDate)))
                     previousMonth = point.startDate.monthValue
                 }
             }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
@@ -131,6 +131,8 @@ private fun TokenActivityVisualization(
     when (state.viewMode) {
         TokenActivityViewMode.DAILY -> TokenActivityDailyHeatmap(state, locale, tokenDisplayUnit, modifier)
         TokenActivityViewMode.WEEKLY -> TokenActivityWeeklyChart(state, locale, tokenDisplayUnit, modifier)
+        TokenActivityViewMode.MONTHLY -> TokenActivityMonthlyChart(state, locale, tokenDisplayUnit, modifier)
+        TokenActivityViewMode.YEARLY -> TokenActivityYearlyChart(state, locale, tokenDisplayUnit, modifier)
         TokenActivityViewMode.CUMULATIVE -> TokenActivityCumulativeChart(state, locale, tokenDisplayUnit, modifier)
     }
 }
@@ -485,10 +487,13 @@ private fun TokenActivityWeeklyChart(
     modifier: Modifier = Modifier,
 ) {
     val data = checkNotNull(state.rangeData)
+    val rangeEnd = data.daily.lastOrNull()?.date
     val points = data.weekly.map { week ->
         TokenActivitySeriesPoint(
             startDate = week.startDate,
-            endDate = week.startDate.plusDays(6),
+            endDate = rangeEnd
+                ?.let { minOf(week.startDate.plusDays(6), it) }
+                ?: week.startDate.plusDays(6),
             tokens = week.tokens,
         )
     }
@@ -501,6 +506,74 @@ private fun TokenActivityWeeklyChart(
     ) { point ->
         stringResource(
             R.string.token_activity_week_detail,
+            point.startDate.format(localizedDateFormatter(locale)),
+            point.endDate.format(localizedDateFormatter(locale)),
+            formatTokenCount(point.tokens, tokenDisplayUnit),
+        )
+    }
+}
+
+@Composable
+private fun TokenActivityMonthlyChart(
+    state: TokenActivityUiState,
+    locale: Locale,
+    tokenDisplayUnit: TokenStatsDisplayUnit,
+    modifier: Modifier = Modifier,
+) {
+    val data = checkNotNull(state.rangeData)
+    val rangeEnd = data.daily.lastOrNull()?.date
+    val points = data.monthly.map { month ->
+        TokenActivitySeriesPoint(
+            startDate = month.startDate,
+            endDate = rangeEnd
+                ?.let { minOf(month.startDate.withDayOfMonth(month.startDate.lengthOfMonth()), it) }
+                ?: month.startDate.withDayOfMonth(month.startDate.lengthOfMonth()),
+            tokens = month.tokens,
+        )
+    }
+    TokenActivityTimeSeriesChart(
+        points = points,
+        style = TokenActivitySeriesStyle.BAR,
+        locale = locale,
+        modifier = modifier,
+        tapHint = stringResource(R.string.token_activity_chart_tap_hint),
+    ) { point ->
+        stringResource(
+            R.string.token_activity_month_detail,
+            point.startDate.format(localizedDateFormatter(locale)),
+            point.endDate.format(localizedDateFormatter(locale)),
+            formatTokenCount(point.tokens, tokenDisplayUnit),
+        )
+    }
+}
+
+@Composable
+private fun TokenActivityYearlyChart(
+    state: TokenActivityUiState,
+    locale: Locale,
+    tokenDisplayUnit: TokenStatsDisplayUnit,
+    modifier: Modifier = Modifier,
+) {
+    val data = checkNotNull(state.rangeData)
+    val rangeEnd = data.daily.lastOrNull()?.date
+    val points = data.yearly.map { year ->
+        TokenActivitySeriesPoint(
+            startDate = year.startDate,
+            endDate = rangeEnd
+                ?.let { minOf(year.startDate.withDayOfYear(year.startDate.lengthOfYear()), it) }
+                ?: year.startDate.withDayOfYear(year.startDate.lengthOfYear()),
+            tokens = year.tokens,
+        )
+    }
+    TokenActivityTimeSeriesChart(
+        points = points,
+        style = TokenActivitySeriesStyle.BAR,
+        locale = locale,
+        modifier = modifier,
+        tapHint = stringResource(R.string.token_activity_chart_tap_hint),
+    ) { point ->
+        stringResource(
+            R.string.token_activity_year_detail,
             point.startDate.format(localizedDateFormatter(locale)),
             point.endDate.format(localizedDateFormatter(locale)),
             formatTokenCount(point.tokens, tokenDisplayUnit),

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
@@ -723,16 +723,19 @@ private fun TokenActivityTimeSeriesChart(
     }
     // When month labels are dense (the twelve-month yearly chart is the densest
     // case), widen the bar spacing so every label stays readable without any
-    // label being skipped or overlapping. Sparse-label charts keep the base width.
+    // label being skipped or overlapping. Sparse bars (weekly 7 / monthly 4-5)
+    // get a fixed wider spacing so the bars read as thick blocks instead of thin
+    // needles. Dense bars (daily 24) keep the base width.
     val pointWidth = if (style == TokenActivitySeriesStyle.BAR) {
-        val base = 18.dp
-        if (monthLabelTexts.size >= 4) {
-            with(density) {
-                val widestPx = monthLabelTexts.maxOf { labelPaint.measureText(it) }
-                maxOf(base, ((widestPx / density.density) + 12f).dp)
+        when {
+            monthLabelTexts.size >= 4 -> {
+                with(density) {
+                    val widestPx = monthLabelTexts.maxOf { labelPaint.measureText(it) }
+                    maxOf(18.dp, ((widestPx / density.density) + 12f).dp)
+                }
             }
-        } else {
-            base
+            points.size <= 7 -> 30.dp
+            else -> 18.dp
         }
     } else {
         14.dp

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenActivitySection.kt
@@ -640,10 +640,13 @@ private fun TokenActivityYearlyChart(
     modifier: Modifier = Modifier,
 ) {
     val data = checkNotNull(state.rangeData)
+    val rangeStart = data.daily.firstOrNull()?.date
     val rangeEnd = data.daily.lastOrNull()?.date
     val points = data.yearly.map { year ->
         TokenActivitySeriesPoint(
-            startDate = year.startDate,
+            startDate = rangeStart
+                ?.let { maxOf(year.startDate, it) }
+                ?: year.startDate,
             endDate = rangeEnd
                 ?.let { minOf(year.startDate.withDayOfYear(year.startDate.lengthOfYear()), it) }
                 ?: year.startDate.withDayOfYear(year.startDate.lengthOfYear()),

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsComponents.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsComponents.kt
@@ -233,6 +233,8 @@ internal fun TokenStatsSegmentedControl(
                     when (mode) {
                         TokenActivityViewMode.DAILY -> R.string.token_activity_daily
                         TokenActivityViewMode.WEEKLY -> R.string.token_activity_weekly
+                        TokenActivityViewMode.MONTHLY -> R.string.token_activity_monthly
+                        TokenActivityViewMode.YEARLY -> R.string.token_activity_yearly
                         TokenActivityViewMode.CUMULATIVE -> R.string.token_activity_cumulative
                     }
                 ),
@@ -246,7 +248,7 @@ internal fun TokenStatsSegmentedControl(
                         if (isSelected) colors.selectedSegmentContainer else Color.Transparent,
                     )
                     .clickable { onSelect(mode) }
-                    .padding(horizontal = 14.dp, vertical = 6.dp),
+                    .padding(horizontal = 10.dp, vertical = 6.dp),
             )
         }
     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenUsageStatisticsViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenUsageStatisticsViewModel.kt
@@ -104,8 +104,10 @@ class TokenUsageStatisticsViewModel(
 
     fun setActivityViewMode(mode: TokenActivityViewMode) {
         val snapshot = _state.value
-        val currentRange = snapshot.currentRange ?: defaultDateRange(nowMs(), zone)
-        val anchorDate = activityRangeAnchorDate(currentRange, zone)
+        // Tapping a mode re-anchors the window to today: daily spans today, weekly
+        // rolls back seven days, monthly/yearly roll back one calendar unit, and
+        // cumulative ends today while keeping the first recorded date.
+        val anchorDate = java.time.Instant.ofEpochMilli(nowMs()).atZone(zone).toLocalDate()
         val providerModels = providerModelsFor(snapshot)
         modeRangeJob?.cancel()
         modeRangeJob = viewModelScope.launch(dispatcher) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenUsageStatisticsViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/tokenstats/TokenUsageStatisticsViewModel.kt
@@ -42,6 +42,7 @@ data class TokenActivityUiState(
     val loading: Boolean = true,
     val viewMode: TokenActivityViewMode = TokenActivityViewMode.DAILY,
     val rangeData: TokenActivityRangeData? = null,
+    val heatmap: TokenActivityRangeData? = null,
 )
 
 data class TokenStatsUiState(
@@ -214,6 +215,18 @@ class TokenUsageStatisticsViewModel(
                     val activityDeferred = async(Dispatchers.IO) {
                         TokenStatsQueryService.activitySnapshot(appContext, range, rangeParams, zone)
                     }
+                    val heatmapDeferred = async(Dispatchers.IO) {
+                        runCatching {
+                            val today = java.time.Instant.ofEpochMilli(nowMs()).atZone(zone).toLocalDate()
+                            val heatmapRange = TokenStatsTimeRanges.customRange(
+                                today.minusDays(364L).atStartOfDay(zone).toInstant().toEpochMilli(),
+                                today.plusDays(1L).atStartOfDay(zone).toInstant().toEpochMilli(),
+                            )
+                            val snapshot =
+                                TokenStatsQueryService.activitySnapshot(appContext, heatmapRange, rangeParams, zone)
+                            TokenActivityAggregator.rangeData(snapshot, heatmapRange)
+                        }.getOrNull()
+                    }
                     val rangeData = rangeDeferred.await()
                     val configurationIds =
                         rangeData
@@ -238,6 +251,7 @@ class TokenUsageStatisticsViewModel(
                         prices = pricesDeferred.await(),
                         configurationNames = configurationNamesDeferred.await(),
                         activity = TokenActivityAggregator.rangeData(activityDeferred.await(), range),
+                        heatmap = heatmapDeferred.await(),
                     )
                 }
 
@@ -260,7 +274,11 @@ class TokenUsageStatisticsViewModel(
                         knownModelNames = knownModelNames.toMap(),
                         configurationNames = result.configurationNames,
                         priceSettings = result.prices,
-                        activity = it.activity.copy(loading = false, rangeData = result.activity),
+                        activity = it.activity.copy(
+                            loading = false,
+                            rangeData = result.activity,
+                            heatmap = result.heatmap,
+                        ),
                         refreshVersion = it.refreshVersion + 1L,
                     )
                 }
@@ -426,6 +444,7 @@ private data class QueryLoadResult(
     val prices: List<TokenStatsPriceSetting>,
     val configurationNames: Map<String, String>,
     val activity: TokenActivityRangeData,
+    val heatmap: TokenActivityRangeData?,
 )
 
 private fun defaultDateRange(nowMs: Long, zone: ZoneId): TokenStatsTimeRange {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8260,6 +8260,7 @@
     <string name="token_activity_monthly">Monthly</string>
     <string name="token_activity_yearly">Yearly</string>
     <string name="token_activity_cumulative">Cumulative</string>
+    <string name="token_activity_calendar">Activity calendar</string>
     <string name="token_activity_title">Activity</string>
     <string name="token_activity_current_streak_badge">%1$d-day streak</string>
     <string name="token_activity_longest_streak_badge">Longest %1$d days</string>
@@ -8270,6 +8271,7 @@
     <string name="token_activity_longest_streak">Longest streak</string>
     <string name="token_activity_days">%1$d days</string>
     <string name="token_activity_day_detail">%1$s used %2$s tokens</string>
+    <string name="token_activity_hour_detail">%1$s %2$d:00 used %3$s tokens</string>
     <string name="token_activity_week_detail">%1$s - %2$s used %3$s tokens</string>
     <string name="token_activity_month_detail">%1$s - %2$s used %3$s tokens</string>
     <string name="token_activity_year_detail">%1$s - %2$s used %3$s tokens</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8257,6 +8257,8 @@
     <string name="permission_review_circuit_what_to_do_body">Review the audit record and check which operation was denied and why. If it is still needed, return to the main chat and clearly state the exact operation, target, and scope before asking the AI to try again. Do not authorize an operation you do not understand.</string>
     <string name="token_activity_daily">Daily</string>
     <string name="token_activity_weekly">Weekly</string>
+    <string name="token_activity_monthly">Monthly</string>
+    <string name="token_activity_yearly">Yearly</string>
     <string name="token_activity_cumulative">Cumulative</string>
     <string name="token_activity_title">Activity</string>
     <string name="token_activity_current_streak_badge">%1$d-day streak</string>
@@ -8269,6 +8271,8 @@
     <string name="token_activity_days">%1$d days</string>
     <string name="token_activity_day_detail">%1$s used %2$s tokens</string>
     <string name="token_activity_week_detail">%1$s - %2$s used %3$s tokens</string>
+    <string name="token_activity_month_detail">%1$s - %2$s used %3$s tokens</string>
+    <string name="token_activity_year_detail">%1$s - %2$s used %3$s tokens</string>
     <string name="token_activity_cumulative_detail">%2$s tokens through %1$s</string>
     <string name="token_activity_tap_hint">Tap a cell to view details</string>
     <string name="token_activity_less">Less</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7519,6 +7519,8 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="token_activity_days">%1$d días</string>
     <string name="token_activity_day_detail">%1$s usó %2$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s usó %3$s Token</string>
+    <string name="token_activity_month_detail">%1$s - %2$s usó %3$s Token</string>
+    <string name="token_activity_year_detail">%1$s - %2$s usó %3$s Token</string>
     <string name="token_activity_cumulative_detail">Hasta %1$s, uso acumulado de %2$s Token</string>
     <string name="token_activity_tap_hint">Toca un cuadrado para ver datos detallados</string>
     <string name="token_activity_less">Menos</string>
@@ -7694,6 +7696,8 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="permission_review_circuit_what_to_do_body">Revisa primero el registro de revisión para confirmar las operaciones denegadas y los motivos. Si aún necesitas ejecutarlas, vuelve al chat principal, especifica claramente la operación, el objetivo y el alcance, y luego haz que la IA lo reintente; no autorices operaciones que no entiendas.</string>
     <string name="token_activity_daily">Diario</string>
     <string name="token_activity_weekly">Semanal</string>
+    <string name="token_activity_monthly">Mensual</string>
+    <string name="token_activity_yearly">Anual</string>
     <string name="token_activity_cumulative">Acumulado</string>
     <string name="token_activity_title">Registro de actividad</string>
     <string name="token_activity_current_streak_badge">Racha actual: %1$d días</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7518,6 +7518,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="token_activity_longest_streak">Racha más larga</string>
     <string name="token_activity_days">%1$d días</string>
     <string name="token_activity_day_detail">%1$s usó %2$s Token</string>
+    <string name="token_activity_hour_detail">%1$s %2$d:00 usó %3$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s usó %3$s Token</string>
     <string name="token_activity_month_detail">%1$s - %2$s usó %3$s Token</string>
     <string name="token_activity_year_detail">%1$s - %2$s usó %3$s Token</string>
@@ -7699,6 +7700,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="token_activity_monthly">Mensual</string>
     <string name="token_activity_yearly">Anual</string>
     <string name="token_activity_cumulative">Acumulado</string>
+    <string name="token_activity_calendar">Calendario de actividad</string>
     <string name="token_activity_title">Registro de actividad</string>
     <string name="token_activity_current_streak_badge">Racha actual: %1$d días</string>
     <string name="token_activity_longest_streak_badge">Racha más larga: %1$d días</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7450,6 +7450,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="token_activity_longest_streak">Lari terpanjang</string>
     <string name="token_activity_days">%1$d hari</string>
     <string name="token_activity_day_detail">%1$s menggunakan %2$s Token</string>
+    <string name="token_activity_hour_detail">%1$s %2$d:00 menggunakan %3$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s menggunakan %3$s Token</string>
     <string name="token_activity_month_detail">%1$s - %2$s menggunakan %3$s Token</string>
     <string name="token_activity_year_detail">%1$s - %2$s menggunakan %3$s Token</string>
@@ -7631,6 +7632,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="token_activity_monthly">Bulanan</string>
     <string name="token_activity_yearly">Tahunan</string>
     <string name="token_activity_cumulative">Kumulatif</string>
+    <string name="token_activity_calendar">Kalender aktivitas</string>
     <string name="token_activity_title">Catatan aktivitas</string>
     <string name="token_activity_current_streak_badge">Streak saat ini %1$d hari</string>
     <string name="token_activity_longest_streak_badge">Streak terpanjang %1$d hari</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7451,6 +7451,8 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="token_activity_days">%1$d hari</string>
     <string name="token_activity_day_detail">%1$s menggunakan %2$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s menggunakan %3$s Token</string>
+    <string name="token_activity_month_detail">%1$s - %2$s menggunakan %3$s Token</string>
+    <string name="token_activity_year_detail">%1$s - %2$s menggunakan %3$s Token</string>
     <string name="token_activity_cumulative_detail">Hingga %1$s total penggunaan %2$s Token</string>
     <string name="token_activity_tap_hint">Ketuk kotak untuk melihat data detail</string>
     <string name="token_activity_less">Sedikit</string>
@@ -7626,6 +7628,8 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="permission_review_circuit_what_to_do_body">Periksa catatan peninjauan terlebih dahulu, konfirmasi operasi yang ditolak dan alasannya. Jika masih perlu dieksekusi, kembali ke percakapan utama, jelaskan secara spesifik operasi, tujuan, dan cakupan, lalu minta AI mencoba lagi; jangan otorisasi operasi yang tidak Anda pahami.</string>
     <string name="token_activity_daily">Harian</string>
     <string name="token_activity_weekly">Mingguan</string>
+    <string name="token_activity_monthly">Bulanan</string>
+    <string name="token_activity_yearly">Tahunan</string>
     <string name="token_activity_cumulative">Kumulatif</string>
     <string name="token_activity_title">Catatan aktivitas</string>
     <string name="token_activity_current_streak_badge">Streak saat ini %1$d hari</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7298,6 +7298,8 @@
     <string name="token_activity_days">%1$d일</string>
     <string name="token_activity_day_detail">%1$s님이 %2$s Token을 사용했습니다</string>
     <string name="token_activity_week_detail">%1$s - %2$s님이 %3$s Token을 사용했습니다</string>
+    <string name="token_activity_month_detail">%1$s - %2$s님이 %3$s Token을 사용했습니다</string>
+    <string name="token_activity_year_detail">%1$s - %2$s님이 %3$s Token을 사용했습니다</string>
     <string name="token_activity_cumulative_detail">%1$s까지 누적 %2$s Token 사용</string>
     <string name="token_activity_tap_hint">셀을 탭하여 상세 데이터 보기</string>
     <string name="token_activity_less">적음</string>
@@ -7473,6 +7475,8 @@
     <string name="permission_review_circuit_what_to_do_body">먼저 검토 기록을 확인하여 거부된 작업과 이유를 확인하세요. 여전히 실행해야 한다면 기본 대화로 돌아가 구체적인 작업, 목표 및 범위를 명확히 설명한 후 AI가 다시 시도하도록 하세요. 이해하지 못하는 작업은 승인하지 마세요.</string>
     <string name="token_activity_daily">일일</string>
     <string name="token_activity_weekly">주간</string>
+    <string name="token_activity_monthly">월간</string>
+    <string name="token_activity_yearly">연간</string>
     <string name="token_activity_cumulative">누적</string>
     <string name="token_activity_title">활동 기록</string>
     <string name="token_activity_current_streak_badge">현재 연속 %1$d일</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7297,6 +7297,7 @@
     <string name="token_activity_longest_streak">최장 연속</string>
     <string name="token_activity_days">%1$d일</string>
     <string name="token_activity_day_detail">%1$s님이 %2$s Token을 사용했습니다</string>
+    <string name="token_activity_hour_detail">%1$s %2$d:00에 %3$s Token을 사용했습니다</string>
     <string name="token_activity_week_detail">%1$s - %2$s님이 %3$s Token을 사용했습니다</string>
     <string name="token_activity_month_detail">%1$s - %2$s님이 %3$s Token을 사용했습니다</string>
     <string name="token_activity_year_detail">%1$s - %2$s님이 %3$s Token을 사용했습니다</string>
@@ -7478,6 +7479,7 @@
     <string name="token_activity_monthly">월간</string>
     <string name="token_activity_yearly">연간</string>
     <string name="token_activity_cumulative">누적</string>
+    <string name="token_activity_calendar">활동 캘린더</string>
     <string name="token_activity_title">활동 기록</string>
     <string name="token_activity_current_streak_badge">현재 연속 %1$d일</string>
     <string name="token_activity_longest_streak_badge">최장 연속 %1$d일</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7447,6 +7447,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="token_activity_longest_streak">Rentetan terpanjang</string>
     <string name="token_activity_days">%1$d hari</string>
     <string name="token_activity_day_detail">%1$s menggunakan %2$s Token</string>
+    <string name="token_activity_hour_detail">%1$s %2$d:00 menggunakan %3$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s menggunakan %3$s Token</string>
     <string name="token_activity_month_detail">%1$s - %2$s menggunakan %3$s Token</string>
     <string name="token_activity_year_detail">%1$s - %2$s menggunakan %3$s Token</string>
@@ -7628,6 +7629,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="token_activity_monthly">Bulanan</string>
     <string name="token_activity_yearly">Tahunan</string>
     <string name="token_activity_cumulative">Kumulatif</string>
+    <string name="token_activity_calendar">Kalendar aktiviti</string>
     <string name="token_activity_title">Rekod Aktiviti</string>
     <string name="token_activity_current_streak_badge">Rentetan semasa %1$d hari</string>
     <string name="token_activity_longest_streak_badge">Rentetan terpanjang %1$d hari</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7448,6 +7448,8 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="token_activity_days">%1$d hari</string>
     <string name="token_activity_day_detail">%1$s menggunakan %2$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s menggunakan %3$s Token</string>
+    <string name="token_activity_month_detail">%1$s - %2$s menggunakan %3$s Token</string>
+    <string name="token_activity_year_detail">%1$s - %2$s menggunakan %3$s Token</string>
     <string name="token_activity_cumulative_detail">Sehingga %1$s, jumlah penggunaan %2$s Token</string>
     <string name="token_activity_tap_hint">Klik petak untuk melihat data terperinci</string>
     <string name="token_activity_less">Kurang</string>
@@ -7623,6 +7625,8 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="permission_review_circuit_what_to_do_body">Semak dahulu rekod semakan untuk mengesahkan operasi yang ditolak dan sebabnya. Jika masih perlu dilaksanakan, kembali ke perbualan utama, nyatakan dengan jelas operasi, matlamat dan skop, kemudian minta AI mencuba semula; jangan benarkan operasi yang anda tidak faham.</string>
     <string name="token_activity_daily">Harian</string>
     <string name="token_activity_weekly">Mingguan</string>
+    <string name="token_activity_monthly">Bulanan</string>
+    <string name="token_activity_yearly">Tahunan</string>
     <string name="token_activity_cumulative">Kumulatif</string>
     <string name="token_activity_title">Rekod Aktiviti</string>
     <string name="token_activity_current_streak_badge">Rentetan semasa %1$d hari</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7288,6 +7288,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="token_activity_longest_streak">Maior sequência</string>
     <string name="token_activity_days">%1$d dias</string>
     <string name="token_activity_day_detail">%1$s usou %2$s Token</string>
+    <string name="token_activity_hour_detail">%1$s %2$d:00 usou %3$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s usou %3$s Token</string>
     <string name="token_activity_month_detail">%1$s - %2$s usou %3$s Token</string>
     <string name="token_activity_year_detail">%1$s - %2$s usou %3$s Token</string>
@@ -7469,6 +7470,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="token_activity_monthly">Mensal</string>
     <string name="token_activity_yearly">Anual</string>
     <string name="token_activity_cumulative">Acumulado</string>
+    <string name="token_activity_calendar">Calendário de atividade</string>
     <string name="token_activity_title">Registro de atividade</string>
     <string name="token_activity_current_streak_badge">Sequência atual: %1$d dias</string>
     <string name="token_activity_longest_streak_badge">Maior sequência: %1$d dias</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7289,6 +7289,8 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="token_activity_days">%1$d dias</string>
     <string name="token_activity_day_detail">%1$s usou %2$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s usou %3$s Token</string>
+    <string name="token_activity_month_detail">%1$s - %2$s usou %3$s Token</string>
+    <string name="token_activity_year_detail">%1$s - %2$s usou %3$s Token</string>
     <string name="token_activity_cumulative_detail">Até %1$s, uso acumulado de %2$s Token</string>
     <string name="token_activity_tap_hint">Toque no quadrado para ver dados detalhados</string>
     <string name="token_activity_less">Menos</string>
@@ -7464,6 +7466,8 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="permission_review_circuit_what_to_do_body">Primeiro, revise os registros de auditoria para confirmar as operações recusadas e os motivos. Se ainda precisar executar, volte ao chat principal, descreva claramente a operação específica, o objetivo e o escopo e peça ao IA para tentar novamente; não autorize operações que você não entende.</string>
     <string name="token_activity_daily">Diário</string>
     <string name="token_activity_weekly">Semanal</string>
+    <string name="token_activity_monthly">Mensal</string>
+    <string name="token_activity_yearly">Anual</string>
     <string name="token_activity_cumulative">Acumulado</string>
     <string name="token_activity_title">Registro de atividade</string>
     <string name="token_activity_current_streak_badge">Sequência atual: %1$d dias</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -8046,6 +8046,8 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="token_activity_days">%1$d zile</string>
     <string name="token_activity_day_detail">%1$s a folosit %2$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s a folosit %3$s Token</string>
+    <string name="token_activity_month_detail">%1$s - %2$s a folosit %3$s Token</string>
+    <string name="token_activity_year_detail">%1$s - %2$s a folosit %3$s Token</string>
     <string name="token_activity_cumulative_detail">Până la %1$s, total utilizat %2$s Token</string>
     <string name="token_activity_tap_hint">Atingeți un pătrat pentru a vedea datele detaliate</string>
     <string name="token_activity_less">Mai puțin</string>
@@ -8221,6 +8223,8 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="permission_review_circuit_what_to_do_body">Verificați mai întâi înregistrările de revizuire pentru a confirma operațiunile refuzate și motivele. Dacă tot trebuie să le executați, reveniți la dialogul principal, specificați clar operațiunea, scopul și domeniul, apoi lăsați AI-ul să reîncerce; nu autorizați operațiuni pe care nu le înțelegeți.</string>
     <string name="token_activity_daily">Zilnic</string>
     <string name="token_activity_weekly">Săptămânal</string>
+    <string name="token_activity_monthly">Lunar</string>
+    <string name="token_activity_yearly">Anual</string>
     <string name="token_activity_cumulative">Cumulativ</string>
     <string name="token_activity_title">Înregistrări de activitate</string>
     <string name="token_activity_current_streak_badge">Curent: %1$d zile consecutive</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -8045,6 +8045,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="token_activity_longest_streak">Cea mai lungă serie</string>
     <string name="token_activity_days">%1$d zile</string>
     <string name="token_activity_day_detail">%1$s a folosit %2$s Token</string>
+    <string name="token_activity_hour_detail">%1$s %2$d:00 a folosit %3$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s a folosit %3$s Token</string>
     <string name="token_activity_month_detail">%1$s - %2$s a folosit %3$s Token</string>
     <string name="token_activity_year_detail">%1$s - %2$s a folosit %3$s Token</string>
@@ -8226,6 +8227,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="token_activity_monthly">Lunar</string>
     <string name="token_activity_yearly">Anual</string>
     <string name="token_activity_cumulative">Cumulativ</string>
+    <string name="token_activity_calendar">Calendar de activitate</string>
     <string name="token_activity_title">Înregistrări de activitate</string>
     <string name="token_activity_current_streak_badge">Curent: %1$d zile consecutive</string>
     <string name="token_activity_longest_streak_badge">Cel mai lung: %1$d zile consecutive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8297,6 +8297,7 @@
     <string name="token_activity_monthly">每月</string>
     <string name="token_activity_yearly">每年</string>
     <string name="token_activity_cumulative">累计</string>
+    <string name="token_activity_calendar">活跃日历</string>
     <string name="token_activity_title">活跃记录</string>
     <string name="token_activity_current_streak_badge">当前连续 %1$d 天</string>
     <string name="token_activity_longest_streak_badge">最长连续 %1$d 天</string>
@@ -8307,6 +8308,7 @@
     <string name="token_activity_longest_streak">最长连续</string>
     <string name="token_activity_days">%1$d 天</string>
     <string name="token_activity_day_detail">%1$s使用了 %2$s Token</string>
+    <string name="token_activity_hour_detail">%1$s %2$d:00 使用了 %3$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s 使用了 %3$s Token</string>
     <string name="token_activity_month_detail">%1$s - %2$s 使用了 %3$s Token</string>
     <string name="token_activity_year_detail">%1$s - %2$s 使用了 %3$s Token</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8294,6 +8294,8 @@
     <string name="permission_review_circuit_what_to_do_body">先查看审核记录，确认被拒绝的操作和原因。若仍需执行，请回到主对话，明确说明具体操作、目标和范围后再让 AI 重试；不要授权你不理解的操作。</string>
     <string name="token_activity_daily">每日</string>
     <string name="token_activity_weekly">每周</string>
+    <string name="token_activity_monthly">每月</string>
+    <string name="token_activity_yearly">每年</string>
     <string name="token_activity_cumulative">累计</string>
     <string name="token_activity_title">活跃记录</string>
     <string name="token_activity_current_streak_badge">当前连续 %1$d 天</string>
@@ -8306,6 +8308,8 @@
     <string name="token_activity_days">%1$d 天</string>
     <string name="token_activity_day_detail">%1$s使用了 %2$s Token</string>
     <string name="token_activity_week_detail">%1$s - %2$s 使用了 %3$s Token</string>
+    <string name="token_activity_month_detail">%1$s - %2$s 使用了 %3$s Token</string>
+    <string name="token_activity_year_detail">%1$s - %2$s 使用了 %3$s Token</string>
     <string name="token_activity_cumulative_detail">截至 %1$s 累计使用 %2$s Token</string>
     <string name="token_activity_tap_hint">点击方格查看详细数据</string>
     <string name="token_activity_less">少</string>

--- a/app/src/test/java/com/ai/assistance/operit/data/stats/TokenActivityAggregatorTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/stats/TokenActivityAggregatorTest.kt
@@ -86,6 +86,26 @@ class TokenActivityAggregatorTest {
     }
 
     @Test
+    fun `range data builds hourly buckets for a single day range`() {
+        val range = dateRange("2026-08-02", "2026-08-02")
+        val snapshot = TokenActivitySnapshot(
+            zone = zone,
+            dayTotals = mapOf(LocalDate.of(2026, 8, 2) to 70L),
+            hourTotals = mapOf(
+                LocalDate.of(2026, 8, 2).atTime(9, 0) to 10L,
+                LocalDate.of(2026, 8, 2).atTime(21, 0) to 60L,
+            ),
+        )
+
+        val result = TokenActivityAggregator.rangeData(snapshot, range)
+
+        assertEquals(24, result.hourly.size)
+        assertEquals(10L, result.hourly.first { it.hour == 9 }.tokens)
+        assertEquals(60L, result.hourly.first { it.hour == 21 }.tokens)
+        assertEquals(0L, result.hourly.first { it.hour == 3 }.tokens)
+    }
+
+    @Test
     fun `range data calculates streaks and cumulative totals inside the selected range`() {
         val range = dateRange("2026-08-01", "2026-08-05")
         val snapshot = TokenActivitySnapshot(

--- a/app/src/test/java/com/ai/assistance/operit/data/stats/TokenActivityAggregatorTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/data/stats/TokenActivityAggregatorTest.kt
@@ -37,6 +37,55 @@ class TokenActivityAggregatorTest {
     }
 
     @Test
+    fun `range data groups monthly totals by calendar month`() {
+        val range = dateRange("2026-01-15", "2026-03-10")
+        val snapshot = TokenActivitySnapshot(
+            zone = zone,
+            dayTotals = mapOf(
+                LocalDate.of(2026, 1, 20) to 10L,
+                LocalDate.of(2026, 2, 5) to 20L,
+                LocalDate.of(2026, 3, 1) to 30L,
+            ),
+        )
+
+        val result = TokenActivityAggregator.rangeData(snapshot, range)
+
+        assertEquals(
+            listOf(
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 2, 1),
+                LocalDate.of(2026, 3, 1),
+            ),
+            result.monthly.map(TokenActivityMonth::startDate),
+        )
+        assertEquals(listOf(10L, 20L, 30L), result.monthly.map(TokenActivityMonth::tokens))
+    }
+
+    @Test
+    fun `range data groups yearly totals by calendar year`() {
+        val range = dateRange("2025-06-01", "2026-06-30")
+        val snapshot = TokenActivitySnapshot(
+            zone = zone,
+            dayTotals = mapOf(
+                LocalDate.of(2025, 7, 1) to 15L,
+                LocalDate.of(2025, 12, 31) to 25L,
+                LocalDate.of(2026, 1, 1) to 35L,
+            ),
+        )
+
+        val result = TokenActivityAggregator.rangeData(snapshot, range)
+
+        assertEquals(
+            listOf(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2026, 1, 1),
+            ),
+            result.yearly.map(TokenActivityYear::startDate),
+        )
+        assertEquals(listOf(40L, 35L), result.yearly.map(TokenActivityYear::tokens))
+    }
+
+    @Test
     fun `range data calculates streaks and cumulative totals inside the selected range`() {
         val range = dateRange("2026-08-01", "2026-08-05")
         val snapshot = TokenActivitySnapshot(

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsActivityRangePolicyTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsActivityRangePolicyTest.kt
@@ -50,7 +50,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `monthly mode covers the previous natural month`() {
+    fun `monthly mode mirrors weekly with the same day last month through yesterday`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.MONTHLY,
             anchorDate = LocalDate.of(2026, 3, 31),
@@ -60,8 +60,8 @@ class TokenStatsActivityRangePolicyTest {
 
         assertEquals(
             customRangeInclusiveEnd(
-                LocalDate.of(2026, 2, 1),
                 LocalDate.of(2026, 2, 28),
+                LocalDate.of(2026, 3, 30),
                 zone,
             ),
             range,
@@ -69,7 +69,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `monthly mode keeps february 29 when the previous month is a leap february`() {
+    fun `monthly mode clamps month-end dates to february 29 in a leap year`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.MONTHLY,
             anchorDate = LocalDate.of(2024, 3, 31),
@@ -79,8 +79,27 @@ class TokenStatsActivityRangePolicyTest {
 
         assertEquals(
             customRangeInclusiveEnd(
-                LocalDate.of(2024, 2, 1),
                 LocalDate.of(2024, 2, 29),
+                LocalDate.of(2024, 3, 30),
+                zone,
+            ),
+            range,
+        )
+    }
+
+    @Test
+    fun `monthly mode spans exactly twenty eight days for a february anchor`() {
+        val range = activityRangeForMode(
+            mode = TokenActivityViewMode.MONTHLY,
+            anchorDate = LocalDate.of(2026, 3, 5),
+            historyStartDate = null,
+            zone = zone,
+        )
+
+        assertEquals(
+            customRangeInclusiveEnd(
+                LocalDate.of(2026, 2, 5),
+                LocalDate.of(2026, 3, 4),
                 zone,
             ),
             range,

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsActivityRangePolicyTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsActivityRangePolicyTest.kt
@@ -31,7 +31,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `weekly mode selects the rolling seven day window ending at the anchor`() {
+    fun `weekly mode covers the last seven complete days ending yesterday`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.WEEKLY,
             anchorDate = LocalDate.of(2026, 8, 22),
@@ -42,7 +42,7 @@ class TokenStatsActivityRangePolicyTest {
         assertEquals(
             customRangeInclusiveEnd(
                 LocalDate.of(2026, 8, 15),
-                LocalDate.of(2026, 8, 22),
+                LocalDate.of(2026, 8, 21),
                 zone,
             ),
             range,
@@ -50,7 +50,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `monthly mode rolls back one calendar month with month-end clamping`() {
+    fun `monthly mode covers the previous natural month`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.MONTHLY,
             anchorDate = LocalDate.of(2026, 3, 31),
@@ -60,8 +60,8 @@ class TokenStatsActivityRangePolicyTest {
 
         assertEquals(
             customRangeInclusiveEnd(
+                LocalDate.of(2026, 2, 1),
                 LocalDate.of(2026, 2, 28),
-                LocalDate.of(2026, 3, 31),
                 zone,
             ),
             range,
@@ -69,7 +69,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `monthly mode keeps february 29 when the previous year is a leap year`() {
+    fun `monthly mode keeps february 29 when the previous month is a leap february`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.MONTHLY,
             anchorDate = LocalDate.of(2024, 3, 31),
@@ -79,8 +79,8 @@ class TokenStatsActivityRangePolicyTest {
 
         assertEquals(
             customRangeInclusiveEnd(
+                LocalDate.of(2024, 2, 1),
                 LocalDate.of(2024, 2, 29),
-                LocalDate.of(2024, 3,31),
                 zone,
             ),
             range,
@@ -88,7 +88,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `yearly mode rolls back one calendar year`() {
+    fun `yearly mode covers the trailing twelve natural months`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.YEARLY,
             anchorDate = LocalDate.of(2026, 9, 5),
@@ -98,8 +98,8 @@ class TokenStatsActivityRangePolicyTest {
 
         assertEquals(
             customRangeInclusiveEnd(
-                LocalDate.of(2025, 9, 5),
-                LocalDate.of(2026, 9, 5),
+                LocalDate.of(2025, 9, 1),
+                LocalDate.of(2026, 8, 31),
                 zone,
             ),
             range,
@@ -107,7 +107,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `yearly mode clamps leap day to february 28 in a non-leap year`() {
+    fun `yearly mode ends at the previous month end regardless of the anchor day`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.YEARLY,
             anchorDate = LocalDate.of(2024, 2, 29),
@@ -117,8 +117,8 @@ class TokenStatsActivityRangePolicyTest {
 
         assertEquals(
             customRangeInclusiveEnd(
-                LocalDate.of(2023, 2, 28),
-                LocalDate.of(2024, 2, 29),
+                LocalDate.of(2023, 2, 1),
+                LocalDate.of(2024, 1, 31),
                 zone,
             ),
             range,

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsActivityRangePolicyTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsActivityRangePolicyTest.kt
@@ -107,7 +107,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `yearly mode covers the trailing twelve natural months`() {
+    fun `yearly mode mirrors weekly with the same day last year through yesterday`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.YEARLY,
             anchorDate = LocalDate.of(2026, 9, 5),
@@ -117,8 +117,8 @@ class TokenStatsActivityRangePolicyTest {
 
         assertEquals(
             customRangeInclusiveEnd(
-                LocalDate.of(2025, 9, 1),
-                LocalDate.of(2026, 8, 31),
+                LocalDate.of(2025, 9, 5),
+                LocalDate.of(2026, 9, 4),
                 zone,
             ),
             range,
@@ -126,7 +126,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `yearly mode ends at the previous month end regardless of the anchor day`() {
+    fun `yearly mode clamps leap day to february 28 in a non-leap year`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.YEARLY,
             anchorDate = LocalDate.of(2024, 2, 29),
@@ -136,8 +136,8 @@ class TokenStatsActivityRangePolicyTest {
 
         assertEquals(
             customRangeInclusiveEnd(
-                LocalDate.of(2023, 2, 1),
-                LocalDate.of(2024, 1, 31),
+                LocalDate.of(2023, 2, 28),
+                LocalDate.of(2024, 2, 28),
                 zone,
             ),
             range,

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsActivityRangePolicyTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/tokenstats/TokenStatsActivityRangePolicyTest.kt
@@ -31,7 +31,7 @@ class TokenStatsActivityRangePolicyTest {
     }
 
     @Test
-    fun `weekly mode selects the existing Sunday-first calendar week`() {
+    fun `weekly mode selects the rolling seven day window ending at the anchor`() {
         val range = activityRangeForMode(
             mode = TokenActivityViewMode.WEEKLY,
             anchorDate = LocalDate.of(2026, 8, 22),
@@ -41,8 +41,84 @@ class TokenStatsActivityRangePolicyTest {
 
         assertEquals(
             customRangeInclusiveEnd(
-                LocalDate.of(2026, 8, 16),
+                LocalDate.of(2026, 8, 15),
                 LocalDate.of(2026, 8, 22),
+                zone,
+            ),
+            range,
+        )
+    }
+
+    @Test
+    fun `monthly mode rolls back one calendar month with month-end clamping`() {
+        val range = activityRangeForMode(
+            mode = TokenActivityViewMode.MONTHLY,
+            anchorDate = LocalDate.of(2026, 3, 31),
+            historyStartDate = null,
+            zone = zone,
+        )
+
+        assertEquals(
+            customRangeInclusiveEnd(
+                LocalDate.of(2026, 2, 28),
+                LocalDate.of(2026, 3, 31),
+                zone,
+            ),
+            range,
+        )
+    }
+
+    @Test
+    fun `monthly mode keeps february 29 when the previous year is a leap year`() {
+        val range = activityRangeForMode(
+            mode = TokenActivityViewMode.MONTHLY,
+            anchorDate = LocalDate.of(2024, 3, 31),
+            historyStartDate = null,
+            zone = zone,
+        )
+
+        assertEquals(
+            customRangeInclusiveEnd(
+                LocalDate.of(2024, 2, 29),
+                LocalDate.of(2024, 3,31),
+                zone,
+            ),
+            range,
+        )
+    }
+
+    @Test
+    fun `yearly mode rolls back one calendar year`() {
+        val range = activityRangeForMode(
+            mode = TokenActivityViewMode.YEARLY,
+            anchorDate = LocalDate.of(2026, 9, 5),
+            historyStartDate = null,
+            zone = zone,
+        )
+
+        assertEquals(
+            customRangeInclusiveEnd(
+                LocalDate.of(2025, 9, 5),
+                LocalDate.of(2026, 9, 5),
+                zone,
+            ),
+            range,
+        )
+    }
+
+    @Test
+    fun `yearly mode clamps leap day to february 28 in a non-leap year`() {
+        val range = activityRangeForMode(
+            mode = TokenActivityViewMode.YEARLY,
+            anchorDate = LocalDate.of(2024, 2, 29),
+            historyStartDate = null,
+            zone = zone,
+        )
+
+        assertEquals(
+            customRangeInclusiveEnd(
+                LocalDate.of(2023, 2, 28),
+                LocalDate.of(2024, 2, 29),
                 zone,
             ),
             range,


### PR DESCRIPTION
## 变更说明 / Description

Token 统计页的“活跃记录”此前只有每日/每周/累计三档，且日期范围固定在上次手动选择的日期——想看当天数据必须打开日期面板手动点选。本 PR 把模式扩展为五档（每日/每周/每月/每年/累计），点击任一模式自动刷新到最近一个完整周期，并按模式展示对应粒度的柱状图；原方格热力图独立为“活跃日历”卡片。

### 背景与动机 / Context and motivation

- 用户想统计“今天”时，需要手动把日期面板的开始/结束都点到今天，操作繁琐；
- 缺少按月、按年查看活跃度的入口；
- 柱状图粒度应与所选周期匹配（日→小时、周→天、月→周、年→月），这是常见的粒度降级设计；
- 原热力图与“每日”模式绑定，模式细化后需要给它一个独立、长期有效的呈现位置。

### 改动范围 / Changes

- 选择器由三段扩展为五段：每日、每周、每月、每年、累计（累计保持最后一格）；
- 点击任一模式时，将范围刷新为“最近一个完整周期”（本地时区，未来时间未发生故不统计）：
  - 每日：今天 ~ 今天 → 24 根小时柱
  - 每周：上周同日 ~ 昨天（对齐今天的星期几，整 7 天）→ 7 根日柱
  - 每月：上月同日 ~ 昨天（`minusMonths` 自动钳制月末）→ 按周分桶，2 月平年 28 天为 4 根，其余 5 根
  - 每年：去年本月 ~ 今年上月（12 个完整自然月）→ 12 根月柱
  - 累计：首次使用日 ~ 今天 → 折线（不变）
- `TokenActivityAggregator` 新增小时分桶（仅短范围计算）与月/年分桶，复用现有分位数等级与柱高逻辑；周分桶改为从范围起点对齐的滚动 7 天分桶；
- 数据层新增一条只读小时聚合查询 `getActivityHoursInRange`（`strftime('%Y-%m-%d %H')` 分组），**不涉及任何表结构/索引/迁移变更**；
- 柱状图月份标签在密度高时自动加宽柱间距（按标签文字宽度计算），保证每年 12 根柱下方每个月的标签完整显示、互不重叠；
- 原方格热力图从“每日”模式中拆出，独立为“活跃日历”卡，固定展示最近一年（独立查询），保留点击查看当天详情与色阶图例；
- 日期面板直接读取当前范围状态，点击模式后再打开面板会正确定位到新模式范围，面板本身无需改动；
- 新增“每月/每年/活跃日历/小时详情”文案（8 种语言：中/英/西/印尼/韩/马来/葡/罗）；
- 测试：更新每周范围用例；新增月末钳制、闰年 2月29日、跨年闰日钳制、月/年聚合分组、小时分桶共 9 个用例；
- 不包含：“本月”“今年”语义、范围持久化策略变更、图表交互变更。

### 兼容性与风险 / Compatibility and risks

- 行为变化：每周从“周日对齐的自然周”改为“对齐今天星期几的最近 7 天”；每月从“上一个自然月”改为与每周同构的滚动月窗口；点击任一模式会重置范围为该模式的最近完整周期；
- 存储的视图模式枚举新增两个值；旧版本读取未知枚举值时回退为默认“每日”（`valueOf` 失败回退 `DAILY`），不会崩溃；
- 日期边界全部由 `java.time` 计算（`minusDays/minusMonths/YearMonth.atEndOfMonth`），无硬编码月长/闰年规则，也不会展示未来日期；
- 数据库仅新增一条只读统计查询，表结构、索引、Room 版本与迁移均无变化，新旧版本数据完全兼容；
- 活跃日历卡增加一次独立查询（最近一年），其余查询数量不变。

## 关联 Issue / Related issue

N/A —— 该改动源自用户对 Token 统计页使用体验的反馈，无对应 Issue。

## 验证方式 / Verification

```text
检查或命令：
- git diff --check
- Android Build（assembleDebug）工作流
- 单元测试：TokenStatsActivityRangePolicyTest（更新 + 新增 7 例）、TokenActivityAggregatorTest（新增 3 例）

环境与变体：
- 本地 Ubuntu 工作区（无可用 Android SDK/NDK，未做本地 Gradle 编译与本地 JVM 测试）
- GitHub Actions Android Build：早期版本 run 33944877588 success；最新提交对应的 run 33949602729 已触发，最终以 PR 页面为准
- 真机功能验证由 fork 作者在 Android Debug 构建上完成

结果：
- git diff --check：通过
- 真机：五档切换、点击刷新范围、各粒度柱状图、每年 12 个月标签不重叠、活跃日历卡、日期面板定位均符合预期

证据 / Evidence

• Android Build 工作流（最新提交）：https://github.com/3316891527/Operit/actions/runs/33949602729
• 源分支：3316891527:feat/tokenstats-period-refresh