### PR TITLE
fix(browser): emulate desktop viewport and user-agent metadata

### DIFF
--- a/app/src/androidTest/js/com/ai/assistance/operit/core/tools/defaultTool/standard/browser/main.js
+++ b/app/src/androidTest/js/com/ai/assistance/operit/core/tools/defaultTool/standard/browser/main.js
@@ -6,6 +6,7 @@ const File = Java.type('java.io.File');
 const FileOutputStream = Java.type('java.io.FileOutputStream');
 const OutputStreamWriter = Java.type('java.io.OutputStreamWriter');
 const Charset = Java.type('java.nio.charset.Charset');
+const BitmapFactory = Java.type('android.graphics.BitmapFactory');
 
 const UTF8 = Charset.forName('UTF-8');
 const BASE_DIR = '/sdcard/Download/Operit/browser_tool_suite';
@@ -72,6 +73,16 @@ function extractRef(snapshotOutput, marker) {
 function extractSavedPath(output) {
   const match = String(output || '').match(/Saved screenshot to ([^\r\n]+)/);
   return match ? match[1].trim() : null;
+}
+
+function bitmapSize(path) {
+  const bitmap = BitmapFactory.decodeFile(String(path));
+  assert(bitmap != null, 'screenshot should decode as a bitmap');
+  try {
+    return { width: Number(bitmap.getWidth()), height: Number(bitmap.getHeight()) };
+  } finally {
+    bitmap.recycle();
+  }
 }
 
 async function tryBrowserTool(name, params) {
@@ -352,10 +363,23 @@ exports.run = async function run() {
       const value = await evaluateExpression('() => document.body.dataset.upload');
       assert(String(value).indexOf('upload_payload.txt') >= 0, 'uploaded file name should be visible');
     }),
-    test('browser_resize reports new viewport', async () => {
+    test('browser_resize changes the page layout viewport', async () => {
       await ensureFixtureOpen();
       const value = await callBrowserTool('browser_resize', { width: 720, height: 1280 });
       assert(String(value).indexOf('720x1280') >= 0, 'resize should report requested viewport');
+      const actualViewport = await evaluateExpression('() => window.innerWidth + "x" + window.innerHeight');
+      assert(String(actualViewport).indexOf('720x1280') >= 0, 'page layout viewport should match requested size');
+    }),
+    test('browser_resize rejects unsafe viewport sizes without mutating the page', async () => {
+      let rejected = false;
+      try {
+        await callBrowserTool('browser_resize', { width: 100000, height: 100000 });
+      } catch (_expected) {
+        rejected = true;
+      }
+      assert(rejected, 'unsafe viewport should be rejected');
+      const actualViewport = await evaluateExpression('() => window.innerWidth + "x" + window.innerHeight');
+      assert(String(actualViewport).indexOf('720x1280') >= 0, 'rejected resize should keep the prior viewport');
     }),
     test('browser_take_screenshot writes an image file', async () => {
       await ensureFixtureOpen();
@@ -364,6 +388,16 @@ exports.run = async function run() {
       assert(savedPath, 'screenshot output should contain saved path');
       const state = fileState(savedPath);
       assert(state.exists && state.length > 0, 'screenshot file should exist');
+      const size = bitmapSize(savedPath);
+      assert(size.width === 720 && size.height === 1280, 'viewport screenshot should use CSS pixel dimensions');
+    }),
+    test('browser_take_screenshot fullPage uses CSS pixel dimensions', async () => {
+      await ensureFixtureOpen();
+      const value = await callBrowserTool('browser_take_screenshot', { type: 'png', fullPage: true });
+      const savedPath = extractSavedPath(value);
+      assert(savedPath, 'full-page screenshot output should contain saved path');
+      const size = bitmapSize(savedPath);
+      assert(size.width === 720 && size.height >= 1280, 'full-page screenshot should not be device-density scaled');
     }),
     test('browser_run_code still works on current page', async () => {
       await ensureFixtureOpen();

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardBrowserSessionTools.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardBrowserSessionTools.kt
@@ -75,9 +75,18 @@ class StandardBrowserSessionTools(internal val context: Context) : ToolExecutor 
         private const val TAG = "BrowserSessionTools"
         internal const val DEFAULT_TIMEOUT_MS = 10_000L
         internal const val MAX_EVENT_LOG_ENTRIES = 500
+        internal const val DESKTOP_CHROME_MAJOR_VERSION = "124"
+        internal const val DESKTOP_CHROME_FULL_VERSION = "124.0.0.0"
+        internal const val DEFAULT_DESKTOP_VIEWPORT_WIDTH = 1280
+        internal const val DEFAULT_DESKTOP_VIEWPORT_HEIGHT = 720
+        internal const val MAX_VIEWPORT_DIMENSION_CSS_PX = 4096
+        internal const val MAX_VIEWPORT_PIXEL_COUNT = 8_388_608L
+        internal const val MAX_VIEWPORT_LAYOUT_PIXEL_COUNT = 33_554_432L
+        internal const val MAX_SCREENSHOT_DIMENSION_PX = 32_768
+        internal const val MAX_SCREENSHOT_PIXEL_COUNT = 16_777_216L
         internal const val DEFAULT_USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
-                "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                "(KHTML, like Gecko) Chrome/$DESKTOP_CHROME_FULL_VERSION Safari/537.36"
         internal const val MOBILE_USER_AGENT =
             "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 " +
                 "(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
@@ -164,7 +173,7 @@ class StandardBrowserSessionTools(internal val context: Context) : ToolExecutor 
         @Volatile var pendingDialog: PendingDialog? = null
         @Volatile var viewportWidthPx: Int? = null
         @Volatile var viewportHeightPx: Int? = null
-        @Volatile var appliedViewportScaleFactor: Float = 1f
+        @Volatile var hasExplicitViewportSize: Boolean = false
         @Volatile var lastSnapshot: BrowserSnapshot? = null
         val stateSignal: Object = Object()
         @Volatile var stateVersion: Long = 0L
@@ -399,8 +408,13 @@ class StandardBrowserSessionTools(internal val context: Context) : ToolExecutor 
 
     private fun dispatchNativeTapByRef(webView: WebView, ref: String): Boolean {
         val rect = resolveElementRect(webView, ref) ?: return false
-        val x = ((rect.left + rect.right) / 2f).coerceIn(1f, (webView.width - 1).coerceAtLeast(1).toFloat())
-        val y = ((rect.top + rect.bottom) / 2f).coerceIn(1f, (webView.height - 1).coerceAtLeast(1).toFloat())
+        val pageScale = webView.scale.takeIf { it > 0f } ?: 1f
+        val x =
+            (((rect.left + rect.right) / 2f) * pageScale)
+                .coerceIn(1f, (webView.width - 1).coerceAtLeast(1).toFloat())
+        val y =
+            (((rect.top + rect.bottom) / 2f) * pageScale)
+                .coerceIn(1f, (webView.height - 1).coerceAtLeast(1).toFloat())
         return runOnMainSync {
             try {
                 webView.requestFocus()
@@ -1391,6 +1405,27 @@ class StandardBrowserSessionTools(internal val context: Context) : ToolExecutor 
         if (width <= 0 || height <= 0) {
             return error(tool.name, "width and height must be positive integers")
         }
+        val density =
+            context.resources.displayMetrics.density
+                .takeIf { it.isFinite() && it > 0f }
+                ?: 1f
+        val cssPixelCount = width.toLong() * height.toLong()
+        val layoutWidth = kotlin.math.ceil(width.toDouble() * density).toLong()
+        val layoutHeight = kotlin.math.ceil(height.toDouble() * density).toLong()
+        val layoutPixelCount = layoutWidth * layoutHeight
+        if (
+            width > MAX_VIEWPORT_DIMENSION_CSS_PX ||
+                height > MAX_VIEWPORT_DIMENSION_CSS_PX ||
+                cssPixelCount > MAX_VIEWPORT_PIXEL_COUNT ||
+                layoutPixelCount > MAX_VIEWPORT_LAYOUT_PIXEL_COUNT
+        ) {
+            return error(
+                tool.name,
+                "viewport is too large for this device; maximum side is " +
+                    "$MAX_VIEWPORT_DIMENSION_CSS_PX CSS px and the requested pixel area " +
+                    "must fit the device rendering budget"
+            )
+        }
 
         val session =
             runOnMainSync {
@@ -1398,9 +1433,10 @@ class StandardBrowserSessionTools(internal val context: Context) : ToolExecutor 
             }
         runOnMainSync<Unit> {
             ensureSessionAttachedOnMain(session.id)
-            browserHost?.setViewportSize(width, height)
             session.viewportWidthPx = width
             session.viewportHeightPx = height
+            session.hasExplicitViewportSize = true
+            browserHost?.setViewportSize(width, height)
             applyViewportOverride(session)
             refreshSessionUiOnMain(session.id)
         }

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/websession/browser/BrowserPageExecutionSupport.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/websession/browser/BrowserPageExecutionSupport.kt
@@ -2351,9 +2351,25 @@ internal fun StandardBrowserSessionTools.takeScreenshot(
         output.parentFile?.mkdirs()
         val bitmap =
             when {
-                fullPage -> captureFullPageBitmap(session.webView)
-                ref != null -> captureElementBitmap(session.webView, ref)
-                else -> captureViewportBitmap(session.webView)
+                fullPage ->
+                    captureFullPageBitmap(
+                        session.webView,
+                        session.viewportWidthPx,
+                        session.viewportHeightPx
+                    )
+                ref != null ->
+                    captureElementBitmap(
+                        session.webView,
+                        ref,
+                        session.viewportWidthPx,
+                        session.viewportHeightPx
+                    )
+                else ->
+                    captureViewportBitmap(
+                        session.webView,
+                        session.viewportWidthPx,
+                        session.viewportHeightPx
+                    )
             }
         FileOutputStream(output).use { stream ->
             bitmap.compress(
@@ -2367,43 +2383,106 @@ internal fun StandardBrowserSessionTools.takeScreenshot(
     }
 }
 
-internal fun StandardBrowserSessionTools.captureViewportBitmap(webView: WebView): Bitmap {
-    val width = webView.width.coerceAtLeast(1)
-    val height = webView.height.coerceAtLeast(1)
-    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+internal fun StandardBrowserSessionTools.captureViewportBitmap(
+    webView: WebView,
+    viewportWidthCssPx: Int? = null,
+    viewportHeightCssPx: Int? = null
+): Bitmap {
+    val sourceWidth = webView.width.coerceAtLeast(1)
+    val sourceHeight = webView.height.coerceAtLeast(1)
+    val width = viewportWidthCssPx ?: sourceWidth
+    val height = viewportHeightCssPx ?: sourceHeight
+    val bitmap = createBrowserScreenshotBitmap(width, height)
     val canvas = Canvas(bitmap)
+    if (width != sourceWidth || height != sourceHeight) {
+        canvas.scale(width.toFloat() / sourceWidth, height.toFloat() / sourceHeight)
+    }
     webView.draw(canvas)
     return bitmap
 }
 
-internal fun StandardBrowserSessionTools.captureFullPageBitmap(webView: WebView): Bitmap {
-    val (width, height) = resolveFullPageBitmapSize(webView)
+internal fun StandardBrowserSessionTools.captureFullPageBitmap(
+    webView: WebView,
+    viewportWidthCssPx: Int? = null,
+    viewportHeightCssPx: Int? = null
+): Bitmap {
+    val pageSize = resolveFullPageCssSize(webView)
     val originalWidth = webView.width.coerceAtLeast(1)
     val originalHeight = webView.height.coerceAtLeast(1)
     val originalScrollX = webView.scrollX
     val originalScrollY = webView.scrollY
-    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    val hasCssViewport = viewportWidthCssPx != null && viewportHeightCssPx != null
+    val outputWidth =
+        if (hasCssViewport) {
+            pageSize.contentWidthCssPx
+        } else {
+            (pageSize.contentWidthCssPx * (webView.scale.takeIf { it > 0f } ?: 1f))
+                .toInt()
+                .coerceAtLeast(originalWidth)
+        }
+    val outputHeight =
+        if (hasCssViewport) {
+            pageSize.contentHeightCssPx
+        } else {
+            (pageSize.contentHeightCssPx * (webView.scale.takeIf { it > 0f } ?: 1f))
+                .toInt()
+                .coerceAtLeast(originalHeight)
+        }
+    val layoutScaleX = originalWidth.toFloat() / pageSize.viewportWidthCssPx.coerceAtLeast(1)
+    val layoutScaleY = originalHeight.toFloat() / pageSize.viewportHeightCssPx.coerceAtLeast(1)
+    val layoutWidth =
+        kotlin.math.ceil(pageSize.contentWidthCssPx * layoutScaleX)
+            .toLong()
+            .also { require(it in 1..Int.MAX_VALUE.toLong()) { "Full-page layout width is too large" } }
+            .toInt()
+    val layoutHeight =
+        kotlin.math.ceil(pageSize.contentHeightCssPx * layoutScaleY)
+            .toLong()
+            .also { require(it in 1..Int.MAX_VALUE.toLong()) { "Full-page layout height is too large" } }
+            .toInt()
+    val layoutPixelCount = layoutWidth.toLong() * layoutHeight.toLong()
+    require(
+        layoutWidth <= StandardBrowserSessionTools.MAX_SCREENSHOT_DIMENSION_PX &&
+            layoutHeight <= StandardBrowserSessionTools.MAX_SCREENSHOT_DIMENSION_PX &&
+            layoutPixelCount <= StandardBrowserSessionTools.MAX_VIEWPORT_LAYOUT_PIXEL_COUNT
+    ) {
+        "Full-page layout dimensions ${layoutWidth}x$layoutHeight exceed the safe rendering budget"
+    }
+    val bitmap = createBrowserScreenshotBitmap(outputWidth, outputHeight)
     val canvas = Canvas(bitmap)
-    webView.measure(
-        View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-        View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
-    )
-    webView.layout(0, 0, width, height)
-    webView.scrollTo(0, 0)
-    webView.draw(canvas)
-    webView.measure(
-        View.MeasureSpec.makeMeasureSpec(originalWidth, View.MeasureSpec.EXACTLY),
-        View.MeasureSpec.makeMeasureSpec(originalHeight, View.MeasureSpec.EXACTLY)
-    )
-    webView.layout(0, 0, originalWidth, originalHeight)
-    webView.scrollTo(originalScrollX, originalScrollY)
-    return bitmap
+    canvas.scale(outputWidth.toFloat() / layoutWidth, outputHeight.toFloat() / layoutHeight)
+    try {
+        webView.measure(
+            View.MeasureSpec.makeMeasureSpec(layoutWidth, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(layoutHeight, View.MeasureSpec.EXACTLY)
+        )
+        webView.layout(0, 0, layoutWidth, layoutHeight)
+        webView.scrollTo(0, 0)
+        webView.draw(canvas)
+        return bitmap
+    } catch (failure: Throwable) {
+        bitmap.recycle()
+        throw failure
+    } finally {
+        webView.measure(
+            View.MeasureSpec.makeMeasureSpec(originalWidth, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(originalHeight, View.MeasureSpec.EXACTLY)
+        )
+        webView.layout(0, 0, originalWidth, originalHeight)
+        webView.scrollTo(originalScrollX, originalScrollY)
+    }
 }
 
-internal fun StandardBrowserSessionTools.resolveFullPageBitmapSize(
+internal data class BrowserFullPageCssSize(
+    val contentWidthCssPx: Int,
+    val contentHeightCssPx: Int,
+    val viewportWidthCssPx: Int,
+    val viewportHeightCssPx: Int
+)
+
+internal fun StandardBrowserSessionTools.resolveFullPageCssSize(
     webView: WebView
-): Pair<Int, Int> {
-    val scale = webView.scale.takeIf { it > 0f } ?: 1f
+): BrowserFullPageCssSize {
     val pageSize =
         runJsonScript(
             webView,
@@ -2425,32 +2504,73 @@ internal fun StandardBrowserSessionTools.resolveFullPageBitmapSize(
                     body ? (body.scrollHeight || 0) : 0,
                     body ? (body.offsetHeight || 0) : 0
                 );
-                return JSON.stringify({ ok: true, width, height });
+                return JSON.stringify({
+                    ok: true,
+                    width,
+                    height,
+                    viewportWidth: window.innerWidth || 0,
+                    viewportHeight: window.innerHeight || 0
+                });
             })();
             """.trimIndent(),
             "page_size_error"
         )
 
-    val width =
-        (((pageSize?.optDouble("width", 0.0) ?: 0.0) * scale).toInt())
-            .coerceAtLeast(webView.width.coerceAtLeast(1))
-    val height =
-        (((pageSize?.optDouble("height", 0.0) ?: 0.0) * scale).toInt())
-            .coerceAtLeast(webView.height.coerceAtLeast(1))
-    return width to height
+    val fallbackScale = webView.scale.takeIf { it.isFinite() && it > 0f } ?: 1f
+    val fallbackViewportWidth = (webView.width / fallbackScale).toInt().coerceAtLeast(1)
+    val fallbackViewportHeight = (webView.height / fallbackScale).toInt().coerceAtLeast(1)
+    val viewportWidth =
+        (pageSize?.optDouble("viewportWidth", 0.0) ?: 0.0)
+            .toInt()
+            .takeIf { it > 0 }
+            ?: fallbackViewportWidth
+    val viewportHeight =
+        (pageSize?.optDouble("viewportHeight", 0.0) ?: 0.0)
+            .toInt()
+            .takeIf { it > 0 }
+            ?: fallbackViewportHeight
+    return BrowserFullPageCssSize(
+        contentWidthCssPx =
+            (pageSize?.optDouble("width", 0.0) ?: 0.0).toInt().coerceAtLeast(viewportWidth),
+        contentHeightCssPx =
+            (pageSize?.optDouble("height", 0.0) ?: 0.0).toInt().coerceAtLeast(viewportHeight),
+        viewportWidthCssPx = viewportWidth,
+        viewportHeightCssPx = viewportHeight
+    )
+}
+
+internal fun StandardBrowserSessionTools.createBrowserScreenshotBitmap(width: Int, height: Int): Bitmap {
+    require(width > 0 && height > 0) { "Screenshot dimensions must be positive" }
+    require(
+        width <= StandardBrowserSessionTools.MAX_SCREENSHOT_DIMENSION_PX &&
+            height <= StandardBrowserSessionTools.MAX_SCREENSHOT_DIMENSION_PX
+    ) {
+        "Screenshot dimensions ${width}x$height exceed the safe side-length limit"
+    }
+    val pixelCount = width.toLong() * height.toLong()
+    require(pixelCount <= StandardBrowserSessionTools.MAX_SCREENSHOT_PIXEL_COUNT) {
+        "Screenshot dimensions ${width}x$height exceed the safe pixel budget"
+    }
+    return Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
 }
 
 internal fun StandardBrowserSessionTools.captureElementBitmap(
     webView: WebView,
-    ref: String
+    ref: String,
+    viewportWidthCssPx: Int? = null,
+    viewportHeightCssPx: Int? = null
 ): Bitmap {
     val rect = resolveElementRect(webView, ref) ?: throw RuntimeException("ref_not_found")
-    val bitmap = captureViewportBitmap(webView)
+    val bitmap = captureViewportBitmap(webView, viewportWidthCssPx, viewportHeightCssPx)
     val left = rect.left.coerceIn(0, bitmap.width - 1)
     val top = rect.top.coerceIn(0, bitmap.height - 1)
     val width = rect.width().coerceAtLeast(1).coerceAtMost(bitmap.width - left)
     val height = rect.height().coerceAtLeast(1).coerceAtMost(bitmap.height - top)
-    return Bitmap.createBitmap(bitmap, left, top, width, height)
+    val cropped = Bitmap.createBitmap(bitmap, left, top, width, height)
+    if (cropped !== bitmap) {
+        bitmap.recycle()
+    }
+    return cropped
 }
 
 internal fun StandardBrowserSessionTools.resolveElementRect(

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/websession/browser/BrowserWebViewSupport.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/websession/browser/BrowserWebViewSupport.kt
@@ -23,6 +23,9 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.core.content.ContextCompat
+import androidx.webkit.UserAgentMetadata
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
 import com.ai.assistance.operit.R
 import com.ai.assistance.operit.core.application.ActivityLifecycleManager
 import com.ai.assistance.operit.core.tools.defaultTool.standard.StandardBrowserSessionTools
@@ -52,6 +55,10 @@ internal fun StandardBrowserSessionTools.createSessionOnMain(
             sessionName = sessionName,
             customUserAgent = customUserAgent
         )
+    if (StandardBrowserSessionTools.desktopModeEnabled) {
+        session.viewportWidthPx = StandardBrowserSessionTools.DEFAULT_DESKTOP_VIEWPORT_WIDTH
+        session.viewportHeightPx = StandardBrowserSessionTools.DEFAULT_DESKTOP_VIEWPORT_HEIGHT
+    }
     configureWebView(session, resolveUserAgent(customUserAgent))
     userscriptManager.attachSession(session.id, session.webView)
     return session
@@ -808,7 +815,11 @@ internal fun StandardBrowserSessionTools.syncProjectedBrowserStateOnMain() {
     val resolvedActiveId = registry.activeSessionId
     val activeSession = resolvedActiveId?.let(::sessionById)
     StandardBrowserSessionTools.activeSessionId = resolvedActiveId
-    StandardBrowserSessionTools.browserHost?.attachActiveWebView(activeSession?.webView)
+    StandardBrowserSessionTools.browserHost?.attachActiveWebView(
+        activeSession?.webView,
+        activeSession?.viewportWidthPx,
+        activeSession?.viewportHeightPx
+    )
     activeSession?.let(::applyViewportOverride)
     userscriptManager.updateVisibleSession(
         sessionId = resolvedActiveId,
@@ -970,48 +981,51 @@ internal fun StandardBrowserSessionTools.applySessionUserAgent(
     session: BrowserToolSession,
     userAgent: String
 ) {
+    val isDesktopMode = StandardBrowserSessionTools.desktopModeEnabled
     with(session.webView.settings) {
         userAgentString = userAgent
-        useWideViewPort = StandardBrowserSessionTools.desktopModeEnabled
-        loadWithOverviewMode =
-            StandardBrowserSessionTools.desktopModeEnabled && session.viewportWidthPx == null
+        useWideViewPort = isDesktopMode && session.viewportWidthPx == null
+        loadWithOverviewMode = isDesktopMode && session.viewportWidthPx == null
+
+        if (
+            session.customUserAgent == null &&
+                WebViewFeature.isFeatureSupported(WebViewFeature.USER_AGENT_METADATA)
+        ) {
+            val userAgentMetadataBuilder =
+                UserAgentMetadata.Builder()
+                    .setMobile(!isDesktopMode)
+                    .setPlatform(if (isDesktopMode) "Windows" else "Android")
+            if (isDesktopMode) {
+                // Null fields inherit Android WebView defaults, which would contradict the desktop UA.
+                val brandVersions =
+                    listOf("Chromium", "Google Chrome").map { brand ->
+                        UserAgentMetadata.BrandVersion.Builder()
+                            .setBrand(brand)
+                            .setMajorVersion(StandardBrowserSessionTools.DESKTOP_CHROME_MAJOR_VERSION)
+                            .setFullVersion(StandardBrowserSessionTools.DESKTOP_CHROME_FULL_VERSION)
+                            .build()
+                    }
+                userAgentMetadataBuilder
+                    .setBrandVersionList(brandVersions)
+                    .setFullVersion(StandardBrowserSessionTools.DESKTOP_CHROME_FULL_VERSION)
+                    .setPlatformVersion("10.0.0")
+                    .setArchitecture("x86")
+                    .setModel("")
+                    .setBitness(64)
+                    .setWow64(false)
+            }
+            WebSettingsCompat.setUserAgentMetadata(this, userAgentMetadataBuilder.build())
+        }
     }
 }
 
 internal fun StandardBrowserSessionTools.applyViewportOverride(session: BrowserToolSession) {
-    val requestedWidth = session.viewportWidthPx
-    val requestedHeight = session.viewportHeightPx
-    val browserAreaWidth =
-        StandardBrowserSessionTools.browserHost?.currentBrowserAreaSize()?.first
-            ?.takeIf { it > 0 }
-            ?: session.webView.width.takeIf { it > 0 }
-            ?: context.resources.displayMetrics.widthPixels
-
-    session.webView.settings.loadWithOverviewMode =
-        StandardBrowserSessionTools.desktopModeEnabled && requestedWidth == null
-
-    val desiredScaleFactor =
-        if (requestedWidth == null || requestedHeight == null || browserAreaWidth <= 0) {
-            1f
-        } else {
-            (browserAreaWidth.toFloat() / requestedWidth.toFloat()).coerceIn(0.25f, 5f)
-        }
-
-    val currentScaleFactor = session.appliedViewportScaleFactor.takeIf { it > 0f } ?: 1f
-    val relativeScaleFactor = (desiredScaleFactor / currentScaleFactor).coerceIn(0.25f, 5f)
-
-    session.webView.post {
-        runCatching {
-            if (relativeScaleFactor != 1f) {
-                session.webView.zoomBy(relativeScaleFactor)
-            }
-            session.appliedViewportScaleFactor = desiredScaleFactor
-        }.onFailure {
-            AppLogger.w(
-                WEBVIEW_SUPPORT_TAG,
-                "Failed to apply viewport override for session=${session.id}: ${it.message}"
-            )
-        }
+    val hasViewportOverride = session.viewportWidthPx != null && session.viewportHeightPx != null
+    with(session.webView.settings) {
+        // Page zoom does not change Chromium's layout viewport. With an explicit viewport,
+        // size the WebView itself and let its control width define the CSS layout width.
+        useWideViewPort = StandardBrowserSessionTools.desktopModeEnabled && !hasViewportOverride
+        loadWithOverviewMode = StandardBrowserSessionTools.desktopModeEnabled && !hasViewportOverride
     }
 }
 
@@ -1275,10 +1289,18 @@ internal fun StandardBrowserSessionTools.setDesktopModeEnabled(enabled: Boolean)
 
     runOnMainSync<Unit> {
         StandardBrowserSessionTools.sessions.values.forEach { session ->
+            if (!session.hasExplicitViewportSize) {
+                session.viewportWidthPx =
+                    StandardBrowserSessionTools.DEFAULT_DESKTOP_VIEWPORT_WIDTH.takeIf { enabled }
+                session.viewportHeightPx =
+                    StandardBrowserSessionTools.DEFAULT_DESKTOP_VIEWPORT_HEIGHT.takeIf { enabled }
+            }
             if (session.customUserAgent == null) {
                 applySessionUserAgent(session, resolveUserAgent(null))
             }
+            applyViewportOverride(session)
         }
+        syncProjectedBrowserStateOnMain()
 
         val activeSession = getActiveSessionOnMain()
         if (activeSession != null && activeSession.customUserAgent == null) {

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/websession/browser/WebSessionBrowserHost.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/websession/browser/WebSessionBrowserHost.kt
@@ -249,8 +249,15 @@ internal class WebSessionBrowserHost(
         updateIndicatorLayoutForCurrentState()
     }
 
-    fun attachActiveWebView(webView: WebView?) {
-        webViewHost.setActiveWebView(webView)
+    fun attachActiveWebView(webView: WebView?, viewportWidth: Int? = null, viewportHeight: Int? = null) {
+        updateHostState {
+            if (it.viewportWidthPx == viewportWidth && it.viewportHeightPx == viewportHeight) {
+                it
+            } else {
+                it.copy(viewportWidthPx = viewportWidth, viewportHeightPx = viewportHeight)
+            }
+        }
+        webViewHost.setActiveWebView(webView, viewportWidth, viewportHeight)
     }
 
     fun showTextSelectionActionsOverlay(anchorX: Double, anchorY: Double) {
@@ -302,14 +309,16 @@ internal class WebSessionBrowserHost(
     fun setViewportSize(width: Int, height: Int) {
         updateHostState {
             it.copy(
-                viewportWidthPx = width.coerceAtLeast(dp(240)),
-                viewportHeightPx = height.coerceAtLeast(dp(320))
+                viewportWidthPx = width,
+                viewportHeightPx = height
             )
         }
+        webViewHost.setViewportSize(width, height)
     }
 
     fun clearViewportSizeOverride() {
         updateHostState { it.copy(viewportWidthPx = null, viewportHeightPx = null) }
+        webViewHost.setViewportSize(null, null)
     }
 
     fun currentViewportSize(): Pair<Int, Int> {
@@ -553,7 +562,7 @@ internal class WebSessionBrowserHost(
 
         val location = IntArray(2)
         webView.getLocationOnScreen(location)
-        val scale = webView.scale
+        val scale = webView.scale * webView.scaleX
         val width = actionsView.measuredWidth
         val height = actionsView.measuredHeight
         val metrics = appContext.resources.displayMetrics

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/websession/browser/WebSessionWebViewHost.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/websession/browser/WebSessionWebViewHost.kt
@@ -1,26 +1,54 @@
 package com.ai.assistance.operit.core.tools.defaultTool.websession.browser
 
+import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.webkit.WebView
+import kotlin.math.min
+import kotlin.math.roundToInt
 
 internal class WebSessionWebViewHost {
     private var container: FrameLayout? = null
     private var activeWebView: WebView? = null
+    private var viewportWidthCssPx: Int? = null
+    private var viewportHeightCssPx: Int? = null
+    private val containerLayoutChangeListener =
+        View.OnLayoutChangeListener { view, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
+            if (
+                right - left != oldRight - oldLeft ||
+                    bottom - top != oldBottom - oldTop
+            ) {
+                applyWebViewLayout(view as FrameLayout)
+            }
+        }
 
     fun attachContainer(target: FrameLayout) {
+        if (container !== target) {
+            container?.removeOnLayoutChangeListener(containerLayoutChangeListener)
+            target.addOnLayoutChangeListener(containerLayoutChangeListener)
+        }
         container = target
         reattach()
     }
 
     fun detachContainer(target: FrameLayout) {
         if (container === target) {
+            target.removeOnLayoutChangeListener(containerLayoutChangeListener)
             container = null
         }
     }
 
-    fun setActiveWebView(webView: WebView?) {
+    fun setActiveWebView(webView: WebView?, viewportWidth: Int?, viewportHeight: Int?) {
         activeWebView = webView
+        viewportWidthCssPx = viewportWidth
+        viewportHeightCssPx = viewportHeight
+        reattach()
+    }
+
+    fun setViewportSize(width: Int?, height: Int?) {
+        viewportWidthCssPx = width
+        viewportHeightCssPx = height
         reattach()
     }
 
@@ -28,8 +56,11 @@ internal class WebSessionWebViewHost {
 
     fun clear() {
         container?.removeAllViews()
+        container?.removeOnLayoutChangeListener(containerLayoutChangeListener)
         container = null
         activeWebView = null
+        viewportWidthCssPx = null
+        viewportHeightCssPx = null
     }
 
     private fun reattach() {
@@ -46,12 +77,8 @@ internal class WebSessionWebViewHost {
             parent.removeView(webView)
         }
 
-        if (target.childCount == 1 && target.getChildAt(0) === webView) {
-            return
-        }
-
-        target.removeAllViews()
-        if (webView.parent == null) {
+        if (target.childCount != 1 || target.getChildAt(0) !== webView) {
+            target.removeAllViews()
             target.addView(
                 webView,
                 FrameLayout.LayoutParams(
@@ -60,5 +87,71 @@ internal class WebSessionWebViewHost {
                 )
             )
         }
+
+        applyWebViewLayout(target)
+    }
+
+    private fun applyWebViewLayout(target: FrameLayout) {
+        val webView = activeWebView ?: return
+        if (webView.parent !== target) {
+            return
+        }
+
+        val requestedWidth = viewportWidthCssPx
+        val requestedHeight = viewportHeightCssPx
+        if (requestedWidth == null || requestedHeight == null) {
+            webView.pivotX = 0f
+            webView.pivotY = 0f
+            webView.scaleX = 1f
+            webView.scaleY = 1f
+            webView.translationX = 0f
+            webView.translationY = 0f
+            updateLayoutParams(
+                webView,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            )
+            return
+        }
+
+        // WebView lays out CSS pixels as density-independent pixels. Giving it the requested
+        // CSS viewport in physical pixels makes window.innerWidth/innerHeight match the tool
+        // arguments; the view transform below only fits that logical viewport on the phone.
+        val density =
+            webView.resources.displayMetrics.density
+                .takeIf { it.isFinite() && it > 0f }
+                ?: 1f
+        val layoutWidth = (requestedWidth * density).roundToInt().coerceAtLeast(1)
+        val layoutHeight = (requestedHeight * density).roundToInt().coerceAtLeast(1)
+        updateLayoutParams(webView, layoutWidth, layoutHeight)
+
+        val availableWidth = target.width
+        val availableHeight = target.height
+        if (availableWidth <= 0 || availableHeight <= 0) {
+            return
+        }
+
+        val previewScale =
+            min(
+                availableWidth.toFloat() / layoutWidth.toFloat(),
+                availableHeight.toFloat() / layoutHeight.toFloat()
+            )
+        webView.pivotX = 0f
+        webView.pivotY = 0f
+        webView.scaleX = previewScale
+        webView.scaleY = previewScale
+        webView.translationX = (availableWidth - layoutWidth * previewScale) / 2f
+        webView.translationY = (availableHeight - layoutHeight * previewScale) / 2f
+    }
+
+    private fun updateLayoutParams(webView: WebView, width: Int, height: Int) {
+        val current = webView.layoutParams as? FrameLayout.LayoutParams
+        if (current?.width == width && current.height == height && current.gravity == Gravity.TOP) {
+            return
+        }
+        webView.layoutParams =
+            FrameLayout.LayoutParams(width, height).apply {
+                gravity = Gravity.TOP
+            }
     }
 }


### PR DESCRIPTION
## 变更说明 / Description

修复内置浏览器桌面模式的设备识别与布局视口不一致问题，并使 `browser_resize` 实际改变页面布局尺寸。同步调整点击坐标与截图输出，保持工具操作和页面视口一致。

### 背景与动机 / Context and motivation

现有桌面模式只修改传统 User-Agent，未同步 WebView 的 UA Client Hints；网站仍可能将其识别为移动设备。现有 resize 使用 `zoomBy`，只能缩放页面，不能保证 `window.innerWidth/innerHeight` 与工具参数一致。

### 改动范围 / Changes

- 在支持的 WebView 上同步桌面模式的 UserAgentMetadata，保留自定义 UA 行为。
- 桌面模式默认使用 1280×720 CSS 视口，按实际 WebView 布局实现 resize，并通过视图变换适配手机显示区域。
- 按标签页保存视口；桌面/手机切换时保留显式设置的尺寸。
- 修正原生点击、选区操作浮层和截图的缩放处理；显式视口下截图按 CSS 像素输出。
- 为视口、临时整页布局和截图位图分配增加尺寸及像素预算限制。
- 扩展现有浏览器 JS 测试脚本，断言实际布局视口、超限 resize 不改变原视口、普通及整页截图尺寸。

范围仅含浏览器实现与对应 JS 测试脚本，共 6 个文件；无品牌、服务路由、发布或构建配置改动。

### 兼容性与风险 / Compatibility and risks

不改变工具名称、参数格式或持久化数据结构，不增加依赖。桌面模式默认布局尺寸会变化；显式视口截图使用 CSS 像素尺寸。超出资源预算的请求返回错误：视口单边最多 4096 CSS px、面积最多 8,388,608 CSS 像素；物理布局面积最多 33,554,432 像素；截图单边最多 32,768 像素、面积最多 16,777,216 像素。特别长的整页截图可能被拒绝。

## 关联 Issue / Related issue

暂无对应 Issue。已搜索上游 desktop、viewport 和 desktop mode 相关 Issue/PR，未发现覆盖本问题的条目。

## 验证方式 / Verification

环境：Windows、JDK 21、Android debug 变体；基于 `upstream/dev` 的 `12f6148068d5c1b69924d6d4048b1374f21f1491`。

- `git diff --cached --check`：通过。
- `node --check app/src/androidTest/js/com/ai/assistance/operit/core/tools/defaultTool/standard/browser/main.js`：通过，仅验证 JS 语法。
- `gradlew.bat :app:compileDebugKotlin :app:testDebugUnitTest :app:lintDebug --continue --no-daemon --console=plain --max-workers=4`：应用 Kotlin 编译通过；测试源码编译失败，JVM 测试未执行。初次 Lint 依赖准备遇到 GitHub 连接超时。
- 单独重试 `gradlew.bat :app:lintDebug --continue --no-daemon --console=plain --max-workers=4`：网络问题消除，完整分析结束，但全仓库报告 1,139 errors、4,917 warnings、118 hints，任务未通过。本次修改的浏览器文件中无 Lint error；新增位图创建调用有一项 `UseKtx` 风格建议。
- 最终差异已由独立代理只读审计，结论 CLEAN；该结论仅代表静态审计。
- 未运行 Android 设备上的浏览器 JS 行为测试，未提供真机或模拟器通过结论。此 PR 先以草稿提交。

## 证据 / Evidence

JVM 测试被以下现有测试源码阻塞；对应测试文件及 provider 实现与上述上游基线完全一致，本 PR 未修改：

- `DeepseekProviderMediaRoleTest.kt:244`：直接调用 `OpenAIResponsesProvider.createRequestBody`，但该方法为 protected。
- `XaiProviderReasoningTest.kt:34,43,49-51`：引用不存在的 `XaiReasoningMapper` 和 `xaiModelSupportsReasoningEffort`。

全仓库 Lint 首项错误位于未修改的 `BluetoothSessionManager.kt:551`，类型为 `MissingPermission`。本 PR 没有更新 Lint baseline、禁用检查或移除失败测试。

新增浏览器脚本预期验证：resize 到 720×1280 后，页面布局视口及普通截图均为 720×1280；整页截图宽度为 720 CSS 像素；拒绝 100000×100000 的 resize 后保留原视口。这些运行时断言尚未在设备上执行。

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 `dev`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `dev` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
- [ ] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [ ] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
