### PR TITLE
feat(settings): improve model list fetching feedback, timeouts, and request cancellation

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelFetchErrorHelper.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelFetchErrorHelper.kt
@@ -58,19 +58,32 @@ object ModelFetchErrorHelper {
         return false
     }
 
+    fun isDnsResolutionException(throwable: Throwable?): Boolean {
+        var current: Throwable? = throwable
+        while (current != null) {
+            if (current is UnknownHostException) return true
+            val msg = current.message?.lowercase() ?: ""
+            if (msg.contains("unable to resolve host") ||
+                msg.contains("no address associated with hostname")
+            ) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
+
     fun isNetworkConnectionException(throwable: Throwable?): Boolean {
         var current: Throwable? = throwable
         while (current != null) {
-            if (current is UnknownHostException ||
-                current is ConnectException ||
+            if (current is ConnectException ||
                 current is NoRouteToHostException ||
                 current is PortUnreachableException
             ) {
                 return true
             }
             val msg = current.message?.lowercase() ?: ""
-            if (msg.contains("unable to resolve host") ||
-                msg.contains("failed to connect") ||
+            if (msg.contains("failed to connect") ||
                 msg.contains("network is unreachable") ||
                 msg.contains("connection refused")
             ) {
@@ -119,12 +132,17 @@ object ModelFetchErrorHelper {
             return context.getString(R.string.model_fetch_error_timeout)
         }
 
-        // 2. 网络无法连接 / 域名无法解析（可能需要梯子）
+        // 2. 域名解析失败（如把 .com 删除了或拼错了域名）
+        if (isDnsResolutionException(throwable)) {
+            return context.getString(R.string.model_fetch_error_dns)
+        }
+
+        // 3. 网络无法连接 / 端口拒绝连接
         if (isNetworkConnectionException(throwable)) {
             return context.getString(R.string.model_fetch_error_network)
         }
 
-        // 3. SSL 握手/证书错误
+        // 4. SSL 握手/证书错误
         if (isSslException(throwable)) {
             return context.getString(R.string.model_fetch_error_ssl)
         }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelFetchErrorHelper.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelFetchErrorHelper.kt
@@ -1,0 +1,196 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import android.content.Context
+import com.ai.assistance.operit.R
+import java.io.IOException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.PortUnreachableException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLException
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * HTTP 状态码异常包装类，实现 HttpStatusCodeException 接口以保留状态码与原始错误响应体
+ */
+class ModelFetchHttpException(
+    override val statusCode: Int,
+    val errorBody: String,
+    message: String
+) : IOException(message), HttpStatusCodeException
+
+/**
+ * 模型列表获取错误友好化解析工具，将底层网络或 HTTP 异常转为用户易懂、可定位原因的提示文案
+ */
+object ModelFetchErrorHelper {
+
+    fun extractErrorMessage(errorBody: String): String? {
+        if (errorBody.isBlank()) return null
+        return try {
+            val json = JSONObject(errorBody)
+            if (json.has("error")) {
+                val errorObj = json.optJSONObject("error")
+                if (errorObj != null && errorObj.has("message")) {
+                    errorObj.optString("message").trim().takeIf { it.isNotBlank() }
+                } else {
+                    json.optString("error").trim().takeIf { it.isNotBlank() }
+                }
+            } else if (json.has("message")) {
+                json.optString("message").trim().takeIf { it.isNotBlank() }
+            } else {
+                null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun isTimeoutException(throwable: Throwable?): Boolean {
+        var current: Throwable? = throwable
+        while (current != null) {
+            if (current is SocketTimeoutException) return true
+            val msg = current.message?.lowercase() ?: ""
+            if (msg.contains("timeout") || msg.contains("timed out")) return true
+            current = current.cause
+        }
+        return false
+    }
+
+    fun isNetworkConnectionException(throwable: Throwable?): Boolean {
+        var current: Throwable? = throwable
+        while (current != null) {
+            if (current is UnknownHostException ||
+                current is ConnectException ||
+                current is NoRouteToHostException ||
+                current is PortUnreachableException
+            ) {
+                return true
+            }
+            val msg = current.message?.lowercase() ?: ""
+            if (msg.contains("unable to resolve host") ||
+                msg.contains("failed to connect") ||
+                msg.contains("network is unreachable") ||
+                msg.contains("connection refused")
+            ) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
+
+    fun isSslException(throwable: Throwable?): Boolean {
+        var current: Throwable? = throwable
+        while (current != null) {
+            if (current is SSLException) return true
+            val msg = current.message?.lowercase() ?: ""
+            if (msg.contains("ssl") || msg.contains("cert")) return true
+            current = current.cause
+        }
+        return false
+    }
+
+    fun extractHttpStatusCode(throwable: Throwable?): Int? {
+        var current: Throwable? = throwable
+        while (current != null) {
+            if (current is HttpStatusCodeException) {
+                return current.statusCode
+            }
+            val msg = current.message ?: ""
+            val regex = Regex("""(?:API请求失败:\s*|HTTP\s*(?:status|code)?\s*|status code:\s*)(\d{3})""", RegexOption.IGNORE_CASE)
+            val match = regex.find(msg)
+            if (match != null) {
+                return match.groupValues[1].toIntOrNull()
+            }
+            current = current.cause
+        }
+        return null
+    }
+
+    fun formatError(context: Context, throwable: Throwable?): String {
+        if (throwable == null) {
+            return context.getString(R.string.unknown_error)
+        }
+
+        // 1. 超时
+        if (isTimeoutException(throwable)) {
+            return context.getString(R.string.model_fetch_error_timeout)
+        }
+
+        // 2. 网络无法连接 / 域名无法解析（可能需要梯子）
+        if (isNetworkConnectionException(throwable)) {
+            return context.getString(R.string.model_fetch_error_network)
+        }
+
+        // 3. SSL 握手/证书错误
+        if (isSslException(throwable)) {
+            return context.getString(R.string.model_fetch_error_ssl)
+        }
+
+        // 4. HTTP 状态码错误
+        val statusCode = extractHttpStatusCode(throwable)
+        if (statusCode != null) {
+            val rawErrorBody = (throwable as? ModelFetchHttpException)?.errorBody ?: throwable.message.orEmpty()
+            val parsedReason = extractErrorMessage(rawErrorBody)
+
+            return when (statusCode) {
+                401 -> {
+                    if (!parsedReason.isNullOrBlank()) {
+                        context.getString(R.string.model_fetch_error_http, statusCode, parsedReason)
+                    } else {
+                        context.getString(R.string.model_fetch_error_unauthorized)
+                    }
+                }
+                403 -> {
+                    if (!parsedReason.isNullOrBlank()) {
+                        context.getString(R.string.model_fetch_error_http, statusCode, parsedReason)
+                    } else {
+                        context.getString(R.string.model_fetch_error_forbidden)
+                    }
+                }
+                404 -> {
+                    if (!parsedReason.isNullOrBlank()) {
+                        context.getString(R.string.model_fetch_error_http, statusCode, parsedReason)
+                    } else {
+                        context.getString(R.string.model_fetch_error_not_found)
+                    }
+                }
+                429 -> {
+                    if (!parsedReason.isNullOrBlank()) {
+                        context.getString(R.string.model_fetch_error_http, statusCode, parsedReason)
+                    } else {
+                        context.getString(R.string.model_fetch_error_rate_limit)
+                    }
+                }
+                in 500..599 -> {
+                    context.getString(R.string.model_fetch_error_server, statusCode)
+                }
+                else -> {
+                    if (!parsedReason.isNullOrBlank()) {
+                        context.getString(R.string.model_fetch_error_http, statusCode, parsedReason)
+                    } else {
+                        context.getString(R.string.model_fetch_api_failed, statusCode, rawErrorBody.take(120))
+                    }
+                }
+            }
+        }
+
+        // 5. JSON 解析错误 / 返回非预期格式
+        var current: Throwable? = throwable
+        while (current != null) {
+            if (current is JSONException) {
+                return context.getString(R.string.model_fetch_error_format)
+            }
+            current = current.cause
+        }
+        val msg = throwable.message.orEmpty()
+        if (msg.contains("modellist_error_missing_data") || msg.contains("Unexpected HTML")) {
+            return context.getString(R.string.model_fetch_error_format)
+        }
+
+        // 6. 兜底
+        return context.getString(R.string.get_models_list_failed, msg.ifBlank { context.getString(R.string.unknown_error) })
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
@@ -13,8 +13,10 @@ import java.net.SocketTimeoutException
 import java.net.URL
 import java.net.UnknownHostException
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
@@ -42,14 +44,13 @@ object ModelListFetcher {
             )
     private val KIMI_CODING_MODELS =
             listOf("kimi-for-coding")
-
-    // 使用更长的超时时间
+    // 模型列表获取专用超时时间（连接10s，读写15s，兼顾响应速度与弱网）
     private val client =
             UnsafeModelSsl.apply(
                     OkHttpClient.Builder()
-                            .connectTimeout(30, TimeUnit.SECONDS)
-                            .readTimeout(30, TimeUnit.SECONDS)
-                            .writeTimeout(30, TimeUnit.SECONDS)
+                            .connectTimeout(10, TimeUnit.SECONDS)
+                            .readTimeout(15, TimeUnit.SECONDS)
+                            .writeTimeout(15, TimeUnit.SECONDS)
             ).build()
 
     /**
@@ -198,243 +199,198 @@ object ModelListFetcher {
             apiProviderType: ApiProviderType = ApiProviderType.OPENAI
     ): Result<List<ModelOption>> {
         AppLogger.d(TAG, "开始获取模型列表: 端点=${sanitizeUrlForLog(apiEndpoint, apiKey)}, 提供商=${apiProviderType.name}")
-
         return withContext(Dispatchers.IO) {
-            val maxRetries = 2
-            var retryCount = 0
-            var lastException: Exception? = null
+            try {
+                val completedEndpoint =
+                        EndpointCompleter.completeEndpoint(apiEndpoint, apiProviderType)
+                if (
+                        apiProviderType == ApiProviderType.MOONSHOT &&
+                                isKimiCodingEndpoint(completedEndpoint)
+                ) {
+                    AppLogger.d(TAG, "检测到 Kimi Code 端点，返回官方配置中的固定模型列表")
+                    return@withContext Result.success(getKimiCodingModels())
+                }
+                // 根据提供商类型获取模型列表URL
+                val modelsUrl = getModelsListUrl(completedEndpoint, apiProviderType)
+                val providerRequiresApiKey =
+                        ApiProviderConfigs.requiresApiKey(apiProviderType, completedEndpoint)
+                AppLogger.d(TAG, "准备发送请求到: ${sanitizeUrlForLog(modelsUrl, apiKey)}")
+                val requestBuilder =
+                        Request.Builder()
+                                .url(modelsUrl)
+                                .addHeader("Content-Type", "application/json")
 
-            while (retryCount <= maxRetries) {
-                try {
-                    val completedEndpoint =
-                            EndpointCompleter.completeEndpoint(apiEndpoint, apiProviderType)
-
-                    if (
-                            apiProviderType == ApiProviderType.MOONSHOT &&
-                                    isKimiCodingEndpoint(completedEndpoint)
-                    ) {
-                        AppLogger.d(TAG, "检测到 Kimi Code 端点，返回官方配置中的固定模型列表")
-                        return@withContext Result.success(getKimiCodingModels())
-                    }
-
-                    // 根据提供商类型获取模型列表URL
-                    val modelsUrl = getModelsListUrl(completedEndpoint, apiProviderType)
-                    val providerRequiresApiKey =
-                            ApiProviderConfigs.requiresApiKey(apiProviderType, completedEndpoint)
-                    AppLogger.d(TAG, "准备发送请求到: ${sanitizeUrlForLog(modelsUrl, apiKey)}, 尝试次数: ${retryCount + 1}/${maxRetries + 1}")
-
-                    val requestBuilder =
-                            Request.Builder()
-                                    .url(modelsUrl)
-                                    .addHeader("Content-Type", "application/json")
-
-                    // 根据不同供应商添加不同的认证头
-                    when (apiProviderType) {
-                        ApiProviderType.GOOGLE,
-                        ApiProviderType.GEMINI_GENERIC -> {
-                            // Google Gemini API 使用 API 密钥作为查询参数
-                            val urlWithKey =
-                                    modelsUrl
-                                            .toHttpUrl()
-                                            .newBuilder()
-                                            .setQueryParameter("key", apiKey)
-                                            .build()
-                            AppLogger.d(
-                                    TAG,
-                                    "添加Google API密钥，完整URL: ${sanitizeUrlForLog(urlWithKey.toString(), apiKey)}"
-                            )
-                            requestBuilder.url(urlWithKey)
-                        }
-                        ApiProviderType.OPENROUTER -> {
-                            // OpenRouter需要添加特定请求头
-                            AppLogger.d(TAG, "使用Bearer认证方式并添加OpenRouter特定请求头")
-                            requestBuilder.addHeader("Authorization", "Bearer $apiKey")
-                            requestBuilder.addHeader("HTTP-Referer", "ai.assistance.operit")
-                            requestBuilder.addHeader("X-Title", "Assistance App")
-                        }
-                        ApiProviderType.NOUS_PORTAL -> {
-                            // Nous Portal 当前沿用 OpenRouter 兼容接入，保持同一组默认头
-                            AppLogger.d(TAG, "使用Bearer认证方式并添加Nous Portal兼容请求头")
-                            requestBuilder.addHeader("Authorization", "Bearer $apiKey")
-                            requestBuilder.addHeader("HTTP-Referer", "ai.assistance.operit")
-                            requestBuilder.addHeader("X-Title", "Assistance App")
-                        }
-                        ApiProviderType.MIMO -> {
-                            AppLogger.d(TAG, "使用MiMo官方兼容认证头")
-                            if (apiKey.isNotBlank()) {
-                                requestBuilder.addHeader("Authorization", "Bearer $apiKey")
-                                requestBuilder.addHeader("api-key", apiKey)
-                            }
-                        }
-                        ApiProviderType.ANTHROPIC,
-                        ApiProviderType.ANTHROPIC_GENERIC -> {
-                            AppLogger.d(TAG, "使用Anthropic x-api-key认证方式")
-                            if (apiKey.isNotBlank()) {
-                                requestBuilder.addHeader("x-api-key", apiKey)
-                            }
-                            requestBuilder.addHeader("anthropic-version", ANTHROPIC_VERSION)
-                        }
-                        else -> {
-                            if (apiKey.isNotBlank()) {
-                                AppLogger.d(TAG, "使用Bearer认证方式")
-                                requestBuilder.addHeader("Authorization", "Bearer $apiKey")
-                            } else if (providerRequiresApiKey) {
-                                AppLogger.d(TAG, "当前提供商需要API Key，但当前请求未提供认证头")
-                            } else {
-                                AppLogger.d(TAG, "当前提供商允许无API Key访问，跳过认证头")
-                            }
-                        }
-                    }
-
-                    val request = requestBuilder.get().build()
-
-                    AppLogger.d(TAG, "发送HTTP请求: ${sanitizeUrlForLog(request.url.toString(), apiKey)}")
-                    val response = client.newCall(request).execute()
-
-                    if (!response.isSuccessful) {
-                        val errorBody = response.body?.string() ?: context.getString(R.string.model_fetch_no_error_details)
-                        val responseCode = response.code
-                        response.close()
-                        if ((apiProviderType == ApiProviderType.OPENAI || apiProviderType == ApiProviderType.XAI || apiProviderType == ApiProviderType.OPENAI_RESPONSES || apiProviderType == ApiProviderType.OPENAI_RESPONSES_GENERIC || apiProviderType == ApiProviderType.OPENAI_GENERIC || apiProviderType == ApiProviderType.OPENAI_LOCAL || apiProviderType == ApiProviderType.IFLOW || apiProviderType == ApiProviderType.NVIDIA || apiProviderType == ApiProviderType.LMSTUDIO || apiProviderType == ApiProviderType.OLLAMA || apiProviderType == ApiProviderType.FOUR_ROUTER || apiProviderType == ApiProviderType.NOUS_PORTAL || apiProviderType == ApiProviderType.MIMO) &&
-                                        modelsUrl.endsWith("/v1/models")) {
-                            val fallbackUrl = modelsUrl.removeSuffix("/v1/models") + "/models"
-                            AppLogger.w(TAG, "API请求失败，尝试兼容路径: $fallbackUrl")
-                            val fallbackRequest = request.newBuilder().url(fallbackUrl).get().build()
-                            val fallbackResponse = client.newCall(fallbackRequest).execute()
-                            if (fallbackResponse.isSuccessful) {
-                                val fallbackBody = fallbackResponse.body?.string()
-                                if (fallbackBody.isNullOrEmpty()) {
-                                    fallbackResponse.close()
-                                    return@withContext Result.failure(IOException(context.getString(R.string.model_fetch_response_empty)))
-                                }
-                                fallbackResponse.close()
-                                val modelOptions = parseOpenAIModelResponse(context, fallbackBody)
-                                AppLogger.d(TAG, "成功解析模型列表，共获取 ${modelOptions.size} 个模型")
-                                return@withContext Result.success(modelOptions)
-                            } else {
-                                val fallbackErrorBody = fallbackResponse.body?.string() ?: context.getString(R.string.model_fetch_no_error_details)
-                                AppLogger.e(
-                                        TAG,
-                                        "API请求失败: 状态码=${fallbackResponse.code}, 错误=$fallbackErrorBody"
-                                )
-                                fallbackResponse.close()
-                                return@withContext Result.failure(
-                                        ModelFetchHttpException(
-                                                statusCode = fallbackResponse.code,
-                                                errorBody = fallbackErrorBody,
-                                                message = context.getString(R.string.model_fetch_api_failed, fallbackResponse.code, fallbackErrorBody)
-                                        )
-                                )
-                            }
-                        }
-                        AppLogger.e(TAG, "API请求失败: 状态码=$responseCode, 错误=$errorBody")
-                        return@withContext Result.failure(
-                                ModelFetchHttpException(
-                                        statusCode = responseCode,
-                                        errorBody = errorBody,
-                                        message = context.getString(R.string.model_fetch_api_failed, responseCode, errorBody)
-                                )
+                // 根据不同供应商添加不同的认证头
+                when (apiProviderType) {
+                    ApiProviderType.GOOGLE,
+                    ApiProviderType.GEMINI_GENERIC -> {
+                        // Google Gemini API 使用 API 密钥作为查询参数
+                        val urlWithKey =
+                                modelsUrl
+                                        .toHttpUrl()
+                                        .newBuilder()
+                                        .setQueryParameter("key", apiKey)
+                                        .build()
+                        AppLogger.d(
+                                TAG,
+                                "添加Google API密钥，完整URL: ${sanitizeUrlForLog(urlWithKey.toString(), apiKey)}"
                         )
+                        requestBuilder.url(urlWithKey)
                     }
-
-                    val responseBody = response.body?.string()
-                    response.close()
-                    if (responseBody == null) {
-                        AppLogger.e(TAG, "响应体为空")
-                        return@withContext Result.failure(IOException(context.getString(R.string.model_fetch_response_empty)))
+                    ApiProviderType.OPENROUTER -> {
+                        // OpenRouter需要添加特定请求头
+                        AppLogger.d(TAG, "使用Bearer认证方式并添加OpenRouter特定请求头")
+                        requestBuilder.addHeader("Authorization", "Bearer $apiKey")
+                        requestBuilder.addHeader("HTTP-Referer", "ai.assistance.operit")
+                        requestBuilder.addHeader("X-Title", "Assistance App")
                     }
-
-                    AppLogger.d(
-                            TAG,
-                            "收到响应: ${responseBody.take(200)}${if (responseBody.length > 200) "..." else ""}"
-                    )
-
-                    // 根据提供商类型解析响应
-                    val modelOptions =
-                            try {
-                                when (apiProviderType) {
-                                    ApiProviderType.OPENAI,
-                                    ApiProviderType.XAI,
-                                    ApiProviderType.OPENAI_RESPONSES,
-                                    ApiProviderType.OPENAI_RESPONSES_GENERIC,
-                                    ApiProviderType.OPENAI_GENERIC,
-                                    ApiProviderType.OPENAI_LOCAL,
-                                    ApiProviderType.DEEPSEEK,
-                                    ApiProviderType.MOONSHOT,
-                                    ApiProviderType.MIMO,
-                                    ApiProviderType.SILICONFLOW,
-                                    ApiProviderType.IFLOW,
-                                    ApiProviderType.DOUBAO,
-                                    ApiProviderType.NVIDIA,
-                                    ApiProviderType.BAICHUAN,
-                                     ApiProviderType.OPENROUTER,
-                                     ApiProviderType.OPENCODE,
-                                     ApiProviderType.FOUR_ROUTER,
-                                    ApiProviderType.NOUS_PORTAL,
-                                    ApiProviderType.INFINIAI,
-                                    ApiProviderType.ALIPAY_BAILING,
-                                    ApiProviderType.ZHIPU,
-                                    ApiProviderType.LMSTUDIO,
-                                    ApiProviderType.OLLAMA,
-                                    ApiProviderType.PPINFRA -> parseOpenAIModelResponse(context, responseBody)
-                                    ApiProviderType.ANTHROPIC,
-                                    ApiProviderType.ANTHROPIC_GENERIC -> parseAnthropicModelResponse(context, responseBody)
-                                    ApiProviderType.GOOGLE,
-                                    ApiProviderType.GEMINI_GENERIC -> parseGoogleModelResponse(context, responseBody)
-
-                                    // 其他提供商可能需要单独的解析方法
-                                    else -> parseOpenAIModelResponse(context, responseBody) // 默认尝试OpenAI格式
-                                }
-                            } catch (e: Exception) {
-                                AppLogger.e(TAG, "解析响应失败: ${e.message}")
-                                return@withContext Result.failure(e)
-                            }
-
-                    AppLogger.d(TAG, "成功解析模型列表，共获取 ${modelOptions.size} 个模型")
-                    return@withContext Result.success(modelOptions)
-                } catch (e: SocketTimeoutException) {
-                    lastException = e
-                    retryCount++
-                    AppLogger.e(TAG, "连接超时: ${e.message}", e)
-                    AppLogger.d(TAG, "网络超时，尝试重试 $retryCount/$maxRetries")
-
-                    if (retryCount <= maxRetries) {
-                        // 指数退避重试
-                        val delayTime = 1000L * retryCount
-                        AppLogger.d(TAG, "延迟 ${delayTime}ms 后重试")
-                        delay(delayTime)
+                    ApiProviderType.NOUS_PORTAL -> {
+                        // Nous Portal 当前沿用 OpenRouter 兼容接入，保持同一组默认头
+                        AppLogger.d(TAG, "使用Bearer认证方式并添加Nous Portal兼容请求头")
+                        requestBuilder.addHeader("Authorization", "Bearer $apiKey")
+                        requestBuilder.addHeader("HTTP-Referer", "ai.assistance.operit")
+                        requestBuilder.addHeader("X-Title", "Assistance App")
                     }
-                } catch (e: IOException) {
-                    lastException = e
-                    retryCount++
-                    AppLogger.e(TAG, "IO异常: ${e.message}", e)
-                    AppLogger.d(TAG, "IO异常，尝试重试 $retryCount/$maxRetries")
-
-                    if (retryCount <= maxRetries) {
-                        val delayTime = 1000L * retryCount
-                        AppLogger.d(TAG, "延迟 ${delayTime}ms 后重试")
-                        delay(delayTime)
+                    ApiProviderType.MIMO -> {
+                        AppLogger.d(TAG, "使用MiMo官方兼容认证头")
+                        if (apiKey.isNotBlank()) {
+                            requestBuilder.addHeader("Authorization", "Bearer $apiKey")
+                            requestBuilder.addHeader("api-key", apiKey)
+                        }
                     }
-                } catch (e: UnknownHostException) {
-                    AppLogger.e(TAG, "无法连接到服务器，域名解析失败", e)
-                    return@withContext Result.failure(IOException(context.getString(R.string.modellist_error_cannot_connect), e))
-                } catch (e: Exception) {
-                    lastException = e
-                    retryCount++
-                    AppLogger.e(TAG, "获取模型列表失败: ${e.message}", e)
-
-                    if (retryCount <= maxRetries) {
-                        // 指数退避重试
-                        val delayTime = 1000L * retryCount
-                        AppLogger.d(TAG, "延迟 ${delayTime}ms 后重试")
-                        delay(delayTime)
+                    ApiProviderType.ANTHROPIC,
+                    ApiProviderType.ANTHROPIC_GENERIC -> {
+                        AppLogger.d(TAG, "使用Anthropic x-api-key认证方式")
+                        if (apiKey.isNotBlank()) {
+                            requestBuilder.addHeader("x-api-key", apiKey)
+                        }
+                        requestBuilder.addHeader("anthropic-version", ANTHROPIC_VERSION)
+                    }
+                    else -> {
+                        if (apiKey.isNotBlank()) {
+                            AppLogger.d(TAG, "使用Bearer认证方式")
+                            requestBuilder.addHeader("Authorization", "Bearer $apiKey")
+                        } else if (providerRequiresApiKey) {
+                            AppLogger.d(TAG, "当前提供商需要API Key，但当前请求未提供认证头")
+                        } else {
+                            AppLogger.d(TAG, "当前提供商允许无API Key访问，跳过认证头")
+                        }
                     }
                 }
-            }
+                val request = requestBuilder.get().build()
 
-            // 所有重试都失败
-            AppLogger.e(TAG, "超过最大重试次数，获取模型列表失败")
-            Result.failure(lastException ?: IOException(context.getString(R.string.modellist_error_fetch_failed)))
+                AppLogger.d(TAG, "发送HTTP请求: ${sanitizeUrlForLog(request.url.toString(), apiKey)}")
+                val call = client.newCall(request)
+                coroutineContext.job.invokeOnCompletion { cause ->
+                    if (cause != null) {
+                        call.cancel()
+                    }
+                }
+                val response = call.execute()
+                if (!response.isSuccessful) {
+                    val errorBody = response.body?.string() ?: context.getString(R.string.model_fetch_no_error_details)
+                    val responseCode = response.code
+                    response.close()
+                    if ((apiProviderType == ApiProviderType.OPENAI || apiProviderType == ApiProviderType.XAI || apiProviderType == ApiProviderType.OPENAI_RESPONSES || apiProviderType == ApiProviderType.OPENAI_RESPONSES_GENERIC || apiProviderType == ApiProviderType.OPENAI_GENERIC || apiProviderType == ApiProviderType.OPENAI_LOCAL || apiProviderType == ApiProviderType.IFLOW || apiProviderType == ApiProviderType.NVIDIA || apiProviderType == ApiProviderType.LMSTUDIO || apiProviderType == ApiProviderType.OLLAMA || apiProviderType == ApiProviderType.FOUR_ROUTER || apiProviderType == ApiProviderType.NOUS_PORTAL || apiProviderType == ApiProviderType.MIMO) &&
+                                    modelsUrl.endsWith("/v1/models")) {
+                        val fallbackUrl = modelsUrl.removeSuffix("/v1/models") + "/models"
+                        AppLogger.w(TAG, "API请求失败，尝试兼容路径: $fallbackUrl")
+                        val fallbackRequest = request.newBuilder().url(fallbackUrl).get().build()
+                        val fallbackCall = client.newCall(fallbackRequest)
+                        coroutineContext.job.invokeOnCompletion { cause ->
+                            if (cause != null) {
+                                fallbackCall.cancel()
+                            }
+                        }
+                        val fallbackResponse = fallbackCall.execute()
+                        if (fallbackResponse.isSuccessful) {
+                            val fallbackBody = fallbackResponse.body?.string()
+                            if (fallbackBody.isNullOrEmpty()) {
+                                fallbackResponse.close()
+                                return@withContext Result.failure(IOException(context.getString(R.string.model_fetch_response_empty)))
+                            }
+                            fallbackResponse.close()
+                            val modelOptions = parseOpenAIModelResponse(context, fallbackBody)
+                            AppLogger.d(TAG, "成功解析模型列表，共获取 ${modelOptions.size} 个模型")
+                            return@withContext Result.success(modelOptions)
+                        } else {
+                            val fallbackErrorBody = fallbackResponse.body?.string() ?: context.getString(R.string.model_fetch_no_error_details)
+                            AppLogger.e(
+                                    TAG,
+                                    "API请求失败: 状态码=${fallbackResponse.code}, 错误=$fallbackErrorBody"
+                            )
+                            fallbackResponse.close()
+                            return@withContext Result.failure(
+                                    ModelFetchHttpException(
+                                            statusCode = fallbackResponse.code,
+                                            errorBody = fallbackErrorBody,
+                                            message = context.getString(R.string.model_fetch_api_failed, fallbackResponse.code, fallbackErrorBody)
+                                    )
+                            )
+                        }
+                    }
+                    AppLogger.e(TAG, "API请求失败: 状态码=$responseCode, 错误=$errorBody")
+                    return@withContext Result.failure(
+                            ModelFetchHttpException(
+                                    statusCode = responseCode,
+                                    errorBody = errorBody,
+                                    message = context.getString(R.string.model_fetch_api_failed, responseCode, errorBody)
+                            )
+                    )
+                }
+                val responseBody = response.body?.string()
+                response.close()
+                if (responseBody == null) {
+                    AppLogger.e(TAG, "响应体为空")
+                    return@withContext Result.failure(IOException(context.getString(R.string.model_fetch_response_empty)))
+                }
+                AppLogger.d(
+                        TAG,
+                        "收到响应: ${responseBody.take(200)}${if (responseBody.length > 200) "..." else ""}"
+                )
+                // 根据提供商类型解析响应
+                val modelOptions =
+                        when (apiProviderType) {
+                            ApiProviderType.OPENAI,
+                            ApiProviderType.XAI,
+                            ApiProviderType.OPENAI_RESPONSES,
+                            ApiProviderType.OPENAI_RESPONSES_GENERIC,
+                            ApiProviderType.OPENAI_GENERIC,
+                            ApiProviderType.OPENAI_LOCAL,
+                            ApiProviderType.DEEPSEEK,
+                            ApiProviderType.MOONSHOT,
+                            ApiProviderType.MIMO,
+                            ApiProviderType.SILICONFLOW,
+                            ApiProviderType.IFLOW,
+                            ApiProviderType.DOUBAO,
+                            ApiProviderType.NVIDIA,
+                            ApiProviderType.BAICHUAN,
+                            ApiProviderType.OPENROUTER,
+                            ApiProviderType.OPENCODE,
+                            ApiProviderType.FOUR_ROUTER,
+                            ApiProviderType.NOUS_PORTAL,
+                            ApiProviderType.INFINIAI,
+                            ApiProviderType.ALIPAY_BAILING,
+                            ApiProviderType.ZHIPU,
+                            ApiProviderType.LMSTUDIO,
+                            ApiProviderType.OLLAMA,
+                            ApiProviderType.PPINFRA -> parseOpenAIModelResponse(context, responseBody)
+                            ApiProviderType.ANTHROPIC,
+                            ApiProviderType.ANTHROPIC_GENERIC -> parseAnthropicModelResponse(context, responseBody)
+                            ApiProviderType.GOOGLE,
+                            ApiProviderType.GEMINI_GENERIC -> parseGoogleModelResponse(context, responseBody)
+                            else -> parseOpenAIModelResponse(context, responseBody)
+                        }
+                AppLogger.d(TAG, "成功解析模型列表，共获取 ${modelOptions.size} 个模型")
+                Result.success(modelOptions)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "获取模型列表失败: ${e.message}", e)
+                Result.failure(e)
+            }
+        }
+    }
         }
     }
 

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
@@ -319,15 +319,22 @@ object ModelListFetcher {
                                 )
                                 fallbackResponse.close()
                                 return@withContext Result.failure(
-                                        IOException(
-                                                context.getString(R.string.model_fetch_api_failed, fallbackResponse.code, fallbackErrorBody)
+                                        ModelFetchHttpException(
+                                                statusCode = fallbackResponse.code,
+                                                errorBody = fallbackErrorBody,
+                                                message = context.getString(R.string.model_fetch_api_failed, fallbackResponse.code, fallbackErrorBody)
                                         )
                                 )
                             }
                         }
-
                         AppLogger.e(TAG, "API请求失败: 状态码=$responseCode, 错误=$errorBody")
-                        return@withContext Result.failure(IOException(context.getString(R.string.model_fetch_api_failed, responseCode, errorBody)))
+                        return@withContext Result.failure(
+                                ModelFetchHttpException(
+                                        statusCode = responseCode,
+                                        errorBody = errorBody,
+                                        message = context.getString(R.string.model_fetch_api_failed, responseCode, errorBody)
+                                )
+                        )
                     }
 
                     val responseBody = response.body?.string()

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ModelListFetcher.kt
@@ -391,9 +391,6 @@ object ModelListFetcher {
             }
         }
     }
-        }
-    }
-
     /** 解析OpenAI格式的模型响应 格式: {"data": [{"id": "model-id", "object": "model", ...}, ...]} */
     private fun parseOpenAIModelResponse(context: Context, jsonResponse: String): List<ModelOption> {
         val modelList = mutableListOf<ModelOption>()

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
@@ -1,6 +1,7 @@
 package com.ai.assistance.operit.ui.features.settings.sections
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.annotation.StringRes
 import com.ai.assistance.operit.util.AppLogger
 import androidx.compose.foundation.BorderStroke
@@ -52,6 +53,7 @@ import com.ai.assistance.operit.api.chat.llmprovider.AIServiceFactory
 import com.ai.assistance.operit.api.chat.llmprovider.CodexModelListFetcher
 import com.ai.assistance.operit.api.chat.llmprovider.LlamaProvider
 import com.ai.assistance.operit.api.chat.llmprovider.ModelListFetcher
+import com.ai.assistance.operit.api.chat.llmprovider.ModelFetchErrorHelper
 import com.ai.assistance.operit.data.api.CodexAuthManager
 import com.ai.assistance.operit.data.api.CodexUsageSnapshot
 import com.ai.assistance.operit.data.api.CodexUsageWindow
@@ -770,53 +772,52 @@ fun ModelApiSettingsSection(
                                     TAG,
                                     "模型列表按钮被点击 - API端点: $apiEndpointInput, API类型: $selectedProviderTypeId"
                             )
+                            if (isLoadingModels) return@IconButton
                             val gettingModelsText = context.getString(R.string.getting_models_list)
-                            val unknownErrorText = context.getString(R.string.unknown_error)
-                            val getModelsFailedText = context.getString(R.string.get_models_list_failed)
                             val defaultConfigNoModelsText = context.getString(R.string.default_config_no_models_list)
                             val fillEndpointKeyText = context.getString(R.string.fill_endpoint_and_key)
                             val modelsListSuccessText = context.getString(R.string.models_list_success)
-                            
-                            showNotification(gettingModelsText)
 
-                            scope.launch {
-                                if (canRequestModelList) {
-                                    isLoadingModels = true
-                                    modelLoadError = null
-                                    AppLogger.d(
-                                            TAG,
-                                            "开始获取模型列表: 端点=$apiEndpointInput, API类型=$selectedProviderTypeId"
-                                    )
-
-                                    try {
-                                        val result = fetchAvailableModels()
-                                        if (result.isSuccess) {
-                                            val models = result.getOrThrow()
-                                            AppLogger.d(TAG, "模型列表获取成功，共 ${models.size} 个模型")
-                                            modelsList = models
-                                            showModelsDialog = true
-                                            showNotification(modelsListSuccessText.format(models.size))
-                                        } else {
-                                            val errorMsg =
-                                                    result.exceptionOrNull()?.message ?: unknownErrorText
-                                            AppLogger.e(TAG, "模型列表获取失败: $errorMsg")
-                                            modelLoadError = getModelsFailedText.format(errorMsg)
-                                            showNotification(modelLoadError ?: getModelsFailedText.format(""))
-                                        }
-                                    } catch (e: Exception) {
-                                        AppLogger.e(TAG, "获取模型列表发生异常", e)
-                                        modelLoadError = getModelsFailedText.format(e.message ?: "")
-                                        showNotification(modelLoadError ?: getModelsFailedText.format(""))
-                                    } finally {
-                                        isLoadingModels = false
-                                        AppLogger.d(TAG, "模型列表获取流程完成")
-                                    }
-                                } else if (!isToolPkgProvider && isUsingDefaultApiKey && providerRequiresApiKey) {
-                                    AppLogger.d(TAG, "使用默认配置，不获取模型列表")
-                                    showNotification(defaultConfigNoModelsText)
+                            if (!canRequestModelList) {
+                                if (!isToolPkgProvider && isUsingDefaultApiKey && providerRequiresApiKey) {
+                                    Toast.makeText(context, defaultConfigNoModelsText, Toast.LENGTH_SHORT).show()
                                 } else {
-                                    AppLogger.d(TAG, "API端点或密钥为空")
-                                    showNotification(fillEndpointKeyText)
+                                    Toast.makeText(context, fillEndpointKeyText, Toast.LENGTH_SHORT).show()
+                                }
+                                return@IconButton
+                            }
+
+                            Toast.makeText(context, gettingModelsText, Toast.LENGTH_SHORT).show()
+                            scope.launch {
+                                isLoadingModels = true
+                                modelLoadError = null
+                                AppLogger.d(
+                                        TAG,
+                                        "开始获取模型列表: 端点=$apiEndpointInput, API类型=$selectedProviderTypeId"
+                                )
+                                try {
+                                    val result = fetchAvailableModels()
+                                    if (result.isSuccess) {
+                                        val models = result.getOrThrow()
+                                        AppLogger.d(TAG, "模型列表获取成功，共 ${models.size} 个模型")
+                                        modelsList = models
+                                        showModelsDialog = true
+                                        Toast.makeText(context, modelsListSuccessText.format(models.size), Toast.LENGTH_SHORT).show()
+                                    } else {
+                                        val throwable = result.exceptionOrNull()
+                                        val errorMsg = ModelFetchErrorHelper.formatError(context, throwable)
+                                        AppLogger.e(TAG, "模型列表获取失败: $errorMsg")
+                                        modelLoadError = errorMsg
+                                        Toast.makeText(context, errorMsg, Toast.LENGTH_LONG).show()
+                                    }
+                                } catch (e: Exception) {
+                                    AppLogger.e(TAG, "获取模型列表发生异常", e)
+                                    val errorMsg = ModelFetchErrorHelper.formatError(context, e)
+                                    modelLoadError = errorMsg
+                                    Toast.makeText(context, errorMsg, Toast.LENGTH_LONG).show()
+                                } finally {
+                                    isLoadingModels = false
+                                    AppLogger.d(TAG, "模型列表获取流程完成")
                                 }
                             }
                         },
@@ -825,7 +826,7 @@ fun ModelApiSettingsSection(
                                 IconButtonDefaults.iconButtonColors(
                                         contentColor = MaterialTheme.colorScheme.primary
                                 ),
-                                enabled = canRequestModelList
+                        enabled = !isLoadingModels
                 ) {
                     if (isLoadingModels) {
                         CircularProgressIndicator(
@@ -976,6 +977,10 @@ fun ModelApiSettingsSection(
 
                         FilledIconButton(
                                 onClick = {
+                                    if (isLoadingModels) return@FilledIconButton
+                                    val gettingModelsText = context.getString(R.string.getting_models_list)
+                                    val modelsListSuccessText = context.getString(R.string.models_list_success)
+                                    Toast.makeText(context, gettingModelsText, Toast.LENGTH_SHORT).show()
                                     scope.launch {
                                         if (canRequestModelList) {
                                             isLoadingModels = true
@@ -983,15 +988,17 @@ fun ModelApiSettingsSection(
                                                 val result = fetchAvailableModels()
                                                 if (result.isSuccess) {
                                                     modelsList = result.getOrThrow()
+                                                    Toast.makeText(context, modelsListSuccessText.format(modelsList.size), Toast.LENGTH_SHORT).show()
                                                 } else {
-                                                    val errorMsg = result.exceptionOrNull()?.message ?: context.getString(R.string.unknown_error)
-                                                    modelLoadError = context.getString(R.string.refresh_models_list_failed, errorMsg)
-                                                    showNotification(modelLoadError ?: context.getString(R.string.refresh_models_failed))
+                                                    val throwable = result.exceptionOrNull()
+                                                    val errorMsg = ModelFetchErrorHelper.formatError(context, throwable)
+                                                    modelLoadError = errorMsg
+                                                    Toast.makeText(context, errorMsg, Toast.LENGTH_LONG).show()
                                                 }
                                             } catch (e: Exception) {
-                                                val errorMsg = e.message ?: context.getString(R.string.unknown_error)
-                                                modelLoadError = context.getString(R.string.refresh_models_list_failed, errorMsg)
-                                                showNotification(modelLoadError ?: context.getString(R.string.refresh_models_failed))
+                                                val errorMsg = ModelFetchErrorHelper.formatError(context, e)
+                                                modelLoadError = errorMsg
+                                                Toast.makeText(context, errorMsg, Toast.LENGTH_LONG).show()
                                             } finally {
                                                 isLoadingModels = false
                                             }
@@ -1005,7 +1012,8 @@ fun ModelApiSettingsSection(
                                                 contentColor =
                                                         MaterialTheme.colorScheme.onPrimaryContainer
                                         ),
-                                modifier = Modifier.size(36.dp)
+                                modifier = Modifier.size(36.dp),
+                                enabled = !isLoadingModels
                         ) {
                             if (isLoadingModels) {
                                 CircularProgressIndicator(

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/sections/ModelApiSettingsSection.kt
@@ -72,8 +72,10 @@ import com.ai.assistance.operit.ui.common.icons.rememberProviderLogoPainter
 import com.ai.assistance.operit.ui.features.settings.RegisterModelConfigSaveAction
 import com.ai.assistance.operit.ui.features.codex.CodexLoginDialog
 import com.ai.assistance.operit.util.LocationUtils
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -434,6 +436,22 @@ fun ModelApiSettingsSection(
     var modelsList by remember { mutableStateOf<List<ModelOption>>(emptyList()) }
     var modelLoadError by remember { mutableStateOf<String?>(null) }
     var showEndpointDialog by remember(config.id) { mutableStateOf(false) }
+    var fetchModelsJob by remember { mutableStateOf<Job?>(null) }
+
+    // 当配置ID或API提供商发生变化时，立即取消正在进行的模型获取任务并重置加载状态
+    LaunchedEffect(config.id, selectedProviderTypeId) {
+        fetchModelsJob?.cancel()
+        fetchModelsJob = null
+        isLoadingModels = false
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            fetchModelsJob?.cancel()
+            fetchModelsJob = null
+            isLoadingModels = false
+        }
+    }
 
     // 检查是否未填写API密钥（仅用于UI显示）
     val isUsingDefaultApiKey = apiKeyInput.isBlank()
@@ -787,8 +805,9 @@ fun ModelApiSettingsSection(
                                 return@IconButton
                             }
 
+                            fetchModelsJob?.cancel()
                             Toast.makeText(context, gettingModelsText, Toast.LENGTH_SHORT).show()
-                            scope.launch {
+                            fetchModelsJob = scope.launch {
                                 isLoadingModels = true
                                 modelLoadError = null
                                 AppLogger.d(
@@ -810,6 +829,8 @@ fun ModelApiSettingsSection(
                                         modelLoadError = errorMsg
                                         Toast.makeText(context, errorMsg, Toast.LENGTH_LONG).show()
                                     }
+                                } catch (e: CancellationException) {
+                                    AppLogger.d(TAG, "获取模型列表任务被取消")
                                 } catch (e: Exception) {
                                     AppLogger.e(TAG, "获取模型列表发生异常", e)
                                     val errorMsg = ModelFetchErrorHelper.formatError(context, e)
@@ -980,8 +1001,9 @@ fun ModelApiSettingsSection(
                                     if (isLoadingModels) return@FilledIconButton
                                     val gettingModelsText = context.getString(R.string.getting_models_list)
                                     val modelsListSuccessText = context.getString(R.string.models_list_success)
+                                    fetchModelsJob?.cancel()
                                     Toast.makeText(context, gettingModelsText, Toast.LENGTH_SHORT).show()
-                                    scope.launch {
+                                    fetchModelsJob = scope.launch {
                                         if (canRequestModelList) {
                                             isLoadingModels = true
                                             try {
@@ -995,6 +1017,8 @@ fun ModelApiSettingsSection(
                                                     modelLoadError = errorMsg
                                                     Toast.makeText(context, errorMsg, Toast.LENGTH_LONG).show()
                                                 }
+                                            } catch (e: CancellationException) {
+                                                AppLogger.d(TAG, "刷新模型列表任务被取消")
                                             } catch (e: Exception) {
                                                 val errorMsg = ModelFetchErrorHelper.formatError(context, e)
                                                 modelLoadError = errorMsg

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8325,4 +8325,14 @@
     <string name="market_version_too_low_message">Current client version %1$s is lower than the minimum required version %2$s for this resource. Please update the client before downloading.</string>
     <string name="market_version_too_high_message">Current client version %1$s is higher than the maximum supported version %2$s for this resource. Please use a supported client version.</string>
     <string name="thinking_config_invalid_json">Invalid Thinking Configuration</string>
+    <string name="model_fetch_error_timeout">Fetching models timed out. Please check network or proxy connection.</string>
+    <string name="model_fetch_error_network">Network request failed. Unable to connect to server. Please check network, endpoint, or proxy.</string>
+    <string name="model_fetch_error_ssl">SSL connection failed. Please check network environment or proxy settings.</string>
+    <string name="model_fetch_error_unauthorized">Invalid or unauthorized API key (HTTP 401)</string>
+    <string name="model_fetch_error_forbidden">Access forbidden (HTTP 403). Possible region restriction or proxy required.</string>
+    <string name="model_fetch_error_not_found">Endpoint not found (HTTP 404). Please verify the endpoint URL.</string>
+    <string name="model_fetch_error_rate_limit">Rate limit reached or quota exhausted (HTTP 429)</string>
+    <string name="model_fetch_error_server">Model provider server error (HTTP %d). Please try again later.</string>
+    <string name="model_fetch_error_format">Failed to parse models: unexpected response format from endpoint.</string>
+    <string name="model_fetch_error_http">Failed to fetch models (HTTP %1$d): %2$s</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8326,7 +8326,8 @@
     <string name="market_version_too_high_message">Current client version %1$s is higher than the maximum supported version %2$s for this resource. Please use a supported client version.</string>
     <string name="thinking_config_invalid_json">Invalid Thinking Configuration</string>
     <string name="model_fetch_error_timeout">Fetching models timed out. Please check network or proxy connection.</string>
-    <string name="model_fetch_error_network">Network request failed. Unable to connect to server. Please check network, endpoint, or proxy.</string>
+    <string name="model_fetch_error_dns">Domain resolution failed. Please check the API address spelling (e.g. domain suffix) or network.</string>
+    <string name="model_fetch_error_network">Unable to connect to server. Please check network, endpoint, or proxy settings.</string>
     <string name="model_fetch_error_ssl">SSL connection failed. Please check network environment or proxy settings.</string>
     <string name="model_fetch_error_unauthorized">Invalid or unauthorized API key (HTTP 401)</string>
     <string name="model_fetch_error_forbidden">Access forbidden (HTTP 403). Possible region restriction or proxy required.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7783,7 +7783,8 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="token_stats_settings">Configuración de estadísticas</string>
     <string name="token_stats_custom_range_confirm">Aceptar</string>
     <string name="model_fetch_error_timeout">Tiempo de espera agotado al obtener modelos. Verifique la conexión o proxy.</string>
-    <string name="model_fetch_error_network">Error de red. No se puede conectar al servidor. Verifique red, punto final o proxy.</string>
+    <string name="model_fetch_error_dns">Error de resolución de dominio. Verifique la ortografía de la dirección API o la red.</string>
+    <string name="model_fetch_error_network">No se puede conectar al servidor. Verifique la red, el puerto o el proxy.</string>
     <string name="model_fetch_error_ssl">Error de conexión SSL. Verifique el entorno de red o configuración de proxy.</string>
     <string name="model_fetch_error_unauthorized">Clave de API no válida o no autorizada (HTTP 401)</string>
     <string name="model_fetch_error_forbidden">Acceso denegado (HTTP 403). Posible restricción regional o proxy requerido.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7782,4 +7782,14 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="token_stats_trends">Análisis de tendencias</string>
     <string name="token_stats_settings">Configuración de estadísticas</string>
     <string name="token_stats_custom_range_confirm">Aceptar</string>
+    <string name="model_fetch_error_timeout">Tiempo de espera agotado al obtener modelos. Verifique la conexión o proxy.</string>
+    <string name="model_fetch_error_network">Error de red. No se puede conectar al servidor. Verifique red, punto final o proxy.</string>
+    <string name="model_fetch_error_ssl">Error de conexión SSL. Verifique el entorno de red o configuración de proxy.</string>
+    <string name="model_fetch_error_unauthorized">Clave de API no válida o no autorizada (HTTP 401)</string>
+    <string name="model_fetch_error_forbidden">Acceso denegado (HTTP 403). Posible restricción regional o proxy requerido.</string>
+    <string name="model_fetch_error_not_found">Punto final no encontrado (HTTP 404). Verifique la dirección de la API.</string>
+    <string name="model_fetch_error_rate_limit">Límite de solicitudes alcanzado o cuota agotada (HTTP 429)</string>
+    <string name="model_fetch_error_server">Error del servidor del proveedor (HTTP %d). Inténtelo de nuevo más tarde.</string>
+    <string name="model_fetch_error_format">Error al analizar modelos: formato de respuesta inesperado del punto final.</string>
+    <string name="model_fetch_error_http">Error al obtener modelos (HTTP %1$d): %2$s</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7634,7 +7634,8 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="token_activity_total_tokens">Total Token</string>
     <string name="token_activity_peak_tokens">Token puncak</string>
     <string name="model_fetch_error_timeout">Batas waktu habis saat mengambil model. Periksa koneksi jaringan atau proxy.</string>
-    <string name="model_fetch_error_network">Gagal mengakses jaringan. Tidak dapat terhubung ke server. Periksa jaringan, endpoint, atau proxy.</string>
+    <string name="model_fetch_error_dns">Gagal menyelesaikan domain. Periksa ejaan alamat API (misal akhiran domain) atau jaringan.</string>
+    <string name="model_fetch_error_network">Tidak dapat terhubung ke server. Periksa jaringan, port, atau pengaturan proxy.</string>
     <string name="model_fetch_error_ssl">Koneksi SSL gagal. Periksa lingkungan jaringan atau pengaturan proxy.</string>
     <string name="model_fetch_error_unauthorized">Kunci API tidak valid atau tidak diizinkan (HTTP 401)</string>
     <string name="model_fetch_error_forbidden">Akses ditolak (HTTP 403). Kemungkinan dibatasi wilayah atau memerlukan proxy.</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7633,4 +7633,14 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="token_activity_chart_tap_hint">Ketuk grafik untuk melihat data detail</string>
     <string name="token_activity_total_tokens">Total Token</string>
     <string name="token_activity_peak_tokens">Token puncak</string>
+    <string name="model_fetch_error_timeout">Batas waktu habis saat mengambil model. Periksa koneksi jaringan atau proxy.</string>
+    <string name="model_fetch_error_network">Gagal mengakses jaringan. Tidak dapat terhubung ke server. Periksa jaringan, endpoint, atau proxy.</string>
+    <string name="model_fetch_error_ssl">Koneksi SSL gagal. Periksa lingkungan jaringan atau pengaturan proxy.</string>
+    <string name="model_fetch_error_unauthorized">Kunci API tidak valid atau tidak diizinkan (HTTP 401)</string>
+    <string name="model_fetch_error_forbidden">Akses ditolak (HTTP 403). Kemungkinan dibatasi wilayah atau memerlukan proxy.</string>
+    <string name="model_fetch_error_not_found">Endpoint tidak ditemukan (HTTP 404). Periksa kembali alamat API.</string>
+    <string name="model_fetch_error_rate_limit">Batas permintaan tercapai atau kuota habis (HTTP 429)</string>
+    <string name="model_fetch_error_server">Kesalahan server penyedia model (HTTP %d). Coba lagi nanti.</string>
+    <string name="model_fetch_error_format">Gagal mengurai model: format respons tidak sesuai dari endpoint.</string>
+    <string name="model_fetch_error_http">Gagal mengambil model (HTTP %1$d): %2$s</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7481,7 +7481,8 @@
     <string name="token_activity_total_tokens">누적 토큰</string>
     <string name="token_activity_peak_tokens">최대 토큰</string>
     <string name="model_fetch_error_timeout">모델 목록 가져오기 시간 초과. 네트워크 또는 프록시 연결을 확인하세요.</string>
-    <string name="model_fetch_error_network">네트워크 오류. 서버에 연결할 수 없습니다. 네트워크, 엔드포인트 또는 프록시를 확인하세요.</string>
+    <string name="model_fetch_error_dns">도메인 이름을 확인할 수 없습니다. API 주소 철자(도메인 접미사 등)나 네트워크를 확인하세요.</string>
+    <string name="model_fetch_error_network">서버에 연결할 수 없습니다. 네트워크 연결, 포트 또는 프록시 설정을 확인하세요.</string>
     <string name="model_fetch_error_ssl">SSL 보안 연결 실패. 네트워크 환경 또는 프록시 설정을 확인하세요.</string>
     <string name="model_fetch_error_unauthorized">유효하지 않거나 권한이 없는 API 키 (HTTP 401)</string>
     <string name="model_fetch_error_forbidden">접근 거부됨 (HTTP 403). 지역 제한이 있거나 프록시가 필요할 수 있습니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7480,4 +7480,14 @@
     <string name="token_activity_chart_tap_hint">차트를 탭하여 자세한 데이터 보기</string>
     <string name="token_activity_total_tokens">누적 토큰</string>
     <string name="token_activity_peak_tokens">최대 토큰</string>
+    <string name="model_fetch_error_timeout">모델 목록 가져오기 시간 초과. 네트워크 또는 프록시 연결을 확인하세요.</string>
+    <string name="model_fetch_error_network">네트워크 오류. 서버에 연결할 수 없습니다. 네트워크, 엔드포인트 또는 프록시를 확인하세요.</string>
+    <string name="model_fetch_error_ssl">SSL 보안 연결 실패. 네트워크 환경 또는 프록시 설정을 확인하세요.</string>
+    <string name="model_fetch_error_unauthorized">유효하지 않거나 권한이 없는 API 키 (HTTP 401)</string>
+    <string name="model_fetch_error_forbidden">접근 거부됨 (HTTP 403). 지역 제한이 있거나 프록시가 필요할 수 있습니다.</string>
+    <string name="model_fetch_error_not_found">엔드포인트를 찾을 수 없음 (HTTP 404). API 주소를 확인하세요.</string>
+    <string name="model_fetch_error_rate_limit">요청 한도 초과 또는 사용량 소진 (HTTP 429)</string>
+    <string name="model_fetch_error_server">모델 제공업체 서버 오류 (HTTP %d). 나중에 다시 시도하세요.</string>
+    <string name="model_fetch_error_format">모델 구문 분석 실패: 엔드포인트에서 예기치 않은 응답 형식을 반환했습니다.</string>
+    <string name="model_fetch_error_http">모델 가져오기 실패 (HTTP %1$d): %2$s</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7711,4 +7711,14 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="token_stats_trends">Analisis trend</string>
     <string name="token_stats_settings">Tetapan statistik</string>
     <string name="token_stats_custom_range_confirm">OK</string>
+    <string name="model_fetch_error_timeout">Masa tamat semasa mendapatkan senarai model. Sila periksa sambungan rangkaian atau proksi.</string>
+    <string name="model_fetch_error_network">Akses rangkaian gagal. Tidak dapat menyambung ke pelayan. Sila periksa rangkaian, endpoint atau proksi.</string>
+    <string name="model_fetch_error_ssl">Sambungan keselamatan SSL gagal. Sila periksa persekitaran rangkaian atau tetapan proksi.</string>
+    <string name="model_fetch_error_unauthorized">Kunci API tidak sah atau tidak dibenarkan (HTTP 401)</string>
+    <string name="model_fetch_error_forbidden">Akses ditolak (HTTP 403). Mungkin dihadkan kawasan atau memerlukan proksi.</string>
+    <string name="model_fetch_error_not_found">Endpoint tidak ditemui (HTTP 404). Sila periksa alamat API.</string>
+    <string name="model_fetch_error_rate_limit">Had permintaan dicapai atau kuota habis (HTTP 429)</string>
+    <string name="model_fetch_error_server">Ralat pelayan penyedia model (HTTP %d). Sila cuba lagi kemudian.</string>
+    <string name="model_fetch_error_format">Gagal menghuraikan model: format respons tidak dijangka dari endpoint.</string>
+    <string name="model_fetch_error_http">Gagal mendapatkan model (HTTP %1$d): %2$s</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7712,7 +7712,8 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="token_stats_settings">Tetapan statistik</string>
     <string name="token_stats_custom_range_confirm">OK</string>
     <string name="model_fetch_error_timeout">Masa tamat semasa mendapatkan senarai model. Sila periksa sambungan rangkaian atau proksi.</string>
-    <string name="model_fetch_error_network">Akses rangkaian gagal. Tidak dapat menyambung ke pelayan. Sila periksa rangkaian, endpoint atau proksi.</string>
+    <string name="model_fetch_error_dns">Resolusi domain gagal. Sila periksa ejaan alamat API (cth. akhiran domain) atau rangkaian.</string>
+    <string name="model_fetch_error_network">Tidak dapat menyambung ke pelayan. Sila periksa rangkaian, port atau tetapan proksi.</string>
     <string name="model_fetch_error_ssl">Sambungan keselamatan SSL gagal. Sila periksa persekitaran rangkaian atau tetapan proksi.</string>
     <string name="model_fetch_error_unauthorized">Kunci API tidak sah atau tidak dibenarkan (HTTP 401)</string>
     <string name="model_fetch_error_forbidden">Akses ditolak (HTTP 403). Mungkin dihadkan kawasan atau memerlukan proksi.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7471,4 +7471,14 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="token_activity_chart_tap_hint">Toque no gráfico para ver dados detalhados</string>
     <string name="token_activity_total_tokens">Tokens acumulados</string>
     <string name="token_activity_peak_tokens">Pico de tokens</string>
+    <string name="model_fetch_error_timeout">Tempo limite esgotado ao obter modelos. Verifique a conexão de rede ou proxy.</string>
+    <string name="model_fetch_error_network">Falha de rede. Não foi possível conectar ao servidor. Verifique a rede, o endpoint ou o proxy.</string>
+    <string name="model_fetch_error_ssl">Falha na conexão SSL. Verifique o ambiente de rede ou configurações de proxy.</string>
+    <string name="model_fetch_error_unauthorized">Chave de API inválida ou não autorizada (HTTP 401)</string>
+    <string name="model_fetch_error_forbidden">Acesso negado (HTTP 403). Possível restrição regional ou necessidade de proxy.</string>
+    <string name="model_fetch_error_not_found">Endpoint não encontrado (HTTP 404). Verifique o endereço da API.</string>
+    <string name="model_fetch_error_rate_limit">Limite de requisições atingido ou cota esgotada (HTTP 429)</string>
+    <string name="model_fetch_error_server">Erro no servidor do provedor de modelo (HTTP %d). Tente novamente mais tarde.</string>
+    <string name="model_fetch_error_format">Falha ao analisar modelos: formato de resposta inesperado do endpoint.</string>
+    <string name="model_fetch_error_http">Falha ao obter modelos (HTTP %1$d): %2$s</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7472,7 +7472,8 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="token_activity_total_tokens">Tokens acumulados</string>
     <string name="token_activity_peak_tokens">Pico de tokens</string>
     <string name="model_fetch_error_timeout">Tempo limite esgotado ao obter modelos. Verifique a conexão de rede ou proxy.</string>
-    <string name="model_fetch_error_network">Falha de rede. Não foi possível conectar ao servidor. Verifique a rede, o endpoint ou o proxy.</string>
+    <string name="model_fetch_error_dns">Falha na resolução do domínio. Verifique a ortografia do endereço da API ou a rede.</string>
+    <string name="model_fetch_error_network">Não foi possível conectar ao servidor. Verifique a rede, a porta ou o proxy.</string>
     <string name="model_fetch_error_ssl">Falha na conexão SSL. Verifique o ambiente de rede ou configurações de proxy.</string>
     <string name="model_fetch_error_unauthorized">Chave de API inválida ou não autorizada (HTTP 401)</string>
     <string name="model_fetch_error_forbidden">Acesso negado (HTTP 403). Possível restrição regional ou necessidade de proxy.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -8309,4 +8309,14 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="token_stats_trends">Analiza tendințelor</string>
     <string name="token_stats_settings">Setări statistici</string>
     <string name="token_stats_custom_range_confirm">OK</string>
+    <string name="model_fetch_error_timeout">Timpul de așteptare a expirat la preluarea modelelor. Verificați rețeaua sau proxy-ul.</string>
+    <string name="model_fetch_error_network">Eroare de rețea. Nu se poate conecta la server. Verificați rețeaua, endpoint-ul sau proxy-ul.</string>
+    <string name="model_fetch_error_ssl">Conexiunea de securitate SSL a eșuat. Verificați rețeaua sau setările proxy.</string>
+    <string name="model_fetch_error_unauthorized">Cheie API nevalidă sau neautorizată (HTTP 401)</string>
+    <string name="model_fetch_error_forbidden">Acces interzis (HTTP 403). Posibilă restricție regională sau este necesar un proxy.</string>
+    <string name="model_fetch_error_not_found">Endpoint negăsit (HTTP 404). Verificați adresa API.</string>
+    <string name="model_fetch_error_rate_limit">Limita de solicitări a fost atinsă sau cota este epuizată (HTTP 429)</string>
+    <string name="model_fetch_error_server">Eroare de server a furnizorului de modele (HTTP %d). Încercați din nou mai târziu.</string>
+    <string name="model_fetch_error_format">Eșec la parsarea modelelor: format de răspuns neașteptat de la endpoint.</string>
+    <string name="model_fetch_error_http">Eșec la preluarea modelelor (HTTP %1$d): %2$s</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -8310,7 +8310,8 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="token_stats_settings">Setări statistici</string>
     <string name="token_stats_custom_range_confirm">OK</string>
     <string name="model_fetch_error_timeout">Timpul de așteptare a expirat la preluarea modelelor. Verificați rețeaua sau proxy-ul.</string>
-    <string name="model_fetch_error_network">Eroare de rețea. Nu se poate conecta la server. Verificați rețeaua, endpoint-ul sau proxy-ul.</string>
+    <string name="model_fetch_error_dns">Eșec la rezolvarea numelui de domeniu. Verificați adresa API (de ex. sufixul domeniului) sau rețeaua.</string>
+    <string name="model_fetch_error_network">Nu se poate conecta la server. Verificați rețeaua, portul sau setările proxy.</string>
     <string name="model_fetch_error_ssl">Conexiunea de securitate SSL a eșuat. Verificați rețeaua sau setările proxy.</string>
     <string name="model_fetch_error_unauthorized">Cheie API nevalidă sau neautorizată (HTTP 401)</string>
     <string name="model_fetch_error_forbidden">Acces interzis (HTTP 403). Posibilă restricție regională sau este necesar un proxy.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8343,7 +8343,8 @@
     <string name="codex_reset_after_days">%1$d 天后重置</string>
     <string name="codex_reset_after_clock">%1$02d:%2$02d 后重置</string>
     <string name="model_fetch_error_timeout">获取模型列表超时，请检查网络连接或代理是否通畅</string>
-    <string name="model_fetch_error_network">网络访问失败，无法连接到服务器，请检查网络、端点地址或是否需要开启代理(梯子)</string>
+    <string name="model_fetch_error_dns">域名解析失败，请检查API端点地址拼写（如域名后缀是否完整），或检查网络设置</string>
+    <string name="model_fetch_error_network">无法连接到服务器，请检查网络连接、服务端口或代理设置</string>
     <string name="model_fetch_error_ssl">SSL安全连接失败，请检查网络环境或代理设置</string>
     <string name="model_fetch_error_unauthorized">API密钥无效或未授权 (HTTP 401)</string>
     <string name="model_fetch_error_forbidden">访问被拒绝 (HTTP 403)，可能受到区域限制或需要代理(梯子)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8342,4 +8342,14 @@
     <string name="codex_usage_unavailable">额度暂时不可用</string>
     <string name="codex_reset_after_days">%1$d 天后重置</string>
     <string name="codex_reset_after_clock">%1$02d:%2$02d 后重置</string>
+    <string name="model_fetch_error_timeout">获取模型列表超时，请检查网络连接或代理是否通畅</string>
+    <string name="model_fetch_error_network">网络访问失败，无法连接到服务器，请检查网络、端点地址或是否需要开启代理(梯子)</string>
+    <string name="model_fetch_error_ssl">SSL安全连接失败，请检查网络环境或代理设置</string>
+    <string name="model_fetch_error_unauthorized">API密钥无效或未授权 (HTTP 401)</string>
+    <string name="model_fetch_error_forbidden">访问被拒绝 (HTTP 403)，可能受到区域限制或需要代理(梯子)</string>
+    <string name="model_fetch_error_not_found">API端点不存在 (HTTP 404)，请检查端点路径是否正确(是否缺少/v1)</string>
+    <string name="model_fetch_error_rate_limit">请求过于频繁或账户额度已用尽 (HTTP 429)</string>
+    <string name="model_fetch_error_server">模型提供商服务器错误 (HTTP %d)，请稍后重试</string>
+    <string name="model_fetch_error_format">解析模型列表失败：端点返回了非预期格式(可能遇到网关拦截或网页报错)</string>
+    <string name="model_fetch_error_http">获取模型失败 (HTTP %1$d): %2$s</string>
 </resources>

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ModelFetchErrorHelperTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ModelFetchErrorHelperTest.kt
@@ -1,0 +1,85 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import java.io.IOException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModelFetchErrorHelperTest {
+
+    @Test
+    fun extractsErrorMessageFromStandardOpenAiJson() {
+        val json = """{"error":{"message":"Incorrect API key provided: sk-test***","type":"invalid_request_error"}}"""
+        val message = ModelFetchErrorHelper.extractErrorMessage(json)
+        assertEquals("Incorrect API key provided: sk-test***", message)
+    }
+
+    @Test
+    fun extractsErrorMessageFromStringErrorField() {
+        val json = """{"error":"Unauthorized access"}"""
+        val message = ModelFetchErrorHelper.extractErrorMessage(json)
+        assertEquals("Unauthorized access", message)
+    }
+
+    @Test
+    fun extractsErrorMessageFromRootMessageField() {
+        val json = """{"message":"Resource not found"}"""
+        val message = ModelFetchErrorHelper.extractErrorMessage(json)
+        assertEquals("Resource not found", message)
+    }
+
+    @Test
+    fun returnsNullForInvalidOrEmptyJson() {
+        assertNull(ModelFetchErrorHelper.extractErrorMessage(""))
+        assertNull(ModelFetchErrorHelper.extractErrorMessage("<html>502 Bad Gateway</html>"))
+        assertNull(ModelFetchErrorHelper.extractErrorMessage("{}"))
+    }
+
+    @Test
+    fun detectsTimeoutExceptions() {
+        assertTrue(ModelFetchErrorHelper.isTimeoutException(SocketTimeoutException("Read timed out")))
+        assertTrue(ModelFetchErrorHelper.isTimeoutException(IOException("connection timeout", SocketTimeoutException())))
+        assertTrue(ModelFetchErrorHelper.isTimeoutException(Exception("Request timed out")))
+        assertFalse(ModelFetchErrorHelper.isTimeoutException(IOException("Connection refused")))
+    }
+
+    @Test
+    fun detectsNetworkConnectionExceptions() {
+        assertTrue(ModelFetchErrorHelper.isNetworkConnectionException(UnknownHostException("api.openai.com")))
+        assertTrue(ModelFetchErrorHelper.isNetworkConnectionException(ConnectException("Connection refused")))
+        assertTrue(ModelFetchErrorHelper.isNetworkConnectionException(NoRouteToHostException("No route to host")))
+        assertTrue(ModelFetchErrorHelper.isNetworkConnectionException(IOException("Unable to resolve host \"api.example.com\": No address associated with hostname")))
+        assertFalse(ModelFetchErrorHelper.isNetworkConnectionException(SocketTimeoutException("timeout")))
+    }
+
+    @Test
+    fun detectsSslExceptions() {
+        assertTrue(ModelFetchErrorHelper.isSslException(SSLException("Handshake failed")))
+        assertTrue(ModelFetchErrorHelper.isSslException(IOException("SSL cert validation error")))
+        assertFalse(ModelFetchErrorHelper.isSslException(ConnectException("Connection refused")))
+    }
+
+    @Test
+    fun extractsHttpStatusCodeFromCustomExceptionAndMessage() {
+        val httpException = ModelFetchHttpException(401, "{\"error\":{\"message\":\"invalid key\"}}", "API请求失败: 401, 错误: ...")
+        assertEquals(401, ModelFetchErrorHelper.extractHttpStatusCode(httpException))
+
+        val wrapped = IOException("wrapped", ModelFetchHttpException(404, "not found", "not found"))
+        assertEquals(404, ModelFetchErrorHelper.extractHttpStatusCode(wrapped))
+
+        val stringException = IOException("API请求失败: 403, 错误: Forbidden")
+        assertEquals(403, ModelFetchErrorHelper.extractHttpStatusCode(stringException))
+
+        val httpStatusException = Exception("HTTP 502 Bad Gateway")
+        assertEquals(502, ModelFetchErrorHelper.extractHttpStatusCode(httpStatusException))
+
+        assertNull(ModelFetchErrorHelper.extractHttpStatusCode(IOException("Network is unreachable")))
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ModelFetchErrorHelperTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ModelFetchErrorHelperTest.kt
@@ -51,11 +51,18 @@ class ModelFetchErrorHelperTest {
     }
 
     @Test
+    fun detectsDnsResolutionExceptions() {
+        assertTrue(ModelFetchErrorHelper.isDnsResolutionException(UnknownHostException("api.deepseek")))
+        assertTrue(ModelFetchErrorHelper.isDnsResolutionException(IOException("Unable to resolve host \"api.deepseek\": No address associated with hostname")))
+        assertFalse(ModelFetchErrorHelper.isDnsResolutionException(ConnectException("Connection refused")))
+        assertFalse(ModelFetchErrorHelper.isDnsResolutionException(SocketTimeoutException("timeout")))
+    }
+
+    @Test
     fun detectsNetworkConnectionExceptions() {
-        assertTrue(ModelFetchErrorHelper.isNetworkConnectionException(UnknownHostException("api.openai.com")))
         assertTrue(ModelFetchErrorHelper.isNetworkConnectionException(ConnectException("Connection refused")))
         assertTrue(ModelFetchErrorHelper.isNetworkConnectionException(NoRouteToHostException("No route to host")))
-        assertTrue(ModelFetchErrorHelper.isNetworkConnectionException(IOException("Unable to resolve host \"api.example.com\": No address associated with hostname")))
+        assertTrue(ModelFetchErrorHelper.isNetworkConnectionException(IOException("failed to connect to /192.168.1.1 (port 80)")))
         assertFalse(ModelFetchErrorHelper.isNetworkConnectionException(SocketTimeoutException("timeout")))
     }
 


### PR DESCRIPTION
## 变更说明 / Description

### 为什么存在这个 PR？
在模型设置页面中，获取可用模型列表（`/v1/models`）的原有逻辑存在若干影响用户体验的问题：
1. **反馈隐蔽无感知**：原有错误和完成通知被放在页面可滑动列表的最末尾（`showNotification` 追加卡片），用户视线停留在上方设置区时完全无法察觉获取状态或失败原因；
2. **按钮禁用死锁**：未填写 API 端点或密钥时，“获取可用模型”按钮被直接置灰禁用，没有任何点击反馈，用户无法得知为何无法点击；
3. **域名解析错误误导**：当用户拼错 API 域名后缀（如不慎遗漏 `.com` 导致 `UnknownHostException`）时，错误提示会被笼统归类为网络不通或“需要梯子”，误导用户排查方向；
4. **超时死等与多余重试**：原有 OkHttp 连接超时为 30s 且包含 3 次重试循环（`while (retryCount <= 2)`），在网络故障或无效端点下会导致进度环长达 60~90 秒死等；
5. **缺少生命周期联动取消**：在获取模型过程中切换配置 ID 或 API 提供商类型时，前一个未完成的网络请求仍在后台继续且转圈菊花无法重置，容易引发状态混乱。

### 主要改动内容：
1. **全链路换用原生 Toast 交互**：
   - 彻底废除页面底部的隐蔽卡片通知，获取发起时即刻弹出“正在获取可用模型列表...”，成功弹出“成功获取 N 个模型”并打开弹窗；
   - 解除未填端点/密钥时的死板置灰限制，用户点击时直接弹 Toast 提示“请填写API端点和API密钥”；
2. **精细化错误分类与提示（`ModelFetchErrorHelper`）**：
   - 剥离 DNS 解析失败（`isDnsResolutionException`，捕获 `UnknownHostException`），精准提示核对端点拼写与域名后缀，不误导为网络/代理故障；
   - 细化区分超时（`isTimeoutException`）、连接拒绝、SSL 证书异常与响应解析错误；
   - 针对 HTTP 状态码（401/403/404/429/5xx）优先解析并展示服务端返回的详细错误信息（如 `error.message`）；
3. **网络超时压降与单次直发**：
   - 移除 `ModelListFetcher.kt` 中冗余的 3 次重试循环；
   - 将连接超时缩短至 10s（读写 15s），失败秒级停转进度环，杜绝长时间卡死；
4. **协程生命周期与取消控制**：
   - `ModelApiSettingsSection` 维护 `fetchModelsJob` 并联动底层 OkHttp `call.cancel()`；
   - 当配置 ID 或 API 提供商发生变更时，自动取消当前请求并毫秒级重置 loading 状态与进度环；
5. **国际化与单元测试**：
   - 补齐了超时、DNS、HTTP 错误等文案在 8 种语言下的定义；
   - 添加 `ModelFetchErrorHelperTest`，覆盖异常分类、DNS 判定及 JSON 状态码提取的边界用例。

---

## 关联 Issue / Related Issues
无直接关联 Issue（属于设置页面交互体验与网络容错优化）。

---

## 验证与测试 / Verification & Testing
- [x] **单元测试**：已添加 `ModelFetchErrorHelperTest` 验证网络异常判定与 HTTP 错误提取逻辑；
- [x] **CI 构建通过**：GitHub Actions Android Build（run [34021940437](https://github.com/3316891527/Operit/actions/runs/34021940437)）编译构建全绿（`success`）。
