### PR TITLE
fix(tools): preserve string param in MCP, optional types in JS, and optimize input IPC (#1125)

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/tools/javascript/JsToolManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/javascript/JsToolManager.kt
@@ -173,13 +173,24 @@ class JsToolManager private constructor(
 
         val converted = linkedMapOf<String, Any?>()
         tool.parameters.forEach { parameter ->
-            val type = parameterDefinitions[parameter.name]?.type?.lowercase() ?: "string"
-            converted[parameter.name] = convertToolParameterValue(
-                toolName = tool.name,
-                parameterName = parameter.name,
-                rawValue = parameter.value,
-                type = type
-            )
+            val definition = parameterDefinitions[parameter.name]
+            val isRequired = definition?.required ?: true
+            val type = definition?.type?.lowercase() ?: "string"
+            val rawValue = parameter.value
+            val isBlankOrNull = rawValue.isBlank() ||
+                rawValue.equals("null", ignoreCase = true) ||
+                rawValue.equals("undefined", ignoreCase = true)
+            if (!isRequired && type != "string" && isBlankOrNull) {
+                // 非必填的非字符串参数传入空值/空白时置为 null，避免数值/布尔/JSON解析异常；字符串类型原样保留
+                converted[parameter.name] = null
+            } else {
+                converted[parameter.name] = convertToolParameterValue(
+                    toolName = tool.name,
+                    parameterName = parameter.name,
+                    rawValue = rawValue,
+                    type = type
+                )
+            }
         }
 
         return buildRuntimeParams(packageName, converted)

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/mcp/MCPToolParameter.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/mcp/MCPToolParameter.kt
@@ -24,6 +24,7 @@ data class MCPToolParameter(
         if (value !is String) return value
 
         return when (type.lowercase()) {
+            "string" -> value
             "number" -> {
                 try {
                     if (value.contains(".")) value.toDouble() else value.toLong()
@@ -77,6 +78,7 @@ data class MCPToolParameter(
             if (value !is String) return value
 
             return when (typeName?.lowercase()) {
+                "string" -> value
                 "number" -> {
                     try {
                         if (value.contains(".")) value.toDouble() else value.toLong()
@@ -107,8 +109,8 @@ data class MCPToolParameter(
                     // 尝试解析对象
                     parseObject(value)
                 }
-                else -> {
-                    // 如果未指定类型，尝试智能猜测
+                null, "" -> {
+                    // 仅当未指定类型时，尝试智能猜测
                     when {
                         // 检测是否为对象格式（JSON对象）
                         value.trimStart().startsWith("{") && value.trimEnd().endsWith("}") -> {
@@ -131,6 +133,7 @@ data class MCPToolParameter(
                         else -> value
                     }
                 }
+                else -> value
             }
         }
 

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/screens/AIChatScreen.kt
@@ -1604,10 +1604,16 @@ private fun ChatInputBottomBar(
     }
 
     fun handleUserMessageChange(value: TextFieldValue) {
-        val clipboardText = clipboardManager.primaryClip?.getItemAt(0)?.text?.toString()
+        val replacedSelectionLength = (userMessage.selection.max - userMessage.selection.min).coerceAtLeast(0)
+        val estimatedPastedLength = value.text.length - userMessage.text.length + replacedSelectionLength
         val pastedText =
-            if (convertLongPastedTextToFile && clipboardText != null) {
-                extractClipboardPastedText(userMessage, value, clipboardText)
+            if (convertLongPastedTextToFile && estimatedPastedLength > longPastedTextFileThreshold) {
+                val clipboardText = clipboardManager.primaryClip?.getItemAt(0)?.text?.toString()
+                if (clipboardText != null) {
+                    extractClipboardPastedText(userMessage, value, clipboardText)
+                } else {
+                    null
+                }
             } else {
                 null
             }

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/mcp/MCPToolParameterTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/mcp/MCPToolParameterTest.kt
@@ -1,0 +1,77 @@
+package com.ai.assistance.operit.core.tools.mcp
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MCPToolParameterTest {
+
+    @Test
+    fun smartConvertPreservesNumericStringsWhenTypeIsString() {
+        // Issue #1125: 显式声明为 "string" 的纯数字或浮点数坐标字符串不应被强转为 Double 或 Long
+        val lat = "32.035599"
+        val lng = "118.773097"
+        val id = "10086"
+
+        val convertedLat = MCPToolParameter.smartConvert(lat, "string")
+        val convertedLng = MCPToolParameter.smartConvert(lng, "string")
+        val convertedId = MCPToolParameter.smartConvert(id, "string")
+
+        assertTrue("参数应保持为 String 类型", convertedLat is String)
+        assertTrue("参数应保持为 String 类型", convertedLng is String)
+        assertTrue("参数应保持为 String 类型", convertedId is String)
+
+        assertEquals("32.035599", convertedLat)
+        assertEquals("118.773097", convertedLng)
+        assertEquals("10086", convertedId)
+    }
+
+    @Test
+    fun smartConvertPreservesBooleanLikeStringsWhenTypeIsString() {
+        val boolStr = "true"
+        val converted = MCPToolParameter.smartConvert(boolStr, "string")
+        assertTrue(converted is String)
+        assertEquals("true", converted)
+    }
+
+    @Test
+    fun smartConvertConvertsNumericStringsWhenTypeIsNumberOrInteger() {
+        val numberResult = MCPToolParameter.smartConvert("32.035599", "number")
+        val intResult = MCPToolParameter.smartConvert("42", "integer")
+
+        assertTrue(numberResult is Double)
+        assertEquals(32.035599, numberResult as Double, 0.000001)
+
+        assertTrue(intResult is Int)
+        assertEquals(42, intResult)
+    }
+
+    @Test
+    fun smartConvertGuessesTypeOnlyWhenTypeNameIsNullOrEmpty() {
+        // 未指定类型时，自动猜测
+        val guessFloatNull = MCPToolParameter.smartConvert("32.035599", null)
+        val guessFloatEmpty = MCPToolParameter.smartConvert("32.035599", "")
+        val guessBool = MCPToolParameter.smartConvert("true", null)
+
+        assertTrue(guessFloatNull is Double)
+        assertTrue(guessFloatEmpty is Double)
+        assertTrue(guessBool is Boolean)
+
+        // 显式声明其他类型时不猜测
+        val customTypeResult = MCPToolParameter.smartConvert("32.035599", "custom_id")
+        assertTrue(customTypeResult is String)
+        assertEquals("32.035599", customTypeResult)
+    }
+
+    @Test
+    fun convertParameterValueHandlesStringExplicitly() {
+        val param = MCPToolParameter(
+            name = "from_lat",
+            type = "string",
+            description = "纬度"
+        )
+        val result = param.convertParameterValue("32.035599")
+        assertTrue(result is String)
+        assertEquals("32.035599", result)
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

本 PR 针对工具参数类型转换与输入性能方面的三个问题进行了集中修复与优化：
1. 修复 Issue #1125：远程 MCP 工具中显式声明为 `string` 的参数在值为纯数字/坐标字符串时被错误强转为 JSON number 的问题；
2. 修复 JS 插件系统（ToolPkg）中声明为 `required: false` 的非字符串参数（number / integer / boolean / array / object）在留空或传入空白时无脑强转导致抛出类型异常的问题；
3. 优化聊天输入框打字性能：移除了普通按键打字时对系统剪贴板（ClipboardService Binder IPC）的同步无意义查询，彻底消除主线程因跨进程通信引起的卡顿与按键粘滞感。

### 背景与动机 / Context and motivation

1. **MCP 参数类型强转（Issue #1125）**：
   在 `MCPToolParameter.kt` 的 `smartConvert` 中，`when (typeName?.lowercase())` 分支漏掉了 `"string"`，且 `else` 分支直接进入正则猜测。当 MCP 服务端声明参数类型为 `string`，而传入的值为纯数字或浮点坐标（如 `"32.035599"`）时，该参数被强转为 Double/Long，序列化为 JSON number 后导致对参数类型严格校验的服务端（如滴滴出行 MCP 等）报错“缺少必填参数”。
2. **JS 插件可选参数留空崩溃**：
   在 `JsToolManager.kt` 中，`convertToolParameters` 遍历参数执行 `convertToolParameterValue` 时未校验参数是否必填（`required: false`）。当模型在调用工具时将可选参数留空（`""`）或传 `null` 时，非字符串类型（number / integer / boolean / array / object）解析失败直接抛出 `ToolParameterConversionException`，导致插件调用失败，迫使开发者只能在 metadata 中把可选参数妥协声明为 `string` 再在 JS 侧手动强转。
3. **输入框打字高频系统 IPC 卡顿**：
   在 `AIChatScreen.kt` 的 `handleUserMessageChange` 中，每次按键输入都会无条件调用 `clipboardManager.primaryClip`。该方法属于跨进程同步 Binder IPC，单次开销可达数毫秒至十数毫秒。在用户打字或长文本编辑场景下，高频 IPC 严重阻塞主线程，配合 Compose 文本排版引发掉帧和打字粘滞。

### 改动范围 / Changes

1. **MCP 参数类型保护**（`MCPToolParameter.kt`）：
   - 在 `smartConvert` 与 `convertParameterValue` 中显式增加 `"string" -> value` 分支，严格保护声明为 string 的纯数字/布尔等字符串原样透传；
   - 将智能猜测逻辑严格限制在未指定类型（`null, ""`）时才触发，其余显式未知类型保持原样，不再盲目正则强转。
2. **JS 插件可选参数留空保护**（`JsToolManager.kt`）：
   - 在 `convertToolParameters` 中，对声明为 `required = false` 且输入值为空白、`"null"` 或 `"undefined"` 的参数，直接赋 `null`，不再调用 `convertToolParameterValue` 触发解析异常。
3. **输入框剪贴板 IPC 闸门**（`AIChatScreen.kt`）：
   - 增加字符增量判断：仅当 `value.text.length - userMessage.text.length > longPastedTextFileThreshold`（增量真正达到大段粘贴阈值）时，才查询系统剪贴板检测粘贴附件；
   - 彻底阻断普通打字、退格和选词时对系统剪贴板的同步 IPC 轮询。
4. **单元测试**：
   - 新增 `MCPToolParameterTest.kt`，覆盖坐标字符串保留、布尔字符串保留、未指定类型猜测以及显式数字类型转换。

明确不包含：
- 未修改数据库 Schema；
- 未改动 MCP 传输底层连接协议及网络管道。

### 兼容性与风险 / Compatibility and risks

- **MCP**：完全向后兼容，恢复了符合 MCP 协议规范的 string 类型参数行为；
- **JS 插件**：完全向后兼容，现有的 `required: false` 插件在可选参数未填时能正确获得 `null` 而不是报错；
- **输入框**：长文本粘贴转附件功能完整保留，普通打字性能显著提升，风险为 0。

## 关联 Issue / Related issue

Resolves #1125

## 验证方式 / Verification

```text
检查或命令：
- 运行新增单元测试 MCPToolParameterTest，验证 string 类型保护与智能猜测逻辑
- 检查 Git diff 确认无无关文件改动
环境与变体：
- Ubuntu / Android 14+ 环境
- assembleDebug 变体
结果：
- 单元测试覆盖并通过；
- 坐标字符串 "32.035599" 经 smartConvert("32.035599", "string") 输出仍为 String，不再转为 Double；
- 输入框在打字时不再触发 ClipboardService Binder IPC。

证据 / Evidence

N/A

检查清单 / Checklist

• x我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
• x日常开发 PR 的目标分支为 dev；如目标为 main，我已说明这是维护者发布同步 / The target branch is dev for regular work; if it is main, I explained why this is a maintainer-led release sync
• x我已确认 Candidate checks 覆盖改动范围，并会处理技术失败项 / Candidate checks covers the change scope and technical failures will be addressed
• x最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
• x已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided