### PR TITLE
feat(logcat): add export filters for debug, system, error context, and sensitive content

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportFilter.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportFilter.kt
@@ -1,0 +1,245 @@
+package com.ai.assistance.operit.ui.features.toolbox.screens.logcat
+
+/**
+ * Parses AppLogger lines and applies export-only filters.
+ * Does not change how logs are written.
+ */
+object LogExportFilter {
+    private val headerRegex =
+        Regex("^(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3})\\s+([VDIWEAF])/(.*?): (.*)$")
+
+    private val systemTags = setOf(
+        "androidruntime",
+        "system",
+        "system.err",
+        "system.out",
+        "webview",
+        "chromium",
+        "chromiumnet",
+        "okhttp",
+        "okhttpclient",
+        "libc",
+        "dalvikvm",
+        "art",
+        "activitymanager",
+        "packagemanager",
+        "windowmanager"
+    )
+
+    private val sensitiveHeaderPrefixes = listOf(
+        "发现系统消息:",
+        "请求体json:",
+        "request body json:",
+        "request body:",
+        "json del cuerpo de la solicitud:",
+        "json badan permintaan:",
+        "요청 본문 json:",
+        "corpo da solicitação json:",
+        "corpul cereriijson:",
+        "final deepseek reasoning mode request body:",
+        "final kimi k2.5 request body:",
+        "claude请求体:",
+        "final prompt before llama generation:"
+    )
+
+    private val sensitiveContinuationPrefixes = listOf(
+        "part "
+    )
+
+    private val sensitiveBodyTokens = listOf(
+        "\"systeminstruction\"",
+        "\"character_setting\"",
+        "\"charactersetting\"",
+        "\"advanced_custom_prompt\"",
+        "\"tag_prompt\""
+    )
+
+    data class ExportRecord(
+        val timestamp: String?,
+        val level: Char?,
+        val tag: String?,
+        val message: String,
+        val continuationLines: List<String> = emptyList()
+    ) {
+        val isHeader: Boolean get() = timestamp != null && level != null
+
+        fun headerLine(): String {
+            if (!isHeader) return message
+            return "$timestamp $level/$tag: $message"
+        }
+
+        fun allLines(): List<String> {
+            return if (isHeader) listOf(headerLine()) + continuationLines else listOf(message) + continuationLines
+        }
+    }
+
+    data class FilterResult(
+        val lines: List<String>,
+        val originalRecordCount: Int,
+        val exportedRecordCount: Int
+    )
+
+    fun parseRecords(rawLines: Sequence<String>): List<ExportRecord> {
+        val records = mutableListOf<ExportRecord>()
+        var current: ExportRecord? = null
+
+        fun flush() {
+            val record = current ?: return
+            records += record
+            current = null
+        }
+
+        for (raw in rawLines) {
+            val line = raw.trimEnd('\r')
+            if (line.isBlank()) continue
+            val match = headerRegex.matchEntire(line)
+            if (match != null) {
+                flush()
+                val (timestamp, level, tag, message) = match.destructured
+                current = ExportRecord(
+                    timestamp = timestamp,
+                    level = level[0],
+                    tag = tag.trim(),
+                    message = message
+                )
+            } else {
+                val existing = current
+                if (existing != null) {
+                    current = existing.copy(continuationLines = existing.continuationLines + line)
+                } else {
+                    records += ExportRecord(
+                        timestamp = null,
+                        level = null,
+                        tag = null,
+                        message = line
+                    )
+                }
+            }
+        }
+        flush()
+        return records
+    }
+
+    fun filter(rawLines: Sequence<String>, options: LogExportOptions): FilterResult {
+        val parsed = parseRecords(rawLines)
+        if (options.isIdentity) {
+            return FilterResult(
+                lines = parsed.flatMap { it.allLines() },
+                originalRecordCount = parsed.size,
+                exportedRecordCount = parsed.size
+            )
+        }
+
+        var working = parsed
+        if (options.excludeDebug) {
+            working = working.filter { record ->
+                val level = record.level ?: return@filter true
+                level != 'V' && level != 'D'
+            }
+        }
+        if (options.excludeSystem) {
+            working = working.filter { record ->
+                val tag = record.tag ?: return@filter true
+                tag.lowercase() !in systemTags
+            }
+        }
+        if (options.hideSensitive) {
+            working = working.map { redactSensitive(it) }
+        }
+        if (options.errorContextOnly) {
+            working = keepErrorContext(working)
+        }
+        val lines = working.flatMap { record ->
+            formatRecord(record, options.stripTimestamp)
+        }
+        return FilterResult(
+            lines = lines,
+            originalRecordCount = parsed.size,
+            exportedRecordCount = working.size
+        )
+    }
+
+    fun filterText(rawText: String, options: LogExportOptions): FilterResult {
+        return filter(rawText.lineSequence(), options)
+    }
+
+    private fun keepErrorContext(records: List<ExportRecord>): List<ExportRecord> {
+        if (records.isEmpty()) return emptyList()
+        val lastErrorIndex = records.indexOfLast { isErrorLevel(it.level) }
+        if (lastErrorIndex < 0) return emptyList()
+        val prefixCount = (records.size / 10).coerceAtLeast(0)
+        val start = (lastErrorIndex - prefixCount).coerceAtLeast(0)
+        return records.subList(start, records.size)
+    }
+
+    private fun isErrorLevel(level: Char?): Boolean {
+        return level == 'E' || level == 'A' || level == 'F'
+    }
+
+    private fun redactSensitive(record: ExportRecord): ExportRecord {
+        val headerSensitive = isSensitiveHeader(record)
+        val redactedMessage = if (headerSensitive) {
+            redactPayload(record.message)
+        } else {
+            record.message
+        }
+        val redactedContinuations = record.continuationLines.map { line ->
+            if (headerSensitive || isSensitiveContinuation(line) || containsSensitiveToken(line)) {
+                redactPayload(line)
+            } else {
+                line
+            }
+        }
+        return record.copy(message = redactedMessage, continuationLines = redactedContinuations)
+    }
+
+    private fun isSensitiveHeader(record: ExportRecord): Boolean {
+        val message = record.message.lowercase()
+        if (sensitiveHeaderPrefixes.any { message.startsWith(it) }) return true
+        if (containsSensitiveToken(record.message)) return true
+        return record.continuationLines.any { containsSensitiveToken(it) }
+    }
+
+    private fun isSensitiveContinuation(line: String): Boolean {
+        val lower = line.trimStart().lowercase()
+        return sensitiveContinuationPrefixes.any { lower.startsWith(it) } ||
+            Regex("^part\\s+\\d+/\\d+:", RegexOption.IGNORE_CASE).containsMatchIn(lower)
+    }
+
+    private fun containsSensitiveToken(text: String): Boolean {
+        val lower = text.lowercase()
+        return sensitiveBodyTokens.any { it in lower }
+    }
+
+    private fun redactPayload(text: String): String {
+        val marker = findRedactMarker(text)
+        val prefix = if (marker != null) {
+            val index = text.indexOf(marker, ignoreCase = true)
+            if (index >= 0) text.substring(0, index + marker.length).trimEnd() else text.substringBefore(':').let { if (it == text) "" else "$it:" }
+        } else {
+            text.substringBefore(':').let { if (it == text) "" else "$it:" }
+        }
+        val hiddenChars = (text.length - prefix.length).coerceAtLeast(0)
+        val label = "[redacted, $hiddenChars chars]"
+        return if (prefix.isBlank()) label else "$prefix $label"
+    }
+
+    private fun findRedactMarker(text: String): String? {
+        val lower = text.lowercase()
+        return sensitiveHeaderPrefixes.firstOrNull { lower.startsWith(it) }?.let { marker ->
+            text.substring(0, marker.length)
+        }
+    }
+
+    private fun formatRecord(record: ExportRecord, stripTimestamp: Boolean): List<String> {
+        if (!record.isHeader) {
+            return listOf(record.message) + record.continuationLines
+        }
+        val header = if (stripTimestamp) {
+            "${record.level}/${record.tag}: ${record.message}"
+        } else {
+            record.headerLine()
+        }
+        return listOf(header) + record.continuationLines
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportOptions.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportOptions.kt
@@ -1,0 +1,20 @@
+package com.ai.assistance.operit.ui.features.toolbox.screens.logcat
+
+/**
+ * Export-time filters for AppLogger files.
+ * All flags default to false so the exported file stays complete.
+ */
+data class LogExportOptions(
+    val excludeDebug: Boolean = false,
+    val excludeSystem: Boolean = false,
+    val errorContextOnly: Boolean = false,
+    val hideSensitive: Boolean = false,
+    val stripTimestamp: Boolean = false
+) {
+    val isIdentity: Boolean
+        get() = !excludeDebug &&
+            !excludeSystem &&
+            !errorContextOnly &&
+            !hideSensitive &&
+            !stripTimestamp
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportPreferences.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportPreferences.kt
@@ -1,0 +1,36 @@
+package com.ai.assistance.operit.ui.features.toolbox.screens.logcat
+
+import android.content.Context
+
+class LogExportPreferences(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun load(): LogExportOptions {
+        return LogExportOptions(
+            excludeDebug = prefs.getBoolean(KEY_EXCLUDE_DEBUG, false),
+            excludeSystem = prefs.getBoolean(KEY_EXCLUDE_SYSTEM, false),
+            errorContextOnly = prefs.getBoolean(KEY_ERROR_CONTEXT, false),
+            hideSensitive = prefs.getBoolean(KEY_HIDE_SENSITIVE, false),
+            stripTimestamp = prefs.getBoolean(KEY_STRIP_TIMESTAMP, false)
+        )
+    }
+
+    fun save(options: LogExportOptions) {
+        prefs.edit()
+            .putBoolean(KEY_EXCLUDE_DEBUG, options.excludeDebug)
+            .putBoolean(KEY_EXCLUDE_SYSTEM, options.excludeSystem)
+            .putBoolean(KEY_ERROR_CONTEXT, options.errorContextOnly)
+            .putBoolean(KEY_HIDE_SENSITIVE, options.hideSensitive)
+            .putBoolean(KEY_STRIP_TIMESTAMP, options.stripTimestamp)
+            .apply()
+    }
+
+    companion object {
+        private const val PREFS_NAME = "log_export_preferences"
+        private const val KEY_EXCLUDE_DEBUG = "exclude_debug"
+        private const val KEY_EXCLUDE_SYSTEM = "exclude_system"
+        private const val KEY_ERROR_CONTEXT = "error_context_only"
+        private const val KEY_HIDE_SENSITIVE = "hide_sensitive"
+        private const val KEY_STRIP_TIMESTAMP = "strip_timestamp"
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogcatExportHelper.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogcatExportHelper.kt
@@ -22,8 +22,10 @@ data class LogcatExportResult(
 )
 
 object LogcatExportHelper {
-
-    suspend fun exportLogs(context: Context): LogcatExportResult = withContext(Dispatchers.IO) {
+    suspend fun exportLogs(
+        context: Context,
+        options: LogExportOptions = LogExportOptions()
+    ): LogcatExportResult = withContext(Dispatchers.IO) {
         try {
             val logFile = AppLogger.getLogFile()
             if (logFile == null || !logFile.exists() || logFile.length() == 0L) {
@@ -33,10 +35,15 @@ object LogcatExportHelper {
                 )
             }
 
-            val logLineCount = countExportableLogLines(logFile)
-            if (logLineCount == 0L) {
+            val exportLines = prepareExportLines(logFile, options)
+            if (exportLines == null) {
+                val emptyMessage = if (options.errorContextOnly) {
+                    context.getString(R.string.logcat_no_error_logs)
+                } else {
+                    context.getString(R.string.logcat_no_logs_to_save)
+                }
                 return@withContext LogcatExportResult(
-                    message = context.getString(R.string.logcat_no_logs_to_save),
+                    message = emptyMessage,
                     success = false
                 )
             }
@@ -44,9 +51,9 @@ object LogcatExportHelper {
             val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
             val fileName = "operit_log_$timestamp.txt"
             val filePath = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                saveUsingMediaStore(context, fileName, logFile, logLineCount)
+                saveUsingMediaStore(context, fileName, exportLines)
             } else {
-                saveUsingFileSystem(context, fileName, logFile, logLineCount)
+                saveUsingFileSystem(context, fileName, exportLines)
             }
 
             LogcatExportResult(
@@ -64,37 +71,40 @@ object LogcatExportHelper {
         }
     }
 
-    private fun countExportableLogLines(logFile: File): Long {
-        var count = 0L
-        logFile.bufferedReader().useLines { lines ->
-            lines.forEach { line ->
-                if (line.isNotBlank()) {
-                    count++
-                }
+    private fun prepareExportLines(
+        logFile: File,
+        options: LogExportOptions
+    ): PreparedExport? {
+        logFile.bufferedReader().use { reader ->
+            if (options.isIdentity) {
+                val lines = reader.lineSequence().map { it.trimEnd('\r') }.filter { it.isNotBlank() }.toList()
+                if (lines.isEmpty()) return null
+                return PreparedExport(lines = lines, recordCount = lines.size.toLong())
             }
+            val result = LogExportFilter.filter(reader.lineSequence(), options)
+            if (result.exportedRecordCount == 0 || result.lines.isEmpty()) {
+                return null
+            }
+            return PreparedExport(
+                lines = result.lines,
+                recordCount = result.exportedRecordCount.toLong()
+            )
         }
-        return count
     }
 
     private fun writeLogContent(
         context: Context,
         writer: Writer,
-        logFile: File,
-        logLineCount: Long
+        export: PreparedExport
     ) {
         val exportTime = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())
         writer.appendLine(context.getString(R.string.logcat_header))
         writer.appendLine(context.getString(R.string.logcat_date, exportTime))
-        writer.appendLine(context.getString(R.string.logcat_total_count, logLineCount))
+        writer.appendLine(context.getString(R.string.logcat_total_count, export.recordCount))
         writer.appendLine("===================================")
         writer.appendLine()
-
-        logFile.bufferedReader().useLines { lines ->
-            lines.forEach { line ->
-                if (line.isNotBlank()) {
-                    writer.appendLine(line)
-                }
-            }
+        export.lines.forEach { line ->
+            writer.appendLine(line)
         }
     }
 
@@ -102,8 +112,7 @@ object LogcatExportHelper {
     private fun saveUsingMediaStore(
         context: Context,
         fileName: String,
-        logFile: File,
-        logLineCount: Long
+        export: PreparedExport
     ): String {
         try {
             val contentValues = ContentValues().apply {
@@ -118,23 +127,21 @@ object LogcatExportHelper {
 
             context.contentResolver.openOutputStream(uri)?.use { outputStream ->
                 outputStream.bufferedWriter().use { writer ->
-                    writeLogContent(context, writer, logFile, logLineCount)
+                    writeLogContent(context, writer, export)
                 }
             } ?: throw Exception(context.getString(R.string.logcat_cannot_open_output_stream))
-
             val downloadsDir =
                 Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
             return "${downloadsDir.absolutePath}/operit/$fileName"
         } catch (e: Exception) {
-            throw Exception(context.getString(R.string.logcat_mediestore_save_failed, e.message ?: ""))
+            throw Exception(context.getString(R.string.logcat_mediastore_save_failed, e.message ?: ""))
         }
     }
 
     private fun saveUsingFileSystem(
         context: Context,
         fileName: String,
-        logFile: File,
-        logLineCount: Long
+        export: PreparedExport
     ): String {
         try {
             val downloadsDir =
@@ -148,7 +155,7 @@ object LogcatExportHelper {
             }
             val file = File(operitDir, fileName)
             FileWriter(file).use { writer ->
-                writeLogContent(context, writer, logFile, logLineCount)
+                writeLogContent(context, writer, export)
             }
             if (!file.exists() || file.length() == 0L) {
                 throw Exception(context.getString(R.string.logcat_file_create_failed))
@@ -158,4 +165,9 @@ object LogcatExportHelper {
             throw Exception(context.getString(R.string.logcat_filesystem_save_failed, e.message ?: ""))
         }
     }
+
+    private data class PreparedExport(
+        val lines: List<String>,
+        val recordCount: Long
+    )
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogcatScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogcatScreen.kt
@@ -1,32 +1,56 @@
 package com.ai.assistance.operit.ui.features.toolbox.screens.logcat
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.DeleteForever
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import com.ai.assistance.operit.R
-import com.ai.assistance.operit.ui.components.CustomScaffold
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.ai.assistance.operit.R
+import com.ai.assistance.operit.ui.components.CustomScaffold
 
-/**
- * 应用日志导出屏幕
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LogcatScreen(navController: NavController? = null) {
     val context = LocalContext.current
     val viewModel: LogcatViewModel = viewModel(factory = LogcatViewModel.Factory(context))
-
     val isSaving by viewModel.isSaving.collectAsState()
     val saveResult by viewModel.saveResult.collectAsState()
+    val exportOptions by viewModel.exportOptions.collectAsState()
 
     CustomScaffold(
         topBar = {
@@ -40,12 +64,17 @@ fun LogcatScreen(navController: NavController? = null) {
             }
         }
     ) { paddingValues ->
-        Box(
-            modifier = Modifier.fillMaxSize().padding(paddingValues),
-            contentAlignment = Alignment.Center
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Card(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp),
+                modifier = Modifier.fillMaxWidth(),
                 elevation = CardDefaults.cardElevation(4.dp)
             ) {
                 Column(
@@ -68,7 +97,7 @@ fun LogcatScreen(navController: NavController? = null) {
                         style = MaterialTheme.typography.bodyMedium,
                         textAlign = TextAlign.Center
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(4.dp))
                     Button(
                         onClick = { viewModel.saveLogsToFile() },
                         enabled = !isSaving,
@@ -86,7 +115,9 @@ fun LogcatScreen(navController: NavController? = null) {
                         onClick = { viewModel.clearLogs() },
                         enabled = !isSaving,
                         modifier = Modifier.fillMaxWidth(),
-                        colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error
+                        )
                     ) {
                         Icon(Icons.Default.DeleteForever, contentDescription = null, modifier = Modifier.size(18.dp))
                         Spacer(modifier = Modifier.width(8.dp))
@@ -94,6 +125,105 @@ fun LogcatScreen(navController: NavController? = null) {
                     }
                 }
             }
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(2.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.logcat_export_filters_title),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = stringResource(R.string.logcat_export_filters_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    LogExportFilterToggle(
+                        title = stringResource(R.string.logcat_filter_exclude_debug),
+                        subtitle = stringResource(R.string.logcat_filter_exclude_debug_desc),
+                        checked = exportOptions.excludeDebug,
+                        enabled = !isSaving,
+                        onCheckedChange = { checked ->
+                            viewModel.updateExportOptions { it.copy(excludeDebug = checked) }
+                        }
+                    )
+                    LogExportFilterToggle(
+                        title = stringResource(R.string.logcat_filter_exclude_system),
+                        subtitle = stringResource(R.string.logcat_filter_exclude_system_desc),
+                        checked = exportOptions.excludeSystem,
+                        enabled = !isSaving,
+                        onCheckedChange = { checked ->
+                            viewModel.updateExportOptions { it.copy(excludeSystem = checked) }
+                        }
+                    )
+                    LogExportFilterToggle(
+                        title = stringResource(R.string.logcat_filter_error_context),
+                        subtitle = stringResource(R.string.logcat_filter_error_context_desc),
+                        checked = exportOptions.errorContextOnly,
+                        enabled = !isSaving,
+                        onCheckedChange = { checked ->
+                            viewModel.updateExportOptions { it.copy(errorContextOnly = checked) }
+                        }
+                    )
+                    LogExportFilterToggle(
+                        title = stringResource(R.string.logcat_filter_hide_sensitive),
+                        subtitle = stringResource(R.string.logcat_filter_hide_sensitive_desc),
+                        checked = exportOptions.hideSensitive,
+                        enabled = !isSaving,
+                        onCheckedChange = { checked ->
+                            viewModel.updateExportOptions { it.copy(hideSensitive = checked) }
+                        }
+                    )
+                    LogExportFilterToggle(
+                        title = stringResource(R.string.logcat_filter_strip_timestamp),
+                        subtitle = stringResource(R.string.logcat_filter_strip_timestamp_desc),
+                        checked = exportOptions.stripTimestamp,
+                        enabled = !isSaving,
+                        onCheckedChange = { checked ->
+                            viewModel.updateExportOptions { it.copy(stripTimestamp = checked) }
+                        }
+                    )
+                }
+            }
         }
+    }
+}
+
+@Composable
+private fun LogExportFilterToggle(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f).padding(end = 12.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Switch(
+            checked = checked,
+            enabled = enabled,
+            onCheckedChange = onCheckedChange
+        )
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogcatViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogcatViewModel.kt
@@ -11,12 +11,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-/**
- * 日志查看器ViewModel - 使用AppLogger文件
- */
 class LogcatViewModel(private val context: Context) : ViewModel() {
     private val logcatManager = LogcatManager(context)
-
+    private val exportPreferences = LogExportPreferences(context)
 
     private val _isSaving = MutableStateFlow(false)
     val isSaving: StateFlow<Boolean> = _isSaving.asStateFlow()
@@ -24,21 +21,27 @@ class LogcatViewModel(private val context: Context) : ViewModel() {
     private val _saveResult = MutableStateFlow<String?>(null)
     val saveResult: StateFlow<String?> = _saveResult.asStateFlow()
 
-
+    private val _exportOptions = MutableStateFlow(exportPreferences.load())
+    val exportOptions: StateFlow<LogExportOptions> = _exportOptions.asStateFlow()
 
     fun clearLogs() {
         logcatManager.clearLogs()
     }
 
+    fun updateExportOptions(transform: (LogExportOptions) -> LogExportOptions) {
+        val updated = transform(_exportOptions.value)
+        _exportOptions.value = updated
+        exportPreferences.save(updated)
+    }
+
     fun saveLogsToFile() {
         if (_isSaving.value) return
-
         _isSaving.value = true
         _saveResult.value = null
-
+        val options = _exportOptions.value
         viewModelScope.launch {
             try {
-                val result = LogcatExportHelper.exportLogs(context)
+                val result = LogcatExportHelper.exportLogs(context, options)
                 _saveResult.value = result.message
                 delay(3000)
                 _saveResult.value = null
@@ -63,10 +66,5 @@ class LogcatViewModel(private val context: Context) : ViewModel() {
             }
             throw IllegalArgumentException("Unknown ViewModel class")
         }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        // No-op, no more monitoring to stop
     }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2594,6 +2594,18 @@
     <string name="logcat_description">You can export all internal logs during app runtime to a file for debugging and issue analysis.</string>
     <string name="logcat_save_to_file">Save logs to file</string>
     <string name="logcat_clear_all">Clear all logs</string>
+    <string name="logcat_export_filters_title">Export filters</string>
+    <string name="logcat_export_filters_subtitle">All filters are off by default and export the full log. They only affect the exported file.</string>
+    <string name="logcat_filter_exclude_debug">Exclude debug logs</string>
+    <string name="logcat_filter_exclude_debug_desc">Drop Verbose and Debug levels</string>
+    <string name="logcat_filter_exclude_system">Exclude system logs</string>
+    <string name="logcat_filter_exclude_system_desc">Drop noisy system tags such as WebView and OkHttp</string>
+    <string name="logcat_filter_error_context">Error context only</string>
+    <string name="logcat_filter_error_context_desc">Keep the last error and the 10% of records above it</string>
+    <string name="logcat_filter_hide_sensitive">Hide sensitive content</string>
+    <string name="logcat_filter_hide_sensitive_desc">Redact prompts and request-body dumps</string>
+    <string name="logcat_filter_strip_timestamp">Omit timestamps</string>
+    <string name="logcat_filter_strip_timestamp_desc">Remove timestamps from the exported file</string>
 
     <!-- Speech-to-Text -->
     <string name="stt_title">Speech Recognition</string>
@@ -5586,6 +5598,7 @@
 
     <!-- Logcat -->
     <string name="logcat_no_logs_to_save">No logs to save</string>
+    <string name="logcat_no_error_logs">No error logs to export</string>
     <string name="logcat_header">=== Operit Logs ===</string>
     <string name="logcat_date">Date: %1$s</string>
     <string name="logcat_total_count">Total count: %1$d</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -5607,7 +5607,7 @@
     <string name="logcat_saved_to">Logs saved to: %1$s</string>
     <string name="logcat_cannot_create_file">Save failed: Unable to create file, possibly due to storage permissions</string>
     <string name="logcat_cannot_open_output_stream">Cannot open output stream</string>
-    <string name="logcat_mediestore_save_failed">MediaStore save failed: %1$s</string>
+    <string name="logcat_mediastore_save_failed">MediaStore save failed: %1$s</string>
     <string name="logcat_cannot_create_download_dir">Cannot create download directory</string>
     <string name="logcat_cannot_create_operit_dir">Cannot create operit directory</string>
     <string name="logcat_file_create_failed">File creation failed or is empty</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2793,6 +2793,18 @@
     <string name="logcat_description">Puede exportar todos los registros internos de la aplicación durante su ejecución a un archivo para depuración y análisis de problemas.</string>
     <string name="logcat_save_to_file">Guardar registros en archivo</string>
     <string name="logcat_clear_all">Limpiar todos los registros</string>
+    <string name="logcat_export_filters_title">Export filters</string>
+    <string name="logcat_export_filters_subtitle">All filters are off by default and export the full log. They only affect the exported file.</string>
+    <string name="logcat_filter_exclude_debug">Exclude debug logs</string>
+    <string name="logcat_filter_exclude_debug_desc">Drop Verbose and Debug levels</string>
+    <string name="logcat_filter_exclude_system">Exclude system logs</string>
+    <string name="logcat_filter_exclude_system_desc">Drop noisy system tags such as WebView and OkHttp</string>
+    <string name="logcat_filter_error_context">Error context only</string>
+    <string name="logcat_filter_error_context_desc">Keep the last error and the 10% of records above it</string>
+    <string name="logcat_filter_hide_sensitive">Hide sensitive content</string>
+    <string name="logcat_filter_hide_sensitive_desc">Redact prompts and request-body dumps</string>
+    <string name="logcat_filter_strip_timestamp">Omit timestamps</string>
+    <string name="logcat_filter_strip_timestamp_desc">Remove timestamps from the exported file</string>
     <string name="stt_title">Reconocimiento de voz</string>
     <string name="stt_start_recording">Iniciar grabación</string>
     <string name="stt_stop_recording">Detener grabación</string>
@@ -5124,6 +5136,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="uidebugger_element_info_package_name">nombre del paquete: %1$s</string>
     <string name="uidebugger_element_info_size_px">tamaño: %1$d×%2$dpx</string>
     <string name="logcat_no_logs_to_save">no hay registros para guardar</string>
+    <string name="logcat_no_error_logs">No error logs to export</string>
     <string name="logcat_header">=== Registros de Operit ===</string>
     <string name="logcat_date">fecha: %1$s</string>
     <string name="logcat_total_count">total: %1$d</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5145,7 +5145,7 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
     <string name="logcat_saved_to">registros guardados en: %1$s</string>
     <string name="logcat_cannot_create_file">error al guardar: no se pudo crear el archivo, posible problema de permisos de almacenamiento</string>
     <string name="logcat_cannot_open_output_stream">no se pudo abrir el flujo de salida</string>
-    <string name="logcat_mediestore_save_failed">error al guardar en MediaStore: %1$s</string>
+    <string name="logcat_mediastore_save_failed">error al guardar en MediaStore: %1$s</string>
     <string name="logcat_cannot_create_download_dir">no se pudo crear el directorio de descargas</string>
     <string name="logcat_cannot_create_operit_dir">no se pudo crear el directorio operit</string>
     <string name="logcat_file_create_failed">no se pudo crear el archivo o está vacío</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -4992,7 +4992,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="backup_raw_snapshot_progress_scanning_files">Menghitung file...</string>
     <string name="backup_raw_snapshot_progress_scanning_files_with_count">Menghitung file: %1$d</string>
 
-    <string name="logcat_mediestore_save_failed">MediaStore gagal menyimpan: %1$s</string>
+    <string name="logcat_mediastore_save_failed">MediaStore gagal menyimpan: %1$s</string>
     <string name="logcat_cannot_create_download_dir">Tidak dapat membuat direktori unduhan</string>
     <string name="logcat_cannot_create_operit_dir">Tidak dapat membuat direktori operit</string>
     <string name="logcat_file_create_failed">Gagal membuat file atau file kosong</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -2334,6 +2334,18 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="logcat_description">Anda dapat mengekspor semua log internal selama aplikasi berjalan ke dalam satu berkas, untuk keperluan debug dan analisis masalah.</string>
     <string name="logcat_save_to_file">Simpan Log ke Berkas</string>
     <string name="logcat_clear_all">Hapus Semua Log</string>
+    <string name="logcat_export_filters_title">Export filters</string>
+    <string name="logcat_export_filters_subtitle">All filters are off by default and export the full log. They only affect the exported file.</string>
+    <string name="logcat_filter_exclude_debug">Exclude debug logs</string>
+    <string name="logcat_filter_exclude_debug_desc">Drop Verbose and Debug levels</string>
+    <string name="logcat_filter_exclude_system">Exclude system logs</string>
+    <string name="logcat_filter_exclude_system_desc">Drop noisy system tags such as WebView and OkHttp</string>
+    <string name="logcat_filter_error_context">Error context only</string>
+    <string name="logcat_filter_error_context_desc">Keep the last error and the 10% of records above it</string>
+    <string name="logcat_filter_hide_sensitive">Hide sensitive content</string>
+    <string name="logcat_filter_hide_sensitive_desc">Redact prompts and request-body dumps</string>
+    <string name="logcat_filter_strip_timestamp">Omit timestamps</string>
+    <string name="logcat_filter_strip_timestamp_desc">Remove timestamps from the exported file</string>
     <string name="stt_title">Pengenalan Suara</string>
     <string name="stt_start_recording">Mulai Rekam</string>
     <string name="stt_stop_recording">Hentikan Rekam</string>
@@ -4806,6 +4818,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="uidebugger_element_info_package_name">Nama paket: %1$s</string>
     <string name="uidebugger_element_info_size_px">Ukuran: %1$d×%2$dpx</string>
     <string name="logcat_no_logs_to_save">Tidak ada log yang dapat disimpan</string>
+    <string name="logcat_no_error_logs">No error logs to export</string>
     <string name="logcat_header">=== Log Operit ===</string>
     <string name="logcat_date">Tanggal: %1$s</string>
     <string name="logcat_total_count">Jumlah total: %1$d</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -5105,7 +5105,7 @@
     <string name="logcat_saved_to">로그 저장 위치: %1$s</string>
     <string name="logcat_cannot_create_file">저장 실패: 저장 권한으로 인해 파일을 생성할 수 없습니다.</string>
     <string name="logcat_cannot_open_output_stream">출력 스트림을 열 수 없습니다.</string>
-    <string name="logcat_mediestore_save_failed">MediaStore 저장 실패: %1$s</string>
+    <string name="logcat_mediastore_save_failed">MediaStore 저장 실패: %1$s</string>
     <string name="logcat_cannot_create_download_dir">다운로드 디렉터리를 생성할 수 없습니다.</string>
     <string name="logcat_cannot_create_operit_dir">operit 디렉터리를 생성할 수 없습니다.</string>
     <string name="logcat_file_create_failed">파일 생성에 실패했거나 비어 있습니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2322,6 +2322,18 @@
     <string name="logcat_description">디버깅 및 문제 분석을 위해 앱 런타임 중 모든 내부 로그를 파일로 내보낼 수 있습니다.</string>
     <string name="logcat_save_to_file">로그를 파일에 저장</string>
     <string name="logcat_clear_all">모든 로그 지우기</string>
+    <string name="logcat_export_filters_title">Export filters</string>
+    <string name="logcat_export_filters_subtitle">All filters are off by default and export the full log. They only affect the exported file.</string>
+    <string name="logcat_filter_exclude_debug">Exclude debug logs</string>
+    <string name="logcat_filter_exclude_debug_desc">Drop Verbose and Debug levels</string>
+    <string name="logcat_filter_exclude_system">Exclude system logs</string>
+    <string name="logcat_filter_exclude_system_desc">Drop noisy system tags such as WebView and OkHttp</string>
+    <string name="logcat_filter_error_context">Error context only</string>
+    <string name="logcat_filter_error_context_desc">Keep the last error and the 10% of records above it</string>
+    <string name="logcat_filter_hide_sensitive">Hide sensitive content</string>
+    <string name="logcat_filter_hide_sensitive_desc">Redact prompts and request-body dumps</string>
+    <string name="logcat_filter_strip_timestamp">Omit timestamps</string>
+    <string name="logcat_filter_strip_timestamp_desc">Remove timestamps from the exported file</string>
     <string name="stt_title">음성 인식</string>
     <string name="stt_start_recording">녹음 시작</string>
     <string name="stt_stop_recording">녹음 중지</string>
@@ -5084,6 +5096,7 @@
     <string name="uidebugger_element_info_package_name">패키지: %1$s</string>
     <string name="uidebugger_element_info_size_px">크기: %1$d×%2$dpx</string>
     <string name="logcat_no_logs_to_save">저장할 로그가 없습니다.</string>
+    <string name="logcat_no_error_logs">No error logs to export</string>
     <string name="logcat_header">=== Operit 로그 ===</string>
     <string name="logcat_date">날짜: %1$s</string>
     <string name="logcat_total_count">총 개수: %1$d</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -4990,7 +4990,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="logcat_saved_to">Log telah disimpan ke: %1$s</string>
     <string name="logcat_cannot_create_file">Gagal menyimpan: Tidak dapat mencipta fail, mungkin masalah kebenaran storan</string>
     <string name="logcat_cannot_open_output_stream">Tidak dapat membuka aliran output</string>
-    <string name="logcat_mediestore_save_failed">MediaStore gagal menyimpan: %1$s</string>
+    <string name="logcat_mediastore_save_failed">MediaStore gagal menyimpan: %1$s</string>
     <string name="logcat_cannot_create_download_dir">Tidak dapat mencipta direktori muat turun</string>
     <string name="logcat_cannot_create_operit_dir">Tidak dapat mencipta direktori operit</string>
     <string name="logcat_file_create_failed">Penciptaan fail gagal atau kosong</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -2288,6 +2288,18 @@
     <string name="logcat_description">Anda boleh mengeksport semua log dalaman semasa aplikasi berjalan ke dalam fail untuk penyahpepijatan dan analisis masalah.</string>
     <string name="logcat_save_to_file">Simpan Log ke Fail</string>
     <string name="logcat_clear_all">Kosongkan Semua Log</string>
+    <string name="logcat_export_filters_title">Export filters</string>
+    <string name="logcat_export_filters_subtitle">All filters are off by default and export the full log. They only affect the exported file.</string>
+    <string name="logcat_filter_exclude_debug">Exclude debug logs</string>
+    <string name="logcat_filter_exclude_debug_desc">Drop Verbose and Debug levels</string>
+    <string name="logcat_filter_exclude_system">Exclude system logs</string>
+    <string name="logcat_filter_exclude_system_desc">Drop noisy system tags such as WebView and OkHttp</string>
+    <string name="logcat_filter_error_context">Error context only</string>
+    <string name="logcat_filter_error_context_desc">Keep the last error and the 10% of records above it</string>
+    <string name="logcat_filter_hide_sensitive">Hide sensitive content</string>
+    <string name="logcat_filter_hide_sensitive_desc">Redact prompts and request-body dumps</string>
+    <string name="logcat_filter_strip_timestamp">Omit timestamps</string>
+    <string name="logcat_filter_strip_timestamp_desc">Remove timestamps from the exported file</string>
     <string name="stt_title">Pengecaman Suara</string>
     <string name="stt_start_recording">Mula Rakaman</string>
     <string name="stt_stop_recording">Hentikan Rakaman</string>
@@ -4969,6 +4981,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
 
     <string name="uidebugger_element_info_size_px">Saiz: %1$d×%2$dpx</string>
     <string name="logcat_no_logs_to_save">Tiada log untuk disimpan</string>
+    <string name="logcat_no_error_logs">No error logs to export</string>
     <string name="logcat_header">=== Log Operit ===</string>
     <string name="logcat_date">Tarikh: %1$s</string>
     <string name="logcat_total_count">Jumlah: %1$d</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -2277,6 +2277,18 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="logcat_description">Você pode exportar todos os logs internos durante a execução do aplicativo para um arquivo para depuração e análise de problemas.</string>
     <string name="logcat_save_to_file">Salvar registro em arquivo</string>
     <string name="logcat_clear_all">Limpar todos os registros</string>
+    <string name="logcat_export_filters_title">Export filters</string>
+    <string name="logcat_export_filters_subtitle">All filters are off by default and export the full log. They only affect the exported file.</string>
+    <string name="logcat_filter_exclude_debug">Exclude debug logs</string>
+    <string name="logcat_filter_exclude_debug_desc">Drop Verbose and Debug levels</string>
+    <string name="logcat_filter_exclude_system">Exclude system logs</string>
+    <string name="logcat_filter_exclude_system_desc">Drop noisy system tags such as WebView and OkHttp</string>
+    <string name="logcat_filter_error_context">Error context only</string>
+    <string name="logcat_filter_error_context_desc">Keep the last error and the 10% of records above it</string>
+    <string name="logcat_filter_hide_sensitive">Hide sensitive content</string>
+    <string name="logcat_filter_hide_sensitive_desc">Redact prompts and request-body dumps</string>
+    <string name="logcat_filter_strip_timestamp">Omit timestamps</string>
+    <string name="logcat_filter_strip_timestamp_desc">Remove timestamps from the exported file</string>
     <string name="stt_title">reconhecimento de fala</string>
     <string name="stt_start_recording">Comece a gravar</string>
     <string name="stt_stop_recording">Pare de gravar</string>
@@ -4667,6 +4679,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="uidebugger_element_info_package_name">Nome do pacote: %1$s</string>
     <string name="uidebugger_element_info_size_px">Tamanho: %1$d×%2$dpx</string>
     <string name="logcat_no_logs_to_save">Não há registros para salvar</string>
+    <string name="logcat_no_error_logs">No error logs to export</string>
     <string name="logcat_header">=== Log de operações ===</string>
     <string name="logcat_date">Data: %1$s</string>
     <string name="logcat_total_count">Número total de itens: %1$d</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -4688,7 +4688,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="logcat_saved_to">Registro salvo em: %1$s</string>
     <string name="logcat_cannot_create_file">Falha ao salvar: não é possível criar o arquivo, possivelmente problema de permissão de armazenamento</string>
     <string name="logcat_cannot_open_output_stream">Não foi possível abrir o fluxo de saída</string>
-    <string name="logcat_mediestore_save_failed">Falha ao salvar no MediaStore: %1$s</string>
+    <string name="logcat_mediastore_save_failed">Falha ao salvar no MediaStore: %1$s</string>
     <string name="logcat_cannot_create_download_dir">Não foi possível criar o diretório de download</string>
     <string name="logcat_cannot_create_operit_dir">Não foi possível criar o diretório operacional</string>
     <string name="logcat_file_create_failed">A criação do arquivo falhou ou está vazia</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -5843,7 +5843,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="logcat_saved_to">Jurnalul a fost salvat în:%1$s</string>
     <string name="logcat_cannot_create_file">Eroare la salvare: nu se poate crea fișierul; este posibil să fie o problemă legată de permisiunile de stocare</string>
     <string name="logcat_cannot_open_output_stream">Nu se poate deschide fluxul de ieșire</string>
-    <string name="logcat_mediestore_save_failed">MediaStoreEroare la salvare:%1$s</string>
+    <string name="logcat_mediastore_save_failed">MediaStoreEroare la salvare:%1$s</string>
     <string name="logcat_cannot_create_download_dir">Nu se poate crea directorul de descărcări</string>
     <string name="logcat_cannot_create_operit_dir">Nu se poate creaoperitCuprins</string>
     <string name="logcat_file_create_failed">Fișierul nu a putut fi creat sau este gol</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -2584,6 +2584,18 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="logcat_description">Puteți exporta toate jurnalele interne generate în timpul rulării aplicației într-un fișier, în scopul depanării și al analizei problemelor.</string>
     <string name="logcat_save_to_file">Salvarea jurnalului într-un fișier</string>
     <string name="logcat_clear_all">Șterge toate jurnalele</string>
+    <string name="logcat_export_filters_title">Export filters</string>
+    <string name="logcat_export_filters_subtitle">All filters are off by default and export the full log. They only affect the exported file.</string>
+    <string name="logcat_filter_exclude_debug">Exclude debug logs</string>
+    <string name="logcat_filter_exclude_debug_desc">Drop Verbose and Debug levels</string>
+    <string name="logcat_filter_exclude_system">Exclude system logs</string>
+    <string name="logcat_filter_exclude_system_desc">Drop noisy system tags such as WebView and OkHttp</string>
+    <string name="logcat_filter_error_context">Error context only</string>
+    <string name="logcat_filter_error_context_desc">Keep the last error and the 10% of records above it</string>
+    <string name="logcat_filter_hide_sensitive">Hide sensitive content</string>
+    <string name="logcat_filter_hide_sensitive_desc">Redact prompts and request-body dumps</string>
+    <string name="logcat_filter_strip_timestamp">Omit timestamps</string>
+    <string name="logcat_filter_strip_timestamp_desc">Remove timestamps from the exported file</string>
 
     <!-- Speech-to-Text -->
     <string name="stt_title">Recunoașterea vocală</string>
@@ -5822,6 +5834,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
 
     <!-- Logcat -->
     <string name="logcat_no_logs_to_save">Nu există jurnale care pot fi salvate</string>
+    <string name="logcat_no_error_logs">No error logs to export</string>
     <string name="logcat_header">=== Operit Jurnal ===</string>
     <string name="logcat_date">Data: %1$s</string>
     <string name="logcat_total_count">Numărul total de articole: %1$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2648,6 +2648,18 @@
     <string name="logcat_description">您可以将应用运行期间的所有内部日志导出到一个文件，用于调试和问题分析。</string>
     <string name="logcat_save_to_file">保存日志到文件</string>
     <string name="logcat_clear_all">清除所有日志</string>
+    <string name="logcat_export_filters_title">导出过滤</string>
+    <string name="logcat_export_filters_subtitle">默认全部关闭，导出完整日志。仅影响导出文件，不改变写入。</string>
+    <string name="logcat_filter_exclude_debug">排除调试日志</string>
+    <string name="logcat_filter_exclude_debug_desc">去掉 Verbose 和 Debug 级别</string>
+    <string name="logcat_filter_exclude_system">排除系统日志</string>
+    <string name="logcat_filter_exclude_system_desc">去掉 WebView、OkHttp 等系统噪声标签</string>
+    <string name="logcat_filter_error_context">仅错误上下文</string>
+    <string name="logcat_filter_error_context_desc">保留最后一条错误及其上方 10% 的日志</string>
+    <string name="logcat_filter_hide_sensitive">隐藏敏感内容</string>
+    <string name="logcat_filter_hide_sensitive_desc">遮盖提示词和请求体正文</string>
+    <string name="logcat_filter_strip_timestamp">不保留时间</string>
+    <string name="logcat_filter_strip_timestamp_desc">导出时去掉时间戳</string>
 
     <!-- Speech-to-Text -->
     <string name="stt_title">语音识别</string>
@@ -6010,6 +6022,7 @@
 
     <!-- Logcat -->
     <string name="logcat_no_logs_to_save">没有日志可保存</string>
+    <string name="logcat_no_error_logs">没有错误日志可导出</string>
     <string name="logcat_header">=== Operit 日志 ===</string>
     <string name="logcat_date">日期: %1$s</string>
     <string name="logcat_total_count">总条数: %1$d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6031,7 +6031,7 @@
     <string name="logcat_saved_to">日志已保存至：%1$s</string>
     <string name="logcat_cannot_create_file">保存失败：无法创建文件，可能是存储权限问题</string>
     <string name="logcat_cannot_open_output_stream">无法打开输出流</string>
-    <string name="logcat_mediestore_save_failed">MediaStore保存失败：%1$s</string>
+    <string name="logcat_mediastore_save_failed">MediaStore保存失败：%1$s</string>
     <string name="logcat_cannot_create_download_dir">无法创建下载目录</string>
     <string name="logcat_cannot_create_operit_dir">无法创建operit目录</string>
     <string name="logcat_file_create_failed">文件创建失败或为空</string>

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportFilterTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportFilterTest.kt
@@ -54,8 +54,7 @@ class LogExportFilterTest {
             "2026-09-07 16:51:00.0${index.toString().padStart(2, '0')} $level/Tag$index: line $index"
         }
         val result = LogExportFilter.filterText(
-            lines.joinToString("
-"),
+            lines.joinToString(separator = "\n"),
             LogExportOptions(errorContextOnly = true)
         )
         assertEquals(2, result.exportedRecordCount)
@@ -65,9 +64,12 @@ class LogExportFilterTest {
 
     @Test
     fun errorContextWithoutErrorsExportsNothing() {
+        val noErrorLog = listOf(
+            "2026-09-07 16:51:00.001 I/ToolPkg: ok",
+            "2026-09-07 16:51:00.002 D/AIService: dbg"
+        ).joinToString(separator = "\n")
         val result = LogExportFilter.filterText(
-            "2026-09-07 16:51:00.001 I/ToolPkg: ok
-2026-09-07 16:51:00.002 D/AIService: dbg",
+            noErrorLog,
             LogExportOptions(errorContextOnly = true)
         )
         assertEquals(0, result.exportedRecordCount)
@@ -86,8 +88,7 @@ class LogExportFilterTest {
             raw,
             LogExportOptions(hideSensitive = true)
         )
-        val joined = result.lines.joinToString("
-")
+        val joined = result.lines.joinToString(separator = "\n")
         assertFalse(joined.contains("secret prompt"))
         assertFalse(joined.contains("hidden"))
         assertTrue(joined.contains("[redacted,"))
@@ -103,3 +104,4 @@ class LogExportFilterTest {
         assertEquals(listOf("I/ToolPkg: package loaded"), result.lines)
     }
 }
+

--- a/app/src/test/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportFilterTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/features/toolbox/screens/logcat/LogExportFilterTest.kt
@@ -1,0 +1,105 @@
+package com.ai.assistance.operit.ui.features.toolbox.screens.logcat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LogExportFilterTest {
+    private val sample = """
+        2026-09-07 16:51:00.001 D/AIService: send start
+        2026-09-07 16:51:00.002 I/ToolPkg: package loaded
+        2026-09-07 16:51:00.003 D/WebView: cookie dump
+        2026-09-07 16:51:00.004 W/ChatViewModel: slow path
+        2026-09-07 16:51:00.005 E/GeminiProvider: request failed
+        java.lang.IllegalStateException: boom
+            at GeminiProvider.send(GeminiProvider.kt:1)
+        2026-09-07 16:51:00.006 I/StreamFramework: done
+    """.trimIndent()
+
+    @Test
+    fun identityKeepsEverything() {
+        val result = LogExportFilter.filterText(sample, LogExportOptions())
+        assertEquals(6, result.exportedRecordCount)
+        assertTrue(result.lines.any { it.contains("D/AIService") })
+        assertTrue(result.lines.any { it.contains("java.lang.IllegalStateException") })
+    }
+
+    @Test
+    fun excludeDebugDropsVerboseAndDebug() {
+        val result = LogExportFilter.filterText(
+            sample,
+            LogExportOptions(excludeDebug = true)
+        )
+        assertFalse(result.lines.any { it.contains("D/AIService") })
+        assertFalse(result.lines.any { it.contains("D/WebView") })
+        assertTrue(result.lines.any { it.contains("I/ToolPkg") })
+        assertTrue(result.lines.any { it.contains("E/GeminiProvider") })
+    }
+
+    @Test
+    fun excludeSystemDropsSystemTagsOnly() {
+        val result = LogExportFilter.filterText(
+            sample,
+            LogExportOptions(excludeSystem = true)
+        )
+        assertFalse(result.lines.any { it.contains("D/WebView") })
+        assertTrue(result.lines.any { it.contains("D/AIService") })
+    }
+
+    @Test
+    fun errorContextKeepsLastErrorAndTenPercentPrefix() {
+        val lines = (1..10).map { index ->
+            val level = if (index == 10) "E" else "I"
+            "2026-09-07 16:51:00.0${index.toString().padStart(2, '0')} $level/Tag$index: line $index"
+        }
+        val result = LogExportFilter.filterText(
+            lines.joinToString("
+"),
+            LogExportOptions(errorContextOnly = true)
+        )
+        assertEquals(2, result.exportedRecordCount)
+        assertTrue(result.lines[0].contains("Tag9"))
+        assertTrue(result.lines[1].contains("Tag10"))
+    }
+
+    @Test
+    fun errorContextWithoutErrorsExportsNothing() {
+        val result = LogExportFilter.filterText(
+            "2026-09-07 16:51:00.001 I/ToolPkg: ok
+2026-09-07 16:51:00.002 D/AIService: dbg",
+            LogExportOptions(errorContextOnly = true)
+        )
+        assertEquals(0, result.exportedRecordCount)
+        assertTrue(result.lines.isEmpty())
+    }
+
+    @Test
+    fun hideSensitiveRedactsPromptAndRequestBody() {
+        val raw = """
+            2026-09-07 16:51:00.001 D/GeminiProvider: 发现系统消息: # Role Configuration secret prompt
+            2026-09-07 16:51:00.002 D/GeminiProvider: 请求体JSON: Part 1/2: {"systemInstruction":"hidden"}
+            extra continuation that still belongs to the dump
+            2026-09-07 16:51:00.003 I/ToolPkg: package loaded
+        """.trimIndent()
+        val result = LogExportFilter.filterText(
+            raw,
+            LogExportOptions(hideSensitive = true)
+        )
+        val joined = result.lines.joinToString("
+")
+        assertFalse(joined.contains("secret prompt"))
+        assertFalse(joined.contains("hidden"))
+        assertTrue(joined.contains("[redacted,"))
+        assertTrue(joined.contains("package loaded"))
+    }
+
+    @Test
+    fun stripTimestampRemovesClockPrefix() {
+        val result = LogExportFilter.filterText(
+            "2026-09-07 16:51:00.001 I/ToolPkg: package loaded",
+            LogExportOptions(stripTimestamp = true)
+        )
+        assertEquals(listOf("I/ToolPkg: package loaded"), result.lines)
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

<!--
日常开发 PR 的目标分支默认为 `dev`；只有维护者执行稳定发布同步时才使用 `main`。
For regular development PRs, the target branch is `dev`; use `main` only for maintainer-led release synchronization.

请先用几句话说明这个 PR 为什么存在，以及用户或维护者会得到什么变化。
Briefly explain why this PR exists and what users or maintainers will gain.
-->

工具箱「日志查看器」原先会把 AppLogger 文件原样导出。短时间对话就能得到上万行、十几 MB 的完整调试日志，里面还夹着系统提示词和请求体 dump，不利于排查，也不适合把文件发出去。

这个 PR 只改导出过滤：界面上增加五个默认关闭的开关。全关时行为和现在一样，导出完整日志；打开后导出文件会变小。写入频率、崩溃页导出都不变。

### 背景与动机 / Context and motivation

<!-- 当前问题、触发背景或相关讨论。Describe the problem, context, or discussion behind the change. -->

实测大约 12 分钟就能写出约 4 万行 / 20MB 的 `operit.log`。体积几乎全是 `D` 级请求体分片（Gemini / AIService），并带有完整系统提示词。现有导出没有过滤，只能整份拷走。

### 改动范围 / Changes

<!-- 列出主要改动和明确不包含的内容。List the main changes and explicitly state what is out of scope. -->

- 工具箱日志导出页增加五个开关，默认全部关闭（全量导出）
  1. 排除调试日志：去掉 V/D
  2. 排除系统日志：去掉 WebView / OkHttp 等噪声 tag
  3. 仅错误上下文：保留最后一条 E/A/F 及其上方总条数的 10%
  4. 隐藏敏感内容：遮盖系统提示词和请求体 dump
  5. 不保留时间：导出时去掉时间戳
- 开关状态写入 `log_export_preferences`，下次进入页面仍保留
- `LogcatExportHelper.exportLogs(context)` 无参调用仍导出全量，崩溃页继续走这条路径
- 补充 `LogExportFilter` 单测和对应文案

不包含：

- 不改 AppLogger 写入频率或落盘内容
- 不改崩溃页的「导出错误报告 / 导出应用日志」行为
- 不做正则过滤

### 兼容性与风险 / Compatibility and risks

<!--
说明用户行为、数据格式、API、配置、性能或安全方面的影响；没有影响时写 N/A。
Describe impacts on behavior, data, APIs, configuration, performance, or security; write N/A when not applicable.
-->

- 默认行为与现网一致：五个开关全关时仍导出完整日志
- 过滤只作用于导出文件，不删除设备上的 `operit.log`
- 崩溃页继续全量导出，不受这些开关影响
- 开关可叠加；「仅错误上下文」在筛完其它开关之后按剩余条数的 10% 截取

## 关联 Issue / Related issue

<!--
修复或功能改动请填写 Closes #123、Fixes #123 或 Resolves #123。
Link bug and feature work with Closes #123, Fixes #123, or Resolves #123.
纯文档、CI 或维护性改动请说明 N/A，并说明相关背景。
For documentation, CI, or maintenance work, write N/A and explain the relevant context.
-->

N/A。没有对应 Issue。这是工具箱日志导出的过滤能力，方便把日志文件缩小后再排查或分享。

## 验证方式 / Verification

<!--
写明运行过的命令、测试、设备/系统、构建变体和结果；未运行时说明原因。
List commands, tests, device/OS, build variants, and results; explain why a check was not run.
-->

```text
检查或命令：
1. Android Build assembleDebug（fork workflow）
2. Android Tests :app:testDebugUnitTest（fork workflow）
3. 真机打开工具箱 → 日志查看器，逐个打开五个开关后导出，对比文件大小和条数

环境与变体：
- fork 分支 feat/logcat-export-presets，基于 upstream/dev
- 真机 debug 包

结果：
- Android Build 绿（run 34120342966）
- Android Tests 红在上游存量测试编译：DeepseekProviderMediaRoleTest（protected createRequestBody）、XaiProviderReasoningTest（缺失 XaiReasoningMapper）。本 PR 的 LogExportFilterTest 未再出现在失败列表中。
- 真机：默认全关仍为全量；每多开一个开关，导出内容确实变少。
```

## 证据 / Evidence

<!-- 可选：截图、录屏、日志、构建产物或对比结果。Optional: screenshots, recordings, logs, artifacts, or before/after results. -->

- Build: https://github.com/3316891527/Operit/actions/runs/34120342966
- Tests: https://github.com/3316891527/Operit/actions/runs/34122053963
- 真机：逐项打开过滤开关后，导出文件体积和条数下降

## 检查清单 / Checklist

<!--
以下项目用于提交前自查，不由自动检查强制匹配。若某项不适用，可在“验证方式”中说明原因。
Use these items for a final self-review. Automated checks do not enforce their exact wording.
-->

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 `dev`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `dev` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
