### PR TITLE
feat(chat): show cache hit rate in token stats brief and message info

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
@@ -1369,6 +1369,7 @@ private fun MessageFooterBar(
                 message.cachedInputTokens,
                 message.inputTokens,
                 message.outputTokens,
+                formatCacheHitRate(message.cachedInputTokens, message.inputTokens),
             )
         }
     val timeSummary =

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/MessageInfoDialog.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/MessageInfoDialog.kt
@@ -204,6 +204,10 @@ private fun MessageInfoTokenRow(
                     append(stringResource(R.string.message_info_token_cached_short))
                     append(" ")
                     append(cachedInputTokens)
+                    append("  ")
+                    append(stringResource(R.string.message_info_token_hit_rate_short))
+                    append(" ")
+                    append(formatCacheHitRate(cachedInputTokens, inputTokens))
                 },
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/TokenHitRateFormat.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/TokenHitRateFormat.kt
@@ -1,0 +1,17 @@
+package com.ai.assistance.operit.ui.features.chat.components
+
+import java.util.Locale
+import kotlin.math.floor
+
+/**
+ * 计算缓存命中率：缓存输入 / 输入，保留两位小数并向下截断（不做四舍五入）。
+ * 例如 99.999% 显示为 99.99%，不会进位到 100.00%。
+ * 输入为 0 时命中率无意义，返回 "-"。
+ */
+internal fun formatCacheHitRate(cachedInput: Long, input: Long): String {
+    if (input <= 0L) return "-"
+    val rate = cachedInput.coerceAtLeast(0L) * 100.0 / input
+    // +1e-9 仅用于抵消浮点表示误差，保证 95.88 不会被截成 95.87
+    val truncated = floor(rate * 100.0 + 1e-9) / 100.0
+    return String.format(Locale.US, "%.2f%%", truncated)
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1656,6 +1656,7 @@
     <string name="message_info_token_input_short">↑</string>
     <string name="message_info_token_output_short">↓</string>
     <string name="message_info_token_cached_short">Cached</string>
+    <string name="message_info_token_hit_rate_short">Hit rate</string>
     <string name="message_info_unavailable">Not recorded</string>
     <string name="selected_content_copied">Selected content copied</string>
     <string name="requesting_root_permission">Requesting Root permission...</string>
@@ -5175,7 +5176,7 @@
     <string name="show_message_timing_stats_description">Show first-token and generation timing below AI messages</string>
     <string name="show_message_timestamp">Show Message Time</string>
     <string name="show_message_timestamp_description">Show the time of that AI message below it</string>
-    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
+    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d (hit: %5$s)</string>
     <string name="chat_message_timing_stats_compact">usage: %1$s (first %2$s out %3$s)</string>
     <string name="chat_message_timestamp_compact">time: %1$s</string>
     <string name="global_user_name">Global User Name</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2064,6 +2064,7 @@
     <string name="message_info_token_input_short">↑</string>
     <string name="message_info_token_output_short">↓</string>
     <string name="message_info_token_cached_short">Caché</string>
+    <string name="message_info_token_hit_rate_short">Tasa de aciertos</string>
     <string name="message_info_unavailable">No registrado</string>
     <string name="webview_ssl_cert_error">Error de certificado SSL</string>
     <string name="webview_ssl_error_untrusted">La entidad emisora del certificado no es de confianza</string>
@@ -4846,7 +4847,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
 
     <string name="show_message_timing_stats">Mostrar estadísticas de tiempo de mensajes</string>
     <string name="show_message_timing_stats_description">Mostrar el tiempo del primer paquete y el tiempo de generación en la parte inferior de los mensajes de IA</string>
-    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (caché: %2$d) ↓ %4$d</string>
+    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (caché: %2$d) ↓ %4$d (hit: %5$s)</string>
     <string name="chat_message_timing_stats_compact">tiempo: %1$s (primer %2$s generar %3$s)</string>
     <string name="global_user_name">Nombre de usuario global</string>
     <string name="system_display_settings">Configuración de pantalla del sistema</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1462,6 +1462,7 @@
     <string name="message_info_token_input_short">↑</string>
     <string name="message_info_token_output_short">↓</string>
     <string name="message_info_token_cached_short">Cache</string>
+    <string name="message_info_token_hit_rate_short">Hit rate</string>
     <string name="message_info_unavailable">Tidak tercatat</string>
 
     <string name="script_code">Kode Skrip</string>
@@ -6900,7 +6901,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="show_message_token_stats_description">Tampilkan informasi ringkas token naik/turun dan cache di bagian bawah pesan AI</string>
     <string name="show_message_timing_stats">Tampilkan statistik waktu pesan</string>
     <string name="show_message_timing_stats_description">Tampilkan waktu paket pertama dan waktu generasi di bagian bawah pesan AI</string>
-    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
+    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d (hit: %5$s)</string>
     <string name="chat_message_timing_stats_compact">waktu: %1$s (pertama %2$s generasi %3$s)</string>
     <string name="software_identity_title">Identitas Perangkat Lunak</string>
     <string name="software_identity_description">Ubah identitas perangkat lunak yang ditampilkan di bagian atas sidebar.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1562,6 +1562,7 @@
     <string name="message_info_token_input_short">↑</string>
     <string name="message_info_token_output_short">↓</string>
     <string name="message_info_token_cached_short">캐시됨</string>
+    <string name="message_info_token_hit_rate_short">적중률</string>
     <string name="message_info_unavailable">기록되지 않음</string>
     <string name="selected_content_copied">선택한 콘텐츠가 복사되었습니다.</string>
     <string name="requesting_root_permission">루트 권한을 요청하는 중...</string>
@@ -4781,7 +4782,7 @@
     <string name="show_message_timing_stats_description">AI 메시지 아래에 첫 토큰 및 생성 소요 시간을 표시합니다</string>
     <string name="show_message_timestamp">메시지 시간 표시</string>
     <string name="show_message_timestamp_description">해당 AI 메시지 아래에 시간을 표시합니다.</string>
-    <string name="chat_message_token_stats_compact">토큰: %1$d ↑ %3$d (캐시: %2$d) ↓ %4$d</string>
+    <string name="chat_message_token_stats_compact">토큰: %1$d ↑ %3$d (캐시: %2$d) ↓ %4$d (hit: %5$s)</string>
     <string name="chat_message_timing_stats_compact">소요 시간: %1$s(대기 %2$s, 출력 %3$s)</string>
     <string name="chat_message_timestamp_compact">시간: %1$s</string>
     <string name="global_user_name">전역 사용자 이름</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1502,6 +1502,7 @@
     <string name="message_info_token_input_short">↑</string>
     <string name="message_info_token_output_short">↓</string>
     <string name="message_info_token_cached_short">Cache</string>
+    <string name="message_info_token_hit_rate_short">Kadar hit</string>
     <string name="message_info_unavailable">Tidak Direkodkan</string>
     <string name="selected_content_copied">Kandungan Terpilih Disalin</string>
     <string name="requesting_root_permission">Meminta kebenaran Root...</string>
@@ -6898,7 +6899,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="show_message_token_stats_description">Paparkan maklumat ringkas token naik/turun dan cache di bahagian bawah mesej AI</string>
     <string name="show_message_timing_stats">Tunjukkan ringkasan masa mesej</string>
     <string name="show_message_timing_stats_description">Paparkan masa paket pertama dan penjanaan di bahagian bawah mesej AI</string>
-    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
+    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d (hit: %5$s)</string>
     <string name="chat_message_timing_stats_compact">masa: %1$s (pertama %2$s jana %3$s)</string>
     <string name="software_identity_title">Identiti Perisian</string>
     <string name="software_identity_description">Tukar identiti perisian yang dipaparkan di bahagian atas bar sisi.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1516,6 +1516,7 @@
     <string name="message_info_token_input_short" />
     <string name="message_info_token_output_short" />
     <string name="message_info_token_cached_short">esconderijo</string>
+    <string name="message_info_token_hit_rate_short">Taxa de acerto</string>
     <string name="message_info_unavailable">Não registrado</string>
     <string name="selected_content_copied">Conteúdo selecionado copiado</string>
     <string name="requesting_root_permission">Solicitando permissão de root...</string>
@@ -6733,7 +6734,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="show_message_token_stats_description">Exibe informações concisas de tokens de subida/descida e cache na parte inferior das mensagens da IA.</string>
     <string name="show_message_timing_stats">Mostrar resumo de tempo da mensagem</string>
     <string name="show_message_timing_stats_description">Exibe o tempo do primeiro pacote e o tempo de geração na parte inferior das mensagens da IA.</string>
-    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
+    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d (hit: %5$s)</string>
     <string name="chat_message_timing_stats_compact">tempo: %1$s (primeiro %2$s geração %3$s)</string>
     <string name="software_identity_title">Identidade do software</string>
     <string name="software_identity_description">Altera a identidade do software exibida no topo da barra lateral.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1753,6 +1753,7 @@
     <string name="message_info_token_input_short">↑</string>
     <string name="message_info_token_output_short">↓</string>
     <string name="message_info_token_cached_short">Cache</string>
+    <string name="message_info_token_hit_rate_short">Rată de hit</string>
     <string name="message_info_unavailable">Nu a fost înregistrat</string>
     <string name="selected_content_copied">Conținutul selectat a fost copiat</string>
     <string name="requesting_root_permission">Se solicităRootDrepturi...</string>
@@ -5482,7 +5483,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="show_message_timing_stats_description">în AI În partea de jos a mesajului se afișează primul pachet și timpul necesar pentru generare</string>
     <string name="show_message_timestamp">Afișează ora mesajului</string>
     <string name="show_message_timestamp_description">în AI În partea de jos a mesajului este afișată ora la care a fost postat mesajul respectiv</string>
-    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
+    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d (hit: %5$s)</string>
     <string name="chat_message_timing_stats_compact">usage: %1$s (Primul %2$s Generare %3$s)</string>
     <string name="chat_message_timestamp_compact">time: %1$s</string>
     <string name="global_user_name">Numele de utilizator global</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1813,6 +1813,7 @@
     <string name="message_info_token_input_short">↑</string>
     <string name="message_info_token_output_short">↓</string>
     <string name="message_info_token_cached_short">缓存</string>
+    <string name="message_info_token_hit_rate_short">命中率</string>
     <string name="message_info_unavailable">未记录</string>
     <string name="selected_content_copied">已复制选中内容</string>
     <string name="requesting_root_permission">正在请求Root权限...</string>
@@ -5665,7 +5666,7 @@
     <string name="show_message_timing_stats_description">在 AI 消息底部显示首包与生成耗时</string>
     <string name="show_message_timestamp">显示消息时间</string>
     <string name="show_message_timestamp_description">在 AI 消息底部显示该条消息的时间</string>
-    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d</string>
+    <string name="chat_message_token_stats_compact">token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d (hit: %5$s)</string>
     <string name="chat_message_timing_stats_compact">usage: %1$s (首 %2$s 生成 %3$s)</string>
     <string name="chat_message_timestamp_compact">time: %1$s</string>
     <string name="global_user_name">全局用户名字</string>

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/TokenHitRateFormatTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/TokenHitRateFormatTest.kt
@@ -1,0 +1,39 @@
+package com.ai.assistance.operit.ui.features.chat.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TokenHitRateFormatTest {
+    @Test
+    fun formatsRealWorldRate() {
+        // 657280 / 685487 = 95.8849...% -> 95.88%
+        assertEquals("95.88%", formatCacheHitRate(657_280L, 685_487L))
+    }
+
+    @Test
+    fun truncatesInsteadOfRounding() {
+        // 99.999% 向下截断为 99.99%，不得四舍五入为 100.00%
+        assertEquals("99.99%", formatCacheHitRate(999_990L, 1_000_000L))
+        assertEquals("99.99%", formatCacheHitRate(999_999L, 1_000_000L))
+        // 99.5% 保留为 99.50%，不得进位为 100.00%
+        assertEquals("99.50%", formatCacheHitRate(995L, 1_000L))
+        // 66.666...% -> 66.66%
+        assertEquals("66.66%", formatCacheHitRate(2L, 3L))
+    }
+
+    @Test
+    fun keepsExactHundredPercent() {
+        assertEquals("100.00%", formatCacheHitRate(1_000L, 1_000L))
+    }
+
+    @Test
+    fun handlesZeroInput() {
+        assertEquals("-", formatCacheHitRate(0L, 0L))
+        assertEquals("-", formatCacheHitRate(10L, 0L))
+    }
+
+    @Test
+    fun handlesZeroCache() {
+        assertEquals("0.00%", formatCacheHitRate(0L, 100L))
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description
### 背景与动机 / Context and motivation
消息底部的 token 简报已展示总消耗、输入、输入缓存与输出，但缺少缓存命中率这一关键指标；消息长按信息面板的 token 统计栏同样只有输入/输出/缓存三项。本 PR 在两处追加缓存命中率显示，帮助用户直观判断缓存复用效果。
命中率 = 缓存输入 ÷ 输入，保留两位小数，**向下截断、不做四舍五入**（如 99.999% 显示 99.99%，不得进位为 100.00%）。
### 改动范围 / Changes
- 新增共享函数 `formatCacheHitRate`（TokenHitRateFormat.kt）：两位小数向下截断、固定小数点格式、输入为 0 时显示 "-"、含浮点误差防护。
- token 简报格式串追加第 5 个参数：`token: %1$d ↑ %3$d (cache: %2$d) ↓ %4$d (hit: %5$s)`，8 语言同步（符号暂用 `hit:` 对齐 `cache:` 风格，如需更换仅改文案）。
- 消息信息面板 token 统计行在"缓存"后追加"命中率"栏（新增标签 `message_info_token_hit_rate_short`，8 语言）。
- 单元测试 `TokenHitRateFormatTest`：覆盖真实数据、截断不四舍五入（99.999%→99.99%、99.5%→99.50%）、精确 100%、零输入、零缓存。
不包含：token 统计大屏（TokenUsageStatisticsScreen）的"缓存率"格式未动（该处为 %.1f 且会四舍五入，属另一界面，如需统一口径另行讨论）；命中率符号尚未最终确定。
### 兼容性与风险 / Compatibility and risks
- 纯显示层改动，无数据、API、配置、性能或安全面影响。
- 格式串参数从 4 个增至 5 个，全仓库唯一调用点已同步，无遗漏调用点。
- 百分比使用 Locale.US 固定小数点，避免区域格式差异。
## 关联 Issue / Related issue
无（由用户直接提出，未关联 issue）
## 验证方式 / Verification
```text
检查或命令：GitHub Actions android-build.yml（assembleDebug）
环境与变体：Ubuntu runner，Android SDK 完整依赖
结果：构建通过（run 33999952180，success）

检查或命令：单元测试 TokenHitRateFormatTest（5 组用例）
环境与变体：已随提交提供；assembleDebug 不执行测试任务
结果：测试代码就绪，尚未在 CI 中实际运行

检查或命令：实机 UI
环境与变体：Android 真机
结果：待安装最新构建 APK 后确认（简报新行格式、信息面板命中率栏）
```
## 证据 / Evidence
- 构建 CI：https://github.com/3316891527/Operit/actions/runs/33999952180（success）
## 检查清单 / Checklist
- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 dev；如目标为 main，我已说明这是维护者发布同步 / The target branch is dev for regular work; if it is main, I explained why this is a maintainer-led release sync
- [x] 我已确认 Candidate checks 覆盖改动范围，并会处理技术失败项 / Candidate checks covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
