### PR TITLE
fix(chat): stop reporting unpaired tool calls as user cancellation

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
@@ -815,14 +815,20 @@ open class ClaudeProvider(
 
             AppLogger.w(
                 "AIService",
-                "发现未完成的tool_use，按取消处理: count=${openToolUses.size}, reason=$reason"
+                "发现未完成的tool_use，按缺失结果补齐: count=${openToolUses.size}, reason=$reason"
             )
             for (openToolUse in openToolUses) {
                 target.put(
                     JSONObject().apply {
                         put("type", "tool_result")
                         put("tool_use_id", openToolUse.id)
-                        put("content", "User cancelled")
+                        put(
+                            "content",
+                            StructuredToolCallBridge.placeholderToolResultContent(
+                                reason,
+                                openToolUse.matchingName
+                            )
+                        )
                     }
                 )
             }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/DeepseekProvider.kt
@@ -297,14 +297,20 @@ class DeepseekProvider(
 
             AppLogger.w(
                 "DeepseekProvider",
-                "发现未完成的tool_calls，按取消处理: count=${openToolCalls.size}, reason=$reason"
+                "发现未完成的tool_calls，按缺失结果补齐: count=${openToolCalls.size}, reason=$reason"
             )
             for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
                         put("tool_call_id", openToolCall.id)
-                        put("content", "User cancelled")
+                        put(
+                            "content",
+                            StructuredToolCallBridge.placeholderToolResultContent(
+                                reason,
+                                openToolCall.matchingName
+                            )
+                        )
                     }
                 )
             }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/GeminiProvider.kt
@@ -753,7 +753,7 @@ open class GeminiProvider(
             emitQueuedFunctionCallsIfNeeded()
             if (openFunctionCalls.isEmpty()) return false
 
-            logDebug("发现未完成的Gemini functionCall，按取消处理: count=${openFunctionCalls.size}, reason=$reason")
+            logDebug("发现未完成的Gemini functionCall，按缺失结果补齐: count=${openFunctionCalls.size}, reason=$reason")
             openFunctionCalls.forEach { openFunctionCall ->
                 target.put(
                     JSONObject().apply {
@@ -764,7 +764,13 @@ open class GeminiProvider(
                                 put(
                                     "response",
                                     JSONObject().apply {
-                                        put("result", "User cancelled")
+                                        put(
+                                            "result",
+                                            StructuredToolCallBridge.placeholderToolResultContent(
+                                                reason,
+                                                openFunctionCall.matchingName
+                                            )
+                                        )
                                     }
                                 )
                             }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/KimiProvider.kt
@@ -240,14 +240,20 @@ open class KimiProvider(
 
             AppLogger.w(
                 "KimiProvider",
-                "发现未完成的tool_calls，按取消处理: count=${openToolCalls.size}, reason=$reason"
+                "发现未完成的tool_calls，按缺失结果补齐: count=${openToolCalls.size}, reason=$reason"
             )
             for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
                         put("tool_call_id", openToolCall.id)
-                        put("content", "User cancelled")
+                        put(
+                            "content",
+                            StructuredToolCallBridge.placeholderToolResultContent(
+                                reason,
+                                openToolCall.matchingName
+                            )
+                        )
                     }
                 )
             }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIProvider.kt
@@ -1088,14 +1088,20 @@ open class OpenAIProvider(
 
             AppLogger.w(
                 "AIService",
-                "发现未完成的tool_calls，按取消处理: count=${openToolCalls.size}, reason=$reason"
+                "发现未完成的tool_calls，按缺失结果补齐: count=${openToolCalls.size}, reason=$reason"
             )
             for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
                         put("tool_call_id", openToolCall.id)
-                        put("content", "User cancelled")
+                        put(
+                            "content",
+                            StructuredToolCallBridge.placeholderToolResultContent(
+                                reason,
+                                openToolCall.matchingName
+                            )
+                        )
                     }
                 )
             }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridge.kt
@@ -89,6 +89,37 @@ internal object StructuredToolCallBridge {
         return matched
     }
 
+    /**
+     * Protocol placeholder for an open tool call that still needs a tool message.
+     * History serialization is not a user-cancel path, so this never reports
+     * `User cancelled`.
+     */
+    fun placeholderToolResultContent(reason: String, toolName: String? = null): String {
+        val toolLabel = toolName?.trim().orEmpty().ifEmpty { "unknown_tool" }
+        return when (reason) {
+            "tool_result_partial_batch",
+            "tool_result_without_structured_match" ->
+                "Tool result missing: no matching execution result was available for `$toolLabel`. This is not a user cancellation."
+            "typed_tool_call_without_payload" ->
+                "Tool result missing: the call for `$toolLabel` had no executable payload. This is not a user cancellation."
+            "tool_call_api_disabled" ->
+                "Tool result missing: structured tool-call protocol was disabled before `$toolLabel` received an execution result. This is not a user cancellation."
+            "user_boundary",
+            "system_boundary",
+            "assistant_boundary",
+            "assistant_tool_call_before_result",
+            "assistant_tool_use_before_result",
+            "assistant_function_call_before_result",
+            "typed_tool_call_before_result",
+            "typed_tool_use_before_result",
+            "typed_function_call_before_result",
+            "history_end" ->
+                "Tool result missing: later conversation history arrived before `$toolLabel` received an execution result. This is not a user cancellation."
+            else ->
+                "Tool result missing: the call for `$toolLabel` was closed without an execution result ($reason). This is not a user cancellation."
+        }
+    }
+
     fun buildToolsJson(toolPrompts: List<ToolPrompt>?): String? {
         if (toolPrompts.isNullOrEmpty()) {
             return null
@@ -278,16 +309,19 @@ internal object StructuredToolCallBridge {
             queuedOpenToolCalls.clear()
         }
 
-        fun flushOpenToolCallsAsCancelled() {
+        fun flushOpenToolCallsAsCancelled(reason: String) {
             emitQueuedToolCallsIfNeeded()
             if (openToolCalls.isEmpty()) return
-
+            AppLogger.w(
+                "StructuredToolCallBridge",
+                "发现未完成的tool_calls，按缺失结果补齐: count=${openToolCalls.size}, reason=$reason"
+            )
             for (openToolCall in openToolCalls) {
                 messagesArray.put(
                     JSONObject().apply {
                         put("role", "tool")
                         put("tool_call_id", openToolCall.id)
-                        put("content", "User cancelled")
+                        put("content", placeholderToolResultContent(reason, openToolCall.matchingName))
                     }
                 )
             }
@@ -305,7 +339,7 @@ internal object StructuredToolCallBridge {
 
             when (turn.kind) {
                 PromptTurnKind.SYSTEM -> {
-                    flushOpenToolCallsAsCancelled()
+                    flushOpenToolCallsAsCancelled("system_boundary")
                     messagesArray.put(
                         JSONObject().apply {
                             put("role", "system")
@@ -316,7 +350,7 @@ internal object StructuredToolCallBridge {
 
                 PromptTurnKind.USER,
                 PromptTurnKind.SUMMARY -> {
-                    flushOpenToolCallsAsCancelled()
+                    flushOpenToolCallsAsCancelled("user_boundary")
                     messagesArray.put(
                         JSONObject().apply {
                             put("role", "user")
@@ -335,10 +369,10 @@ internal object StructuredToolCallBridge {
                         }
 
                     if (toolCalls != null && toolCalls.length() > 0) {
-                        flushOpenToolCallsAsCancelled()
+                        flushOpenToolCallsAsCancelled("assistant_tool_call_before_result")
                         queueToolCalls(textContent, toolCalls)
                     } else {
-                        flushOpenToolCallsAsCancelled()
+                        flushOpenToolCallsAsCancelled("assistant_boundary")
                         messagesArray.put(
                             JSONObject().apply {
                                 put("role", "assistant")
@@ -358,10 +392,10 @@ internal object StructuredToolCallBridge {
                         }
 
                     if (toolCalls != null && toolCalls.length() > 0) {
-                        flushOpenToolCallsAsCancelled()
+                        flushOpenToolCallsAsCancelled("typed_tool_call_before_result")
                         queueToolCalls(textContent, toolCalls)
                     } else {
-                        flushOpenToolCallsAsCancelled()
+                        flushOpenToolCallsAsCancelled("typed_tool_call_without_payload")
                         messagesArray.put(
                             JSONObject().apply {
                                 put("role", "assistant")
@@ -399,7 +433,7 @@ internal object StructuredToolCallBridge {
                             )
                         }
 
-                        flushOpenToolCallsAsCancelled()
+                        flushOpenToolCallsAsCancelled("tool_result_partial_batch")
                         if (textContent.isNotBlank()) {
                             messagesArray.put(
                                 JSONObject().apply {
@@ -409,7 +443,7 @@ internal object StructuredToolCallBridge {
                             )
                         }
                     } else {
-                        flushOpenToolCallsAsCancelled()
+                        flushOpenToolCallsAsCancelled("tool_result_without_structured_match")
                         if (textContent.isNotBlank()) {
                             messagesArray.put(
                                 JSONObject().apply {
@@ -423,7 +457,7 @@ internal object StructuredToolCallBridge {
             }
         }
 
-        flushOpenToolCallsAsCancelled()
+        flushOpenToolCallsAsCancelled("history_end")
         return messagesArray
     }
     private fun nonEmptyContent(content: String): String {

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiToolCallHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAiToolCallHistoryTest.kt
@@ -81,6 +81,16 @@ class OpenAiToolCallHistoryTest {
             listOf("system", "user", "assistant", "tool", "tool", "user"),
             messages.roles()
         )
+        assertEquals("alpha", messages.at(3).getString("content"))
+        val unanswered = messages.at(4).getString("content")
+        assertEquals(
+            StructuredToolCallBridge.placeholderToolResultContent(
+                "tool_result_partial_batch",
+                "read_file_part"
+            ),
+            unanswered
+        )
+        assertFalse(unanswered.contains("User cancelled"))
         assertEquals("The second read was skipped.", messages.at(5).getString("content"))
     }
 
@@ -171,8 +181,33 @@ class OpenAiToolCallHistoryTest {
         assertEquals(toolCalls.getJSONObject(0).getString("id"), messages.at(2).getString("tool_call_id"))
         assertEquals("ok", messages.at(2).getString("content"))
         assertEquals(toolCalls.getJSONObject(1).getString("id"), messages.at(3).getString("tool_call_id"))
-        assertEquals("User cancelled", messages.at(3).getString("content"))
+        val placeholder = messages.at(3).getString("content")
+        assertEquals(
+            StructuredToolCallBridge.placeholderToolResultContent(
+                "tool_result_partial_batch",
+                "second"
+            ),
+            placeholder
+        )
+        assertFalse(placeholder.contains("User cancelled"))
+        assertTrue(placeholder.contains("Tool result missing"))
         assertEquals(4, messages.length())
+    }
+
+    @Test
+    fun `history placeholders never report user cancellation`() {
+        assertEquals(
+            "Tool result missing: no matching execution result was available for `second`. This is not a user cancellation.",
+            StructuredToolCallBridge.placeholderToolResultContent("tool_result_partial_batch", "second")
+        )
+        assertEquals(
+            "Tool result missing: later conversation history arrived before `read_file` received an execution result. This is not a user cancellation.",
+            StructuredToolCallBridge.placeholderToolResultContent("user_boundary", "read_file")
+        )
+        assertFalse(
+            StructuredToolCallBridge.placeholderToolResultContent("history_end", "echo")
+                .contains("User cancelled")
+        )
     }
 
     @Test

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridgeHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/StructuredToolCallBridgeHistoryTest.kt
@@ -5,6 +5,7 @@ import com.ai.assistance.operit.core.chat.hooks.PromptTurnKind
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -34,6 +35,16 @@ class StructuredToolCallBridgeHistoryTest {
             )
 
         assertEquals(listOf("user", "assistant", "tool", "tool", "user"), messages.roles())
+        assertEquals("alpha", messages.at(2).getString("content"))
+        val unanswered = messages.at(3).getString("content")
+        assertEquals(
+            StructuredToolCallBridge.placeholderToolResultContent(
+                "tool_result_partial_batch",
+                "read_file_part"
+            ),
+            unanswered
+        )
+        assertFalse(unanswered.contains("User cancelled"))
         assertEquals("The second read was skipped.", messages.at(4).getString("content"))
         assertToolResultsFollowTheirCalls(messages)
     }


### PR DESCRIPTION
## 变更说明 / Description

历史序列化时，没配上结果的 tool_call 仍要补一条 tool 消息才能满足提供商协议，但以前统一写成 `User cancelled`。模型会把配对失败、历史断层当成用户点了停止。

这个 PR 把占位文案改成缺少执行结果，不再写用户取消。真正的停止按钮、权限拒绝、PhoneAgent 取消都不动。

### 背景与动机 / Context and motivation

OpenAI / Claude / Gemini 要求每个 tool_call 都有对应结果。历史里有孤儿调用时，序列化会补一条 tool 消息。之前 content 写死 `User cancelled`，内部 reason 只打日志。

常见触发不是用户停止：一批结果只配上一部分、名字对不上、历史已经走到下一条 user/assistant。模型看到 User cancelled 会道歉、不再重试。

### 改动范围 / Changes

- 新增 `StructuredToolCallBridge.placeholderToolResultContent(reason, toolName)`，按 reason 生成英文占位结果
- OpenAI / Deepseek / Kimi / Claude / Gemini / structured bridge 的补齐路径都走这套文案
- 能配上的真实执行结果仍原样回写
- 回给模型的文案只有工具名和缺失原因，不写提供商、不写 tool id
- 单测改为断言 `Tool result missing`，不再断言 `User cancelled`

不包含：

- 停止按钮 / `AIMessageManager.cancelOperation()`
- 权限拒绝中文
- PhoneAgent `User cancelled UI automation`
- 日志导出过滤、extended_chat 插件

### 兼容性与风险 / Compatibility and risks

- 协议仍补 tool 消息，不会因缺 tool_result 而 400
- 模型看到的是「结果缺失」而不是「用户取消」，可能会重试工具，这是预期行为
- 无数据格式 / API / 配置变更

## 关联 Issue / Related issue

N/A。对照历史序列化里的假 `User cancelled` 占位。

## 验证方式 / Verification

```text
检查或命令：
- Android Build (assembleDebug)
- Android Tests (JVM)
- git merge-tree 对最新 upstream/dev
环境与变体：
- GitHub Actions / fork 3316891527/Operit / 分支 fix/tool-result-cancel-semantics
- 基线 upstream/dev abecc37
结果：
- Build 绿：https://github.com/3316891527/Operit/actions/runs/34127005181
- Tests 红在上游 DeepseekProviderMediaRoleTest / XaiProviderReasoningTest 编译，不是本 PR 引入的
- 与最新 dev 无冲突
- 未真机：这是请求序列化文案，真机点停止不会覆盖这条路径
```

## 证据 / Evidence

- 单测：`OpenAiToolCallHistoryTest` 对不上的调用断言 `Tool result missing`，不再断言 `User cancelled`
- 占位文案示例：`Tool result missing: no matching execution result was available for `second`. This is not a user cancellation.`

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 `dev`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `dev` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / `Candidate checks` covers the change scope and technical failures will be addressed
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided
