### PR TITLE
fix(chat): dispatch message_persisted event on message variant addition (#1085)

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/plugins/toolpkg/ToolPkgChatMessageHookBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/plugins/toolpkg/ToolPkgChatMessageHookBridge.kt
@@ -34,7 +34,11 @@ internal object ToolPkgChatMessageHookBridge {
         syncToolPkgRegistrations(manager.getEnabledToolPkgContainerRuntimes())
     }
 
+    @Volatile
+    internal var onMessagePersistedDispatchedForTest: ((chatId: String, message: ChatMessage) -> Unit)? = null
+
     fun dispatchMessagePersisted(chatId: String, message: ChatMessage) {
+        onMessagePersistedDispatchedForTest?.invoke(chatId, message)
         val activeHooks = hooks
         if (activeHooks.isEmpty()) {
             return
@@ -83,7 +87,7 @@ internal object ToolPkgChatMessageHookBridge {
             )
     }
 
-    private fun buildChatMessageEventPayload(
+    internal fun buildChatMessageEventPayload(
         chatId: String,
         message: ChatMessage
     ): Map<String, Any?> =

--- a/app/src/main/java/com/ai/assistance/operit/services/core/ChatHistoryDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/ChatHistoryDelegate.kt
@@ -1186,10 +1186,22 @@ class ChatHistoryDelegate(
     ): Int {
         val chatId = chatIdOverride ?: _currentChatId.value ?: throw IllegalStateException("No active chat")
         val isCurrentChat = chatId == _currentChatId.value
-        val selectedVariantIndex = historyUpdateMutex.withLock {
+        val (selectedVariantIndex, persistedMessage) = historyUpdateMutex.withLock {
+            val baseMessage = if (isCurrentChat) {
+                _chatHistory.value.firstOrNull { it.timestamp == timestamp }
+            } else {
+                null
+            } ?: runCatching {
+                chatHistoryManager.loadChatMessagesWindow(chatId, timestamp, timestamp).firstOrNull { it.timestamp == timestamp }
+            }.getOrNull()
             val selectedVariantIndex =
                 chatHistoryManager.addMessageVariant(chatId, timestamp, message)
-            selectedVariantIndex
+            val persistedMessage = message.copy(
+                selectedVariantIndex = selectedVariantIndex,
+                isFavorite = baseMessage?.isFavorite ?: message.isFavorite
+            )
+            ToolPkgChatMessageHookBridge.dispatchMessagePersisted(chatId, persistedMessage)
+            selectedVariantIndex to persistedMessage
         }
         if (isCurrentChat && chatId == _currentChatId.value) {
             reloadCurrentChatDisplayHistory(chatId)

--- a/app/src/test/java/com/ai/assistance/operit/plugins/toolpkg/ToolPkgChatMessageHookBridgeTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/plugins/toolpkg/ToolPkgChatMessageHookBridgeTest.kt
@@ -1,0 +1,88 @@
+package com.ai.assistance.operit.plugins.toolpkg
+
+import com.ai.assistance.operit.data.model.ChatMessage
+import com.ai.assistance.operit.data.model.ChatMessageDisplayMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class ToolPkgChatMessageHookBridgeTest {
+
+    @Test
+    fun `buildChatMessageEventPayload contains all required message fields including variant index`() {
+        val message = ChatMessage(
+            sender = "ai",
+            roleName = "Assistant",
+            content = "This is a regenerated variant response",
+            timestamp = 1700000000000L,
+            completedAt = 1700000005000L,
+            provider = "deepseek",
+            modelName = "deepseek-chat",
+            inputTokens = 120,
+            outputTokens = 250,
+            cachedInputTokens = 64,
+            sentAt = 1699999999000L,
+            outputDurationMs = 3500L,
+            waitDurationMs = 500L,
+            displayMode = ChatMessageDisplayMode.NORMAL,
+            selectedVariantIndex = 2,
+            isFavorite = false
+        )
+
+        val payload = ToolPkgChatMessageHookBridge.buildChatMessageEventPayload(
+            chatId = "test-chat-123",
+            message = message
+        )
+
+        assertEquals("test-chat-123", payload["chatId"])
+        assertEquals(1700000000000L, payload["timestamp"])
+        assertEquals("ai", payload["sender"])
+        assertEquals("Assistant", payload["roleName"])
+        assertEquals("This is a regenerated variant response", payload["content"])
+        assertEquals(1700000005000L, payload["completedAt"])
+        assertEquals("deepseek", payload["provider"])
+        assertEquals("deepseek-chat", payload["modelName"])
+        assertEquals(120L, payload["inputTokens"])
+        assertEquals(250L, payload["outputTokens"])
+        assertEquals(64L, payload["cachedInputTokens"])
+        assertEquals(1699999999000L, payload["sentAt"])
+        assertEquals(3500L, payload["outputDurationMs"])
+        assertEquals(500L, payload["waitDurationMs"])
+        assertEquals("NORMAL", payload["displayMode"])
+        assertEquals(2, payload["selectedVariantIndex"])
+        assertEquals(false, payload["isFavorite"])
+    }
+
+    @Test
+    fun `dispatchMessagePersisted triggers test listener with correct variant information`() {
+        var receivedChatId: String? = null
+        var receivedMessage: ChatMessage? = null
+
+        ToolPkgChatMessageHookBridge.onMessagePersistedDispatchedForTest = { chatId, message ->
+            receivedChatId = chatId
+            receivedMessage = message
+        }
+
+        try {
+            val variantMessage = ChatMessage(
+                sender = "ai",
+                content = "Regenerated content from roll",
+                timestamp = 1700000000000L,
+                selectedVariantIndex = 3
+            )
+
+            ToolPkgChatMessageHookBridge.dispatchMessagePersisted(
+                chatId = "chat-abc",
+                message = variantMessage
+            )
+
+            assertEquals("chat-abc", receivedChatId)
+            assertNotNull(receivedMessage)
+            assertEquals("Regenerated content from roll", receivedMessage?.content)
+            assertEquals(1700000000000L, receivedMessage?.timestamp)
+            assertEquals(3, receivedMessage?.selectedVariantIndex)
+        } finally {
+            ToolPkgChatMessageHookBridge.onMessagePersistedDispatchedForTest = null
+        }
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

### 为什么存在这个 PR？
修复 #1085 中报告的问题：
当用户在对话中对某条 assistant 消息执行重新生成（roll 原地变体替换）并落库时，底层通过 `ChatHistoryDelegate.addMessageVariant` 写入了数据库并刷新了界面，但该路径遗漏了向 `ToolPkgChatMessageHookBridge` 派发 `message_persisted` 广播事件。
这导致依赖 `registerChatMessageHook` 监听 `message_persisted` 事件的外部 ToolPkg 插件（如自动备份、外部数据库同步插件）无法感知到消息内容已更新，导致本地显示内容与外部同步库不一致。

### 主要改动内容：
1. **补齐变体落库事件广播（`ChatHistoryDelegate.kt`）**：
   - 在 `addMessageVariant` 方法成功写入变体并获得变体索引后，构造包含最新变体内容与 `selectedVariantIndex` 的 `persistedMessage`，并调用 `ToolPkgChatMessageHookBridge.dispatchMessagePersisted(chatId, persistedMessage)`。
2. **测试支持与单测覆盖（`ToolPkgChatMessageHookBridgeTest.kt`）**：
   - 在 `ToolPkgChatMessageHookBridge` 中暴露 internal 测试钩子 `onMessagePersistedDispatchedForTest`；
   - 增加单元测试，验证事件 payload 正确包含变体索引、内容、时间戳等关键元数据，并验证派发调用能正确执行。

---

## 关联 Issue / Related Issues
- Resolves #1085

---

## 验证与测试 / Verification & Testing
- [x] **单元测试**：`ToolPkgChatMessageHookBridgeTest` 覆盖了变体 payload 构造与派发逻辑；
- [x] **CI 构建通过**：GitHub Actions Android Build（run [34024135577](https://github.com/3316891527/Operit/actions/runs/34024135577)）构建及单测全绿（`success`）。
