### PR TITLE
fix(toolpkg): unify archive manifest selection

### DIFF
--- a/app/src/main/assets/packages/operit_editor.js
+++ b/app/src/main/assets/packages/operit_editor.js
@@ -2486,7 +2486,7 @@ description: one-line summary of what this skill does
     const TOOLPKG_ID_PATTERN = /^\s*["']?toolpkg_id["']?\s*:\s*["']([^"']+)["']/m;
     const TOOLPKG_MAIN_PATTERN = /^\s*["']?main["']?\s*:\s*["']([^"']+)["']/m;
     const TOOLPKG_SUBPACKAGE_ID_PATTERN = /^\s*["']?id["']?\s*:\s*["']([^"']+)["']/gm;
-    const TOOLPKG_SKIP_DIR_NAMES = new Set([".git", "__pycache__"]);
+    const TOOLPKG_SKIP_DIR_NAMES = new Set([".git", "__pycache__", ".backup", "backup", ".operit"]);
     const TOOLPKG_SKIP_FILE_NAMES = new Set([".DS_Store", "Thumbs.db"]);
     function collect_related_package_load_errors(payload, packageName, ...relatedPaths) {
         const normalizedPackageName = normalize_package_key(packageName);
@@ -2833,17 +2833,57 @@ description: one-line summary of what this skill does
             temporaryPaths
         };
     }
+    async function copy_toolpkg_sources_filtered(sourceDir, targetDir, relativePath = "", stats = { copiedFiles: 0, skippedEntries: [] }) {
+        await ensure_android_directory(targetDir);
+        const listing = await Tools.Files.list(sourceDir, "android");
+        for (const entry of listing?.entries ?? []) {
+            const entryName = String(entry?.name ?? "").trim();
+            if (!entryName || entryName === "." || entryName === "..") {
+                continue;
+            }
+            const entryRelativePath = relativePath ? `${relativePath}/${entryName}` : entryName;
+            const sourceEntryPath = path_join(sourceDir, entryName);
+            if (entry?.isDirectory) {
+                if (TOOLPKG_SKIP_DIR_NAMES.has(entryName)) {
+                    stats.skippedEntries.push(`${entryRelativePath}/`);
+                    continue;
+                }
+                await copy_toolpkg_sources_filtered(sourceEntryPath, path_join(targetDir, entryName), entryRelativePath, stats);
+                continue;
+            }
+            if (TOOLPKG_SKIP_FILE_NAMES.has(entryName)) {
+                stats.skippedEntries.push(entryRelativePath);
+                continue;
+            }
+            await Tools.Files.copy(sourceEntryPath, path_join(targetDir, entryName), false, "android", "android");
+            stats.copiedFiles += 1;
+        }
+        return stats;
+    }
     async function build_toolpkg_archive_from_folder(source) {
         const tempBuildDir = path_join(OPERIT_CLEAN_ON_EXIT_DIR, `operit_editor_toolpkg_build_${safe_debug_file_stem(source.packageId, "toolpkg")}_${Date.now()}`);
         await ensure_android_directory(tempBuildDir);
         const archivePath = path_join(tempBuildDir, `${safe_debug_file_stem(source.packageId, "toolpkg")}.toolpkg`);
-        await Tools.Files.zip(source.folderPath, archivePath, "android", false);
+        // 工作区绑定对话后会生成 .backup/（含聊天记录与快照），且在工作区文件树中不可见。
+        // 直接 zip 整个目录会把它打进 toolpkg，因此先按排除名单拷贝出一份干净的打包源。
+        const stageDir = path_join(tempBuildDir, "stage");
+        const stats = await copy_toolpkg_sources_filtered(source.folderPath, stageDir);
+        if (stats.copiedFiles === 0) {
+            throw new Error(`No packable files found in source folder: ${source.folderPath}`);
+        }
+        const stagedManifestExists = (await android_path_exists(path_join(stageDir, "manifest.json")))
+            || (await android_path_exists(path_join(stageDir, "manifest.hjson")));
+        if (!stagedManifestExists) {
+            throw new Error(`Root manifest is missing after filtering source folder: ${source.folderPath}`);
+        }
+        await Tools.Files.zip(stageDir, archivePath, "android", false);
         if (!(await android_path_exists(archivePath))) {
             throw new Error(`Failed to create ToolPkg archive: ${archivePath}`);
         }
         return {
             archivePath,
-            temporaryPaths: [tempBuildDir]
+            temporaryPaths: [tempBuildDir],
+            skippedEntries: stats.skippedEntries
         };
     }
     function parse_requested_package_ids(raw) {

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgParser.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgParser.kt
@@ -1642,26 +1642,56 @@ internal object ToolPkgArchiveParser {
     }
 
     fun readToolPkgManifestPreview(inputStreamFactory: () -> InputStream): ToolPkgManifestPreview? {
+        var bestEntryName: String? = null
+        var bestManifestText: String? = null
+        var bestRank = Int.MAX_VALUE
+        var bestDepth = Int.MAX_VALUE
+
         inputStreamFactory().use { input ->
             ZipInputStream(input.buffered()).use { zipInput ->
                 while (true) {
                     val entry = zipInput.nextEntry ?: break
                     val normalizedName = normalizeZipEntryPath(entry.name)
                     if (!entry.isDirectory && normalizedName != null && isManifestEntryName(normalizedName)) {
-                        val manifestText =
-                            zipInput.bufferedReader(StandardCharsets.UTF_8).use { reader ->
-                                reader.readText()
-                            }
-                        return ToolPkgManifestPreview(
-                            entryName = normalizedName,
-                            manifest = parseToolPkgManifest(manifestText, normalizedName)
-                        )
+                        val rank = manifestEntryPriority(normalizedName)
+                        val depth = normalizedName.count { it == '/' }
+                        if (rank < bestRank || (rank == bestRank && depth < bestDepth)) {
+                            bestEntryName = normalizedName
+                            bestManifestText =
+                                zipInput.bufferedReader(StandardCharsets.UTF_8).use { reader ->
+                                    reader.readText()
+                                }
+                            bestRank = rank
+                            bestDepth = depth
+                        }
                     }
                     zipInput.closeEntry()
+                    if (bestRank == 0) break
                 }
             }
         }
-        return null
+
+        val entryName = bestEntryName ?: return null
+        val manifestText = bestManifestText ?: return null
+        return ToolPkgManifestPreview(
+            entryName = entryName,
+            manifest = parseToolPkgManifest(manifestText, entryName)
+        )
+    }
+
+    /**
+     * 与 findManifestEntry 保持一致的优先级：根目录 hjson > 根目录 json > 嵌套 hjson > 嵌套 json。
+     * 避免打包时混入的嵌套 manifest（例如工作区 .backup/ 残留）被当成包的根 manifest。
+     */
+    private fun manifestEntryPriority(normalizedName: String): Int {
+        val isNested = normalizedName.contains('/')
+        val isHjson = normalizedName.endsWith(".hjson", ignoreCase = true)
+        return when {
+            !isNested && isHjson -> 0
+            !isNested -> 1
+            isHjson -> 2
+            else -> 3
+        }
     }
 
     fun extractZipEntriesFromExternal(zipFilePath: String, destinationDir: File): Boolean {

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgParser.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgParser.kt
@@ -1657,10 +1657,10 @@ internal object ToolPkgArchiveParser {
                         val depth = normalizedName.count { it == '/' }
                         if (rank < bestRank || (rank == bestRank && depth < bestDepth)) {
                             bestEntryName = normalizedName
+                            // Read the entry without closing the shared ZipInputStream:
+                            // closing a reader over it would close the whole archive stream.
                             bestManifestText =
-                                zipInput.bufferedReader(StandardCharsets.UTF_8).use { reader ->
-                                    reader.readText()
-                                }
+                                String(zipInput.readBytes(), StandardCharsets.UTF_8)
                             bestRank = rank
                             bestDepth = depth
                         }

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgParser.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgParser.kt
@@ -1642,10 +1642,7 @@ internal object ToolPkgArchiveParser {
     }
 
     fun readToolPkgManifestPreview(inputStreamFactory: () -> InputStream): ToolPkgManifestPreview? {
-        var bestEntryName: String? = null
-        var bestManifestText: String? = null
-        var bestRank = Int.MAX_VALUE
-        var bestDepth = Int.MAX_VALUE
+        val manifests = linkedMapOf<String, String>()
 
         inputStreamFactory().use { input ->
             ZipInputStream(input.buffered()).use { zipInput ->
@@ -1653,45 +1650,20 @@ internal object ToolPkgArchiveParser {
                     val entry = zipInput.nextEntry ?: break
                     val normalizedName = normalizeZipEntryPath(entry.name)
                     if (!entry.isDirectory && normalizedName != null && isManifestEntryName(normalizedName)) {
-                        val rank = manifestEntryPriority(normalizedName)
-                        val depth = normalizedName.count { it == '/' }
-                        if (rank < bestRank || (rank == bestRank && depth < bestDepth)) {
-                            bestEntryName = normalizedName
-                            // Read the entry without closing the shared ZipInputStream:
-                            // closing a reader over it would close the whole archive stream.
-                            bestManifestText =
-                                String(zipInput.readBytes(), StandardCharsets.UTF_8)
-                            bestRank = rank
-                            bestDepth = depth
-                        }
+                        // Do not close a reader over the shared ZipInputStream.
+                        manifests[normalizedName] = String(zipInput.readBytes(), StandardCharsets.UTF_8)
                     }
                     zipInput.closeEntry()
-                    if (bestRank == 0) break
                 }
             }
         }
 
-        val entryName = bestEntryName ?: return null
-        val manifestText = bestManifestText ?: return null
+        val entryName = findManifestEntry(manifests.keys) ?: return null
+        val manifestText = manifests.getValue(entryName)
         return ToolPkgManifestPreview(
             entryName = entryName,
             manifest = parseToolPkgManifest(manifestText, entryName)
         )
-    }
-
-    /**
-     * 与 findManifestEntry 保持一致的优先级：根目录 hjson > 根目录 json > 嵌套 hjson > 嵌套 json。
-     * 避免打包时混入的嵌套 manifest（例如工作区 .backup/ 残留）被当成包的根 manifest。
-     */
-    private fun manifestEntryPriority(normalizedName: String): Int {
-        val isNested = normalizedName.contains('/')
-        val isHjson = normalizedName.endsWith(".hjson", ignoreCase = true)
-        return when {
-            !isNested && isHjson -> 0
-            !isNested -> 1
-            isHjson -> 2
-            else -> 3
-        }
     }
 
     fun extractZipEntriesFromExternal(zipFilePath: String, destinationDir: File): Boolean {
@@ -1754,22 +1726,38 @@ internal object ToolPkgArchiveParser {
         return true
     }
 
-    private fun findManifestEntry(entryNames: Collection<String>): String? {
-        val exactHjson = entryNames.firstOrNull { it.equals("manifest.hjson", ignoreCase = true) }
-        if (exactHjson != null) return exactHjson
+    internal fun findManifestEntry(entryNames: Collection<String>): String? {
+        return entryNames
+            .asSequence()
+            .mapNotNull(::normalizeZipEntryPath)
+            .filter(::isManifestEntryName)
+            .minWithOrNull(Comparator(::compareManifestEntries))
+    }
 
-        val exactJson = entryNames.firstOrNull { it.equals("manifest.json", ignoreCase = true) }
-        if (exactJson != null) return exactJson
+    private fun compareManifestEntries(left: String, right: String): Int {
+        return compareValuesBy(
+            left,
+            right,
+            ::manifestEntryPriority,
+            ::manifestEntryDepth,
+            { it.lowercase() },
+            { it }
+        )
+    }
 
-        val nestedHjson =
-            entryNames.firstOrNull {
-                it.substringAfterLast('/').equals("manifest.hjson", ignoreCase = true)
-            }
-        if (nestedHjson != null) return nestedHjson
-
-        return entryNames.firstOrNull {
-            it.substringAfterLast('/').equals("manifest.json", ignoreCase = true)
+    private fun manifestEntryPriority(entryName: String): Int {
+        val nested = entryName.contains('/')
+        val hjson = entryName.endsWith(".hjson", ignoreCase = true)
+        return when {
+            !nested && hjson -> 0
+            !nested -> 1
+            hjson -> 2
+            else -> 3
         }
+    }
+
+    private fun manifestEntryDepth(entryName: String): Int {
+        return entryName.count { it == '/' }
     }
 
     private fun isManifestEntryName(entryName: String): Boolean {

--- a/app/src/main/java/com/ai/assistance/operit/util/ToolPkgArtifactMinifier.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/ToolPkgArtifactMinifier.kt
@@ -149,6 +149,17 @@ object ToolPkgArtifactMinifier {
                 } else {
                     emptySet()
                 }
+            if (minify) {
+                // 剪枝以 manifest 所在目录为根。若这里选错了 manifest（例如包内混入嵌套 manifest），
+                // 真正的入口会被判为不可达并整包丢弃，产出"能装但内容为空壳"的包，因此必须显式校验。
+                require(manifestEntryName in reachableEntryNames) {
+                    "Minified toolpkg lost its manifest entry: $manifestEntryName"
+                }
+                val missingExecutables = executableEntryNames.filterNot { it in reachableEntryNames }
+                require(missingExecutables.isEmpty()) {
+                    "Minified toolpkg lost executable entries: ${missingExecutables.joinToString()}"
+                }
+            }
             ZipOutputStream(outputBytes).use { zipOutput ->
                 archiveEntries.forEach { entry ->
                     val normalizedName = ToolPkgArchiveParser.normalizeZipEntryPath(entry.name)

--- a/app/src/test/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgManifestSelectionTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/core/tools/packTool/ToolPkgManifestSelectionTest.kt
@@ -1,0 +1,57 @@
+package com.ai.assistance.operit.core.tools.packTool
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ToolPkgManifestSelectionTest {
+    @Test
+    fun `preview and loading select the shallow package manifest regardless of zip order`() {
+        val archive = zipOf(
+            "package/.backup/manifest.json" to manifest("backup"),
+            "package/manifest.json" to manifest("package"),
+            "package/main.js" to "// package entry"
+        )
+
+        val preview = ToolPkgArchiveParser.readToolPkgManifestPreview {
+            ByteArrayInputStream(archive)
+        }
+
+        assertEquals("package/manifest.json", preview?.entryName)
+        assertEquals("package/manifest.json", ToolPkgArchiveParser.findManifestEntry(
+            listOf("package/.backup/manifest.json", "package/manifest.json", "package/main.js")
+        ))
+        assertEquals("package", preview?.manifest?.toolpkgId)
+    }
+
+    @Test
+    fun `root hjson wins over every other manifest`() {
+        assertEquals(
+            "manifest.hjson",
+            ToolPkgArchiveParser.findManifestEntry(
+                listOf("wrapped/manifest.hjson", "manifest.json", "manifest.hjson")
+            )
+        )
+    }
+
+    private fun manifest(id: String): String {
+        return """{"toolpkg_id":"$id","main":"main.js"}"""
+    }
+
+    private fun zipOf(vararg entries: Pair<String, String>): ByteArray {
+        return ByteArrayOutputStream().use { output ->
+            ZipOutputStream(output).use { zip ->
+                entries.forEach { (name, content) ->
+                    zip.putNextEntry(ZipEntry(name))
+                    zip.write(content.toByteArray(StandardCharsets.UTF_8))
+                    zip.closeEntry()
+                }
+            }
+            output.toByteArray()
+        }
+    }
+}

--- a/tools/toolpkg/debug_toolpkg.py
+++ b/tools/toolpkg/debug_toolpkg.py
@@ -34,7 +34,7 @@ MAIN_PATTERN = re.compile(
     r'^\s*["\']?main["\']?\s*:\s*["\']([^"\']+)["\']',
     re.MULTILINE,
 )
-SKIP_DIR_NAMES = {".git", "__pycache__"}
+SKIP_DIR_NAMES = {".git", "__pycache__", ".backup", "backup", ".operit"}
 SKIP_FILE_NAMES = {".DS_Store", "Thumbs.db"}
 
 


### PR DESCRIPTION
## Summary
- integrate the ToolPkg packaging and manifest fixes from #1097 on current dev
- use one deterministic manifest selector for archive preview and runtime loading
- prevent workspace backup directories from entering newly packaged archives
- cover an archive where package/.backup/manifest.json precedes the real package manifest

## Verification
- git diff --check
- Gradle build and unit tests not run, following repository instructions that prohibit build/test commands unless explicitly requested

## Compatibility
- root HJSON, root JSON, nested HJSON, and nested JSON keep their documented precedence
- nested manifests are deterministically ordered by depth and normalized path

Closes #1084
Supersedes #1097