### PR TITLE
feat(chat): add scroll speed limit for streaming output and top positioning for non-streaming output (#1116)

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/DisplayPreferencesManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/DisplayPreferencesManager.kt
@@ -74,10 +74,38 @@ class DisplayPreferencesManager private constructor(private val context: Context
         // 工具折叠设置（多个只读工具 / 多个任意工具 / 全部工具）
         private val KEY_TOOL_COLLAPSE_MODE = stringPreferencesKey("tool_collapse_mode")
         // 滚动行为相关设置的 Key
-        private val KEY_ENABLE_STREAM_SCROLL_SPEED_LIMIT =
-            booleanPreferencesKey("enable_stream_scroll_speed_limit")
+        private val KEY_STREAM_SCROLL_MAX_SPEED_DP =
+            intPreferencesKey("stream_scroll_max_speed_dp")
         private val KEY_ENABLE_NON_STREAMING_SCROLL_TO_TOP =
             booleanPreferencesKey("enable_non_streaming_scroll_to_top")
+
+        /** 流式输出滚动速度上限的起步档（dp/s） */
+        const val STREAM_SCROLL_SPEED_MIN_DP = 50
+
+        /** 流式输出滚动速度上限的档位步进（dp/s） */
+        const val STREAM_SCROLL_SPEED_STEP_DP = 50
+
+        /**
+         * 流式输出滚动速度上限的最高有效限速档（dp/s）。
+         * 即倒数第二档；再往上一档为 [STREAM_SCROLL_SPEED_UNLIMITED]。
+         */
+        const val STREAM_SCROLL_SPEED_MAX_LIMITED_DP = 1000
+
+        /**
+         * 最后一档：不设上限。
+         * 此时滚动速度完全跟随模型吞吐量，模型输出多快屏幕就滚多快。
+         */
+        const val STREAM_SCROLL_SPEED_UNLIMITED = Int.MAX_VALUE
+
+        /** 流式输出滚动速度上限的默认值（dp/s），默认即启用限速 */
+        const val STREAM_SCROLL_SPEED_DEFAULT_DP = 600
+
+        /**
+         * 全部可选档位：50..1000（步进 50，共 20 档）+ 不限速（第 21 档）。
+         */
+        val STREAM_SCROLL_SPEED_OPTIONS: List<Int> =
+            (STREAM_SCROLL_SPEED_MIN_DP..STREAM_SCROLL_SPEED_MAX_LIMITED_DP step STREAM_SCROLL_SPEED_STEP_DP)
+                .toList() + STREAM_SCROLL_SPEED_UNLIMITED
     }
 
     /**
@@ -210,12 +238,13 @@ class DisplayPreferencesManager private constructor(private val context: Context
         }
 
     /**
-     * 是否启用流式输出滚动速度限制
-     * 默认值：true
+     * 流式输出时页面自动滚动的速度上限（dp/s）。
+     * 取 [STREAM_SCROLL_SPEED_UNLIMITED] 时表示最后一档“不设上限”，滚动速度跟随模型吞吐量。
+     * 默认值：[STREAM_SCROLL_SPEED_DEFAULT_DP]
      */
-    val enableStreamScrollSpeedLimit: Flow<Boolean> =
+    val streamScrollMaxSpeedDp: Flow<Int> =
         context.displayPreferencesDataStore.data.map { preferences ->
-            preferences[KEY_ENABLE_STREAM_SCROLL_SPEED_LIMIT] ?: true
+            preferences[KEY_STREAM_SCROLL_MAX_SPEED_DP] ?: STREAM_SCROLL_SPEED_DEFAULT_DP
         }
 
     /**
@@ -250,7 +279,7 @@ class DisplayPreferencesManager private constructor(private val context: Context
         toolPkgHookTimeoutSeconds: Int? = null,
         virtualDisplayBitrateKbps: Int? = null,
         toolCollapseMode: ToolCollapseMode? = null,
-        enableStreamScrollSpeedLimit: Boolean? = null,
+        streamScrollMaxSpeedDp: Int? = null,
         enableNonStreamingScrollToTop: Boolean? = null
     ) {
         context.displayPreferencesDataStore.edit { preferences ->
@@ -289,8 +318,13 @@ class DisplayPreferencesManager private constructor(private val context: Context
             }
             virtualDisplayBitrateKbps?.let { preferences[KEY_VIRTUAL_DISPLAY_BITRATE_KBPS] = it }
             toolCollapseMode?.let { preferences[KEY_TOOL_COLLAPSE_MODE] = it.value }
-            enableStreamScrollSpeedLimit?.let {
-                preferences[KEY_ENABLE_STREAM_SCROLL_SPEED_LIMIT] = it
+            streamScrollMaxSpeedDp?.let {
+                preferences[KEY_STREAM_SCROLL_MAX_SPEED_DP] =
+                    if (it == STREAM_SCROLL_SPEED_UNLIMITED) {
+                        STREAM_SCROLL_SPEED_UNLIMITED
+                    } else {
+                        it.coerceIn(STREAM_SCROLL_SPEED_MIN_DP, STREAM_SCROLL_SPEED_MAX_LIMITED_DP)
+                    }
             }
             enableNonStreamingScrollToTop?.let {
                 preferences[KEY_ENABLE_NON_STREAMING_SCROLL_TO_TOP] = it

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/DisplayPreferencesManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/DisplayPreferencesManager.kt
@@ -73,6 +73,11 @@ class DisplayPreferencesManager private constructor(private val context: Context
 
         // 工具折叠设置（多个只读工具 / 多个任意工具 / 全部工具）
         private val KEY_TOOL_COLLAPSE_MODE = stringPreferencesKey("tool_collapse_mode")
+        // 滚动行为相关设置的 Key
+        private val KEY_ENABLE_STREAM_SCROLL_SPEED_LIMIT =
+            booleanPreferencesKey("enable_stream_scroll_speed_limit")
+        private val KEY_ENABLE_NON_STREAMING_SCROLL_TO_TOP =
+            booleanPreferencesKey("enable_non_streaming_scroll_to_top")
     }
 
     /**
@@ -205,6 +210,24 @@ class DisplayPreferencesManager private constructor(private val context: Context
         }
 
     /**
+     * 是否启用流式输出滚动速度限制
+     * 默认值：true
+     */
+    val enableStreamScrollSpeedLimit: Flow<Boolean> =
+        context.displayPreferencesDataStore.data.map { preferences ->
+            preferences[KEY_ENABLE_STREAM_SCROLL_SPEED_LIMIT] ?: true
+        }
+
+    /**
+     * 是否在非流式输出时将页面定位到消息开头
+     * 默认值：true
+     */
+    val enableNonStreamingScrollToTop: Flow<Boolean> =
+        context.displayPreferencesDataStore.data.map { preferences ->
+            preferences[KEY_ENABLE_NON_STREAMING_SCROLL_TO_TOP] ?: true
+        }
+
+    /**
      * 保存显示设置
      */
     suspend fun saveDisplaySettings(
@@ -226,7 +249,9 @@ class DisplayPreferencesManager private constructor(private val context: Context
         visitWebWaitSeconds: Int? = null,
         toolPkgHookTimeoutSeconds: Int? = null,
         virtualDisplayBitrateKbps: Int? = null,
-        toolCollapseMode: ToolCollapseMode? = null
+        toolCollapseMode: ToolCollapseMode? = null,
+        enableStreamScrollSpeedLimit: Boolean? = null,
+        enableNonStreamingScrollToTop: Boolean? = null
     ) {
         context.displayPreferencesDataStore.edit { preferences ->
             showFpsCounter?.let { preferences[KEY_SHOW_FPS_COUNTER] = it }
@@ -264,6 +289,12 @@ class DisplayPreferencesManager private constructor(private val context: Context
             }
             virtualDisplayBitrateKbps?.let { preferences[KEY_VIRTUAL_DISPLAY_BITRATE_KBPS] = it }
             toolCollapseMode?.let { preferences[KEY_TOOL_COLLAPSE_MODE] = it.value }
+            enableStreamScrollSpeedLimit?.let {
+                preferences[KEY_ENABLE_STREAM_SCROLL_SPEED_LIMIT] = it
+            }
+            enableNonStreamingScrollToTop?.let {
+                preferences[KEY_ENABLE_NON_STREAMING_SCROLL_TO_TOP] = it
+            }
         }
     }
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
@@ -1,5 +1,5 @@
 package com.ai.assistance.operit.ui.features.chat.components
-
+import com.ai.assistance.operit.data.preferences.DisplayPreferencesManager
 import android.widget.Toast
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.StartOffset
@@ -261,8 +261,12 @@ fun ChatArea(
     val showMessageTokenStats = themeSnapshot.showMessageTokenStats
     val showMessageTimingStats = themeSnapshot.showMessageTimingStats
     val showMessageTimestamp = themeSnapshot.showMessageTimestamp
+    val displayPreferencesManager = remember { DisplayPreferencesManager.getInstance(context) }
+    val enableStreamScrollSpeedLimit by displayPreferencesManager.enableStreamScrollSpeedLimit.collectAsState(initial = true)
+    val enableNonStreamingScrollToTop by displayPreferencesManager.enableNonStreamingScrollToTop.collectAsState(initial = true)
     var viewportHeightPx by remember { mutableStateOf(0) }
     val messageAnchors = remember(currentChatId) { mutableStateMapOf<Long, ChatScrollMessageAnchor>() }
+    val streamedAiMessageTimestamps = remember(currentChatId) { mutableSetOf<Long>() }
     var pendingJumpToMessageTimestamp by remember(currentChatId) { mutableStateOf<Long?>(null) }
     val lastMessage = chatHistory.lastOrNull()
     val pendingTargetAnchor =
@@ -270,14 +274,13 @@ fun ChatArea(
     var hasLastAiMessageStartedStreaming by remember(lastMessage?.timestamp) {
         mutableStateOf(lastMessage?.run { sender == "ai" && content.isNotBlank() } == true)
     }
-
     val messagesCount = chatHistory.size
     LaunchedEffect(currentChatId, chatHistory.isEmpty()) {
         if (chatHistory.isEmpty()) {
             pendingJumpToMessageTimestamp = null
+            streamedAiMessageTimestamps.clear()
         }
     }
-
     val lastMessageContentLength = lastMessage?.content?.length
     LaunchedEffect(
         autoScrollToBottom,
@@ -297,7 +300,6 @@ fun ChatArea(
             pendingJumpToMessageTimestamp = lastMessage?.timestamp
         }
     }
-
     LaunchedEffect(
         pendingJumpToMessageTimestamp,
         messagesCount,
@@ -315,9 +317,25 @@ fun ChatArea(
         val targetAnchor = pendingTargetAnchor ?: return@LaunchedEffect
         val isActualLatestMessage = targetIndex == messagesCount - 1 && !hasNewerDisplayHistory
         onAutoScrollToBottomChange?.invoke(isActualLatestMessage)
-
         if (targetIndex == messagesCount - 1) {
-            scrollState.animateScrollTo(scrollState.maxValue)
+            val targetMessage = chatHistory.getOrNull(targetIndex)
+            val isTargetAi = targetMessage?.sender == "ai"
+            val isNonStreamingAi = isTargetAi &&
+                targetMessage?.contentStream == null &&
+                targetMessage?.timestamp !in streamedAiMessageTimestamps
+
+            if (isNonStreamingAi && enableNonStreamingScrollToTop) {
+                val targetOffset =
+                    targetAnchor.absoluteTopPx.roundToInt().coerceIn(0, scrollState.maxValue)
+                scrollState.animateScrollTo(targetOffset)
+            } else {
+                val isStreaming = isTargetAi && (targetMessage?.contentStream != null || targetMessage?.timestamp in streamedAiMessageTimestamps)
+                scrollState.animateScrollToWithSpeedLimit(
+                    targetValue = scrollState.maxValue,
+                    density = density,
+                    enableLimit = enableStreamScrollSpeedLimit && isStreaming
+                )
+            }
         } else {
             val targetOffset =
                 targetAnchor.absoluteTopPx.roundToInt().coerceIn(0, scrollState.maxValue)
@@ -325,27 +343,29 @@ fun ChatArea(
         }
         pendingJumpToMessageTimestamp = null
     }
-
     LaunchedEffect(lastMessage?.timestamp, lastMessage?.contentStream) {
         val lastAiMessageHasStaticContent =
             lastMessage?.let { it.sender == "ai" && it.content.isNotBlank() } == true
         hasLastAiMessageStartedStreaming = lastAiMessageHasStaticContent
-
         val shouldAwaitFirstChunk =
             lastMessage?.let {
                 it.sender == "ai" && it.content.isBlank() && it.contentStream != null
             } == true
         val stream = lastMessage?.contentStream
 
+        if (lastMessage?.sender == "ai" && stream != null) {
+            lastMessage.timestamp.let { streamedAiMessageTimestamps.add(it) }
+        }
+
         if (!lastAiMessageHasStaticContent && shouldAwaitFirstChunk && stream != null) {
             stream.collect { chunk ->
                 if (!hasLastAiMessageStartedStreaming && chunk.isNotEmpty()) {
                     hasLastAiMessageStartedStreaming = true
+                    lastMessage?.timestamp?.let { streamedAiMessageTimestamps.add(it) }
                 }
             }
         }
     }
-
     LaunchedEffect(
         messagesCount,
         chatHistory.firstOrNull()?.timestamp,
@@ -356,8 +376,8 @@ fun ChatArea(
             .toList()
             .filterNot { it in visibleTimestamps }
             .forEach(messageAnchors::remove)
+        streamedAiMessageTimestamps.retainAll(visibleTimestamps)
     }
-
     val isLatestMessageVisible = messagesCount > 0 && !hasNewerDisplayHistory
     val showLoadingIndicator =
         isLatestMessageVisible &&

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatArea.kt
@@ -262,7 +262,9 @@ fun ChatArea(
     val showMessageTimingStats = themeSnapshot.showMessageTimingStats
     val showMessageTimestamp = themeSnapshot.showMessageTimestamp
     val displayPreferencesManager = remember { DisplayPreferencesManager.getInstance(context) }
-    val enableStreamScrollSpeedLimit by displayPreferencesManager.enableStreamScrollSpeedLimit.collectAsState(initial = true)
+    val streamScrollMaxSpeedDp by displayPreferencesManager.streamScrollMaxSpeedDp.collectAsState(
+        initial = DisplayPreferencesManager.STREAM_SCROLL_SPEED_DEFAULT_DP
+    )
     val enableNonStreamingScrollToTop by displayPreferencesManager.enableNonStreamingScrollToTop.collectAsState(initial = true)
     var viewportHeightPx by remember { mutableStateOf(0) }
     val messageAnchors = remember(currentChatId) { mutableStateMapOf<Long, ChatScrollMessageAnchor>() }
@@ -333,7 +335,8 @@ fun ChatArea(
                 scrollState.animateScrollToWithSpeedLimit(
                     targetValue = scrollState.maxValue,
                     density = density,
-                    enableLimit = enableStreamScrollSpeedLimit && isStreaming
+                    maxSpeedDpPerSecond =
+                        if (isStreaming) streamScrollMaxSpeedDp else UNLIMITED_SCROLL_SPEED
                 )
             }
         } else {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollSpeedLimit.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollSpeedLimit.kt
@@ -4,8 +4,12 @@ import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ScrollState
 import androidx.compose.ui.unit.Density
+import com.ai.assistance.operit.data.preferences.DisplayPreferencesManager
 
-const val DEFAULT_MAX_SCROLL_SPEED_DP_PER_SECOND = 800f
+/**
+ * 表示“不限速”的速度值：滚动速度完全跟随模型吞吐量。
+ */
+const val UNLIMITED_SCROLL_SPEED = DisplayPreferencesManager.STREAM_SCROLL_SPEED_UNLIMITED
 
 /**
  * 根据位移像素与屏幕密度，计算限速滚动所需的动画持续时间（毫秒）。
@@ -14,7 +18,7 @@ const val DEFAULT_MAX_SCROLL_SPEED_DP_PER_SECOND = 800f
 internal fun calculateScrollDurationMs(
     deltaPx: Int,
     densityDpiRatio: Float,
-    maxSpeedDpPerSecond: Float = DEFAULT_MAX_SCROLL_SPEED_DP_PER_SECOND,
+    maxSpeedDpPerSecond: Float,
     minDurationMs: Long = 100L,
     maxDurationMs: Long = 1000L
 ): Int {
@@ -28,18 +32,19 @@ internal fun calculateScrollDurationMs(
 
 /**
  * 带有最大速度限制的平滑滚动。
- * 如果 [enableLimit] 为 true 且目标位置在当前位置下方，
- * 则限制单位时间内的位移速度，避免流式大段输出或突发 chunk 导致页面猛烈滑移。
+ *
+ * [maxSpeedDpPerSecond] 是速度上限而非固定速度：模型输出较慢时不会介入，
+ * 只有在单次位移会导致滚动超速时才拉长动画时长削峰。
+ * 传入 [UNLIMITED_SCROLL_SPEED] 时不做任何限制，滚动速度完全跟随模型吞吐量。
  */
 suspend fun ScrollState.animateScrollToWithSpeedLimit(
     targetValue: Int,
     density: Density,
-    enableLimit: Boolean = true,
-    maxSpeedDpPerSecond: Float = DEFAULT_MAX_SCROLL_SPEED_DP_PER_SECOND
+    maxSpeedDpPerSecond: Int
 ) {
     val clampedTarget = targetValue.coerceIn(0, maxValue)
     val delta = clampedTarget - value
-    if (!enableLimit || delta <= 0) {
+    if (maxSpeedDpPerSecond == UNLIMITED_SCROLL_SPEED || delta <= 0) {
         animateScrollTo(clampedTarget)
         return
     }
@@ -47,7 +52,7 @@ suspend fun ScrollState.animateScrollToWithSpeedLimit(
     val duration = calculateScrollDurationMs(
         deltaPx = delta,
         densityDpiRatio = density.density,
-        maxSpeedDpPerSecond = maxSpeedDpPerSecond
+        maxSpeedDpPerSecond = maxSpeedDpPerSecond.toFloat()
     )
     animateScrollTo(
         clampedTarget,

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollSpeedLimit.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollSpeedLimit.kt
@@ -1,0 +1,56 @@
+package com.ai.assistance.operit.ui.features.chat.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ScrollState
+import androidx.compose.ui.unit.Density
+
+const val DEFAULT_MAX_SCROLL_SPEED_DP_PER_SECOND = 800f
+
+/**
+ * 根据位移像素与屏幕密度，计算限速滚动所需的动画持续时间（毫秒）。
+ * 当内容产生大量下移时，拉长动画时间以将滚动速度限制在 [maxSpeedDpPerSecond] 之下。
+ */
+internal fun calculateScrollDurationMs(
+    deltaPx: Int,
+    densityDpiRatio: Float,
+    maxSpeedDpPerSecond: Float = DEFAULT_MAX_SCROLL_SPEED_DP_PER_SECOND,
+    minDurationMs: Long = 100L,
+    maxDurationMs: Long = 1000L
+): Int {
+    if (deltaPx <= 0 || densityDpiRatio <= 0f || maxSpeedDpPerSecond <= 0f) {
+        return minDurationMs.toInt()
+    }
+    val deltaDp = deltaPx / densityDpiRatio
+    val calculatedMs = ((deltaDp / maxSpeedDpPerSecond) * 1000f).toLong()
+    return calculatedMs.coerceIn(minDurationMs, maxDurationMs).toInt()
+}
+
+/**
+ * 带有最大速度限制的平滑滚动。
+ * 如果 [enableLimit] 为 true 且目标位置在当前位置下方，
+ * 则限制单位时间内的位移速度，避免流式大段输出或突发 chunk 导致页面猛烈滑移。
+ */
+suspend fun ScrollState.animateScrollToWithSpeedLimit(
+    targetValue: Int,
+    density: Density,
+    enableLimit: Boolean = true,
+    maxSpeedDpPerSecond: Float = DEFAULT_MAX_SCROLL_SPEED_DP_PER_SECOND
+) {
+    val clampedTarget = targetValue.coerceIn(0, maxValue)
+    val delta = clampedTarget - value
+    if (!enableLimit || delta <= 0) {
+        animateScrollTo(clampedTarget)
+        return
+    }
+
+    val duration = calculateScrollDurationMs(
+        deltaPx = delta,
+        densityDpiRatio = density.density,
+        maxSpeedDpPerSecond = maxSpeedDpPerSecond
+    )
+    animateScrollTo(
+        clampedTarget,
+        animationSpec = tween(durationMillis = duration, easing = LinearEasing)
+    )
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -186,6 +186,8 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
     val chatHeaderOverlayMode = themeSnapshot.chatHeaderOverlayMode
     val showInputProcessingStatus = themeSnapshot.showInputProcessingStatus
     val enableEnterToSend by displayPreferencesManager.enableEnterToSend.collectAsState(initial = false)
+    val enableStreamScrollSpeedLimit by displayPreferencesManager.enableStreamScrollSpeedLimit.collectAsState(initial = true)
+    val enableNonStreamingScrollToTop by displayPreferencesManager.enableNonStreamingScrollToTop.collectAsState(initial = true)
     val showChatFloatingDotsAnimation = themeSnapshot.showChatFloatingDotsAnimation
     val hasBackgroundImageFromPrefs = useBackgroundImage && backgroundImageUri != null
     val effectiveHasBackgroundImage = hasBackgroundImage || hasBackgroundImageFromPrefs
@@ -676,8 +678,18 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
                     !latestIsLoadingDisplayWindow
             ) {
                 try {
+                    val lastMsg = latestChatHistory.lastOrNull()
+                    val isNonStreamingAi = lastMsg?.sender == "ai" && lastMsg.contentStream == null
+                    if (isNonStreamingAi && enableNonStreamingScrollToTop) {
+                        return@collect
+                    }
                     if (latestChatHistory.isNotEmpty()) {
-                        scrollState.animateScrollTo(scrollState.maxValue)
+                        val isStreaming = lastMsg?.sender == "ai" && lastMsg.contentStream != null
+                        scrollState.animateScrollToWithSpeedLimit(
+                            targetValue = scrollState.maxValue,
+                            density = density,
+                            enableLimit = enableStreamScrollSpeedLimit && isStreaming
+                        )
                     }
                 } catch (e: Exception) {
                     // AppLogger.e("AIChatScreen", "自动滚动失败", e)

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -186,7 +186,9 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
     val chatHeaderOverlayMode = themeSnapshot.chatHeaderOverlayMode
     val showInputProcessingStatus = themeSnapshot.showInputProcessingStatus
     val enableEnterToSend by displayPreferencesManager.enableEnterToSend.collectAsState(initial = false)
-    val enableStreamScrollSpeedLimit by displayPreferencesManager.enableStreamScrollSpeedLimit.collectAsState(initial = true)
+    val streamScrollMaxSpeedDp by displayPreferencesManager.streamScrollMaxSpeedDp.collectAsState(
+        initial = DisplayPreferencesManager.STREAM_SCROLL_SPEED_DEFAULT_DP
+    )
     val enableNonStreamingScrollToTop by displayPreferencesManager.enableNonStreamingScrollToTop.collectAsState(initial = true)
     val showChatFloatingDotsAnimation = themeSnapshot.showChatFloatingDotsAnimation
     val hasBackgroundImageFromPrefs = useBackgroundImage && backgroundImageUri != null
@@ -688,7 +690,8 @@ val actualViewModel: ChatViewModel = viewModel ?: viewModel { ChatViewModel(cont
                         scrollState.animateScrollToWithSpeedLimit(
                             targetValue = scrollState.maxValue,
                             density = density,
-                            enableLimit = enableStreamScrollSpeedLimit && isStreaming
+                            maxSpeedDpPerSecond =
+                                if (isStreaming) streamScrollMaxSpeedDp else UNLIMITED_SCROLL_SPEED
                         )
                     }
                 } catch (e: Exception) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/GlobalDisplaySettingsScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/GlobalDisplaySettingsScreen.kt
@@ -73,6 +73,8 @@ fun GlobalDisplaySettingsScreen(
     val screenshotScalePercent by displayPreferencesManager.screenshotScalePercent.collectAsState(initial = 75)
     val visitWebWaitSeconds by displayPreferencesManager.visitWebWaitSeconds.collectAsState(initial = 0)
     val toolPkgHookTimeoutSeconds by displayPreferencesManager.toolPkgHookTimeoutSeconds.collectAsState(initial = 10)
+    val enableStreamScrollSpeedLimit by displayPreferencesManager.enableStreamScrollSpeedLimit.collectAsState(initial = true)
+    val enableNonStreamingScrollToTop by displayPreferencesManager.enableNonStreamingScrollToTop.collectAsState(initial = true)
     val virtualDisplayBitrateKbps by displayPreferencesManager.virtualDisplayBitrateKbps.collectAsState(initial = 3000)
     val keepScreenOn by apiPreferences.keepScreenOnFlow.collectAsState(initial = true)
     val convertLongPastedTextToFile by userPreferences.convertLongPastedTextToFile.collectAsState(initial = true)
@@ -281,7 +283,28 @@ fun GlobalDisplaySettingsScreen(
                     }
                 },
             )
-
+            DisplayToggleItem(
+                title = stringResource(R.string.enable_stream_scroll_speed_limit),
+                subtitle = stringResource(R.string.enable_stream_scroll_speed_limit_desc),
+                checked = enableStreamScrollSpeedLimit,
+                onCheckedChange = {
+                    scope.launch {
+                        displayPreferencesManager.saveDisplaySettings(enableStreamScrollSpeedLimit = it)
+                    }
+                },
+                backgroundColor = componentBackgroundColor
+            )
+            DisplayToggleItem(
+                title = stringResource(R.string.enable_non_streaming_scroll_to_top),
+                subtitle = stringResource(R.string.enable_non_streaming_scroll_to_top_desc),
+                checked = enableNonStreamingScrollToTop,
+                onCheckedChange = {
+                    scope.launch {
+                        displayPreferencesManager.saveDisplaySettings(enableNonStreamingScrollToTop = it)
+                    }
+                },
+                backgroundColor = componentBackgroundColor
+            )
             Spacer(modifier = Modifier.height(16.dp))
 
             // ======= 系统显示设置 =======

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/GlobalDisplaySettingsScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/GlobalDisplaySettingsScreen.kt
@@ -73,7 +73,10 @@ fun GlobalDisplaySettingsScreen(
     val screenshotScalePercent by displayPreferencesManager.screenshotScalePercent.collectAsState(initial = 75)
     val visitWebWaitSeconds by displayPreferencesManager.visitWebWaitSeconds.collectAsState(initial = 0)
     val toolPkgHookTimeoutSeconds by displayPreferencesManager.toolPkgHookTimeoutSeconds.collectAsState(initial = 10)
-    val enableStreamScrollSpeedLimit by displayPreferencesManager.enableStreamScrollSpeedLimit.collectAsState(initial = true)
+    val streamScrollMaxSpeedDp by displayPreferencesManager.streamScrollMaxSpeedDp.collectAsState(
+        initial = DisplayPreferencesManager.STREAM_SCROLL_SPEED_DEFAULT_DP
+    )
+    val streamScrollSpeedOptions = DisplayPreferencesManager.STREAM_SCROLL_SPEED_OPTIONS
     val enableNonStreamingScrollToTop by displayPreferencesManager.enableNonStreamingScrollToTop.collectAsState(initial = true)
     val virtualDisplayBitrateKbps by displayPreferencesManager.virtualDisplayBitrateKbps.collectAsState(initial = 3000)
     val keepScreenOn by apiPreferences.keepScreenOnFlow.collectAsState(initial = true)
@@ -105,6 +108,17 @@ fun GlobalDisplaySettingsScreen(
     var toolPkgHookTimeoutSliderValue by remember(toolPkgHookTimeoutSeconds) {
         mutableFloatStateOf(toolPkgHookTimeoutSeconds.toFloat())
     }
+    var streamScrollSpeedSliderValue by remember(streamScrollMaxSpeedDp) {
+        mutableFloatStateOf(
+            streamScrollSpeedOptions.indexOf(streamScrollMaxSpeedDp)
+                .let { if (it < 0) streamScrollSpeedOptions.indexOf(DisplayPreferencesManager.STREAM_SCROLL_SPEED_DEFAULT_DP) else it }
+                .toFloat()
+        )
+    }
+    val selectedStreamScrollSpeed =
+        streamScrollSpeedOptions[
+            streamScrollSpeedSliderValue.roundToInt().coerceIn(0, streamScrollSpeedOptions.lastIndex)
+        ]
     var qualitySliderValue by remember(screenshotQuality) {
         mutableFloatStateOf(screenshotQuality.toFloat())
     }
@@ -149,6 +163,7 @@ fun GlobalDisplaySettingsScreen(
         collapseModeSliderValue,
         visitWebWaitSliderValue,
         toolPkgHookTimeoutSliderValue,
+        streamScrollSpeedSliderValue,
         qualitySliderValue,
         scaleSliderValue
     ) {
@@ -156,6 +171,7 @@ fun GlobalDisplaySettingsScreen(
             collapseModeOptions[collapseModeSliderValue.roundToInt().coerceIn(0, collapseModeOptions.lastIndex)]
         val localVisitWebWaitSeconds = visitWebWaitSliderValue.roundToInt().coerceIn(0, 10)
         val localToolPkgHookTimeoutSeconds = toolPkgHookTimeoutSliderValue.roundToInt().coerceIn(1, 60)
+        val localStreamScrollMaxSpeedDp = selectedStreamScrollSpeed
         val localScreenshotQuality = qualitySliderValue.roundToInt().coerceIn(50, 100)
         val localScreenshotScalePercent = scaleSliderValue.roundToInt().coerceIn(50, 100)
 
@@ -163,6 +179,7 @@ fun GlobalDisplaySettingsScreen(
             localCollapseMode != toolCollapseMode ||
                 localVisitWebWaitSeconds != visitWebWaitSeconds ||
                 localToolPkgHookTimeoutSeconds != toolPkgHookTimeoutSeconds ||
+                localStreamScrollMaxSpeedDp != streamScrollMaxSpeedDp ||
                 localScreenshotQuality != screenshotQuality ||
                 localScreenshotScalePercent != screenshotScalePercent
 
@@ -174,6 +191,7 @@ fun GlobalDisplaySettingsScreen(
             toolCollapseMode = if (localCollapseMode != toolCollapseMode) localCollapseMode else null,
             visitWebWaitSeconds = if (localVisitWebWaitSeconds != visitWebWaitSeconds) localVisitWebWaitSeconds else null,
             toolPkgHookTimeoutSeconds = if (localToolPkgHookTimeoutSeconds != toolPkgHookTimeoutSeconds) localToolPkgHookTimeoutSeconds else null,
+            streamScrollMaxSpeedDp = if (localStreamScrollMaxSpeedDp != streamScrollMaxSpeedDp) localStreamScrollMaxSpeedDp else null,
             screenshotQuality = if (localScreenshotQuality != screenshotQuality) localScreenshotQuality else null,
             screenshotScalePercent = if (localScreenshotScalePercent != screenshotScalePercent) localScreenshotScalePercent else null
         )
@@ -283,17 +301,51 @@ fun GlobalDisplaySettingsScreen(
                     }
                 },
             )
-            DisplayToggleItem(
-                title = stringResource(R.string.enable_stream_scroll_speed_limit),
-                subtitle = stringResource(R.string.enable_stream_scroll_speed_limit_desc),
-                checked = enableStreamScrollSpeedLimit,
-                onCheckedChange = {
-                    scope.launch {
-                        displayPreferencesManager.saveDisplaySettings(enableStreamScrollSpeedLimit = it)
-                    }
-                },
-                backgroundColor = componentBackgroundColor
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 4.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(componentBackgroundColor)
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.stream_scroll_max_speed_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = stringResource(R.string.stream_scroll_max_speed_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Slider(
+                        value = streamScrollSpeedSliderValue,
+                        onValueChange = { streamScrollSpeedSliderValue = it.roundToInt().toFloat() },
+                        valueRange = 0f..streamScrollSpeedOptions.lastIndex.toFloat(),
+                        steps = (streamScrollSpeedOptions.size - 2).coerceAtLeast(0),
+                        modifier = Modifier.weight(1f).padding(vertical = 8.dp),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = if (selectedStreamScrollSpeed == DisplayPreferencesManager.STREAM_SCROLL_SPEED_UNLIMITED) {
+                            stringResource(R.string.stream_scroll_max_speed_unlimited)
+                        } else {
+                            stringResource(
+                                R.string.stream_scroll_max_speed_value,
+                                selectedStreamScrollSpeed
+                            )
+                        },
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
             DisplayToggleItem(
                 title = stringResource(R.string.enable_non_streaming_scroll_to_top),
                 subtitle = stringResource(R.string.enable_non_streaming_scroll_to_top_desc),

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8325,4 +8325,8 @@
     <string name="market_version_too_low_message">Current client version %1$s is lower than the minimum required version %2$s for this resource. Please update the client before downloading.</string>
     <string name="market_version_too_high_message">Current client version %1$s is higher than the maximum supported version %2$s for this resource. Please use a supported client version.</string>
     <string name="thinking_config_invalid_json">Invalid Thinking Configuration</string>
+    <string name="enable_stream_scroll_speed_limit">Limit Streaming Scroll Speed</string>
+    <string name="enable_stream_scroll_speed_limit_desc">Cap the maximum auto-scroll speed during rapid AI output to keep reading smooth</string>
+    <string name="enable_non_streaming_scroll_to_top">Show Top for Non-streaming Output</string>
+    <string name="enable_non_streaming_scroll_to_top_desc">Position the page at the top of complete single-turn AI responses instead of jumping to the bottom</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8325,8 +8325,10 @@
     <string name="market_version_too_low_message">Current client version %1$s is lower than the minimum required version %2$s for this resource. Please update the client before downloading.</string>
     <string name="market_version_too_high_message">Current client version %1$s is higher than the maximum supported version %2$s for this resource. Please use a supported client version.</string>
     <string name="thinking_config_invalid_json">Invalid Thinking Configuration</string>
-    <string name="enable_stream_scroll_speed_limit">Limit Streaming Scroll Speed</string>
-    <string name="enable_stream_scroll_speed_limit_desc">Cap the maximum auto-scroll speed during rapid AI output to keep reading smooth</string>
+    <string name="stream_scroll_max_speed_title">Streaming Scroll Speed Cap</string>
+    <string name="stream_scroll_max_speed_description">Cap the maximum auto-scroll speed while the AI generates quickly. This is an upper bound, not a fixed speed, so slower models are unaffected. The last step removes the cap and scrolling follows the model throughput.</string>
+    <string name="stream_scroll_max_speed_value">%1$d dp/s</string>
+    <string name="stream_scroll_max_speed_unlimited">No cap</string>
     <string name="enable_non_streaming_scroll_to_top">Show Top for Non-streaming Output</string>
     <string name="enable_non_streaming_scroll_to_top_desc">Position the page at the top of complete single-turn AI responses instead of jumping to the bottom</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7782,8 +7782,10 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="token_stats_trends">Análisis de tendencias</string>
     <string name="token_stats_settings">Configuración de estadísticas</string>
     <string name="token_stats_custom_range_confirm">Aceptar</string>
-    <string name="enable_stream_scroll_speed_limit">Limitar velocidad de desplazamiento en salida de flujo</string>
-    <string name="enable_stream_scroll_speed_limit_desc">Limita la velocidad máxima de desplazamiento automático durante la generación rápida de la IA para facilitar la lectura</string>
+    <string name="stream_scroll_max_speed_title">Límite de velocidad de desplazamiento en flujo</string>
+    <string name="stream_scroll_max_speed_description">Limita la velocidad máxima de desplazamiento automático durante la generación rápida de la IA. Es un límite superior, no una velocidad fija, por lo que los modelos lentos no se ven afectados. El último paso elimina el límite y el desplazamiento sigue el rendimiento del modelo.</string>
+    <string name="stream_scroll_max_speed_value">%1$d dp/s</string>
+    <string name="stream_scroll_max_speed_unlimited">Sin límite</string>
     <string name="enable_non_streaming_scroll_to_top">Mostrar inicio en salidas no continuas</string>
     <string name="enable_non_streaming_scroll_to_top_desc">Posiciona la página al principio de las respuestas completas de la IA en lugar de ir directamente al final</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7782,4 +7782,8 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="token_stats_trends">Análisis de tendencias</string>
     <string name="token_stats_settings">Configuración de estadísticas</string>
     <string name="token_stats_custom_range_confirm">Aceptar</string>
+    <string name="enable_stream_scroll_speed_limit">Limitar velocidad de desplazamiento en salida de flujo</string>
+    <string name="enable_stream_scroll_speed_limit_desc">Limita la velocidad máxima de desplazamiento automático durante la generación rápida de la IA para facilitar la lectura</string>
+    <string name="enable_non_streaming_scroll_to_top">Mostrar inicio en salidas no continuas</string>
+    <string name="enable_non_streaming_scroll_to_top_desc">Posiciona la página al principio de las respuestas completas de la IA en lugar de ir directamente al final</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7633,4 +7633,8 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="token_activity_chart_tap_hint">Ketuk grafik untuk melihat data detail</string>
     <string name="token_activity_total_tokens">Total Token</string>
     <string name="token_activity_peak_tokens">Token puncak</string>
+    <string name="enable_stream_scroll_speed_limit">Batasi Kecepatan Gulir Output Streaming</string>
+    <string name="enable_stream_scroll_speed_limit_desc">Batasi kecepatan gulir otomatis maksimum saat AI menghasilkan teks cepat agar mudah dibaca</string>
+    <string name="enable_non_streaming_scroll_to_top">Tampilkan Awal Pesan untuk Output Non-streaming</string>
+    <string name="enable_non_streaming_scroll_to_top_desc">Posisikan halaman di awal respons lengkap AI alih-alih langsung melompat ke bagian bawah</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7633,8 +7633,10 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="token_activity_chart_tap_hint">Ketuk grafik untuk melihat data detail</string>
     <string name="token_activity_total_tokens">Total Token</string>
     <string name="token_activity_peak_tokens">Token puncak</string>
-    <string name="enable_stream_scroll_speed_limit">Batasi Kecepatan Gulir Output Streaming</string>
-    <string name="enable_stream_scroll_speed_limit_desc">Batasi kecepatan gulir otomatis maksimum saat AI menghasilkan teks cepat agar mudah dibaca</string>
+    <string name="stream_scroll_max_speed_title">Batas Kecepatan Gulir Output Streaming</string>
+    <string name="stream_scroll_max_speed_description">Batasi kecepatan gulir otomatis maksimum saat AI menghasilkan teks dengan cepat. Ini adalah batas atas, bukan kecepatan tetap, sehingga model yang lambat tidak terpengaruh. Langkah terakhir menghapus batas dan gulir mengikuti throughput model.</string>
+    <string name="stream_scroll_max_speed_value">%1$d dp/s</string>
+    <string name="stream_scroll_max_speed_unlimited">Tanpa batas</string>
     <string name="enable_non_streaming_scroll_to_top">Tampilkan Awal Pesan untuk Output Non-streaming</string>
     <string name="enable_non_streaming_scroll_to_top_desc">Posisikan halaman di awal respons lengkap AI alih-alih langsung melompat ke bagian bawah</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7480,4 +7480,8 @@
     <string name="token_activity_chart_tap_hint">차트를 탭하여 자세한 데이터 보기</string>
     <string name="token_activity_total_tokens">누적 토큰</string>
     <string name="token_activity_peak_tokens">최대 토큰</string>
+    <string name="enable_stream_scroll_speed_limit">스트리밍 출력 스크롤 속도 제한</string>
+    <string name="enable_stream_scroll_speed_limit_desc">빠른 AI 생성 중 자동 스크롤 최대 속도를 제한하여 편안한 읽기를 유지합니다</string>
+    <string name="enable_non_streaming_scroll_to_top">비스트리밍 출력 시 메시지 상단으로 이동</string>
+    <string name="enable_non_streaming_scroll_to_top_desc">AI 전체 응답이 한 번에 반환될 때 맨 아래로 이동하지 않고 응답 시작 부분에 페이지를 맞춥니다</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7480,8 +7480,10 @@
     <string name="token_activity_chart_tap_hint">차트를 탭하여 자세한 데이터 보기</string>
     <string name="token_activity_total_tokens">누적 토큰</string>
     <string name="token_activity_peak_tokens">최대 토큰</string>
-    <string name="enable_stream_scroll_speed_limit">스트리밍 출력 스크롤 속도 제한</string>
-    <string name="enable_stream_scroll_speed_limit_desc">빠른 AI 생성 중 자동 스크롤 최대 속도를 제한하여 편안한 읽기를 유지합니다</string>
+    <string name="stream_scroll_max_speed_title">스트리밍 출력 스크롤 속도 상한</string>
+    <string name="stream_scroll_max_speed_description">AI가 빠르게 생성할 때 자동 스크롤의 최대 속도를 제한합니다. 고정 속도가 아닌 상한이므로 느린 모델에는 영향이 없습니다. 마지막 단계에서는 상한을 해제하여 스크롤이 모델 처리량을 그대로 따릅니다.</string>
+    <string name="stream_scroll_max_speed_value">%1$d dp/초</string>
+    <string name="stream_scroll_max_speed_unlimited">제한 없음</string>
     <string name="enable_non_streaming_scroll_to_top">비스트리밍 출력 시 메시지 상단으로 이동</string>
     <string name="enable_non_streaming_scroll_to_top_desc">AI 전체 응답이 한 번에 반환될 때 맨 아래로 이동하지 않고 응답 시작 부분에 페이지를 맞춥니다</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7711,4 +7711,8 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="token_stats_trends">Analisis trend</string>
     <string name="token_stats_settings">Tetapan statistik</string>
     <string name="token_stats_custom_range_confirm">OK</string>
+    <string name="enable_stream_scroll_speed_limit">Hadkan Kelajuan Tatalan Output Penstriman</string>
+    <string name="enable_stream_scroll_speed_limit_desc">Hadkan kelajuan tatalan automatik maksimum semasa AI menjana teks pantas agar mudah dibaca</string>
+    <string name="enable_non_streaming_scroll_to_top">Papar Bahagian Atas Mesej untuk Output Bukan Penstriman</string>
+    <string name="enable_non_streaming_scroll_to_top_desc">Letakkan halaman pada permulaan respons lengkap AI dan bukannya melompat terus ke bahagian bawah</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7711,8 +7711,10 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="token_stats_trends">Analisis trend</string>
     <string name="token_stats_settings">Tetapan statistik</string>
     <string name="token_stats_custom_range_confirm">OK</string>
-    <string name="enable_stream_scroll_speed_limit">Hadkan Kelajuan Tatalan Output Penstriman</string>
-    <string name="enable_stream_scroll_speed_limit_desc">Hadkan kelajuan tatalan automatik maksimum semasa AI menjana teks pantas agar mudah dibaca</string>
+    <string name="stream_scroll_max_speed_title">Had Kelajuan Tatalan Output Penstriman</string>
+    <string name="stream_scroll_max_speed_description">Hadkan kelajuan tatalan automatik maksimum semasa AI menjana teks dengan pantas. Ini ialah had atas dan bukan kelajuan tetap, jadi model perlahan tidak terjejas. Langkah terakhir membuang had dan tatalan mengikut throughput model.</string>
+    <string name="stream_scroll_max_speed_value">%1$d dp/s</string>
+    <string name="stream_scroll_max_speed_unlimited">Tiada had</string>
     <string name="enable_non_streaming_scroll_to_top">Papar Bahagian Atas Mesej untuk Output Bukan Penstriman</string>
     <string name="enable_non_streaming_scroll_to_top_desc">Letakkan halaman pada permulaan respons lengkap AI dan bukannya melompat terus ke bahagian bawah</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7471,8 +7471,10 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="token_activity_chart_tap_hint">Toque no gráfico para ver dados detalhados</string>
     <string name="token_activity_total_tokens">Tokens acumulados</string>
     <string name="token_activity_peak_tokens">Pico de tokens</string>
-    <string name="enable_stream_scroll_speed_limit">Limitar velocidade de rolagem no fluxo</string>
-    <string name="enable_stream_scroll_speed_limit_desc">Limita a velocidade máxima de rolagem automática durante a geração rápida da IA para manter a leitura confortável</string>
+    <string name="stream_scroll_max_speed_title">Limite de velocidade de rolagem no fluxo</string>
+    <string name="stream_scroll_max_speed_description">Limita a velocidade máxima de rolagem automática durante a geração rápida da IA. É um limite superior, não uma velocidade fixa, então modelos mais lentos não são afetados. A última etapa remove o limite e a rolagem acompanha a taxa do modelo.</string>
+    <string name="stream_scroll_max_speed_value">%1$d dp/s</string>
+    <string name="stream_scroll_max_speed_unlimited">Sem limite</string>
     <string name="enable_non_streaming_scroll_to_top">Mostrar topo em saída não transmitida</string>
     <string name="enable_non_streaming_scroll_to_top_desc">Posiciona a página no início de respostas completas da IA em vez de rolar diretamente para o final</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7471,4 +7471,8 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="token_activity_chart_tap_hint">Toque no gráfico para ver dados detalhados</string>
     <string name="token_activity_total_tokens">Tokens acumulados</string>
     <string name="token_activity_peak_tokens">Pico de tokens</string>
+    <string name="enable_stream_scroll_speed_limit">Limitar velocidade de rolagem no fluxo</string>
+    <string name="enable_stream_scroll_speed_limit_desc">Limita a velocidade máxima de rolagem automática durante a geração rápida da IA para manter a leitura confortável</string>
+    <string name="enable_non_streaming_scroll_to_top">Mostrar topo em saída não transmitida</string>
+    <string name="enable_non_streaming_scroll_to_top_desc">Posiciona a página no início de respostas completas da IA em vez de rolar diretamente para o final</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -8309,4 +8309,8 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="token_stats_trends">Analiza tendințelor</string>
     <string name="token_stats_settings">Setări statistici</string>
     <string name="token_stats_custom_range_confirm">OK</string>
+    <string name="enable_stream_scroll_speed_limit">Limitează viteza de derulare în flux</string>
+    <string name="enable_stream_scroll_speed_limit_desc">Limitează viteza maximă de derulare automată în timpul generării rapide AI pentru a menține o lectură confortabilă</string>
+    <string name="enable_non_streaming_scroll_to_top">Afișează începutul pentru răspunsurile non-streaming</string>
+    <string name="enable_non_streaming_scroll_to_top_desc">Poziționează pagina la începutul răspunsului complet al AI-ului, în loc să deruleze direct la sfârșit</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -8309,8 +8309,10 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="token_stats_trends">Analiza tendințelor</string>
     <string name="token_stats_settings">Setări statistici</string>
     <string name="token_stats_custom_range_confirm">OK</string>
-    <string name="enable_stream_scroll_speed_limit">Limitează viteza de derulare în flux</string>
-    <string name="enable_stream_scroll_speed_limit_desc">Limitează viteza maximă de derulare automată în timpul generării rapide AI pentru a menține o lectură confortabilă</string>
+    <string name="stream_scroll_max_speed_title">Limita vitezei de derulare în flux</string>
+    <string name="stream_scroll_max_speed_description">Limitează viteza maximă de derulare automată în timpul generării rapide AI. Este o limită superioară, nu o viteză fixă, așa că modelele lente nu sunt afectate. Ultima treaptă elimină limita, iar derularea urmează debitul modelului.</string>
+    <string name="stream_scroll_max_speed_value">%1$d dp/s</string>
+    <string name="stream_scroll_max_speed_unlimited">Fără limită</string>
     <string name="enable_non_streaming_scroll_to_top">Afișează începutul pentru răspunsurile non-streaming</string>
     <string name="enable_non_streaming_scroll_to_top_desc">Poziționează pagina la începutul răspunsului complet al AI-ului, în loc să deruleze direct la sfârșit</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8342,8 +8342,10 @@
     <string name="codex_usage_unavailable">额度暂时不可用</string>
     <string name="codex_reset_after_days">%1$d 天后重置</string>
     <string name="codex_reset_after_clock">%1$02d:%2$02d 后重置</string>
-    <string name="enable_stream_scroll_speed_limit">流式输出滚动限速</string>
-    <string name="enable_stream_scroll_speed_limit_desc">限制 AI 快速生成时页面的最大自动滚动速度，避免滚动过快影响阅读</string>
+    <string name="stream_scroll_max_speed_title">流式输出滚动速度上限</string>
+    <string name="stream_scroll_max_speed_description">限制 AI 快速生成时页面的最大自动滚动速度上限；这是上限而非固定速度，模型输出较慢时不会介入。拉到最后一档为不设上限，屏幕滚动完全跟随模型吞吐量。</string>
+    <string name="stream_scroll_max_speed_value">%1$d dp/秒</string>
+    <string name="stream_scroll_max_speed_unlimited">不设上限</string>
     <string name="enable_non_streaming_scroll_to_top">非流式输出定位到消息开头</string>
     <string name="enable_non_streaming_scroll_to_top_desc">AI 单次完整回复时，页面自动定位在回复内容开头，避免直接滚动到底部</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8342,4 +8342,8 @@
     <string name="codex_usage_unavailable">额度暂时不可用</string>
     <string name="codex_reset_after_days">%1$d 天后重置</string>
     <string name="codex_reset_after_clock">%1$02d:%2$02d 后重置</string>
+    <string name="enable_stream_scroll_speed_limit">流式输出滚动限速</string>
+    <string name="enable_stream_scroll_speed_limit_desc">限制 AI 快速生成时页面的最大自动滚动速度，避免滚动过快影响阅读</string>
+    <string name="enable_non_streaming_scroll_to_top">非流式输出定位到消息开头</string>
+    <string name="enable_non_streaming_scroll_to_top_desc">AI 单次完整回复时，页面自动定位在回复内容开头，避免直接滚动到底部</string>
 </resources>

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollSpeedLimitTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollSpeedLimitTest.kt
@@ -1,0 +1,36 @@
+package com.ai.assistance.operit.ui.features.chat.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatScrollSpeedLimitTest {
+
+    @Test
+    fun returnsMinDurationWhenDeltaIsZeroOrNegative() {
+        assertEquals(100, calculateScrollDurationMs(0, 2.0f, 800f))
+        assertEquals(100, calculateScrollDurationMs(-50, 2.0f, 800f))
+    }
+
+    @Test
+    fun scalesDurationProportionallyWithDelta() {
+        // density = 2.0f, 800 dp/s => 1600 px/s => 1.6 px/ms
+        // delta = 800 px => 400 dp => 400 / 800 * 1000 = 500 ms
+        assertEquals(500, calculateScrollDurationMs(800, 2.0f, 800f))
+        // delta = 400 px => 200 dp => 200 / 800 * 1000 = 250 ms
+        assertEquals(250, calculateScrollDurationMs(400, 2.0f, 800f))
+    }
+
+    @Test
+    fun clampsDurationBetweenMinAndMax() {
+        // Very small delta -> clamped to min (100ms)
+        assertEquals(100, calculateScrollDurationMs(10, 2.0f, 800f))
+        // Very large delta -> clamped to max (1000ms)
+        assertEquals(1000, calculateScrollDurationMs(10000, 2.0f, 800f))
+    }
+
+    @Test
+    fun handlesInvalidDensityOrSpeedGracefully() {
+        assertEquals(100, calculateScrollDurationMs(500, 0f, 800f))
+        assertEquals(100, calculateScrollDurationMs(500, 2.0f, 0f))
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollSpeedLimitTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/chat/components/ChatScrollSpeedLimitTest.kt
@@ -1,36 +1,64 @@
 package com.ai.assistance.operit.ui.features.chat.components
 
+import com.ai.assistance.operit.data.preferences.DisplayPreferencesManager
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatScrollSpeedLimitTest {
 
     @Test
     fun returnsMinDurationWhenDeltaIsZeroOrNegative() {
-        assertEquals(100, calculateScrollDurationMs(0, 2.0f, 800f))
-        assertEquals(100, calculateScrollDurationMs(-50, 2.0f, 800f))
+        assertEquals(100, calculateScrollDurationMs(0, 2.0f, 600f))
+        assertEquals(100, calculateScrollDurationMs(-50, 2.0f, 600f))
     }
 
     @Test
     fun scalesDurationProportionallyWithDelta() {
-        // density = 2.0f, 800 dp/s => 1600 px/s => 1.6 px/ms
-        // delta = 800 px => 400 dp => 400 / 800 * 1000 = 500 ms
-        assertEquals(500, calculateScrollDurationMs(800, 2.0f, 800f))
-        // delta = 400 px => 200 dp => 200 / 800 * 1000 = 250 ms
-        assertEquals(250, calculateScrollDurationMs(400, 2.0f, 800f))
+        // density = 2.0f, 600 dp/s => 1200 px/s
+        // delta = 1200 px => 600 dp => 600 / 600 * 1000 = 1000 ms
+        assertEquals(1000, calculateScrollDurationMs(1200, 2.0f, 600f))
+        // delta = 600 px => 300 dp => 300 / 600 * 1000 = 500 ms
+        assertEquals(500, calculateScrollDurationMs(600, 2.0f, 600f))
+    }
+
+    @Test
+    fun lowerSpeedCapProducesLongerDuration() {
+        val slow = calculateScrollDurationMs(400, 2.0f, 50f)
+        val fast = calculateScrollDurationMs(400, 2.0f, 1000f)
+        assertTrue("更低的速度上限应产生更长的动画时长", slow > fast)
     }
 
     @Test
     fun clampsDurationBetweenMinAndMax() {
-        // Very small delta -> clamped to min (100ms)
-        assertEquals(100, calculateScrollDurationMs(10, 2.0f, 800f))
-        // Very large delta -> clamped to max (1000ms)
-        assertEquals(1000, calculateScrollDurationMs(10000, 2.0f, 800f))
+        assertEquals(100, calculateScrollDurationMs(10, 2.0f, 600f))
+        assertEquals(1000, calculateScrollDurationMs(10000, 2.0f, 600f))
     }
 
     @Test
     fun handlesInvalidDensityOrSpeedGracefully() {
-        assertEquals(100, calculateScrollDurationMs(500, 0f, 800f))
+        assertEquals(100, calculateScrollDurationMs(500, 0f, 600f))
         assertEquals(100, calculateScrollDurationMs(500, 2.0f, 0f))
+    }
+
+    @Test
+    fun speedOptionsHave20LimitedStepsPlusUnlimited() {
+        val options = DisplayPreferencesManager.STREAM_SCROLL_SPEED_OPTIONS
+        // 50..1000 步进 50 共 20 档，加上最后一档“不设上限”共 21 档
+        assertEquals(21, options.size)
+        assertEquals(DisplayPreferencesManager.STREAM_SCROLL_SPEED_MIN_DP, options.first())
+        assertEquals(
+            DisplayPreferencesManager.STREAM_SCROLL_SPEED_MAX_LIMITED_DP,
+            options[options.lastIndex - 1]
+        )
+        assertEquals(DisplayPreferencesManager.STREAM_SCROLL_SPEED_UNLIMITED, options.last())
+    }
+
+    @Test
+    fun defaultSpeedIsSelectableOption() {
+        assertTrue(
+            DisplayPreferencesManager.STREAM_SCROLL_SPEED_DEFAULT_DP
+                in DisplayPreferencesManager.STREAM_SCROLL_SPEED_OPTIONS
+        )
     }
 }


### PR DESCRIPTION
---

## 变更说明 / Description

### 背景与动机 / Context and motivation

针对 Issue #1116 反映的两个对话阅读体验问题：
1. **流式输出时页面滚动过快**：高吞吐量模型高速吐字时，视线被剧烈拖拽下移，来不及阅读；
2. **非流式输出时直接跳到底部**：单次完整返回长回答时，页面直接掉入底部，需要手动向上翻找开头。

### 改动范围 / Changes

#### 1. 流式输出滚动速度上限（21 档可调滑块）

将原先的二值开关（硬编码 800 dp/s）升级为连续可调滑块，共 21 档：

| 档位 | 速度 |
| --- | --- |
| 第 1 档 | 50 dp/s |
| 第 2–20 档 | 100 ~ 1000 dp/s（步进 50）|
| 第 21 档（最后） | **不设上限**，跟随模型吞吐量 |

- 默认值：**600 dp/s**
- 这是**上限而非固定速度**：模型输出较慢时完全不介入，仅在超速时拉长动画时长削峰，慢模型体验不受影响
- 设置入口：【显示与行为 → 消息显示设置 → 流式输出滚动速度上限】

#### 2. 非流式输出定位到消息开头

- AI 单次完整回复时，页面自动平滑定位至该条消息顶部，默认开启
- 设置入口：【显示与行为 → 消息显示设置 → 非流式输出定位到消息开头】

#### 3. 核心文件改动

- `DisplayPreferencesManager.kt`：原布尔键替换为 `int` 键 `stream_scroll_max_speed_dp`，新增 21 档选项列表与"不限速"标记常量
- `ChatScrollSpeedLimit.kt`：参数从 `enableLimit: Boolean` 改为 `maxSpeedDpPerSecond: Int`，传入不限速常量时走直通路径
- `ChatArea.kt` / `AIChatScreen.kt`：读取新的速度 Flow，流式时传速度上限值，非流式时传不限速
- `GlobalDisplaySettingsScreen.kt`：开关替换为 Slider，档位列表驱动，实时显示当前 dp/s 值（最后档显示"不设上限"）
- 8 种语言 `strings.xml`：旧开关文案替换为 title / description / value / unlimited 四条本地化字符串

#### 4. 明确不包含

- 未改动网络请求、LLM 生成管道及消息持久化结构
- 未修改任何数据库 schema

### 兼容性与风险 / Compatibility and risks

- 旧版保存的布尔值废弃后，存量用户首次打开将回落到默认值 600 dp/s，不会报错
- 风险低，仅约束动画插值时长，不涉及底层消息布局与内容状态

## 关联 Issue / Related issue

Resolves #1116

## 验证方式 / Verification

- 单元测试 `ChatScrollSpeedLimitTest`：6 组断言，覆盖比例计算、上下界 clamp、档位列表结构（21 档、首尾值、默认值可选）
- CI `android-build.yml` assembleDebug：run [34031171863](https://github.com/3316891527/Operit/actions/runs/34031171863)，结论 **success**
- 实机测试（@bylt-max）：非流式定位已符合预期；流式限速效果明显改善，800 dp/s 偏快，已据此将默认值调为 600 dp/s 并改为可调

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因
- [x] 日常开发 PR 的目标分支为 `dev`
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据