### PR TITLE
fix(summary): compose configurable summary sections

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/EnhancedAIService.kt
@@ -38,6 +38,7 @@ import com.ai.assistance.operit.data.model.ToolResult
 import com.ai.assistance.operit.data.model.ModelConfigData
 import com.ai.assistance.operit.data.model.ModelParameter
 import com.ai.assistance.operit.data.model.AITool
+import com.ai.assistance.operit.data.model.ConversationSummaryConfig
 import com.ai.assistance.operit.data.preferences.ApiPreferences
 import com.ai.assistance.operit.data.preferences.ExternalHttpApiPreferences
 import com.ai.assistance.operit.data.preferences.WakeWordPreferences
@@ -2594,13 +2595,13 @@ class EnhancedAIService private constructor(private val context: Context) {
     suspend fun generateSummary(
             messages: List<Pair<String, String>>,
             previousSummary: String?,
-            customRules: String? = null,
+            summaryConfig: ConversationSummaryConfig = ConversationSummaryConfig(),
             recordTokenUsage: Boolean = true,
     ): String {
         return generateSummaryFromPromptTurns(
             messages.toPromptTurns(),
             previousSummary,
-            customRules,
+            summaryConfig,
             recordTokenUsage,
         )
     }
@@ -2608,7 +2609,7 @@ class EnhancedAIService private constructor(private val context: Context) {
     suspend fun generateSummaryFromPromptTurns(
             messages: List<PromptTurn>,
             previousSummary: String?,
-            customRules: String? = null,
+            summaryConfig: ConversationSummaryConfig = ConversationSummaryConfig(),
             recordTokenUsage: Boolean = true,
     ): String {
         // 调用ConversationService中的方法
@@ -2616,7 +2617,7 @@ class EnhancedAIService private constructor(private val context: Context) {
             messages,
             previousSummary,
             multiServiceManager,
-            customRules,
+            summaryConfig,
             recordTokenUsage,
         )
     }

--- a/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationService.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/enhance/ConversationService.kt
@@ -16,6 +16,7 @@ import com.ai.assistance.operit.R
 import com.ai.assistance.operit.core.tools.AIToolHandler
 import com.ai.assistance.operit.core.tools.packTool.PackageManager
 import com.ai.assistance.operit.data.model.AITool
+import com.ai.assistance.operit.data.model.ConversationSummaryConfig
 import com.ai.assistance.operit.data.model.FunctionType
 import com.ai.assistance.operit.data.model.ModelParameter
 import com.ai.assistance.operit.data.model.ToolParameter
@@ -114,17 +115,18 @@ class ConversationService(
             messages: List<PromptTurn>,
             previousSummary: String?,
             multiServiceManager: MultiServiceManager,
-            customRules: String? = null,
+            summaryConfig: ConversationSummaryConfig = ConversationSummaryConfig(),
             recordTokenUsage: Boolean = true,
     ): String {
         try {
             val useEnglish = !LocaleUtils.usesChineseContent(context)
             val activePromptMetadata = buildActivePromptHookMetadata(context)
-            var systemPrompt = FunctionalPrompts.buildSummarySystemPrompt(previousSummary, useEnglish)
-            // 注入自定义总结规则
-            if (!customRules.isNullOrBlank()) {
-                systemPrompt += "\n\n${customRules.trim()}"
-            }
+            var systemPrompt =
+                FunctionalPrompts.buildSummarySystemPrompt(
+                    previousSummary = previousSummary,
+                    useEnglish = useEnglish,
+                    summaryConfig = summaryConfig
+                )
             val sanitizedMessages =
                 ChatUtils.stripOpenAiResponsesProtocolMarkupTurns(
                     ChatUtils.stripGeminiThoughtSignatureMetaTurns(messages)

--- a/app/src/main/java/com/ai/assistance/operit/core/chat/AIMessageManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/chat/AIMessageManager.kt
@@ -20,6 +20,7 @@ import com.ai.assistance.operit.core.tools.packTool.PackageManager
 import com.ai.assistance.operit.data.model.AITool
 import com.ai.assistance.operit.data.model.AttachmentInfo
 import com.ai.assistance.operit.data.model.ChatMessage
+import com.ai.assistance.operit.data.model.ConversationSummaryConfig
 import com.ai.assistance.operit.data.model.ChatMessageTimestampAllocator
 import com.ai.assistance.operit.data.model.ToolParameter
 import com.ai.assistance.operit.data.model.PromptFunctionType
@@ -678,7 +679,7 @@ object AIMessageManager {
         messages: List<ChatMessage>,
         autoContinue: Boolean = false,
         isGroupChat: Boolean = false,
-        summaryCustomRules: String? = null
+        summaryConfig: ConversationSummaryConfig = ConversationSummaryConfig()
     ): ChatMessage? {
         val lastSummaryIndex = messages.indexOfLast { it.sender == "summary" }
         val previousSummary = if (lastSummaryIndex != -1) messages[lastSummaryIndex].content.trim() else null
@@ -1034,7 +1035,12 @@ object AIMessageManager {
 
         return try {
             AppLogger.d(TAG, "开始使用AI生成对话总结：总结 ${messagesToSummarize.size} 条消息")
-            val summary = enhancedAiService.generateSummary(conversationToSummarize, previousSummary, summaryCustomRules)
+            val summary =
+                enhancedAiService.generateSummary(
+                    conversationToSummarize,
+                    previousSummary,
+                    summaryConfig
+                )
             AppLogger.d(TAG, "AI生成总结完成: ${summary.take(50)}...")
 
             if (summary.isBlank()) {

--- a/app/src/main/java/com/ai/assistance/operit/core/config/FunctionalPrompts.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/config/FunctionalPrompts.kt
@@ -2,6 +2,9 @@ package com.ai.assistance.operit.core.config
 
 import com.ai.assistance.operit.core.avatar.common.state.AvatarCustomMoodDefinition
 import com.ai.assistance.operit.core.avatar.common.state.AvatarMoodTypes
+import com.ai.assistance.operit.data.model.ConversationSummaryConfig
+import com.ai.assistance.operit.data.model.SummarySectionConfig
+import com.ai.assistance.operit.data.model.SummarySectionOverride
 
 /**
  * A centralized repository for system prompts used across various functional services.
@@ -112,27 +115,176 @@ object FunctionalPrompts {
         return if (useEnglish) SUMMARY_PROMPT_EN else SUMMARY_PROMPT
     }
 
-    fun buildSummarySystemPrompt(previousSummary: String?, useEnglish: Boolean): String {
-        var prompt = summaryPrompt(useEnglish).trimIndent()
-        if (!previousSummary.isNullOrBlank()) {
-            prompt +=
-                if (useEnglish) {
-                    """
+    private val summarySectionIds = listOf("core_task", "interaction", "progress", "key_info")
 
-                    Previous Summary (to inherit context):
-                    ${previousSummary.trim()}
-                    Please merge the key information from the previous summary with the new conversation and generate a brand-new, more complete summary.
-                    """.trimIndent()
-                } else {
-                    """
-
-                    上一次的摘要（用于继承上下文）：
-                    ${previousSummary.trim()}
-                    请将以上摘要中的关键信息，与本次新的对话内容相融合，生成一份全新的、更完整的摘要。
-                    """.trimIndent()
-                }
+    private fun summarySectionTitles(useEnglish: Boolean): List<String> {
+        return if (useEnglish) {
+            listOf(
+                "Core Task Status",
+                "Interaction & Scenario",
+                "Conversation Progress & Overview",
+                "Key Information & Context"
+            )
+        } else {
+            listOf("核心任务状态", "互动情节与设定", "对话历程与概要", "关键信息与上下文")
         }
-        return prompt
+    }
+
+    private fun summaryPromptTemplate(useEnglish: Boolean): SummaryPromptTemplate {
+        val prompt = summaryPrompt(useEnglish).trimIndent()
+        val titles = summarySectionTitles(useEnglish)
+        val separator = if (useEnglish) "=======================================" else "============================"
+        val starts = titles.map { title ->
+            prompt.indexOf(summarySectionHeader(title, useEnglish)).also { start ->
+                check(start >= 0) { "Summary prompt is missing section: $title" }
+            }
+        }
+        val sections = starts.mapIndexed { index, start ->
+            val end = starts.getOrNull(index + 1) ?: prompt.indexOf(separator, start)
+            check(end >= 0) { "Summary prompt is missing the end of section: ${titles[index]}" }
+            val block = prompt.substring(start, end)
+            SummaryPromptSection(
+                config = SummarySectionConfig(
+                    id = summarySectionIds[index],
+                    title = titles[index],
+                    instruction = block.substringAfter('\n').trimEnd()
+                ),
+                block = block
+            )
+        }
+        return SummaryPromptTemplate(
+            prefix = prompt.substring(0, starts.first()),
+            sections = sections,
+            suffix = prompt.substring(sections.last().block.let { starts.last() + it.length })
+        )
+    }
+
+    private fun legacyPromptSections(useEnglish: Boolean): List<SummarySectionConfig> {
+        return summaryPromptTemplate(useEnglish).sections.map { it.config }
+    }
+
+    fun resolveSummarySections(
+        overrides: List<SummarySectionOverride>,
+        useEnglish: Boolean
+    ): List<SummarySectionConfig> {
+        val overridesById = overrides.associateBy { it.id.trim() }
+        return legacyPromptSections(useEnglish).map { defaultSection ->
+            val override = overridesById[defaultSection.id] ?: return@map defaultSection
+            defaultSection.copy(
+                enabled = override.enabled ?: defaultSection.enabled,
+                title = override.title?.trim()?.takeIf { it.isNotBlank() } ?: defaultSection.title,
+                instruction =
+                    override.instruction?.trim()?.takeIf { it.isNotBlank() }
+                        ?: defaultSection.instruction
+            )
+        }
+    }
+
+    fun buildSummarySectionOverrides(
+        sections: List<SummarySectionConfig>,
+        useEnglish: Boolean
+    ): List<SummarySectionOverride> {
+        val sectionsById = sections.associateBy { it.id.trim() }
+        return legacyPromptSections(useEnglish).mapNotNull { defaultSection ->
+            val section = sectionsById[defaultSection.id] ?: return@mapNotNull null
+            val enabled = section.enabled.takeIf { it != defaultSection.enabled }
+            val title = section.title.trim().takeIf { it.isNotBlank() && it != defaultSection.title }
+            val instruction =
+                section.instruction.trim().takeIf {
+                    it.isNotBlank() && it != defaultSection.instruction
+                }
+            if (enabled == null && title == null && instruction == null) {
+                null
+            } else {
+                SummarySectionOverride(
+                    id = defaultSection.id,
+                    enabled = enabled,
+                    title = title,
+                    instruction = instruction
+                )
+            }
+        }
+    }
+
+    fun buildSummarySystemPrompt(
+        previousSummary: String?,
+        useEnglish: Boolean,
+        summaryConfig: ConversationSummaryConfig = ConversationSummaryConfig()
+    ): String {
+        var prompt = summaryPrompt(useEnglish).trimIndent()
+        if (summaryConfig.sectionOverrides.isNotEmpty()) {
+            prompt = applySummarySectionOverrides(summaryConfig.sectionOverrides, useEnglish)
+        }
+        val promptWithPreviousSummary = appendPreviousSummary(prompt, previousSummary, useEnglish)
+        return summaryConfig.globalRules?.trim()?.takeIf { it.isNotBlank() }?.let { rules ->
+            "$promptWithPreviousSummary\n\n$rules"
+        } ?: promptWithPreviousSummary
+    }
+
+    private fun applySummarySectionOverrides(
+        overrides: List<SummarySectionOverride>,
+        useEnglish: Boolean
+    ): String {
+        val template = summaryPromptTemplate(useEnglish)
+        val overridesById = overrides.associateBy { it.id.trim() }
+        return buildString {
+            append(template.prefix)
+            template.sections.forEach { section ->
+                val override = overridesById[section.config.id]
+                if (override?.enabled != false) {
+                    val title = override?.title?.trim()?.takeIf { it.isNotBlank() }
+                    val instruction = override?.instruction?.trim()?.takeIf { it.isNotBlank() }
+                    if (title == null && instruction == null) {
+                        append(section.block)
+                    } else {
+                        append(summarySectionHeader(title ?: section.config.title, useEnglish))
+                        append('\n')
+                        append(instruction ?: section.config.instruction)
+                        append("\n\n")
+                    }
+                }
+            }
+            append(template.suffix)
+        }
+    }
+
+    private data class SummaryPromptSection(
+        val config: SummarySectionConfig,
+        val block: String
+    )
+
+    private data class SummaryPromptTemplate(
+        val prefix: String,
+        val sections: List<SummaryPromptSection>,
+        val suffix: String
+    )
+
+    private fun summarySectionHeader(title: String, useEnglish: Boolean): String {
+        return if (useEnglish) "[$title]" else "【$title】"
+    }
+
+    private fun appendPreviousSummary(
+        prompt: String,
+        previousSummary: String?,
+        useEnglish: Boolean
+    ): String {
+        if (previousSummary.isNullOrBlank()) return prompt
+        return prompt +
+            if (useEnglish) {
+                """
+
+                Previous Summary (to inherit context):
+                ${previousSummary.trim()}
+                Please merge the key information from the previous summary with the new conversation and generate a brand-new, more complete summary.
+                """.trimIndent()
+            } else {
+                """
+
+                上一次的摘要（用于继承上下文）：
+                ${previousSummary.trim()}
+                请将以上摘要中的关键信息，与本次新的对话内容相融合，生成一份全新的、更完整的摘要。
+                """.trimIndent()
+            }
     }
 
     /**

--- a/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/model/ModelConfigData.kt
@@ -68,6 +68,26 @@ object ModelConfigDefaults {
         const val DEFAULT_SUMMARY_MESSAGE_COUNT_THRESHOLD = 16
 }
 
+data class SummarySectionConfig(
+        val id: String,
+        val enabled: Boolean = true,
+        val title: String = "",
+        val instruction: String = ""
+)
+
+@Serializable
+data class SummarySectionOverride(
+        val id: String,
+        val enabled: Boolean? = null,
+        val title: String? = null,
+        val instruction: String? = null
+)
+
+data class ConversationSummaryConfig(
+        val globalRules: String? = null,
+        val sectionOverrides: List<SummarySectionOverride> = emptyList()
+)
+
 /** 表示完整的模型配置，包括API设置和模型参数 */
 @Serializable
 data class ModelConfigData(
@@ -132,6 +152,7 @@ data class ModelConfigData(
                 ModelConfigDefaults.DEFAULT_SUMMARY_MESSAGE_COUNT_THRESHOLD,
         // 自定义总结规则
         val summaryCustomRules: String = "",
+        val summarySectionOverrides: List<SummarySectionOverride> = emptyList(),
 
         // MNN特定配置
         // 注意：MNN模型路径会根据modelName自动构建，不需要单独存储

--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/ModelConfigManager.kt
@@ -18,6 +18,7 @@ import com.ai.assistance.operit.data.model.ModelParameter
 import com.ai.assistance.operit.data.model.ParameterCategory
 import com.ai.assistance.operit.data.model.ParameterValueType
 import com.ai.assistance.operit.data.model.StandardModelParameters
+import com.ai.assistance.operit.data.model.SummarySectionOverride
 import com.ai.assistance.operit.data.model.ApiProviderType
 import com.ai.assistance.operit.data.model.ApiKeyInfo
 import java.util.Locale
@@ -940,15 +941,18 @@ class ModelConfigManager(
             summaryTokenThreshold: Float,
             enableSummaryByMessageCount: Boolean,
             summaryMessageCountThreshold: Int,
-            summaryCustomRules: String = ""
+            summaryCustomRules: String? = null,
+            summarySectionOverrides: List<SummarySectionOverride>? = null
     ): ModelConfigData {
-        return updateConfigInternal(configId) {
-            it.copy(
+        return updateConfigInternal(configId) { current ->
+            current.copy(
                     enableSummary = enableSummary,
                     summaryTokenThreshold = summaryTokenThreshold,
                     enableSummaryByMessageCount = enableSummaryByMessageCount,
                     summaryMessageCountThreshold = summaryMessageCountThreshold,
-                    summaryCustomRules = summaryCustomRules
+                    summaryCustomRules = summaryCustomRules ?: current.summaryCustomRules,
+                    summarySectionOverrides =
+                        summarySectionOverrides ?: current.summarySectionOverrides
             )
         }
     }

--- a/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
@@ -12,6 +12,7 @@ import com.ai.assistance.operit.api.chat.enhance.MultiServiceManager
 import com.ai.assistance.operit.api.chat.llmprovider.AIService
 import com.ai.assistance.operit.data.model.ModelParameter
 import com.ai.assistance.operit.data.model.CharacterCard
+import com.ai.assistance.operit.data.model.ConversationSummaryConfig
 import com.ai.assistance.operit.data.model.FunctionType
 import com.ai.assistance.operit.data.model.PromptFunctionType
 import com.ai.assistance.operit.data.model.ChatMessage
@@ -1776,13 +1777,13 @@ class MessageCoordinationDelegate(
                 val currentChat = chatHistoryDelegate.chatHistories.value.firstOrNull { it.id == originalChatId }
                 val isGroupChat = currentChat?.characterGroupId != null
 
-                val summaryCustomRules = readSummaryCustomRules()
+                val summaryConfig = readSummaryConfig()
                 val summaryMessage = AIMessageManager.summarizeMemory(
                     enhancedAiService = service,
                     messages = snapshotMessages,
                     autoContinue = false,
                     isGroupChat = isGroupChat,
-                    summaryCustomRules = summaryCustomRules
+                    summaryConfig = summaryConfig
                 ) ?: return@launch
 
                 val currentChatId = chatHistoryDelegate.currentChatId.value
@@ -1902,9 +1903,15 @@ class MessageCoordinationDelegate(
                 summaryInsertReferenceMessages.getOrNull(insertPosition - 1)?.timestamp
             val afterTimestamp =
                 summaryInsertReferenceMessages.getOrNull(insertPosition)?.timestamp
-            val summaryCustomRules = readSummaryCustomRules()
+            val summaryConfig = readSummaryConfig()
             val summaryMessage =
-                AIMessageManager.summarizeMemory(service, currentMessages, autoContinue, effectiveIsGroupChat, summaryCustomRules)
+                AIMessageManager.summarizeMemory(
+                    service,
+                    currentMessages,
+                    autoContinue,
+                    effectiveIsGroupChat,
+                    summaryConfig
+                )
 
             if (summaryMessage != null) {
                 chatHistoryDelegate.addSummaryMessage(
@@ -2013,8 +2020,8 @@ class MessageCoordinationDelegate(
         this.uiBridge = uiBridge
     }
 
-    /** 从当前聊天绑定的模型配置中读取自定义总结规则 */
-    suspend fun readSummaryCustomRules(): String? {
+    /** 从当前聊天绑定的模型配置中读取总结配置。 */
+    suspend fun readSummaryConfig(): ConversationSummaryConfig {
         return try {
             val functionalConfigManager = FunctionalConfigManager(context)
             val modelConfigManager = ModelConfigManager(context)
@@ -2022,13 +2029,16 @@ class MessageCoordinationDelegate(
             val chatMapping = functionMappings[FunctionType.CHAT] ?: FunctionConfigMapping()
             if (chatMapping.configId.isNotBlank()) {
                 val config = modelConfigManager.getModelConfigFlow(chatMapping.configId).first()
-                config.summaryCustomRules.takeIf { it.isNotBlank() }
+                ConversationSummaryConfig(
+                    globalRules = config.summaryCustomRules.takeIf { it.isNotBlank() },
+                    sectionOverrides = config.summarySectionOverrides
+                )
             } else {
-                null
+                ConversationSummaryConfig()
             }
         } catch (e: Exception) {
-            AppLogger.w(TAG, "读取自定义总结规则失败", e)
-            null
+            AppLogger.w(TAG, "读取总结配置失败", e)
+            ConversationSummaryConfig()
         }
     }
 }

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/ChatViewModel.kt
@@ -899,14 +899,14 @@ class ChatViewModel(private val context: Context) : ViewModel() {
                 // 检查是否是群聊
                 val currentChat = chatHistoryDelegate.chatHistories.value.firstOrNull { it.id == currentChatId }
                 val isGroupChat = currentChat?.characterGroupId != null
-                val summaryCustomRules = messageCoordinationDelegate.readSummaryCustomRules()
+                val summaryConfig = messageCoordinationDelegate.readSummaryConfig()
 
                 val summaryMessage = AIMessageManager.summarizeMemory(
                     enhancedAiService!!,
                     messagesToSummarize,
                     autoContinue = false,
                     isGroupChat = isGroupChat,
-                    summaryCustomRules = summaryCustomRules
+                    summaryConfig = summaryConfig
                 )
 
                 if (summaryMessage != null) {

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/ContextSummarySettingsScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/settings/screens/ContextSummarySettingsScreen.kt
@@ -10,9 +10,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -21,6 +23,9 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Analytics
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.RestartAlt
@@ -28,10 +33,15 @@ import androidx.compose.material.icons.filled.Summarize
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Switch
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -57,17 +67,24 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.ai.assistance.operit.R
+import com.ai.assistance.operit.core.config.FunctionalPrompts
 import com.ai.assistance.operit.data.model.FunctionType
 import com.ai.assistance.operit.data.model.ModelConfigData
+import com.ai.assistance.operit.data.model.SummarySectionConfig
 import com.ai.assistance.operit.data.preferences.ApiPreferences
 import com.ai.assistance.operit.data.preferences.FunctionConfigMapping
 import com.ai.assistance.operit.data.preferences.FunctionalConfigManager
 import com.ai.assistance.operit.data.preferences.ModelConfigManager
 import com.ai.assistance.operit.ui.components.CustomScaffold
 import com.ai.assistance.operit.ui.theme.LocalThemePreferenceSnapshot
+import com.ai.assistance.operit.util.LocaleUtils
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
@@ -146,6 +163,13 @@ fun ContextSummarySettingsScreen(onBackPressed: () -> Unit) {
     var summaryCustomRulesInput by remember(currentConfig?.id) {
         mutableStateOf(currentConfig?.summaryCustomRules.orEmpty())
     }
+    val useEnglish = !LocaleUtils.usesChineseContent(context)
+    var summarySectionsInput by remember(currentConfig?.id) {
+        mutableStateOf(emptyList<SummarySectionConfig>())
+    }
+    var fullscreenTextEditor by remember(currentConfig?.id) {
+        mutableStateOf<FullscreenTextEditorRequest?>(null)
+    }
     var summaryError by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(currentConfig?.id, currentConfig?.contextLength) {
@@ -169,6 +193,12 @@ fun ContextSummarySettingsScreen(onBackPressed: () -> Unit) {
     }
     LaunchedEffect(currentConfig?.id, currentConfig?.summaryCustomRules) {
         summaryCustomRulesInput = currentConfig?.summaryCustomRules.orEmpty()
+    }
+    LaunchedEffect(currentConfig?.id, currentConfig?.summarySectionOverrides, useEnglish) {
+        summarySectionsInput = FunctionalPrompts.resolveSummarySections(
+            currentConfig?.summarySectionOverrides.orEmpty(),
+            useEnglish
+        )
     }
 
     val errorValidContextLength = stringResource(id = R.string.model_config_error_valid_context_length)
@@ -216,6 +246,14 @@ fun ContextSummarySettingsScreen(onBackPressed: () -> Unit) {
         apiPreferences = apiPreferences,
         errorSaveFailed = errorSaveFailed,
         onHistoryErrorChange = { historyError = it }
+    )
+    ContextSummarySectionsAutoSaveEffect(
+        currentConfig = currentConfig,
+        summarySectionsInputProvider = { summarySectionsInput },
+        useEnglish = useEnglish,
+        modelConfigManager = modelConfigManager,
+        errorSaveFailed = errorSaveFailed,
+        onSummaryErrorChange = { summaryError = it }
     )
 
     CustomScaffold() { paddingValues ->
@@ -282,6 +320,15 @@ fun ContextSummarySettingsScreen(onBackPressed: () -> Unit) {
                     onSummaryCustomRulesInputChange = {
                         summaryCustomRulesInput = it
                     },
+                    summarySectionsInput = summarySectionsInput,
+                    onSummarySectionsInputChange = { summarySectionsInput = it },
+                    onOpenFullscreenEditor = { title, value, onValueChange ->
+                        fullscreenTextEditor = FullscreenTextEditorRequest(
+                            title = title,
+                            value = value,
+                            onValueChange = onValueChange
+                        )
+                    },
                     summaryError = summaryError
                 )
 
@@ -313,6 +360,12 @@ fun ContextSummarySettingsScreen(onBackPressed: () -> Unit) {
                 showSaveSuccessMessage = showSaveSuccessMessage,
                 onDismissSaveSuccess = { showSaveSuccessMessage = false }
             )
+            fullscreenTextEditor?.let { request ->
+                FullscreenSettingsTextEditor(
+                    request = request,
+                    onDismiss = { fullscreenTextEditor = null }
+                )
+            }
         }
     }
 }
@@ -521,6 +574,46 @@ private fun ContextSummaryCustomRulesAutoSaveEffect(
 }
 
 @Composable
+private fun ContextSummarySectionsAutoSaveEffect(
+    currentConfig: ModelConfigData?,
+    summarySectionsInputProvider: () -> List<SummarySectionConfig>,
+    useEnglish: Boolean,
+    modelConfigManager: ModelConfigManager,
+    errorSaveFailed: String,
+    onSummaryErrorChange: (String?) -> Unit
+) {
+    val latestConfig by rememberUpdatedState(currentConfig)
+
+    LaunchedEffect(currentConfig?.id) {
+        val configId = currentConfig?.id ?: return@LaunchedEffect
+        snapshotFlow { summarySectionsInputProvider() }
+            .drop(1)
+            .debounce(700)
+            .distinctUntilChanged()
+            .collectLatest { sections ->
+                val current = latestConfig ?: return@collectLatest
+                if (current.id != configId) return@collectLatest
+                val overrides =
+                    FunctionalPrompts.buildSummarySectionOverrides(sections, useEnglish)
+                if (current.summarySectionOverrides == overrides) return@collectLatest
+                try {
+                    modelConfigManager.updateSummarySettings(
+                        configId = current.id,
+                        enableSummary = current.enableSummary,
+                        summaryTokenThreshold = current.summaryTokenThreshold,
+                        enableSummaryByMessageCount = current.enableSummaryByMessageCount,
+                        summaryMessageCountThreshold = current.summaryMessageCountThreshold,
+                        summarySectionOverrides = overrides
+                    )
+                    onSummaryErrorChange(null)
+                } catch (e: Exception) {
+                    onSummaryErrorChange(e.message ?: errorSaveFailed)
+                }
+            }
+    }
+}
+
+@Composable
 private fun RenderContextSummaryConfigSections(
     componentBackgroundColor: Color,
     contextLengthInput: String,
@@ -538,6 +631,9 @@ private fun RenderContextSummaryConfigSections(
     onSummaryMessageCountThresholdInputChange: (String) -> Unit,
     summaryCustomRulesInput: String,
     onSummaryCustomRulesInputChange: (String) -> Unit,
+    summarySectionsInput: List<SummarySectionConfig>,
+    onSummarySectionsInputChange: (List<SummarySectionConfig>) -> Unit,
+    onOpenFullscreenEditor: (String, String, (String) -> Unit) -> Unit,
     summaryError: String?
 ) {
     SectionTitle(
@@ -629,14 +725,84 @@ private fun RenderContextSummaryConfigSections(
     }
 
     Spacer(modifier = Modifier.size(8.dp))
+    val globalRulesTitle = stringResource(id = R.string.settings_summary_custom_rules)
     SettingsMultilineTextField(
-        title = stringResource(id = R.string.settings_summary_custom_rules),
+        title = globalRulesTitle,
         subtitle = stringResource(id = R.string.settings_summary_custom_rules_desc),
         value = summaryCustomRulesInput,
         onValueChange = onSummaryCustomRulesInputChange,
         backgroundColor = componentBackgroundColor,
-        enabled = enableSummary
+        enabled = enableSummary,
+        onOpenFullscreen = {
+            onOpenFullscreenEditor(
+                globalRulesTitle,
+                summaryCustomRulesInput,
+                onSummaryCustomRulesInputChange
+            )
+        }
     )
+    Spacer(modifier = Modifier.size(12.dp))
+    SectionTitle(
+        text = stringResource(id = R.string.settings_summary_structure),
+        icon = Icons.Default.Summarize
+    )
+    summarySectionsInput.forEachIndexed { index, section ->
+        SummarySectionEditor(
+            section = section,
+            onSectionChange = { updatedSection ->
+                onSummarySectionsInputChange(
+                    summarySectionsInput.mapIndexed { currentIndex, currentSection ->
+                        if (currentIndex == index) updatedSection else currentSection
+                    }
+                )
+            },
+            backgroundColor = componentBackgroundColor,
+            enabled = enableSummary,
+            onOpenFullscreenEditor = onOpenFullscreenEditor
+        )
+    }
+}
+
+@Composable
+private fun SummarySectionEditor(
+    section: SummarySectionConfig,
+    onSectionChange: (SummarySectionConfig) -> Unit,
+    backgroundColor: Color,
+    enabled: Boolean,
+    onOpenFullscreenEditor: (String, String, (String) -> Unit) -> Unit
+) {
+    SettingsSwitchRow(
+        title = section.title,
+        subtitle = stringResource(id = R.string.settings_summary_section_enabled_desc),
+        checked = section.enabled,
+        onCheckedChange = { onSectionChange(section.copy(enabled = it)) },
+        backgroundColor = backgroundColor,
+        enabled = enabled
+    )
+    SettingsMultilineTextField(
+        title = stringResource(id = R.string.settings_summary_section_title),
+        subtitle = stringResource(id = R.string.settings_summary_section_title_desc),
+        value = section.title,
+        onValueChange = { onSectionChange(section.copy(title = it)) },
+        backgroundColor = backgroundColor,
+        enabled = enabled && section.enabled,
+        singleLine = true,
+        minHeight = 40.dp
+    )
+    SettingsMultilineTextField(
+        title = stringResource(id = R.string.settings_summary_section_instruction),
+        subtitle = stringResource(id = R.string.settings_summary_section_instruction_desc),
+        value = section.instruction,
+        onValueChange = { onSectionChange(section.copy(instruction = it)) },
+        backgroundColor = backgroundColor,
+        enabled = enabled && section.enabled,
+        onOpenFullscreen = {
+            onOpenFullscreenEditor(section.title, section.instruction) { value ->
+                onSectionChange(section.copy(instruction = value))
+            }
+        }
+    )
+    Spacer(modifier = Modifier.size(8.dp))
 }
 
 @Composable
@@ -929,7 +1095,10 @@ private fun SettingsMultilineTextField(
     value: String,
     onValueChange: (String) -> Unit,
     backgroundColor: Color,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    singleLine: Boolean = false,
+    minHeight: Dp = 80.dp,
+    onOpenFullscreen: (() -> Unit)? = null
 ) {
     val contentAlpha = if (enabled) 1f else 0.38f
     Column(
@@ -962,7 +1131,7 @@ private fun SettingsMultilineTextField(
             enabled = enabled,
             modifier =
                 Modifier.fillMaxWidth()
-                    .heightIn(min = 80.dp)
+                    .let { if (singleLine) it.heightIn(min = minHeight) else it.heightIn(min = 120.dp) }
                     .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(6.dp))
                     .padding(horizontal = 10.dp, vertical = 8.dp),
             textStyle =
@@ -971,16 +1140,116 @@ private fun SettingsMultilineTextField(
                     fontSize = 13.sp
                 ),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+            singleLine = singleLine,
+            minLines = if (singleLine) 1 else 5,
+            maxLines = if (singleLine) 1 else 5,
             decorationBox = { innerTextField ->
-                if (value.isEmpty()) {
-                    Text(
-                        text = stringResource(id = R.string.settings_summary_custom_rules_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-                    )
+                Row(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalAlignment = if (singleLine) Alignment.CenterVertically else Alignment.Top
+                ) {
+                    Box(
+                        modifier = Modifier.weight(1f).fillMaxSize(),
+                        contentAlignment =
+                            if (singleLine) Alignment.CenterStart else Alignment.TopStart
+                    ) {
+                        if (value.isEmpty()) {
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                            )
+                        }
+                        innerTextField()
+                    }
+                    if (!singleLine && onOpenFullscreen != null) {
+                        IconButton(
+                            onClick = onOpenFullscreen,
+                            enabled = enabled,
+                            modifier = Modifier.size(28.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Fullscreen,
+                                contentDescription = stringResource(id = R.string.chat_fullscreen_input),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+                    }
                 }
-                innerTextField()
             }
         )
+    }
+}
+
+private data class FullscreenTextEditorRequest(
+    val title: String,
+    val value: String,
+    val onValueChange: (String) -> Unit
+)
+
+@Composable
+private fun FullscreenSettingsTextEditor(
+    request: FullscreenTextEditorRequest,
+    onDismiss: () -> Unit
+) {
+    var editorValue by remember(request.title, request.value) { mutableStateOf(request.value) }
+    fun finishEditing() {
+        request.onValueChange(editorValue)
+        onDismiss()
+    }
+
+    Dialog(
+        onDismissRequest = { finishEditing() },
+        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false)
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.surface
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize().imePadding()
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = { finishEditing() }) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(id = R.string.common_close)
+                        )
+                    }
+                    Text(
+                        text = request.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    IconButton(onClick = { finishEditing() }) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = stringResource(id = R.string.save)
+                        )
+                    }
+                }
+                HorizontalDivider()
+                TextField(
+                    value = editorValue,
+                    onValueChange = { editorValue = it },
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    colors =
+                        TextFieldDefaults.colors(
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
+                            disabledContainerColor = Color.Transparent,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                    textStyle = MaterialTheme.typography.bodyLarge
+                )
+            }
+        }
     }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -950,6 +950,12 @@
     <string name="settings_summary_message_count_threshold_subtitle">Number of new messages to trigger summary (1-20)</string>
     <string name="settings_summary_custom_rules">Custom Summary Rules</string>
     <string name="settings_summary_custom_rules_desc">Extra rules sent when summarizing the conversation. Leave blank for none</string>
+    <string name="settings_summary_structure">Summary Structure</string>
+    <string name="settings_summary_section_enabled_desc">Turn off to omit this section from generated summaries</string>
+    <string name="settings_summary_section_title">Section Title</string>
+    <string name="settings_summary_section_title_desc">Title shown in the summary</string>
+    <string name="settings_summary_section_instruction">Section Instructions</string>
+    <string name="settings_summary_section_instruction_desc">Describe what this section should record</string>
     
     <string name="settings_section_display">Display and Behavior</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7413,6 +7413,12 @@ Ahora puede usar el modo AutoGLM en la interfaz de conversación.</string>
 
     <string name="settings_summary_custom_rules">Reglas personalizadas de resumen</string>
     <string name="settings_summary_custom_rules_desc">Reglas adicionales enviadas al resumir la conversación. Déjelo en blanco para no agregar ninguna.</string>
+    <string name="settings_summary_structure">Estructura del resumen</string>
+    <string name="settings_summary_section_enabled_desc">Desactívalo para omitir esta sección de los resúmenes generados</string>
+    <string name="settings_summary_section_title">Título de la sección</string>
+    <string name="settings_summary_section_title_desc">Título mostrado en el resumen</string>
+    <string name="settings_summary_section_instruction">Instrucciones de la sección</string>
+    <string name="settings_summary_section_instruction_desc">Describe qué debe registrar esta sección</string>
     <string name="title_activity_data_recovery">Recuperación de datos</string>
     <string name="shortcut_data_recovery">Recuperación de datos</string>
     <string name="memory_space_select">Seleccionar espacio de memoria</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -7345,6 +7345,12 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
 
     <string name="settings_summary_custom_rules">Aturan Ringkasan Kustom</string>
     <string name="settings_summary_custom_rules_desc">Aturan tambahan yang dikirim saat meringkas percakapan, biarkan kosong jika tidak ingin menambahkan</string>
+    <string name="settings_summary_structure">Struktur Ringkasan</string>
+    <string name="settings_summary_section_enabled_desc">Nonaktifkan untuk menghilangkan bagian ini dari ringkasan yang dibuat</string>
+    <string name="settings_summary_section_title">Judul Bagian</string>
+    <string name="settings_summary_section_title_desc">Judul yang ditampilkan dalam ringkasan</string>
+    <string name="settings_summary_section_instruction">Petunjuk Bagian</string>
+    <string name="settings_summary_section_instruction_desc">Jelaskan isi yang harus dicatat bagian ini</string>
     <string name="title_activity_data_recovery">Pemulihan Data</string>
     <string name="shortcut_data_recovery">Pemulihan Data</string>
     <string name="memory_space_select">Pilih Ruang Memori</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="settings_summary_structure">要約の構成</string>
+    <string name="settings_summary_section_enabled_desc">オフにすると、生成される要約からこのセクションを除外します</string>
+    <string name="settings_summary_section_title">セクションのタイトル</string>
+    <string name="settings_summary_section_title_desc">要約に表示するタイトル</string>
+    <string name="settings_summary_section_instruction">セクションの指示</string>
+    <string name="settings_summary_section_instruction_desc">このセクションに記録する内容を説明します</string>
     <!-- Main navigation -->
     <string name="nav_ai_chat">AIチャット</string>
     <string name="nav_adb_commands">権限</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -7192,6 +7192,12 @@
 
     <string name="settings_summary_custom_rules">사용자 정의 요약 규칙</string>
     <string name="settings_summary_custom_rules_desc">대화 요약 시 전송할 추가 규칙, 비워두면 추가하지 않음</string>
+    <string name="settings_summary_structure">요약 구조</string>
+    <string name="settings_summary_section_enabled_desc">끄면 생성된 요약에서 이 섹션을 제외합니다</string>
+    <string name="settings_summary_section_title">섹션 제목</string>
+    <string name="settings_summary_section_title_desc">요약에 표시할 제목</string>
+    <string name="settings_summary_section_instruction">섹션 설명</string>
+    <string name="settings_summary_section_instruction_desc">이 섹션에 기록할 내용을 설명합니다</string>
     <string name="title_activity_data_recovery">데이터 복구</string>
     <string name="shortcut_data_recovery">데이터 복구</string>
     <string name="memory_space_select">메모리 공간 선택</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -7342,6 +7342,12 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
 
     <string name="settings_summary_custom_rules">Peraturan Ringkasan Tersuai</string>
     <string name="settings_summary_custom_rules_desc">Peraturan tambahan yang dihantar semasa meringkaskan perbualan, biarkan kosong untuk tidak menambah</string>
+    <string name="settings_summary_structure">Struktur Ringkasan</string>
+    <string name="settings_summary_section_enabled_desc">Matikan untuk mengecualikan bahagian ini daripada ringkasan yang dijana</string>
+    <string name="settings_summary_section_title">Tajuk Bahagian</string>
+    <string name="settings_summary_section_title_desc">Tajuk yang dipaparkan dalam ringkasan</string>
+    <string name="settings_summary_section_instruction">Arahan Bahagian</string>
+    <string name="settings_summary_section_instruction_desc">Terangkan perkara yang perlu direkodkan oleh bahagian ini</string>
     <string name="title_activity_data_recovery">Pemulihan Data</string>
     <string name="shortcut_data_recovery">Pemulihan Data</string>
     <string name="memory_space_select">Pilih Ruang Memori</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7183,6 +7183,12 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
 
     <string name="settings_summary_custom_rules">Regras personalizadas de resumo</string>
     <string name="settings_summary_custom_rules_desc">Regras extras enviadas ao resumir conversas. Deixe em branco para não adicionar.</string>
+    <string name="settings_summary_structure">Estrutura do resumo</string>
+    <string name="settings_summary_section_enabled_desc">Desative para omitir esta seção dos resumos gerados</string>
+    <string name="settings_summary_section_title">Título da seção</string>
+    <string name="settings_summary_section_title_desc">Título exibido no resumo</string>
+    <string name="settings_summary_section_instruction">Instruções da seção</string>
+    <string name="settings_summary_section_instruction_desc">Descreva o que esta seção deve registrar</string>
     <string name="title_activity_data_recovery">Recuperação de dados</string>
     <string name="shortcut_data_recovery">Recuperação de dados</string>
     <string name="memory_space_select">Selecionar espaço de memória</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -893,6 +893,12 @@
     <string name="settings_summary_message_count_threshold_subtitle">Numărul de mesaje noi care declanșează generarea unui rezumat(1-20articol)</string>
     <string name="settings_summary_custom_rules">Reguli personalizate de rezumare</string>
     <string name="settings_summary_custom_rules_desc">Rezumați regulile suplimentare trimise în timpul conversației; dacă lăsați câmpul gol, nu se adaugă nimic</string>
+    <string name="settings_summary_structure">Structura rezumatului</string>
+    <string name="settings_summary_section_enabled_desc">Dezactivați pentru a omite această secțiune din rezumatele generate</string>
+    <string name="settings_summary_section_title">Titlul secțiunii</string>
+    <string name="settings_summary_section_title_desc">Titlul afișat în rezumat</string>
+    <string name="settings_summary_section_instruction">Instrucțiuni pentru secțiune</string>
+    <string name="settings_summary_section_instruction_desc">Descrieți ce trebuie să înregistreze această secțiune</string>
 
     <string name="settings_section_display">Afișare și comportament</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -901,6 +901,12 @@
     <string name="settings_summary_message_count_threshold_subtitle">触发总结的新消息数量(1-20条)</string>
     <string name="settings_summary_custom_rules">自定义总结规则</string>
     <string name="settings_summary_custom_rules_desc">总结对话时发送的额外规则，留空为不添加</string>
+    <string name="settings_summary_structure">总结结构</string>
+    <string name="settings_summary_section_enabled_desc">关闭后生成摘要时不输出该板块</string>
+    <string name="settings_summary_section_title">板块标题</string>
+    <string name="settings_summary_section_title_desc">摘要中显示的标题</string>
+    <string name="settings_summary_section_instruction">板块说明</string>
+    <string name="settings_summary_section_instruction_desc">说明此板块应记录什么内容</string>
 
     <string name="settings_section_display">显示与行为</string>
 

--- a/app/src/test/java/com/ai/assistance/operit/core/config/FunctionalPromptsSummaryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/config/FunctionalPromptsSummaryTest.kt
@@ -1,0 +1,70 @@
+package com.ai.assistance.operit.core.config
+
+import com.ai.assistance.operit.data.model.ConversationSummaryConfig
+import com.ai.assistance.operit.data.model.SummarySectionOverride
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FunctionalPromptsSummaryTest {
+    @Test
+    fun buildSummarySystemPrompt_withoutOverridesKeepsLegacyPrompt() {
+        val prompt = FunctionalPrompts.buildSummarySystemPrompt(
+            previousSummary = null,
+            useEnglish = false
+        )
+
+        assertEquals(FunctionalPrompts.SUMMARY_PROMPT.trimIndent(), prompt)
+    }
+
+    @Test
+    fun buildSummarySystemPrompt_disablingMiddleSectionDoesNotRemoveLaterSections() {
+        val prompt = FunctionalPrompts.buildSummarySystemPrompt(
+            previousSummary = null,
+            useEnglish = false,
+            summaryConfig = ConversationSummaryConfig(
+                sectionOverrides = listOf(
+                    SummarySectionOverride(
+                        id = "core_task",
+                        title = "工程状态",
+                        instruction = "仅记录已验证的工程变更。"
+                    ),
+                    SummarySectionOverride(id = "interaction", enabled = false)
+                )
+            )
+        )
+
+        assertTrue(prompt.contains("【工程状态】"))
+        assertTrue(prompt.contains("仅记录已验证的工程变更。"))
+        assertFalse(prompt.contains("【互动情节与设定】"))
+        assertTrue(prompt.contains("【对话历程与概要】"))
+        assertTrue(prompt.contains("【关键信息与上下文】"))
+    }
+
+    @Test
+    fun buildSummarySystemPrompt_unknownOverrideKeepsLegacyTemplate() {
+        val prompt = FunctionalPrompts.buildSummarySystemPrompt(
+            previousSummary = null,
+            useEnglish = true,
+            summaryConfig = ConversationSummaryConfig(
+                sectionOverrides = listOf(SummarySectionOverride(id = "unknown"))
+            )
+        )
+
+        assertEquals(FunctionalPrompts.SUMMARY_PROMPT_EN.trimIndent(), prompt)
+    }
+
+    @Test
+    fun buildSummarySectionOverrides_onlyPersistsChangedFields() {
+        val sections = FunctionalPrompts.resolveSummarySections(emptyList(), useEnglish = false)
+            .map { section ->
+                if (section.id == "core_task") section.copy(title = "工程状态") else section
+            }
+
+        assertEquals(
+            listOf(SummarySectionOverride(id = "core_task", title = "工程状态")),
+            FunctionalPrompts.buildSummarySectionOverrides(sections, useEnglish = false)
+        )
+    }
+}

--- a/docs/TODO/summary-section-overrides/01-structured-summary-prompt.md
+++ b/docs/TODO/summary-section-overrides/01-structured-summary-prompt.md
@@ -1,0 +1,16 @@
+# Structured Summary Prompt
+
+## Old Implementation
+
+The proposed implementation finds headers in a mutable prompt string. Removing one section can
+remove the header needed as the boundary for a previous section.
+
+## Change
+
+Represent the built-in sections as data and assemble the prompt from the resolved section list.
+
+## Expected Result
+
+Disabling and editing any number of sections cannot remove unrelated enabled sections.
+
+[DONE]

--- a/docs/TODO/summary-section-overrides/02-config-and-settings.md
+++ b/docs/TODO/summary-section-overrides/02-config-and-settings.md
@@ -1,0 +1,16 @@
+# Config And Settings
+
+## Old Implementation
+
+Only one global custom-rules field is stored and exposed in the context-summary settings.
+
+## Change
+
+Persist only fields that differ from the built-in section defaults. Add the four section controls
+to the existing settings screen and save them with the existing debounce flow.
+
+## Expected Result
+
+Users can customize individual sections without storing a duplicate copy of the default prompt.
+
+[DONE]

--- a/docs/TODO/summary-section-overrides/03-summary-callers-and-tests.md
+++ b/docs/TODO/summary-section-overrides/03-summary-callers-and-tests.md
@@ -1,0 +1,17 @@
+# Summary Callers And Tests
+
+## Old Implementation
+
+Automatic and manual summary generation only pass global custom rules.
+
+## Change
+
+Pass the selected model configuration's overrides through both generation paths and add focused
+unit tests for the resolved prompt structure.
+
+## Expected Result
+
+Manual and automatic summaries use the same configuration, and regressions in combined section
+changes are detected.
+
+[DONE]

--- a/docs/TODO/summary-section-overrides/index.md
+++ b/docs/TODO/summary-section-overrides/index.md
@@ -1,0 +1,30 @@
+---
+fork: https://github.com/AAswordman/Operit
+---
+
+# Summary Section Overrides
+
+## Current State
+
+Conversation summaries use a fixed prompt. PR #1098 introduced editable summary sections by
+searching and replacing section text inside that prompt. When a later section is disabled before
+an earlier section is replaced, the replacement loses its end marker and removes following
+sections.
+
+## Intent
+
+Keep the four built-in summary sections configurable without changing the default prompt for
+users who have no overrides. Build the configured prompt from structured sections so any
+combination of enablement, title, and instruction changes has deterministic boundaries.
+
+## Scope
+
+- Add field-level summary-section overrides to the model configuration
+- Render the existing context-summary settings with editable sections
+- Pass overrides through manual and automatic summary generation
+- Replace prompt string slicing with structured prompt generation
+- Cover default, combined disable-and-edit, and persistence-diff behavior with unit tests
+
+## Pull Request
+
+Target branch: `dev`


### PR DESCRIPTION
## Summary\n- add per-section conversation-summary overrides to the existing context-summary settings\n- parse the built-in prompt once into prefix, named sections, and suffix, then reassemble it without mutable string replacement\n- pass the selected chat model's summary configuration through manual, automatic, and asynchronous summary generation\n- add regression coverage for disabling a middle section while editing an earlier section\n\n## Compatibility\n- configurations without section overrides keep the legacy summary prompt unchanged\n- existing global summary rules retain their original placement\n\n## Verification\n- git diff --check\n- Gradle build and unit tests not run, per repository instruction to avoid build/test commands unless explicitly requested\n\n## Issue\n- Closes #1039