### PR TITLE
fix(character-card): keep cleared default voice prompt empty

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/data/preferences/CharacterCardManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/data/preferences/CharacterCardManager.kt
@@ -233,7 +233,9 @@ class CharacterCardManager private constructor(private val context: Context) {
                 if (!legacyValue.isNullOrBlank() && preferences[chatKey].isNullOrBlank()) {
                     preferences[chatKey] = legacyValue
                 }
-                if (preferences[voiceKey].isNullOrBlank() && cardId == DEFAULT_CHARACTER_CARD_ID) {
+                // Only seed the default voice prompt when the field has never been written.
+                // An explicit empty string means the user cleared it and must be kept.
+                if (!preferences.contains(voiceKey) && cardId == DEFAULT_CHARACTER_CARD_ID) {
                     preferences[voiceKey] = CharacterCardBilingualData.getDefaultOtherContentVoice(context)
                 }
                 preferences.remove(legacyKey)


### PR DESCRIPTION
## 变更说明 / Description

修复默认角色卡「其他内容（语音）」提示词清空后过一会儿又被默认文案写回去的问题。

### 背景与动机 / Context and motivation

角色卡 DataStore 从 schema 0 迁到 1 时，会把旧的 `other_content` 拆成聊天 / 语音两个字段。迁移里对默认角色卡有一条补偿：只要语音字段为空，就写回内置默认语音提示词。

用户清空并保存后，存储值是空字符串。空字符串被 `isNullOrBlank()` 当成未初始化，再次触发迁移或进程重建 DataStore 时就会把默认文案填回去。保存路径本身已经能写入空字符串，问题不在编辑框。

### 改动范围 / Changes

- `migrateLegacyOtherContentToChat()` 只在默认角色卡的语音字段 **键不存在** 时才写入默认提示词。
- 已经保存过的空字符串视为用户主动清空，不再回填。
- 不改默认角色卡首次创建逻辑，也不改「重置默认角色卡」。

### 兼容性与风险 / Compatibility and risks

- 从未写过语音字段的默认角色卡，升级时仍会补上默认提示词。
- 已经清空过的默认角色卡会保持空白。
- 自定义角色卡不受影响。

## 验证方式 / Verification

```text
检查：git diff --check upstream/dev...HEAD
环境：Linux 工作树；已对 fix/character-card-voice-prompt-reset 触发 Tests / Build
```

## 检查清单 / Checklist

- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容
- [x] 改动范围仅限默认角色卡语音提示词回填条件