### PR TITLE
fix(i18n): rename package and market labels

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/packages/screens/PackageManagerScreen.kt
@@ -726,7 +726,7 @@ fun PackageManagerScreen(
                         )
                         Spacer(Modifier.width(6.dp))
                         Text(
-                            context.getString(R.string.skills),
+                            context.getString(R.string.package_tab_skills),
                             style = MaterialTheme.typography.bodySmall,
                             softWrap = false,
                             color = if (selectedTab == PackageTab.SKILLS)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1071,7 +1071,7 @@
     <string name="tag_count_locked_status">Selected %1$d / Limit %2$d</string>
     
     <!-- Package Manager Screen -->
-    <string name="packages">Packages</string>
+    <string name="packages">Scripts</string>
     <string name="skills">Skills</string>
     <string name="show_to_ai_short">AI</string>
     <string name="package_manager">Package Manager</string>
@@ -7759,7 +7759,7 @@
     <string name="market_tab_mine">Mine</string>
     <string name="market_category_type_all">All</string>
     <string name="market_category_type_script">Script</string>
-    <string name="market_category_type_package">Package</string>
+    <string name="market_category_type_package">Plugin</string>
     <string name="market_category_type_skill">Skill</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">Search &amp; Research</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7423,7 +7423,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="market_tab_categories">Categorías</string>
     <string name="market_category_type_all">Todo</string>
     <string name="market_category_type_script">Script</string>
-    <string name="market_category_type_package">Plugin</string>
+    <string name="market_category_type_package">Complemento</string>
     <string name="market_category_type_skill">Skill</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">Búsqueda e investigación</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -213,7 +213,7 @@
     <string name="preference_lock_desc">Una vez bloqueado, no podrá modificar la información de preferencias de usuario</string>
 
     <!-- Package Manager Screen -->
-    <string name="packages">Gestión de paquetes</string>
+    <string name="packages">Scripts</string>
     <string name="package_manager">Gestor de paquetes</string>
     <string name="available_packages">Paquetes disponibles</string>
     <string name="imported_packages">Paquetes importados</string>
@@ -7423,7 +7423,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="market_tab_categories">Categorías</string>
     <string name="market_category_type_all">Todo</string>
     <string name="market_category_type_script">Script</string>
-    <string name="market_category_type_package">Paquete de herramientas</string>
+    <string name="market_category_type_package">Plugin</string>
     <string name="market_category_type_skill">Skill</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">Búsqueda e investigación</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -714,7 +714,7 @@
     <string name="preferences_guide_title">Untuk layanan yang lebih baik, harap lengkapi pengaturan berikut</string>
     <string name="preference_lock">Kunci preferensi pengguna</string>
     <string name="preference_lock_desc">Setelah dikunci, informasi preferensi pengguna tidak dapat diubah</string>
-    <string name="packages">Manajemen paket</string>
+    <string name="packages">Skrip</string>
     <string name="skills">Keterampilan</string>
     <string name="show_to_ai_short">AI</string>
     <string name="package_manager">Manajer paket</string>
@@ -7355,7 +7355,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="market_tab_categories">Kategori</string>
     <string name="market_category_type_all">Semua</string>
     <string name="market_category_type_script">Skrip</string>
-    <string name="market_category_type_package">Paket Alat</string>
+    <string name="market_category_type_package">Plugin</string>
     <string name="market_category_type_skill">Skill</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">Pencarian &amp; Riset</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -910,7 +910,7 @@
     <string name="tag_count_lock">잠금 횟수</string>
     <string name="tag_count_limit">최대 선택 가능</string>
     <string name="tag_count_locked_status">%1$d 선택 / %2$d 제한</string>
-    <string name="packages">패키지</string>
+    <string name="packages">스크립트</string>
     <string name="skills">스킬</string>
     <string name="quick_plugin_creator_title">신속하게 플러그인 만들기</string>
     <string name="quick_plugin_creator_desc">내장 목록이나 마켓에서 원하는 플러그인을 찾을 수 없나요? 직접 만들어 보세요.</string>
@@ -7202,7 +7202,7 @@
     <string name="market_tab_categories">카테고리</string>
     <string name="market_category_type_all">전체</string>
     <string name="market_category_type_script">스크립트</string>
-    <string name="market_category_type_package">도구 패키지</string>
+    <string name="market_category_type_package">플러그인</string>
     <string name="market_category_type_skill">Skill</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">검색 및 연구</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7352,7 +7352,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="market_tab_categories">Kategori</string>
     <string name="market_category_type_all">Semua</string>
     <string name="market_category_type_script">Skrip</string>
-    <string name="market_category_type_package">Plugin</string>
+    <string name="market_category_type_package">Pemalam</string>
     <string name="market_category_type_skill">Kemahiran</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">Carian &amp; Penyelidikan</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -704,7 +704,7 @@
     <string name="preferences_guide_title">Untuk memberikan perkhidmatan yang lebih baik, sila lengkapkan tetapan berikut</string>
     <string name="preference_lock">Kunci keutamaan pengguna</string>
     <string name="preference_lock_desc">Keutamaan pengguna tidak boleh diubah selepas dikunci</string>
-    <string name="packages">Pengurusan pakej</string>
+    <string name="packages">Skrip</string>
     <string name="skills">Kemahiran</string>
     <string name="show_to_ai_short">AI</string>
     <string name="package_manager">Pengurus pakej</string>
@@ -7352,7 +7352,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="market_tab_categories">Kategori</string>
     <string name="market_category_type_all">Semua</string>
     <string name="market_category_type_script">Skrip</string>
-    <string name="market_category_type_package">Kit Alat</string>
+    <string name="market_category_type_package">Plugin</string>
     <string name="market_category_type_skill">Kemahiran</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">Carian &amp; Penyelidikan</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -897,7 +897,7 @@
     <string name="preferences_guide_title">Para melhor atendê-lo, preencha as seguintes configurações</string>
     <string name="preference_lock">Bloquear preferências do usuário</string>
     <string name="preference_lock_desc">Uma vez bloqueadas, as informações de preferência do usuário não podem ser modificadas.</string>
-    <string name="packages">Gerenciamento de pacotes</string>
+    <string name="packages">Scripts</string>
     <string name="skills">Habilidade</string>
     <string name="show_to_ai_short">IA</string>
     <string name="package_manager">Gerenciador de pacotes</string>
@@ -7193,7 +7193,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="market_tab_categories">Categorias</string>
     <string name="market_category_type_all">Todos</string>
     <string name="market_category_type_script">Script</string>
-    <string name="market_category_type_package">Pacote de ferramentas</string>
+    <string name="market_category_type_package">Plugin</string>
     <string name="market_category_type_skill">Skill</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">Pesquisa e estudo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1003,7 +1003,7 @@
     <string name="tag_count_locked_status">A fost selectat %1$d / Limita maximă %2$d</string>
 
     <!-- Package Manager Screen -->
-    <string name="packages">Gestionarea pachetelor</string>
+    <string name="packages">Scripturi</string>
     <string name="skills">Abilități</string>
     <string name="quick_plugin_creator_title">Creează-ți rapid pluginul</string>
     <string name="quick_plugin_creator_desc">Nu găsești pluginul dorit nici în cele preinstalate, nici în magazin? Creează-l tu însuți!</string>
@@ -4287,7 +4287,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="market_tab_mine">Al meu</string>
     <string name="market_category_type_all">Toate</string>
     <string name="market_category_type_script">Scenariu</string>
-    <string name="market_category_type_package">Set de instrumente</string>
+    <string name="market_category_type_package">Plugin</string>
     <string name="market_category_type_skill">Skill</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">Căutare și cercetare</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1026,6 +1026,7 @@
     <!-- Package Manager Screen -->
     <string name="packages">沙盒包</string>
     <string name="skills">技能</string>
+    <string name="package_tab_skills">Skill</string>
     <string name="quick_plugin_creator_title">快速创作你的插件</string>
     <string name="quick_plugin_creator_desc">内置和市场都找不到想要的插件？创作你自己想要的！</string>
     <string name="quick_plugin_creator_step1_title">1. 更新或者下载包创作 Skill</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1024,7 +1024,7 @@
     <string name="tag_count_locked_status">已选择 %1$d / 上限 %2$d</string>
     
     <!-- Package Manager Screen -->
-    <string name="packages">包管理</string>
+    <string name="packages">沙盒包</string>
     <string name="skills">技能</string>
     <string name="quick_plugin_creator_title">快速创作你的插件</string>
     <string name="quick_plugin_creator_desc">内置和市场都找不到想要的插件？创作你自己想要的！</string>
@@ -4410,8 +4410,8 @@
     <string name="market_tab_skill">Skill</string>
     <string name="market_tab_mine">我的</string>
     <string name="market_category_type_all">全部</string>
-    <string name="market_category_type_script">脚本</string>
-    <string name="market_category_type_package">工具包</string>
+    <string name="market_category_type_script">沙盒包</string>
+    <string name="market_category_type_package">插件</string>
     <string name="market_category_type_skill">Skill</string>
     <string name="market_category_type_mcp">MCP</string>
     <string name="market_category_search_research">搜索与研究</string>


### PR DESCRIPTION
## 背景

统一并明确包管理界面与市场界面中沙盒包、插件、脚本和技能相关标签的显示名称。

## 修改内容

- 将中文包管理界面的“包管理”标签改为“沙盒包”。
- 将英文包管理界面的“Packages”改为“Scripts”，并为其他语言使用对应翻译。
- 将市场界面中文的“脚本”类型标签改为“沙盒包”。
- 将市场界面的“Package”类型标签改为“Plugin”，并使用各语言对应的插件翻译：
  - 中文：插件
  - 西班牙文：Complemento
  - 印尼文：Plugin
  - 韩文：플러그인
  - 马来文：Pemalam
  - 巴西葡萄牙文：Plugin
  - 罗马尼亚文：Plugin
- 将中文包管理界面的“技能”标签改为“Skill”。

## 兼容性影响

仅修改界面本地化文本，不涉及数据、配置、API 或运行时行为变化。

## 验证

- 通过 GitHub Actions 构建APK。
- GitHub Actions `assembleDebug` 构建成功。
- 构建提交：`d1a28473`
- Workflow Run #10：<https://github.com/YunXi-Aurora/Operit/actions/runs/33998478591>
- 已下载 `operit-android-10` APK Artifact。
- 已通过 `unzip -t` 验证 APK 压缩包完整性。
- 中文“包管理”界面和“市场”界面的修改已生效，其他语言的情况待验证。
