### PR TITLE
fix(mcp): register remote MCP tools after discovery

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/mcp/MCPRepository.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/mcp/MCPRepository.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.runBlocking
 
 /**
  * 统一的MCP仓库管理类
@@ -1095,7 +1094,8 @@ class MCPRepository(private val context: Context) {
     }
 
     /**
-     * Returns the names exposed by a remote MCP service for list presentation.
+     * Returns the names exposed by a remote MCP service for list presentation, and registers
+     * the service with the AI runtime once its tools are known.
      *
      * Remote configuration is persisted independently from the in-memory runtime. This
      * method establishes that runtime boundary from the current metadata before asking
@@ -1108,23 +1108,39 @@ class MCPRepository(private val context: Context) {
             return@withContext emptyList()
         }
 
+        val toolNames = discoverRemoteToolNames(pluginId, metadata)
+
+        // Discovery is also the moment the server proves it is usable, so hand it to the AI
+        // runtime here. Otherwise the management screen lists tools that the AI never sees,
+        // because the only other registration trigger runs once during startup.
+        if (toolNames.isNotEmpty() && !metadata.disabled) {
+            registerToolsForPlugin(pluginId)
+        }
+
+        toolNames
+    }
+
+    private suspend fun discoverRemoteToolNames(
+        pluginId: String,
+        metadata: MCPLocalServer.PluginMetadata
+    ): List<String> {
         val cachedToolNames = mcpLocalServer.getCachedTools(pluginId)
             .orEmpty()
             .map { cachedTool -> cachedTool.name.trim() }
             .filter { toolName -> toolName.isNotEmpty() }
             .distinct()
         if (cachedToolNames.isNotEmpty()) {
-            return@withContext cachedToolNames
+            return cachedToolNames
         }
 
         if (metadata.disabled) {
-            return@withContext emptyList()
+            return emptyList()
         }
 
         val mcpManager = MCPManager.getInstance(context)
         mcpManager.registerRuntime(pluginId, createRuntimeDescriptor(metadata))
         val session = mcpManager.getOrCreateSession(pluginId)
-            ?: return@withContext emptyList()
+            ?: return emptyList()
         val discoveredTools = session.listTools()
             .mapNotNull { tool ->
                 val toolName = tool.name.trim()
@@ -1141,7 +1157,7 @@ class MCPRepository(private val context: Context) {
             mcpLocalServer.cacheServerTools(pluginId, discoveredTools)
         }
 
-        discoveredTools.map { tool -> tool.name }.distinct()
+        return discoveredTools.map { tool -> tool.name }.distinct()
     }
 
     /**
@@ -1171,74 +1187,78 @@ class MCPRepository(private val context: Context) {
         }
 
         AppLogger.d(TAG, "开始为 ${successfulPluginIds.size} 个插件注册工具: ${successfulPluginIds.joinToString()}")
-
-        val mcpManager = MCPManager.getInstance(context)
-        val toolHandler = AIToolHandler.getInstance(context)
-        val mcpToolExecutor = MCPToolExecutor(context, mcpManager)
-
-        successfulPluginIds.forEach { pluginId ->
-            try {
-                AppLogger.d(TAG, "正在为插件 $pluginId 注册工具...")
-
-                val pluginMetadata = mcpLocalServer.getPluginMetadata(pluginId)
-                if (pluginMetadata == null) {
-                    AppLogger.w(TAG, "在MCPLocalServer中找不到插件 $pluginId 的元数据")
-                    return@forEach
-                }
-
-                val runtimeDescriptor = createRuntimeDescriptor(pluginMetadata)
-                val serverConfig = MCPServerConfig(
-                    name = pluginId,
-                    endpoint = when (runtimeDescriptor) {
-                        is McpRuntimeDescriptor.Local -> "mcp://plugin/${runtimeDescriptor.serviceName}"
-                        is McpRuntimeDescriptor.Remote -> runtimeDescriptor.endpoint
-                    },
-                    description = pluginMetadata.description,
-                    capabilities = listOf("tools"),
-                    extraData = emptyMap()
-                )
-                mcpManager.registerServer(pluginId, serverConfig, runtimeDescriptor)
-                AppLogger.d(TAG, "已在MCPManager中注册服务器: $pluginId (类型: ${pluginMetadata.type})")
-
-                // 获取工具信息
-                val toolsToRegister = getToolsForPlugin(pluginId)
-
-                if (toolsToRegister.isEmpty()) {
-                    AppLogger.w(TAG, "插件 $pluginId 没有可注册的工具")
-                    return@forEach
-                }
-
-                // 统一注册工具
-                toolsToRegister.forEach { toolInfo ->
-                    val prefixedToolName = "$pluginId:${toolInfo.name}"
-
-                    if (toolHandler.getToolExecutor(prefixedToolName) != null) {
-                        AppLogger.d(TAG, "工具 $prefixedToolName 已注册，跳过")
-                        return@forEach
-                    }
-
-                    runBlocking {
-                        toolHandler.registerTool(
-                            name = prefixedToolName,
-                            executor = mcpToolExecutor,
-                            descriptionGenerator = { tool ->
-                                val baseDescription = toolInfo.description
-                                val paramsString = if (tool.parameters.isNotEmpty()) {
-                                    "\nParameters: " + tool.parameters.joinToString(", ") { "${it.name}='${it.value}'" }
-                                } else ""
-                                baseDescription + paramsString
-                            }
-                        )
-                    }
-                    AppLogger.i(TAG, "成功注册工具: $prefixedToolName")
-                }
-                AppLogger.d(TAG, "插件 $pluginId 的工具注册完成，共 ${toolsToRegister.size} 个")
-
-            } catch (e: Exception) {
-                AppLogger.e(TAG, "为插件 $pluginId 注册工具时发生异常", e)
-            }
-        }
+        successfulPluginIds.forEach { pluginId -> registerToolsForPlugin(pluginId) }
         AppLogger.d(TAG, "所有插件的工具注册流程完成")
+    }
+
+    /**
+     * 把单个插件接入 AI 运行时：在 MCPManager 中注册服务器（这是 AI 能看到该包的前提），
+     * 并把它的工具注册到 AIToolHandler。
+     *
+     * 注册由多个生命周期节点触发（启动校验、MCP 管理页的远程发现），所以这里必须幂等：
+     * 已注册的工具会被跳过，重复调用不会产生重复注册。
+     */
+    fun registerToolsForPlugin(pluginId: String) {
+        try {
+            AppLogger.d(TAG, "正在为插件 $pluginId 注册工具...")
+
+            val pluginMetadata = mcpLocalServer.getPluginMetadata(pluginId)
+            if (pluginMetadata == null) {
+                AppLogger.w(TAG, "在MCPLocalServer中找不到插件 $pluginId 的元数据")
+                return
+            }
+
+            val mcpManager = MCPManager.getInstance(context)
+            val runtimeDescriptor = createRuntimeDescriptor(pluginMetadata)
+            val serverConfig = MCPServerConfig(
+                name = pluginId,
+                endpoint = when (runtimeDescriptor) {
+                    is McpRuntimeDescriptor.Local -> "mcp://plugin/${runtimeDescriptor.serviceName}"
+                    is McpRuntimeDescriptor.Remote -> runtimeDescriptor.endpoint
+                },
+                description = pluginMetadata.description,
+                capabilities = listOf("tools"),
+                extraData = emptyMap()
+            )
+            mcpManager.registerServer(pluginId, serverConfig, runtimeDescriptor)
+            AppLogger.d(TAG, "已在MCPManager中注册服务器: $pluginId (类型: ${pluginMetadata.type})")
+
+            // 获取工具信息
+            val toolsToRegister = getToolsForPlugin(pluginId)
+
+            if (toolsToRegister.isEmpty()) {
+                AppLogger.w(TAG, "插件 $pluginId 没有可注册的工具")
+                return
+            }
+
+            // 统一注册工具
+            val toolHandler = AIToolHandler.getInstance(context)
+            val mcpToolExecutor = MCPToolExecutor(context, mcpManager)
+            toolsToRegister.forEach { toolInfo ->
+                val prefixedToolName = "$pluginId:${toolInfo.name}"
+
+                if (toolHandler.getToolExecutor(prefixedToolName) != null) {
+                    AppLogger.d(TAG, "工具 $prefixedToolName 已注册，跳过")
+                    return@forEach
+                }
+
+                toolHandler.registerTool(
+                    name = prefixedToolName,
+                    executor = mcpToolExecutor,
+                    descriptionGenerator = { tool ->
+                        val baseDescription = toolInfo.description
+                        val paramsString = if (tool.parameters.isNotEmpty()) {
+                            "\nParameters: " + tool.parameters.joinToString(", ") { "${it.name}='${it.value}'" }
+                        } else ""
+                        baseDescription + paramsString
+                    }
+                )
+                AppLogger.i(TAG, "成功注册工具: $prefixedToolName")
+            }
+            AppLogger.d(TAG, "插件 $pluginId 的工具注册完成，共 ${toolsToRegister.size} 个")
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "为插件 $pluginId 注册工具时发生异常", e)
+        }
     }
 
     /**

--- a/app/src/main/java/com/ai/assistance/operit/data/mcp/plugins/MCPStarter.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/mcp/plugins/MCPStarter.kt
@@ -455,7 +455,12 @@ class MCPStarter(private val context: Context) {
                                     totalPluginsToProcess
                                 )
 
-                                processPlugin(pluginId, serviceName, progressListener)
+                                processPlugin(
+                                    pluginId,
+                                    serviceName,
+                                    mcpRepository,
+                                    progressListener
+                                )
                             }
 
                             synchronized(allVerificationResults) {
@@ -481,7 +486,6 @@ class MCPStarter(private val context: Context) {
 
                 val successfulResults = allVerificationResults.filter { it.isResponding }
                 if (successfulResults.isNotEmpty()) {
-                    registerToolsForVerifiedPlugins(successfulResults)
                     generateMissingDescriptions(successfulResults)
                 }
 
@@ -504,6 +508,7 @@ class MCPStarter(private val context: Context) {
     private suspend fun processPlugin(
         pluginId: String,
         serviceName: String,
+        mcpRepository: MCPRepository,
         progressListener: PluginStartProgressListener
     ): VerificationResult {
         val mcpLocalServer = MCPLocalServer.getInstance(context)
@@ -522,6 +527,11 @@ class MCPStarter(private val context: Context) {
         if (!mcpLocalServer.hasValidToolCache(pluginId)) {
             cacheToolsFromService(pluginId)
         }
+
+        // Register while this plugin is known to be up. Registering the whole batch after the
+        // fan-out means a stalled or failing plugin keeps every other plugin, remote ones
+        // included, out of the AI tool list.
+        mcpRepository.registerToolsForPlugin(pluginId)
 
         return VerificationResult(
             pluginId = pluginId,

--- a/app/src/main/java/com/ai/assistance/operit/ui/permissions/ToolPermissionSystem.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/permissions/ToolPermissionSystem.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.resume
 
 // Define DataStore
@@ -113,8 +114,8 @@ class ToolPermissionSystem private constructor(private val context: Context) {
         }
     }
     
-    // Registry of operation descriptions by tool name
-    private val operationDescriptionRegistry = mutableMapOf<String, (AITool) -> String>()
+    // MCP startup registers verified plugins concurrently, while permission checks may read this.
+    private val operationDescriptionRegistry = ConcurrentHashMap<String, (AITool) -> String>()
     
     /**
      * Register a description generator for a tool

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/mcp/McpServerRegistrationTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/mcp/McpServerRegistrationTest.kt
@@ -1,0 +1,100 @@
+package com.ai.assistance.operit.core.tools.mcp
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * Guards the registration surface remote MCP plugins depend on (issue #907).
+ *
+ * Bringing a remote plugin up only installs a runtime descriptor. The AI can reach it only once
+ * the plugin is also registered as a server, because the "Available packages" prompt section and
+ * the package auto-activation path both read [MCPManager.getRegisteredServers].
+ */
+class McpServerRegistrationTest {
+
+    private val context: Context = mock()
+
+    private val remoteDescriptor = McpRuntimeDescriptor.Remote(
+        endpoint = "https://example.invalid/mcp",
+        connectionType = "httpStream",
+        bearerToken = "token",
+        headers = mapOf("X-Client" to "Operit")
+    )
+
+    private fun remoteServerConfig() = MCPServerConfig(
+        name = PLUGIN_ID,
+        endpoint = remoteDescriptor.endpoint,
+        description = "Remote MCP service",
+        capabilities = listOf("tools"),
+        extraData = emptyMap()
+    )
+
+    @Test
+    fun `connecting a remote runtime does not expose the server to the AI`() {
+        val manager = MCPManager(context)
+
+        manager.registerRuntime(PLUGIN_ID, remoteDescriptor)
+
+        assertFalse(manager.isServerRegistered(PLUGIN_ID))
+        assertTrue(manager.getRegisteredServers().isEmpty())
+    }
+
+    @Test
+    fun `registering the server exposes the remote endpoint to the AI`() {
+        val manager = MCPManager(context)
+
+        manager.registerServer(PLUGIN_ID, remoteServerConfig(), remoteDescriptor)
+
+        assertTrue(manager.isServerRegistered(PLUGIN_ID))
+        assertEquals(
+            remoteDescriptor.endpoint,
+            manager.getRegisteredServers().getValue(PLUGIN_ID).endpoint
+        )
+    }
+
+    @Test
+    fun `repeated registration keeps a single server entry`() {
+        val manager = MCPManager(context)
+
+        repeat(3) {
+            manager.registerServer(PLUGIN_ID, remoteServerConfig(), remoteDescriptor.copy())
+        }
+
+        assertEquals(setOf(PLUGIN_ID), manager.getRegisteredServers().keys)
+    }
+
+    @Test
+    fun `descriptors rebuilt from the same metadata compare equal`() {
+        // registerRuntime closes the cached session whenever the incoming descriptor differs from
+        // the previous one. Registration runs from several lifecycle points, so unchanged plugin
+        // metadata has to keep producing an equal descriptor or a live session gets torn down on
+        // every refresh.
+        val rebuilt = McpRuntimeDescriptor.Remote(
+            endpoint = "https://example.invalid/mcp",
+            connectionType = "httpStream",
+            bearerToken = "token",
+            headers = mapOf("X-Client" to "Operit")
+        )
+
+        assertEquals(remoteDescriptor, rebuilt)
+    }
+
+    @Test
+    fun `unregistering a server hides it from the AI again`() {
+        val manager = MCPManager(context)
+        manager.registerServer(PLUGIN_ID, remoteServerConfig(), remoteDescriptor)
+
+        manager.unregisterServer(PLUGIN_ID)
+
+        assertFalse(manager.isServerRegistered(PLUGIN_ID))
+        assertTrue(manager.getRegisteredServers().isEmpty())
+    }
+
+    private companion object {
+        const val PLUGIN_ID = "galatea-garden"
+    }
+}


### PR DESCRIPTION
## Background\n\nRemote MCP services added from the management screen could connect and cache tools without becoming available to the AI until a later startup pass.\n\nReplaces #1080 because its fork-owned head branch cannot be updated by the maintainer account.\n\n## Changes\n\n- Register remote servers and their tools after successful discovery\n- Register each verified startup plugin immediately\n- Make permission operation-description registration safe for concurrent plugin startup\n\n## Compatibility\n\nNo persisted data or public configuration format changes. Disabled MCP services remain unregistered.\n\n## Verification\n\n- Ran git diff --check\n- Did not run build or tests, following workspace instructions