### PR TITLE
feat(packages): add update check for packages, skills and MCP servers

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/components/dialogs/MCPServerDetailsDialog.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/components/dialogs/MCPServerDetailsDialog.kt
@@ -27,6 +27,7 @@ import com.ai.assistance.operit.ui.features.packages.components.dialogs.content.
 import com.ai.assistance.operit.ui.features.packages.components.dialogs.content.MCPServerDetailsContent
 import com.ai.assistance.operit.ui.features.packages.components.dialogs.header.MCPServerDetailsHeader
 import com.ai.assistance.operit.ui.features.packages.components.dialogs.tabs.MCPServerDetailsTabs
+import com.ai.assistance.operit.data.api.MarketV2Entry
 import com.ai.assistance.operit.data.mcp.MCPLocalServer
 
 /**
@@ -52,7 +53,8 @@ fun MCPServerDetailsDialog(
         pluginConfig: String = "",
         onSaveConfig: () -> Unit = {},
         onUpdateConfig: (String) -> Unit = {},
-        mdFontSize: Float = 14f
+        mdFontSize: Float = 14f,
+        onOpenMarketDetail: (MarketV2Entry) -> Unit = {}
 ) {
     val isInstalled = server.isInstalled
     val supportsLocalConfigEditing = server.type != "remote"
@@ -135,7 +137,9 @@ fun MCPServerDetailsDialog(
                             server = server,
                             isInstalled = isInstalled,
                             onInstall = onInstall,
-                            onUninstall = onUninstall
+                            onUninstall = onUninstall,
+                            installedPath = installedPath,
+                            onOpenMarketDetail = onOpenMarketDetail
                     )
                 }
             }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/components/dialogs/actions/MCPServerDetailsActions.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/components/dialogs/actions/MCPServerDetailsActions.kt
@@ -23,7 +23,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.ai.assistance.operit.R
+import com.ai.assistance.operit.data.api.MarketV2Entry
 import com.ai.assistance.operit.data.mcp.MCPLocalServer
+import com.ai.assistance.operit.ui.features.packages.market.MarketUpdateCheckButton
+import com.ai.assistance.operit.ui.features.packages.market.readMarketInstallMarkerForMcp
 
 /**
  * Actions component for the MCP server details diaAppLogger.
@@ -38,10 +41,11 @@ fun MCPServerDetailsActions(
     server: MCPLocalServer.PluginMetadata,
     isInstalled: Boolean,
     onInstall: (MCPLocalServer.PluginMetadata) -> Unit,
-    onUninstall: (MCPLocalServer.PluginMetadata) -> Unit
+    onUninstall: (MCPLocalServer.PluginMetadata) -> Unit,
+    installedPath: String? = null,
+    onOpenMarketDetail: (MarketV2Entry) -> Unit = {}
 ) {
     val context = LocalContext.current
-
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -69,7 +73,14 @@ fun MCPServerDetailsActions(
                 Text(text = stringResource(R.string.repo))
             }
         }
-
+        // 市场更新检查（仅已安装时可用）
+        if (isInstalled) {
+            MarketUpdateCheckButton(
+                markerProvider = { readMarketInstallMarkerForMcp(context, server.id, installedPath) },
+                onOpenMarketDetail = onOpenMarketDetail,
+                modifier = Modifier.weight(1f)
+            )
+        }
         // Install/Uninstall button
         if (isInstalled) {
             Button(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/dialogs/PackageDetailsDialog.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/dialogs/PackageDetailsDialog.kt
@@ -27,10 +27,24 @@ import com.ai.assistance.operit.R
 import com.ai.assistance.operit.core.tools.PackageTool
 import com.ai.assistance.operit.core.tools.ToolPackage
 import com.ai.assistance.operit.core.tools.packTool.PackageManager
+import com.ai.assistance.operit.data.api.MarketStatsApiService
+import com.ai.assistance.operit.data.api.MarketV2Entry
 import com.ai.assistance.operit.ui.common.icons.rememberLogoPainter
+import com.ai.assistance.operit.ui.features.packages.market.readMarketInstallMarkerForPackage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+private sealed interface PackageUpdateCheckState {
+    data object UpToDate : PackageUpdateCheckState
+    data class UpdateAvailable(
+        val entry: MarketV2Entry,
+        val latestVersion: String
+    ) : PackageUpdateCheckState
+    data object NotFromMarket : PackageUpdateCheckState
+    data object EntryMissing : PackageUpdateCheckState
+    data object Failed : PackageUpdateCheckState
+}
 
 @Composable
 fun PackageDetailsDialog(
@@ -41,11 +55,60 @@ fun PackageDetailsDialog(
         onRunScript: (String, PackageTool) -> Unit,
         onOpenToolPkgPluginConfig: (String, String, String, Boolean) -> Unit,
         onDismiss: () -> Unit,
-        onPackageDeleted: () -> Unit
+        onPackageDeleted: () -> Unit,
+        onOpenMarketDetail: (MarketV2Entry) -> Unit
 ) {
     val context = LocalContext.current
     var showDeleteConfirmDialog by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
+    var updateCheckState by remember(packageName) { mutableStateOf<PackageUpdateCheckState?>(null) }
+    var isCheckingUpdate by remember { mutableStateOf(false) }
+
+    fun runUpdateCheck() {
+        if (isCheckingUpdate) return
+        isCheckingUpdate = true
+        updateCheckState = null
+        scope.launch {
+            try {
+                val marker =
+                    withContext(Dispatchers.IO) {
+                        readMarketInstallMarkerForPackage(packageManager, packageName)
+                    }
+                if (marker == null) {
+                    updateCheckState = PackageUpdateCheckState.NotFromMarket
+                    return@launch
+                }
+                val entryResult =
+                    withContext(Dispatchers.IO) {
+                        MarketStatsApiService().getEntry(marker.entryId)
+                    }
+                if (entryResult.isFailure) {
+                    updateCheckState = PackageUpdateCheckState.Failed
+                    return@launch
+                }
+                val entry = entryResult.getOrNull()
+                if (entry == null) {
+                    updateCheckState = PackageUpdateCheckState.EntryMissing
+                    return@launch
+                }
+                val latest = entry.latestVersion
+                if (latest == null || latest.id.isBlank() || latest.id == marker.versionId) {
+                    updateCheckState = PackageUpdateCheckState.UpToDate
+                } else {
+                    updateCheckState =
+                        PackageUpdateCheckState.UpdateAvailable(
+                            entry = entry,
+                            latestVersion = latest.version.ifBlank { latest.id }
+                        )
+                }
+            } catch (error: Exception) {
+                AppLogger.e("PackageDetailsDialog", "Update check failed", error)
+                updateCheckState = PackageUpdateCheckState.Failed
+            } finally {
+                isCheckingUpdate = false
+            }
+        }
+    }
 
     val resolvedPackage by produceState<ToolPackage?>(initialValue = toolPackage, packageName, toolPackage) {
         value = toolPackage
@@ -182,6 +245,56 @@ fun PackageDetailsDialog(
                         Text(stringResource(R.string.pkg_cancel))
                     }
                 }
+        )
+    }
+
+    val currentUpdateCheckState = updateCheckState
+    if (currentUpdateCheckState != null) {
+        AlertDialog(
+            onDismissRequest = { updateCheckState = null },
+            title = { Text(stringResource(R.string.pkg_check_update)) },
+            text = {
+                Text(
+                    when (currentUpdateCheckState) {
+                        is PackageUpdateCheckState.UpToDate ->
+                            stringResource(R.string.pkg_check_update_up_to_date)
+                        is PackageUpdateCheckState.UpdateAvailable ->
+                            stringResource(
+                                R.string.pkg_check_update_available,
+                                currentUpdateCheckState.latestVersion
+                            )
+                        PackageUpdateCheckState.NotFromMarket ->
+                            stringResource(R.string.pkg_check_update_not_market)
+                        PackageUpdateCheckState.EntryMissing ->
+                            stringResource(R.string.pkg_check_update_entry_missing)
+                        PackageUpdateCheckState.Failed ->
+                            stringResource(R.string.pkg_check_update_failed)
+                    }
+                )
+            },
+            confirmButton = {
+                if (currentUpdateCheckState is PackageUpdateCheckState.UpdateAvailable) {
+                    Button(
+                        onClick = {
+                            updateCheckState = null
+                            onOpenMarketDetail(currentUpdateCheckState.entry)
+                        }
+                    ) {
+                        Text(stringResource(R.string.pkg_check_update_go))
+                    }
+                } else {
+                    Button(onClick = { updateCheckState = null }) {
+                        Text(stringResource(R.string.pkg_ok))
+                    }
+                }
+            },
+            dismissButton = {
+                if (currentUpdateCheckState is PackageUpdateCheckState.UpdateAvailable) {
+                    TextButton(onClick = { updateCheckState = null }) {
+                        Text(stringResource(R.string.pkg_cancel))
+                    }
+                }
+            }
         )
     }
 
@@ -621,6 +734,25 @@ fun PackageDetailsDialog(
                     horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End)
                 ) {
                     if (metaPackage != null && !metaPackage.isBuiltIn) {
+                        OutlinedButton(
+                            onClick = { runUpdateCheck() },
+                            enabled = !isCheckingUpdate
+                        ) {
+                            if (isCheckingUpdate) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(14.dp),
+                                    strokeWidth = 2.dp
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.Default.Refresh,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(stringResource(R.string.pkg_check_update))
+                        }
                         OutlinedButton(
                             onClick = { showDeleteConfirmDialog = true },
                             colors = ButtonDefaults.outlinedButtonColors(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketInstallMarker.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketInstallMarker.kt
@@ -78,6 +78,35 @@ fun readMarketInstallMarkerForPackage(
     }
 }
 
+/** 读取技能安装目录下的市场安装标记（无则返回 null） */
+fun readMarketInstallMarkerForSkill(skillDirectory: File): MarketInstallMarker? {
+    return try {
+        readMarketInstallMarker(skillDirectory)
+    } catch (error: Exception) {
+        AppLogger.w(TAG, "Failed to read market install marker for skill: ${skillDirectory.absolutePath}", error)
+        null
+    }
+}
+
+/**
+ * 读取 MCP 的市场安装标记。MCP 有两种安装形态：
+ * 1) 纯配置安装：标记写在 market_install_markers/mcp_config/{serverId}；
+ * 2) 物理安装：标记写在插件安装目录（installedPath）。
+ * 任一位置读到即返回。
+ */
+fun readMarketInstallMarkerForMcp(context: Context, serverId: String, installedPath: String?): MarketInstallMarker? {
+    try {
+        readMarketInstallMarker(mcpConfigMarketMarkerRoot(context, serverId))?.let { return it }
+        installedPath
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?.let { path -> readMarketInstallMarker(File(path))?.let { return it } }
+    } catch (error: Exception) {
+        AppLogger.w(TAG, "Failed to read market install marker for MCP: $serverId", error)
+    }
+    return null
+}
+
 fun findInstalledMarketMarkerRoots(
     context: Context,
     packageManager: PackageManager,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketInstallMarker.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketInstallMarker.kt
@@ -66,6 +66,18 @@ fun findInstalledMarketMarkerRoot(
     return findInstalledMarketMarkerRoots(context, packageManager, entryId).firstOrNull()
 }
 
+fun readMarketInstallMarkerForPackage(
+    packageManager: PackageManager,
+    packageName: String
+): MarketInstallMarker? {
+    return try {
+        readMarketInstallMarker(artifactMarketMarkerRoot(packageManager, packageName))
+    } catch (error: Exception) {
+        AppLogger.w(TAG, "Failed to read market install marker for package: $packageName", error)
+        null
+    }
+}
+
 fun findInstalledMarketMarkerRoots(
     context: Context,
     packageManager: PackageManager,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketUpdateCheckButton.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketUpdateCheckButton.kt
@@ -1,0 +1,124 @@
+package com.ai.assistance.operit.ui.features.packages.market
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.ai.assistance.operit.R
+import com.ai.assistance.operit.data.api.MarketV2Entry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * 市场检查更新按钮 + 结果弹窗（包 / MCP / 技能三类界面共用）。
+ * @param markerProvider 读取当前安装项市场安装标记的挂起函数；返回 null 视为非市场来源
+ * @param onOpenMarketDetail 有更新时点击"前往更新"跳转市场详情页
+ */
+@Composable
+fun MarketUpdateCheckButton(
+    markerProvider: suspend () -> MarketInstallMarker?,
+    onOpenMarketDetail: (MarketV2Entry) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var isChecking by remember { mutableStateOf(false) }
+    var result by remember { mutableStateOf<MarketUpdateCheckResult?>(null) }
+    val scope = rememberCoroutineScope()
+
+    OutlinedButton(
+        onClick = {
+            if (isChecking) return@OutlinedButton
+            isChecking = true
+            result = null
+            scope.launch {
+                val marker =
+                    try {
+                        withContext(Dispatchers.IO) { markerProvider() }
+                    } catch (e: Exception) {
+                        null
+                    }
+                result = checkMarketUpdate(marker)
+                isChecking = false
+            }
+        },
+        modifier = modifier,
+        enabled = !isChecking
+    ) {
+        if (isChecking) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(14.dp),
+                strokeWidth = 2.dp
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Default.Refresh,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(stringResource(R.string.pkg_check_update))
+    }
+
+    val current = result
+    if (current != null) {
+        AlertDialog(
+            onDismissRequest = { result = null },
+            title = { Text(stringResource(R.string.pkg_check_update)) },
+            text = {
+                Text(
+                    text =
+                        when (current) {
+                            is MarketUpdateCheckResult.UpToDate ->
+                                stringResource(R.string.pkg_check_update_up_to_date)
+                            is MarketUpdateCheckResult.UpdateAvailable ->
+                                stringResource(R.string.pkg_check_update_available, current.latestVersion)
+                            MarketUpdateCheckResult.NotFromMarket ->
+                                stringResource(R.string.pkg_check_update_not_market)
+                            MarketUpdateCheckResult.EntryMissing ->
+                                stringResource(R.string.pkg_check_update_entry_missing)
+                            MarketUpdateCheckResult.Failed ->
+                                stringResource(R.string.pkg_check_update_failed)
+                        }
+                )
+            },
+            confirmButton = {
+                if (current is MarketUpdateCheckResult.UpdateAvailable) {
+                    TextButton(
+                        onClick = {
+                            result = null
+                            onOpenMarketDetail(current.entry)
+                        }
+                    ) {
+                        Text(stringResource(R.string.pkg_check_update_go))
+                    }
+                } else {
+                    TextButton(onClick = { result = null }) {
+                        Text(stringResource(R.string.ok))
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { result = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketUpdateChecker.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/market/MarketUpdateChecker.kt
@@ -1,0 +1,47 @@
+package com.ai.assistance.operit.ui.features.packages.market
+
+import com.ai.assistance.operit.data.api.MarketStatsApiService
+import com.ai.assistance.operit.data.api.MarketV2Entry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** 市场更新检查的统一结果（包 / MCP / 技能三类界面共用） */
+sealed interface MarketUpdateCheckResult {
+    /** 本地安装无市场来源标记（例如手工导入） */
+    data object NotFromMarket : MarketUpdateCheckResult
+
+    /** 市场条目已不存在 */
+    data object EntryMissing : MarketUpdateCheckResult
+
+    /** 网络或服务端错误 */
+    data object Failed : MarketUpdateCheckResult
+
+    /** 已是最新版 */
+    data class UpToDate(val entry: MarketV2Entry) : MarketUpdateCheckResult
+
+    /** 有更新可用 */
+    data class UpdateAvailable(val entry: MarketV2Entry, val latestVersion: String) : MarketUpdateCheckResult
+}
+
+/**
+ * 依据安装标记执行一次市场更新检查。
+ * @param marker 安装标记；为 null 时直接返回 NotFromMarket
+ */
+suspend fun checkMarketUpdate(marker: MarketInstallMarker?): MarketUpdateCheckResult {
+    if (marker == null) return MarketUpdateCheckResult.NotFromMarket
+    val entryResult =
+        withContext(Dispatchers.IO) {
+            MarketStatsApiService().getEntry(marker.entryId)
+        }
+    if (entryResult.isFailure) return MarketUpdateCheckResult.Failed
+    val entry = entryResult.getOrNull() ?: return MarketUpdateCheckResult.EntryMissing
+    val latest = entry.latestVersion
+    return if (latest == null || latest.id.isBlank() || latest.id == marker.versionId) {
+        MarketUpdateCheckResult.UpToDate(entry)
+    } else {
+        MarketUpdateCheckResult.UpdateAvailable(
+            entry = entry,
+            latestVersion = latest.version.ifBlank { latest.id }
+        )
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/MCPConfigScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/MCPConfigScreen.kt
@@ -54,6 +54,7 @@ import com.ai.assistance.operit.util.AppLogger
 import android.widget.Toast
 import androidx.compose.ui.res.stringResource
 import com.ai.assistance.operit.R
+import com.ai.assistance.operit.data.api.MarketV2Entry
 import org.json.JSONObject
 
 import java.util.*
@@ -70,6 +71,7 @@ import com.ai.assistance.operit.ui.features.startup.screens.LocalPluginLoadingSt
 @Composable
 fun MCPConfigScreen(
     onNavigateToMCPMarket: () -> Unit = {},
+    onOpenMcpMarketDetail: (MarketV2Entry) -> Unit = {},
     searchQuery: String = ""
 ) {
     val context = LocalContext.current
@@ -435,6 +437,10 @@ fun MCPConfigScreen(
                 },
                 installedPath = installedPath,
                 pluginConfig = pluginConfigJson,
+                onOpenMarketDetail = { entry ->
+                    selectedPluginForDetails = null
+                    onOpenMcpMarketDetail(entry)
+                },
                 onSaveConfig = {
                     selectedPluginId?.let { pluginId ->
                         scope.launch {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
@@ -1,6 +1,7 @@
 package com.ai.assistance.operit.ui.features.packages.screens
 
 import com.ai.assistance.operit.util.AppLogger
+import com.ai.assistance.operit.data.api.MarketV2Entry
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -130,6 +131,7 @@ fun PackageManagerScreen(
     onNavigateToArtifactMarket: () -> Unit = {},
     onStartPluginCreation: (PluginCreationIntent) -> Unit = {},
     onOpenToolPkgPluginConfig: (String, String, String, Boolean) -> Unit = { _, _, _, _ -> },
+    onOpenMarketDetail: (MarketV2Entry) -> Unit = {},
 ) {
     val context = LocalContext.current
     val toolHandler = remember { AIToolHandler.getInstance(context) }
@@ -947,6 +949,10 @@ fun PackageManagerScreen(
                     onOpenToolPkgPluginConfig = { containerPackageName, uiModuleId, title, keepAlive ->
                         showDetails = false
                         onOpenToolPkgPluginConfig(containerPackageName, uiModuleId, title, keepAlive)
+                    },
+                    onOpenMarketDetail = { entry ->
+                        showDetails = false
+                        onOpenMarketDetail(entry)
                     },
                     onDismiss = {
                         showDetails = false

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
@@ -913,6 +913,7 @@ fun PackageManagerScreen(
                             skillRepository = skillRepository,
                             snackbarHostState = snackbarHostState,
                             onNavigateToSkillMarket = onNavigateToSkillMarket,
+                            onOpenSkillMarketDetail = onOpenMarketDetail,
                             searchQuery = skillSearchQuery,
                             skillOrder = skillOrder,
                             onSaveSkillOrder = { newOrder ->
@@ -927,6 +928,7 @@ fun PackageManagerScreen(
                     PackageTab.MCP -> {
                         MCPConfigScreen(
                             onNavigateToMCPMarket = onNavigateToMCPMarket,
+                            onOpenMcpMarketDetail = onOpenMarketDetail,
                             searchQuery = mcpSearchQuery
                         )
                     }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/SkillConfigScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/SkillConfigScreen.kt
@@ -74,9 +74,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.core.tools.skill.SkillPackage
+import com.ai.assistance.operit.data.api.MarketV2Entry
 import com.ai.assistance.operit.data.preferences.SkillVisibilityPreferences
 import com.ai.assistance.operit.data.skill.SkillRepository
 import com.ai.assistance.operit.ui.common.displays.MarkdownTextComposable
+import com.ai.assistance.operit.ui.features.packages.market.MarketUpdateCheckButton
+import com.ai.assistance.operit.ui.features.packages.market.readMarketInstallMarkerForSkill
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -90,6 +93,7 @@ fun SkillConfigScreen(
     skillRepository: SkillRepository,
     snackbarHostState: SnackbarHostState,
     onNavigateToSkillMarket: () -> Unit = {},
+    onOpenSkillMarketDetail: (MarketV2Entry) -> Unit = {},
     searchQuery: String = "",
     skillOrder: List<String> = emptyList(),
     onSaveSkillOrder: (List<String>) -> Unit = {},
@@ -748,6 +752,12 @@ fun SkillConfigScreen(
             skill = skill,
             detail = selectedSkillDetail,
             isLoading = isSkillDetailLoading,
+            onOpenMarketDetail = { entry ->
+                selectedSkill = null
+                selectedSkillDetail = null
+                isSkillDetailLoading = false
+                onOpenSkillMarketDetail(entry)
+            },
             onDismiss = {
                 selectedSkill = null
                 selectedSkillDetail = null
@@ -876,7 +886,8 @@ private fun SkillDetailDialog(
     detail: SkillDetailDialogData?,
     isLoading: Boolean,
     onDismiss: () -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    onOpenMarketDetail: (MarketV2Entry) -> Unit
 ) {
     var showSkillMarkdown by remember(skill.directory.absolutePath) { mutableStateOf(false) }
 
@@ -993,8 +1004,16 @@ private fun SkillDetailDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = onDelete) {
-                Text(text = stringResource(R.string.skillmgr_delete))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End)
+            ) {
+                MarketUpdateCheckButton(
+                    markerProvider = { readMarketInstallMarkerForSkill(skill.directory) },
+                    onOpenMarketDetail = onOpenMarketDetail
+                )
+                TextButton(onClick = onDelete) {
+                    Text(text = stringResource(R.string.skillmgr_delete))
+                }
             }
         },
         dismissButton = {

--- a/app/src/main/java/com/ai/assistance/operit/ui/main/screens/OperitScreens.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/main/screens/OperitScreens.kt
@@ -201,6 +201,9 @@ sealed class Screen(
                 onNavigateToMCPMarket = { navigateTo(Market(MarketHomeTab.ALL)) },
                 onNavigateToSkillMarket = { navigateTo(Market(MarketHomeTab.ALL)) },
                 onNavigateToArtifactMarket = { navigateTo(Market(MarketHomeTab.ALL)) },
+                onOpenMarketDetail = { entry ->
+                    navigateTo(MarketEntryDetail(entry = entry))
+                },
                 onStartPluginCreation = { intent ->
                     PendingChatDraftHandler.setPendingDraft(intent.toPrompt(context))
                     navigateTo(AiChat)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -3057,6 +3057,14 @@
     <string name="pkg_automation_func_removed">Kotlin UI automation function execution (route/config) has been removed.</string>
     <string name="pkg_automation_feature">Automation Feature</string>
     <string name="pkg_close">Close</string>
+    <string name="pkg_check_update">Check for updates</string>
+    <string name="pkg_check_update_up_to_date">You are on the latest version</string>
+    <string name="pkg_check_update_available">New version %1$s available. Go to the plugin market to update.</string>
+    <string name="pkg_check_update_go">Go to update</string>
+    <string name="pkg_check_update_not_market">This plugin was not installed from the market, so updates cannot be checked.</string>
+    <string name="pkg_check_update_entry_missing">This plugin was not found in the market. It may have been removed.</string>
+    <string name="pkg_check_update_failed">Failed to check for updates. Please check your network and try again.</string>
+    <string name="pkg_ok">OK</string>
     <string name="dialog_command_result">Command Result</string>
     <string name="dialog_copied_to_clipboard">Copied to clipboard</string>
     <string name="dialog_copy_failed">Copy failed: %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5363,6 +5363,14 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="pkg_delete_warning">¿Estás seguro de que deseas eliminar el paquete "%1$s"? Esta acción no se puede deshacer.</string>
     <string name="pkg_delete">Eliminar</string>
     <string name="pkg_close">Cerrar</string>
+    <string name="pkg_check_update">Buscar actualizaciones</string>
+    <string name="pkg_check_update_up_to_date">Ya tienes la última versión</string>
+    <string name="pkg_check_update_available">Nueva versión %1$s disponible. Ve al mercado de plugins para actualizar.</string>
+    <string name="pkg_check_update_go">Ir a actualizar</string>
+    <string name="pkg_check_update_not_market">Este plugin no se instaló desde el mercado, no se pueden buscar actualizaciones.</string>
+    <string name="pkg_check_update_entry_missing">No se encontró este plugin en el mercado. Es posible que se haya retirado.</string>
+    <string name="pkg_check_update_failed">No se pudo buscar actualizaciones. Comprueba tu red e inténtalo de nuevo.</string>
+    <string name="pkg_ok">Aceptar</string>
     <string name="pkg_tool_list">Lista de herramientas</string>
     <string name="pkg_no_tools">No hay herramientas disponibles</string>
     <string name="mcp_market_search_hint">Buscar plugin o autor</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -5296,6 +5296,14 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="pkg_delete_warning">Yakin ingin menghapus paket "%1$s"? Tindakan ini tidak dapat dibatalkan.</string>
     <string name="pkg_delete">Hapus</string>
     <string name="pkg_close">Tutup</string>
+    <string name="pkg_check_update">Periksa pembaruan</string>
+    <string name="pkg_check_update_up_to_date">Anda sudah menggunakan versi terbaru</string>
+    <string name="pkg_check_update_available">Tersedia versi baru %1$s. Buka pasar plugin untuk memperbarui.</string>
+    <string name="pkg_check_update_go">Pergi ke pembaruan</string>
+    <string name="pkg_check_update_not_market">Plugin ini tidak diinstal dari pasar, tidak dapat memeriksa pembaruan.</string>
+    <string name="pkg_check_update_entry_missing">Plugin tidak ditemukan di pasar. Mungkin sudah dihapus.</string>
+    <string name="pkg_check_update_failed">Gagal memeriksa pembaruan. Periksa jaringan Anda dan coba lagi.</string>
+    <string name="pkg_ok">Oke</string>
     <string name="pkg_tool_list">Daftar alat</string>
     <string name="pkg_no_tools">Belum ada alat yang tersedia</string>
     <string name="mcp_market_search_hint">Cari nama plugin, deskripsi, penulis...</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -5494,6 +5494,14 @@
     <string name="pkg_delete_warning">정말로 "%1$s" 패키지를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.</string>
     <string name="pkg_delete">삭제</string>
     <string name="pkg_close">닫기</string>
+    <string name="pkg_check_update">업데이트 확인</string>
+    <string name="pkg_check_update_up_to_date">최신 버전입니다</string>
+    <string name="pkg_check_update_available">새 버전 %1$s이(가) 있습니다. 플러그인 마켓에서 업데이트하세요.</string>
+    <string name="pkg_check_update_go">업데이트하러 가기</string>
+    <string name="pkg_check_update_not_market">이 플러그인은 마켓에서 설치되지 않아 업데이트를 확인할 수 없습니다.</string>
+    <string name="pkg_check_update_entry_missing">마켓에서 이 플러그인을 찾을 수 없습니다. 삭제되었을 수 있습니다.</string>
+    <string name="pkg_check_update_failed">업데이트 확인 실패. 네트워크를 확인한 후 다시 시도하세요.</string>
+    <string name="pkg_ok">확인</string>
     <string name="pkg_tool_list">도구 목록</string>
     <string name="pkg_no_tools">사용 가능한 도구 없음</string>
     <string name="mcp_market_search_hint">플러그인 또는 작성자 검색</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -5294,6 +5294,14 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="pkg_delete_warning">Adakah anda pasti mahu memadam pakej "%1$s"? Tindakan ini tidak boleh dibatalkan.</string>
     <string name="pkg_delete">Padam</string>
     <string name="pkg_close">Tutup</string>
+    <string name="pkg_check_update">Semak kemas kini</string>
+    <string name="pkg_check_update_up_to_date">Anda sudah menggunakan versi terkini</string>
+    <string name="pkg_check_update_available">Versi baharu %1$s tersedia. Pergi ke pasaran plugin untuk mengemas kini.</string>
+    <string name="pkg_check_update_go">Pergi kemas kini</string>
+    <string name="pkg_check_update_not_market">Plugin ini tidak dipasang dari pasaran, tidak dapat menyemak kemas kini.</string>
+    <string name="pkg_check_update_entry_missing">Plugin tidak ditemui di pasaran. Ia mungkin telah dialih keluar.</string>
+    <string name="pkg_check_update_failed">Gagal menyemak kemas kini. Sila semak rangkaian anda dan cuba lagi.</string>
+    <string name="pkg_ok">OK</string>
 
     <string name="memory_embedding_rebuild_failed">Pelengkap dan pembinaan semula vektor gagal: %1$s</string>
     <string name="memory_embedding_rebuild_requires_config">Sila konfigurasi dan simpan perkhidmatan vektor yang tersedia terlebih dahulu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -5065,6 +5065,14 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="pkg_delete_warning">Tem certeza de que deseja excluir o pacote "%1$s"? Esta ação não pode ser desfeita.</string>
     <string name="pkg_delete">excluir</string>
     <string name="pkg_close">encerramento</string>
+    <string name="pkg_check_update">Verificar atualizações</string>
+    <string name="pkg_check_update_up_to_date">Você já está na versão mais recente</string>
+    <string name="pkg_check_update_available">Nova versão %1$s disponível. Acesse o mercado de plugins para atualizar.</string>
+    <string name="pkg_check_update_go">Ir para atualização</string>
+    <string name="pkg_check_update_not_market">Este plugin não foi instalado pelo mercado, não é possível verificar atualizações.</string>
+    <string name="pkg_check_update_entry_missing">Este plugin não foi encontrado no mercado. Ele pode ter sido removido.</string>
+    <string name="pkg_check_update_failed">Falha ao verificar atualizações. Verifique sua rede e tente novamente.</string>
+    <string name="pkg_ok">OK</string>
     <string name="pkg_tool_list">Lista de ferramentas</string>
     <string name="pkg_no_tools">Nenhuma ferramenta disponível ainda</string>
     <string name="mcp_market_search_hint">Pesquise o nome do plugin, descrição, autor...</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -6260,6 +6260,14 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="pkg_delete_warning">Sunteți sigur că doriți să ștergeți pachetul „%1$s" ? Această operațiune nu poate fi anulată.</string>
     <string name="pkg_delete">Ștergere</string>
     <string name="pkg_close">Închide</string>
+    <string name="pkg_check_update">Verifică actualizări</string>
+    <string name="pkg_check_update_up_to_date">Aveți deja cea mai recentă versiune</string>
+    <string name="pkg_check_update_available">Este disponibilă versiunea nouă %1$s. Accesați piața de pluginuri pentru actualizare.</string>
+    <string name="pkg_check_update_go">Mergi la actualizare</string>
+    <string name="pkg_check_update_not_market">Acest plugin nu a fost instalat din piață, nu se pot verifica actualizările.</string>
+    <string name="pkg_check_update_entry_missing">Pluginul nu a fost găsit în piață. Este posibil să fi fost retras.</string>
+    <string name="pkg_check_update_failed">Verificarea actualizărilor a eșuat. Verificați rețeaua și încercați din nou.</string>
+    <string name="pkg_ok">OK</string>
     <string name="pkg_tool_list">Lista de instrumente</string>
     <string name="pkg_no_tools">Nu există instrumente disponibile în acest moment</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6447,6 +6447,14 @@
     <string name="pkg_delete_warning">确定要删除包 "%1$s" 吗？此操作无法撤销。</string>
     <string name="pkg_delete">删除</string>
     <string name="pkg_close">关闭</string>
+    <string name="pkg_check_update">检查更新</string>
+    <string name="pkg_check_update_up_to_date">当前已是最新版本</string>
+    <string name="pkg_check_update_available">发现新版本 %1$s，可前往插件市场更新</string>
+    <string name="pkg_check_update_go">前往更新</string>
+    <string name="pkg_check_update_not_market">该插件不是从市场安装的，无法检查更新</string>
+    <string name="pkg_check_update_entry_missing">未在市场中找到该插件，可能已被下架</string>
+    <string name="pkg_check_update_failed">检查更新失败，请检查网络后重试</string>
+    <string name="pkg_ok">确定</string>
     <string name="pkg_tool_list">工具列表</string>
     <string name="pkg_no_tools">暂无可用工具</string>
 


### PR DESCRIPTION
## 变更说明 / Description
### 背景与动机 / Context and motivation
issue #1099 希望为已安装插件提供版本更新检查。经讨论收敛范围：第一版只做单插件入口（插件详情对话框内"检查更新"按钮），不做进入包管理时的自动全量检查；版本选择交给市场详情页已有的版本列表，本 PR 不实现批量更新。后续将同一能力扩展到技能与 MCP 服务器。
### 改动范围 / Changes
- 插件详情对话框删除按钮左侧新增"检查更新"按钮。
- 抽取共享组件 MarketUpdateChecker（5 态结果）与 MarketUpdateCheckButton（按钮+弹窗），插件 / 技能 / MCP 三类入口共用同一套状态机。
- 技能详情对话框新增"检查更新"按钮（删除旁）；MCP 服务器详情操作栏新增"检查更新"按钮（repo 链接与卸载之间，仅已安装时显示）。
- 通过安装时写入的 market marker（`<插件目录>/.operit/market.json`）判定插件是否来自市场安装；本地导入（无 marker）提示非市场来源，无法检查。技能按技能目录读取 marker；MCP 同时支持 config 目录与 installedPath 两种形态，任一命中即返回。
- 点击后请求市场静态 JSON（`MarketStatsApiService.getEntry`），以 versionId 对比判定是否有更新。
- 五种结果状态：已最新、有更新（前往更新 + 取消）、非市场来源、市场条目缺失、检查失败。
- "前往更新"关闭详情框并导航到该插件的市场详情页。
- 8 语言文案（values 及 values-en / es / id / ko / ms / pt-rBR / ro）。
不包含：进入包管理自动全量检查、多插件批量更新、版本选择 UI（复用市场详情页）。
### 兼容性与风险 / Compatibility and risks
- 无数据格式、API、配置、性能或安全面影响。
- 新增按钮不改变现有删除 / 关闭按钮行为；仅市场安装（有 marker）的插件可检查更新，与现网安装流程语义一致。
## 关联 Issue / Related issue
Resolves #1099（范围收敛为单插件入口，见背景与动机）
## 验证方式 / Verification
```text
检查或命令：GitHub Actions android-build.yml（assembleDebug）
环境与变体：Ubuntu runner，Android SDK 完整依赖
结果：构建通过（run 33954664937，success；含技能/MCP 检查更新按钮的最新构建 run 33966989717，success）

检查或命令：实机测试（插件详情页检查更新）
环境与变体：Android 真机
结果：
- 市场下载旧版 -> 检测到有新版，可跳转到市场详情页 ✅
- 文件直接导入 -> 识别不到 marker，提示非市场来源无法更新 ✅
- 市场安装最新版 -> 提示已是最新版本，检测不到更新 ✅
- 断网 -> 检查失败提示，不崩溃 ✅
- 市场条目已下架（EntryMissing）：无现成条目可构造，未实机验证（代码有兜底分支）

检查或命令：实机测试（技能 / MCP 检查更新按钮）
环境与变体：Android 真机
结果：待安装最新构建 APK 后验证（市场安装可检测版本、本地导入提示非市场来源）
```

## 证据 / Evidence
- 构建 CI：https://github.com/3316891527/Operit/actions/runs/33954664937（success）
- 最新构建（含技能/MCP 检查更新按钮）：https://github.com/3316891527/Operit/actions/runs/33966989717（success）
## 检查清单 / Checklist
- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 `dev`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `dev` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
