### PR TITLE
feat(github): expand built-in github package from 19 to 86 REST tools

### DIFF
--- a/app/src/main/assets/packages/github.js
+++ b/app/src/main/assets/packages/github.js
@@ -1,12 +1,11 @@
 /* METADATA
 {
   "name": "github",
-
   "display_name": {
       "zh": "GitHub API",
       "en": "GitHub API"
   },
-  "description": { "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异提交）与本地侧（apply_file 差异更新、terminal 终端）能力。", "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs) and local-side utilities (apply_file patch updates, terminal)." },
+  "description": { "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。", "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)." },
   "category": "Development",
   "env": [
     {
@@ -24,229 +23,2613 @@
   "enabledByDefault": false,
   "tools": [
     {
-      "name": "search_repositories",
-      "description": { "zh": "搜索 GitHub 仓库（/search/repositories）。", "en": "Search GitHub repositories (/search/repositories)." },
-      "parameters": [
-        { "name": "query", "description": { "zh": "搜索关键词（GitHub search query）", "en": "Search keywords (GitHub search query)." }, "type": "string", "required": true },
-        { "name": "sort", "description": { "zh": "排序字段：stars/forks/help-wanted-issues/updated", "en": "Sort field: stars/forks/help-wanted-issues/updated." }, "type": "string", "required": false },
-        { "name": "order", "description": { "zh": "排序方向：desc/asc", "en": "Sort order: desc/asc." }, "type": "string", "required": false },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false }
-      ]
+        "name": "search_repositories",
+        "description": {
+            "zh": "搜索 GitHub 仓库（/search/repositories）。",
+            "en": "Search GitHub repositories (/search/repositories)."
+        },
+        "parameters": [
+            {
+                "name": "query",
+                "description": {
+                    "zh": "搜索关键词（GitHub search query）",
+                    "en": "Search keywords (GitHub search query)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sort",
+                "description": {
+                    "zh": "排序字段：stars/forks/help-wanted-issues/updated",
+                    "en": "Sort field: stars/forks/help-wanted-issues/updated."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "order",
+                "description": {
+                    "zh": "排序方向：desc/asc",
+                    "en": "Sort order: desc/asc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30，最大 100）",
+                    "en": "Items per page (default: 30, max: 100)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "get_repository",
-      "description": { "zh": "获取仓库信息（/repos/{owner}/{repo}）。", "en": "Get repository information (/repos/{owner}/{repo})." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true }
-      ]
+        "name": "get_repository",
+        "description": {
+            "zh": "获取仓库信息（/repos/{owner}/{repo}）。",
+            "en": "Get repository information (/repos/{owner}/{repo})."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "list_issues",
-      "description": { "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。注意：GitHub 的 issues API 默认也会包含 PR，需要时可用 include_pull_requests 控制。", "en": "List repository issues (/repos/{owner}/{repo}/issues). Note: GitHub issues API also includes PRs by default; use include_pull_requests when needed." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "state", "description": { "zh": "open/closed/all（默认 open）", "en": "open/closed/all (default: open)." }, "type": "string", "required": false },
-        { "name": "labels", "description": { "zh": "labels 逗号分隔", "en": "Labels, comma-separated." }, "type": "string", "required": false },
-        { "name": "creator", "description": { "zh": "创建者 login", "en": "Creator login." }, "type": "string", "required": false },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false },
-        { "name": "include_pull_requests", "description": { "zh": "是否保留 PR（默认 false，仅返回 issue）", "en": "Whether to include PRs (default: false; issues only)." }, "type": "boolean", "required": false }
-      ]
+        "name": "list_issues",
+        "description": {
+            "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。",
+            "en": "List repository issues (/repos/{owner}/{repo}/issues)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed/all（默认 open）",
+                    "en": "open/closed/all (default: open)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "labels",
+                "description": {
+                    "zh": "labels 逗号分隔",
+                    "en": "Labels, comma-separated."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "creator",
+                "description": {
+                    "zh": "创建者 login",
+                    "en": "Creator login."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "include_pull_requests",
+                "description": {
+                    "zh": "是否保留 PR（默认 false）",
+                    "en": "Whether to include PRs (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "create_issue",
-      "description": { "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。", "en": "Create an issue (/repos/{owner}/{repo}/issues)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "title", "description": { "zh": "Issue 标题", "en": "Issue title." }, "type": "string", "required": true },
-        { "name": "body", "description": { "zh": "Issue 内容", "en": "Issue body." }, "type": "string", "required": false },
-        { "name": "labels", "description": { "zh": "labels 数组（字符串数组）", "en": "Labels array (string array)." }, "type": "array", "required": false },
-        { "name": "assignees", "description": { "zh": "assignees 数组（字符串数组）", "en": "Assignees array (string array)." }, "type": "array", "required": false }
-      ]
+        "name": "get_issue",
+        "description": {
+            "zh": "获取单个 Issue 详情（/repos/{owner}/{repo}/issues/{issue_number}）。",
+            "en": "Get a single issue."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "comment_issue",
-      "description": { "zh": "给 Issue/PR 评论（/repos/{owner}/{repo}/issues/{issue_number}/comments）。", "en": "Comment on an issue/PR (/repos/{owner}/{repo}/issues/{issue_number}/comments)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "issue_number", "description": { "zh": "Issue 编号", "en": "Issue number." }, "type": "number", "required": true },
-        { "name": "body", "description": { "zh": "评论内容", "en": "Comment body." }, "type": "string", "required": true }
-      ]
+        "name": "create_issue",
+        "description": {
+            "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。",
+            "en": "Create an issue."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "Issue 标题",
+                    "en": "Issue title."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "Issue 内容",
+                    "en": "Issue body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "labels",
+                "description": {
+                    "zh": "labels 数组",
+                    "en": "Labels array."
+                },
+                "type": "array",
+                "required": false
+            },
+            {
+                "name": "assignees",
+                "description": {
+                    "zh": "assignees 数组",
+                    "en": "Assignees array."
+                },
+                "type": "array",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "list_issue_comments",
-      "description": { "zh": "列出 Issue/PR 的评论（/repos/{owner}/{repo}/issues/{issue_number}/comments）。", "en": "List comments on an issue/PR (/repos/{owner}/{repo}/issues/{issue_number}/comments)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "issue_number", "description": { "zh": "Issue 编号", "en": "Issue number." }, "type": "number", "required": true },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false }
-      ]
+        "name": "update_issue",
+        "description": {
+            "zh": "更新 Issue。",
+            "en": "Update an issue."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "新标题",
+                    "en": "New title."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "新内容",
+                    "en": "New body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed",
+                    "en": "open/closed."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "labels",
+                "description": {
+                    "zh": "labels 数组",
+                    "en": "Labels array."
+                },
+                "type": "array",
+                "required": false
+            },
+            {
+                "name": "assignees",
+                "description": {
+                    "zh": "assignees 数组",
+                    "en": "Assignees array."
+                },
+                "type": "array",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "list_pull_requests",
-      "description": { "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。", "en": "List pull requests (/repos/{owner}/{repo}/pulls)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "state", "description": { "zh": "open/closed/all（默认 open）", "en": "open/closed/all (default: open)." }, "type": "string", "required": false },
-        { "name": "head", "description": { "zh": "head 过滤（可选）", "en": "Head filter (optional)." }, "type": "string", "required": false },
-        { "name": "base", "description": { "zh": "base 过滤（可选）", "en": "Base filter (optional)." }, "type": "string", "required": false },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false }
-      ]
+        "name": "comment_issue",
+        "description": {
+            "zh": "给 Issue/PR 评论。",
+            "en": "Comment on an issue/PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "评论内容",
+                    "en": "Comment body."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "create_pull_request",
-      "description": { "zh": "创建 PR（/repos/{owner}/{repo}/pulls）。", "en": "Create a pull request (/repos/{owner}/{repo}/pulls)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "title", "description": { "zh": "PR 标题", "en": "PR title." }, "type": "string", "required": true },
-        { "name": "head", "description": { "zh": "源分支，例如 feature-branch 或 owner:branch", "en": "Head branch, e.g. feature-branch or owner:branch." }, "type": "string", "required": true },
-        { "name": "base", "description": { "zh": "目标分支，例如 main", "en": "Base branch, e.g. main." }, "type": "string", "required": true },
-        { "name": "body", "description": { "zh": "PR 内容", "en": "PR body." }, "type": "string", "required": false },
-        { "name": "draft", "description": { "zh": "是否为 Draft", "en": "Whether this is a draft PR." }, "type": "boolean", "required": false }
-      ]
+        "name": "list_issue_comments",
+        "description": {
+            "zh": "列出 Issue/PR 的评论。",
+            "en": "List comments on an issue/PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "get_pull_request",
-      "description": { "zh": "获取 PR 详情（/repos/{owner}/{repo}/pulls/{pull_number}）。", "en": "Get pull request details (/repos/{owner}/{repo}/pulls/{pull_number})." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "pull_number", "description": { "zh": "PR 编号", "en": "PR number." }, "type": "number", "required": true }
-      ]
+        "name": "list_pull_requests",
+        "description": {
+            "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。",
+            "en": "List pull requests."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed/all（默认 open）",
+                    "en": "open/closed/all (default: open)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head 分支过滤，格式 user:branch",
+                    "en": "Head branch filter (user:branch)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "base 分支过滤",
+                    "en": "Base branch filter."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "merge_pull_request",
-      "description": { "zh": "合并 PR（/repos/{owner}/{repo}/pulls/{pull_number}/merge）。", "en": "Merge a pull request (/repos/{owner}/{repo}/pulls/{pull_number}/merge)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "pull_number", "description": { "zh": "PR 编号", "en": "PR number." }, "type": "number", "required": true },
-        { "name": "commit_title", "description": { "zh": "可选，merge commit 标题", "en": "Optional: merge commit title." }, "type": "string", "required": false },
-        { "name": "commit_message", "description": { "zh": "可选，merge commit 内容", "en": "Optional: merge commit message." }, "type": "string", "required": false },
-        { "name": "merge_method", "description": { "zh": "merge/squash/rebase", "en": "merge/squash/rebase." }, "type": "string", "required": false }
-      ]
+        "name": "create_pull_request",
+        "description": {
+            "zh": "创建 PR。",
+            "en": "Create a pull request."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "PR 标题",
+                    "en": "PR title."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head 分支（含跨 fork 的 user:branch 格式）",
+                    "en": "Head branch (use user:branch for cross-fork)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "目标 base 分支",
+                    "en": "Target base branch."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "PR 描述",
+                    "en": "PR body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "draft",
+                "description": {
+                    "zh": "是否草稿",
+                    "en": "Whether to create as draft."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "get_file_content",
-      "description": { "zh": "读取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。若文件是 base64 返回，将自动解码为文本并返回。", "en": "Read repository file content (/repos/{owner}/{repo}/contents/{path}). If the API returns base64, it will be decoded and returned as text." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径（如 README.md）", "en": "File path (e.g. README.md)." }, "type": "string", "required": true },
-        { "name": "ref", "description": { "zh": "分支/Tag/SHA（可选）", "en": "Branch/Tag/SHA (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "get_pull_request",
+        "description": {
+            "zh": "获取单个 PR 详情。",
+            "en": "Get a single pull request."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "create_or_update_file",
-      "description": { "zh": "创建或更新仓库文件并提交（/repos/{owner}/{repo}/contents/{path}，PUT）。", "en": "Create or update a repository file and commit it (/repos/{owner}/{repo}/contents/{path}, PUT)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径", "en": "File path." }, "type": "string", "required": true },
-        { "name": "message", "description": { "zh": "提交信息", "en": "Commit message." }, "type": "string", "required": true },
-        { "name": "content", "description": { "zh": "文件内容（默认按 utf-8 文本编码为 base64）", "en": "File content (base64-encoded as utf-8 text by default)." }, "type": "string", "required": true },
-        { "name": "content_encoding", "description": { "zh": "utf-8/base64（默认 utf-8）", "en": "utf-8/base64 (default: utf-8)." }, "type": "string", "required": false },
-        { "name": "branch", "description": { "zh": "目标分支（可选）", "en": "Target branch (optional)." }, "type": "string", "required": false },
-        { "name": "sha", "description": { "zh": "可选：已知 sha（更新文件时）", "en": "Optional: known sha (when updating a file)." }, "type": "string", "required": false }
-      ]
+        "name": "update_pull_request",
+        "description": {
+            "zh": "更新 PR 标题/描述/状态/base/draft。",
+            "en": "Update PR title/body/state/base/draft."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "新标题",
+                    "en": "New title."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "新描述",
+                    "en": "New body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed",
+                    "en": "open/closed."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "新 base 分支",
+                    "en": "New base branch."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "draft",
+                "description": {
+                    "zh": "是否草稿",
+                    "en": "Whether draft."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "patch_file_in_repo",
-      "description": { "zh": "对仓库文件做差异更新（传入 [START-REPLACE]/[START-DELETE] 块），并提交。", "en": "Patch a repository file by applying diff blocks ([START-REPLACE]/[START-DELETE]) and commit." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径", "en": "File path." }, "type": "string", "required": true },
-        { "name": "message", "description": { "zh": "提交信息", "en": "Commit message." }, "type": "string", "required": true },
-        { "name": "patch", "description": { "zh": "差异块字符串（可多块）", "en": "Diff blocks string (can include multiple blocks)." }, "type": "string", "required": true },
-        { "name": "branch", "description": { "zh": "目标分支（可选）", "en": "Target branch (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "merge_pull_request",
+        "description": {
+            "zh": "合并 PR。",
+            "en": "Merge a pull request."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "commit_title",
+                "description": {
+                    "zh": "合并 commit 标题",
+                    "en": "Merge commit title."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "commit_message",
+                "description": {
+                    "zh": "合并 commit 消息",
+                    "en": "Merge commit message."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "merge_method",
+                "description": {
+                    "zh": "merge/squash/rebase（默认 merge）",
+                    "en": "merge/squash/rebase (default: merge)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "delete_file",
-      "description": { "zh": "删除仓库文件并提交（/repos/{owner}/{repo}/contents/{path}，DELETE）。", "en": "Delete a repository file and commit (/repos/{owner}/{repo}/contents/{path}, DELETE)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径", "en": "File path." }, "type": "string", "required": true },
-        { "name": "message", "description": { "zh": "提交信息", "en": "Commit message." }, "type": "string", "required": true },
-        { "name": "branch", "description": { "zh": "目标分支（可选）", "en": "Target branch (optional)." }, "type": "string", "required": false },
-        { "name": "sha", "description": { "zh": "可选：已知 sha（删除文件时）", "en": "Optional: known sha (when deleting a file)." }, "type": "string", "required": false }
-      ]
+        "name": "list_pull_request_files",
+        "description": {
+            "zh": "列出 PR 变更文件。",
+            "en": "List files changed in a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "include_patch",
+                "description": {
+                    "zh": "是否包含 patch 内容（默认 false）",
+                    "en": "Include patch content (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 100）",
+                    "en": "Items per page (default: 100)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "create_branch",
-      "description": { "zh": "基于已有分支创建新分支（/git/refs）。", "en": "Create a new branch from an existing branch (/git/refs)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "new_branch", "description": { "zh": "新分支名", "en": "New branch name." }, "type": "string", "required": true },
-        { "name": "from_branch", "description": { "zh": "源分支（可选，默认使用 default_branch）", "en": "Source branch (optional; defaults to default_branch)." }, "type": "string", "required": false }
-      ]
+        "name": "get_pull_request_diff",
+        "description": {
+            "zh": "获取 PR 的 unified diff 文本。",
+            "en": "Get PR unified diff text."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "max_chars",
+                "description": {
+                    "zh": "截断字符数（默认 20000）",
+                    "en": "Truncate to this many chars (default: 20000)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "apply_local_replace",
-      "description": { "zh": "使用 Tools.Files.apply 对本地文件做 REPLACE（结构化块）。", "en": "Run Tools.Files.apply REPLACE on a local file (structured blocks)." },
-      "parameters": [
-        { "name": "path", "description": { "zh": "本地文件路径", "en": "Local file path." }, "type": "string", "required": true },
-        { "name": "old", "description": { "zh": "要替换的旧内容片段", "en": "Old content snippet to replace." }, "type": "string", "required": true },
-        { "name": "new", "description": { "zh": "替换后的新内容片段", "en": "New content snippet." }, "type": "string", "required": true },
-        { "name": "environment", "description": { "zh": "android/linux（可选）", "en": "android/linux (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "list_pull_request_commits",
+        "description": {
+            "zh": "列出 PR 的提交。",
+            "en": "List commits in a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "apply_local_delete",
-      "description": { "zh": "使用 Tools.Files.apply 对本地文件做 DELETE（结构化块）。", "en": "Run Tools.Files.apply DELETE on a local file (structured blocks)." },
-      "parameters": [
-        { "name": "path", "description": { "zh": "本地文件路径", "en": "Local file path." }, "type": "string", "required": true },
-        { "name": "old", "description": { "zh": "要删除的旧内容片段", "en": "Old content snippet to delete." }, "type": "string", "required": true },
-        { "name": "environment", "description": { "zh": "android/linux（可选）", "en": "android/linux (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "list_pull_request_reviews",
+        "description": {
+            "zh": "列出 PR 的 review。",
+            "en": "List reviews on a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "overwrite_local_file",
-      "description": { "zh": "覆盖写入本地文件（如果存在会先删除再写入）。", "en": "Overwrite a local file (if it exists, it will be deleted before writing)." },
-      "parameters": [
-        { "name": "path", "description": { "zh": "本地文件路径", "en": "Local file path." }, "type": "string", "required": true },
-        { "name": "content", "description": { "zh": "完整文件内容", "en": "Full file content." }, "type": "string", "required": true },
-        { "name": "environment", "description": { "zh": "android/linux（可选）", "en": "android/linux (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "list_review_comments",
+        "description": {
+            "zh": "列出 PR 的行内 review comments。",
+            "en": "List inline review comments on a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "terminal_exec",
-      "description": { "zh": "在终端会话中执行命令（Tools.System.terminal）。", "en": "Execute a command in a terminal session (Tools.System.terminal)." },
-      "parameters": [
-        { "name": "command", "description": { "zh": "要执行的命令", "en": "Command to execute." }, "type": "string", "required": true },
-        { "name": "session_name", "description": { "zh": "会话名（可选，默认 github_tools_session）", "en": "Session name (optional; default: github_tools_session)." }, "type": "string", "required": false },
-        { "name": "close", "description": { "zh": "是否执行后关闭会话", "en": "Whether to close the session after execution." }, "type": "boolean", "required": false }
-      ]
+        "name": "create_review",
+        "description": {
+            "zh": "提交 PR review（APPROVE/REQUEST_CHANGES/COMMENT）。",
+            "en": "Submit a PR review (APPROVE/REQUEST_CHANGES/COMMENT)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "review 总评内容",
+                    "en": "Review body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "event",
+                "description": {
+                    "zh": "APPROVE/REQUEST_CHANGES/COMMENT（默认 COMMENT）",
+                    "en": "APPROVE/REQUEST_CHANGES/COMMENT (default: COMMENT)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "commit_id",
+                "description": {
+                    "zh": "关联的 commit sha",
+                    "en": "Commit SHA to associate."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "comments",
+                "description": {
+                    "zh": "行内评论数组（JSON 字符串），每项含 path/line/body",
+                    "en": "Inline comments array (JSON string), each with path/line/body."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "main",
-      "description": { "zh": "用于快速连通性自测：拉取一个仓库信息并做一次仓库搜索，然后返回结果。", "en": "Quick connectivity self-test: fetch a repository and run a repository search, then return results." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner（默认 octocat）", "en": "Repository owner (default: octocat)." }, "type": "string", "required": false },
-        { "name": "repo", "description": { "zh": "仓库名（默认 Hello-World）", "en": "Repository name (default: Hello-World)." }, "type": "string", "required": false },
-        { "name": "query", "description": { "zh": "搜索关键词（默认 operit）", "en": "Search keyword (default: operit)." }, "type": "string", "required": false }
-      ]
+        "name": "reply_review_comment",
+        "description": {
+            "zh": "回复 PR 行内 review comment。",
+            "en": "Reply to a PR inline review comment."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "comment_id",
+                "description": {
+                    "zh": "被回复的 comment id",
+                    "en": "Comment ID to reply to."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "回复内容",
+                    "en": "Reply body."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "request_reviewers",
+        "description": {
+            "zh": "请求 PR reviewer。",
+            "en": "Request reviewers for a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "reviewers",
+                "description": {
+                    "zh": "reviewer login 列表，逗号分隔或数组",
+                    "en": "Reviewer logins, comma-separated or array."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "team_reviewers",
+                "description": {
+                    "zh": "team reviewer slug 列表，逗号分隔或数组",
+                    "en": "Team reviewer slugs, comma-separated or array."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_file_content",
+        "description": {
+            "zh": "获取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。",
+            "en": "Get file content from a repository."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径（相对仓库根目录）",
+                    "en": "File path relative to repository root."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "分支/tag/commit（默认默认分支）",
+                    "en": "Branch/tag/commit (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "create_or_update_file",
+        "description": {
+            "zh": "创建或更新仓库文件。更新时需传 sha。",
+            "en": "Create or update a file in the repository. Provide sha when updating."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径",
+                    "en": "File path."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "message",
+                "description": {
+                    "zh": "commit 消息",
+                    "en": "Commit message."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "content",
+                "description": {
+                    "zh": "文件内容（明文，会自动 base64 编码）",
+                    "en": "File content (plain text, will be base64-encoded)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "更新时必填：现有文件的 blob sha",
+                    "en": "Required when updating: existing file blob SHA."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "目标分支（默认默认分支）",
+                    "en": "Target branch (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "delete_file",
+        "description": {
+            "zh": "删除仓库文件。",
+            "en": "Delete a file from the repository."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径",
+                    "en": "File path."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "message",
+                "description": {
+                    "zh": "commit 消息",
+                    "en": "Commit message."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "文件的 blob sha",
+                    "en": "File blob SHA."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "目标分支",
+                    "en": "Target branch."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "create_branch",
+        "description": {
+            "zh": "创建分支。",
+            "en": "Create a branch."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "新分支名",
+                    "en": "New branch name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "from_branch",
+                "description": {
+                    "zh": "基于哪个分支创建（默认默认分支）",
+                    "en": "Branch to create from (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "直接指定起始 commit sha（优先于 from_branch）",
+                    "en": "Starting commit SHA (overrides from_branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_branches",
+        "description": {
+            "zh": "列出仓库分支。",
+            "en": "List repository branches."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "protected_only",
+                "description": {
+                    "zh": "只返回受保护分支（默认 false）",
+                    "en": "Return only protected branches (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_commits",
+        "description": {
+            "zh": "列出仓库提交。",
+            "en": "List repository commits."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "分支/tag/commit sha（默认默认分支）",
+                    "en": "Branch/tag/commit SHA (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "只返回修改了该路径的提交",
+                    "en": "Only commits affecting this path."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "author",
+                "description": {
+                    "zh": "作者 login 过滤",
+                    "en": "Author login filter."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_commit",
+        "description": {
+            "zh": "获取单个提交详情。",
+            "en": "Get a single commit."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "commit sha / 分支 / tag",
+                    "en": "Commit SHA, branch, or tag."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "include_files",
+                "description": {
+                    "zh": "是否包含文件变更列表（默认 true）",
+                    "en": "Whether to include file changes (default: true)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "compare_refs",
+        "description": {
+            "zh": "比较两个 ref。",
+            "en": "Compare two refs."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "base ref（分支/tag/sha）",
+                    "en": "Base ref (branch/tag/sha)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head ref（分支/tag/sha）",
+                    "en": "Head ref (branch/tag/sha)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "include_files",
+                "description": {
+                    "zh": "是否包含文件列表（默认 true）",
+                    "en": "Whether to include file list (default: true)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "include_patch",
+                "description": {
+                    "zh": "文件列表是否包含 patch（默认 false）",
+                    "en": "Whether file list includes patch (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_compare_diff",
+        "description": {
+            "zh": "获取两个 ref 之间的 unified diff 文本。",
+            "en": "Get unified diff text between two refs."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "base ref",
+                    "en": "Base ref."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head ref",
+                    "en": "Head ref."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "max_chars",
+                "description": {
+                    "zh": "截断字符数（默认 20000）",
+                    "en": "Truncate to this many chars (default: 20000)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_workflows",
+        "description": {
+            "zh": "列出仓库 GitHub Actions workflow。",
+            "en": "List GitHub Actions workflows."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_workflow_runs",
+        "description": {
+            "zh": "列出 workflow run。",
+            "en": "List workflow runs."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "workflow_id",
+                "description": {
+                    "zh": "workflow id 或文件名（如 android-tests.yml），不传则列出所有",
+                    "en": "Workflow ID or filename (e.g. android-tests.yml); omit to list all."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "按分支过滤",
+                    "en": "Filter by branch."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "status",
+                "description": {
+                    "zh": "按状态过滤：queued/in_progress/completed/failure/success 等",
+                    "en": "Filter by status: queued/in_progress/completed/failure/success etc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "event",
+                "description": {
+                    "zh": "按触发事件过滤：push/pull_request/workflow_dispatch 等",
+                    "en": "Filter by event: push/pull_request/workflow_dispatch etc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_workflow_run",
+        "description": {
+            "zh": "获取单个 workflow run 详情。",
+            "en": "Get a single workflow run."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "trigger_workflow",
+        "description": {
+            "zh": "手动触发 workflow（workflow_dispatch）。",
+            "en": "Manually trigger a workflow (workflow_dispatch)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "workflow_id",
+                "description": {
+                    "zh": "workflow id 或文件名（如 android-tests.yml）",
+                    "en": "Workflow ID or filename (e.g. android-tests.yml)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "触发分支或 tag",
+                    "en": "Branch or tag to trigger on."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "inputs",
+                "description": {
+                    "zh": "workflow inputs（JSON 字符串或对象）",
+                    "en": "Workflow inputs (JSON string or object)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_workflow_jobs",
+        "description": {
+            "zh": "获取 workflow run 的 jobs（含可选日志）。",
+            "en": "Get jobs for a workflow run (with optional logs)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "include_logs",
+                "description": {
+                    "zh": "是否拉取每个 job 的日志（默认 false）",
+                    "en": "Whether to fetch logs for each job (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "failed_only",
+                "description": {
+                    "zh": "只返回失败/非成功的 job（默认 false）",
+                    "en": "Return only failed/non-success jobs (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "max_log_chars",
+                "description": {
+                    "zh": "日志截断字符数（默认 8000）",
+                    "en": "Log truncation in characters (default: 8000)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 50）",
+                    "en": "Items per page (default: 50)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "rerun_workflow_run",
+        "description": {
+            "zh": "重新运行 workflow run（全部或仅失败 job）。",
+            "en": "Re-run a workflow run (all jobs or failed jobs only)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "failed_jobs_only",
+                "description": {
+                    "zh": "只重跑失败 job（默认 false）",
+                    "en": "Only re-run failed jobs (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "enable_debug_logging",
+                "description": {
+                    "zh": "是否开启 debug 日志",
+                    "en": "Whether to enable debug logging."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "cancel_workflow_run",
+        "description": {
+            "zh": "取消 workflow run。",
+            "en": "Cancel a workflow run."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "list_check_runs",
+        "description": {
+            "zh": "列出某个 commit 的 check runs。",
+            "en": "List check runs for a commit."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "commit sha / 分支 / tag",
+                    "en": "Commit SHA, branch, or tag."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "status",
+                "description": {
+                    "zh": "queued/in_progress/completed 过滤",
+                    "en": "Filter by status: queued/in_progress/completed."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "filter",
+                "description": {
+                    "zh": "latest/all（默认 latest）",
+                    "en": "latest/all (default: latest)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "search_code",
+        "description": {
+            "zh": "搜索代码（/search/code）。",
+            "en": "Search code (/search/code)."
+        },
+        "parameters": [
+            {
+                "name": "query",
+                "description": {
+                    "zh": "搜索查询（支持 GitHub code search 语法）",
+                    "en": "Search query (GitHub code search syntax, e.g. repo:owner/name keyword)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sort",
+                "description": {
+                    "zh": "排序字段（indexed）",
+                    "en": "Sort field (indexed)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "order",
+                "description": {
+                    "zh": "排序方向：desc/asc",
+                    "en": "Sort order: desc/asc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "search_issues",
+        "description": {
+            "zh": "搜索 Issue/PR（/search/issues）。",
+            "en": "Search issues and PRs (/search/issues)."
+        },
+        "parameters": [
+            {
+                "name": "query",
+                "description": {
+                    "zh": "搜索查询（支持 GitHub issue search 语法）",
+                    "en": "Search query (GitHub issue search syntax)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sort",
+                "description": {
+                    "zh": "排序字段：comments/reactions/created/updated 等",
+                    "en": "Sort field: comments/reactions/created/updated etc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "order",
+                "description": {
+                    "zh": "排序方向：desc/asc",
+                    "en": "Sort order: desc/asc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_authenticated_user",
+        "description": {
+            "zh": "获取当前认证用户信息（/user）。",
+            "en": "Get the currently authenticated user (/user)."
+        },
+        "parameters": []
+    },
+    {
+        "name": "get_rate_limit",
+        "description": {
+            "zh": "查询 GitHub API 请求频率限制（/rate_limit）。",
+            "en": "Query GitHub API rate limit (/rate_limit)."
+        },
+        "parameters": []
+    },
+    {
+        "name": "fork_repository",
+        "description": {
+            "zh": "fork 仓库（/repos/{owner}/{repo}/forks）。",
+            "en": "Fork a repository."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "organization",
+                "description": {
+                    "zh": "fork 到指定组织（不填则 fork 到个人账号）",
+                    "en": "Fork to a specific organization (omit for personal account)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "name",
+                "description": {
+                    "zh": "fork 后的仓库名（默认与原仓库同名）",
+                    "en": "Name for the forked repository (default: same as original)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "default_branch_only",
+                "description": {
+                    "zh": "只 fork 默认分支（默认 false）",
+                    "en": "Fork only the default branch (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "sync_fork",
+        "description": {
+            "zh": "同步 fork 到上游（/repos/{owner}/{repo}/merge-upstream）。",
+            "en": "Sync a fork with upstream."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "fork 仓库的 owner",
+                    "en": "Fork repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "fork 仓库名",
+                    "en": "Fork repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "要同步的分支（默认默认分支）",
+                    "en": "Branch to sync (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "patch_file_in_repo",
+        "description": {
+            "zh": "在仓库中对文件应用 search/replace patch（先读取文件，替换内容后写回）。",
+            "en": "Apply a search/replace patch to a file in the repository (read -> replace -> write back)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径",
+                    "en": "File path."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "search",
+                "description": {
+                    "zh": "要查找的文本（精确匹配）",
+                    "en": "Text to search for (exact match)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "replace",
+                "description": {
+                    "zh": "替换后的文本",
+                    "en": "Replacement text."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "message",
+                "description": {
+                    "zh": "commit 消息",
+                    "en": "Commit message."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "目标分支",
+                    "en": "Target branch."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "apply_local_replace",
+        "description": {
+            "zh": "在本地文件系统中对文件应用 search/replace（不经过 GitHub API）。",
+            "en": "Apply a search/replace patch to a local file (no GitHub API)."
+        },
+        "parameters": [
+            {
+                "name": "path",
+                "description": {
+                    "zh": "本地文件路径（绝对路径）",
+                    "en": "Local file path (absolute)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "search",
+                "description": {
+                    "zh": "要查找的文本",
+                    "en": "Text to search for."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "replace",
+                "description": {
+                    "zh": "替换后的文本",
+                    "en": "Replacement text."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "apply_local_delete",
+        "description": {
+            "zh": "删除本地文件（不经过 GitHub API）。",
+            "en": "Delete a local file (no GitHub API)."
+        },
+        "parameters": [
+            {
+                "name": "path",
+                "description": {
+                    "zh": "本地文件路径（绝对路径）",
+                    "en": "Local file path (absolute)."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "overwrite_local_file",
+        "description": {
+            "zh": "用新内容完整覆盖本地文件（不经过 GitHub API）。",
+            "en": "Overwrite a local file with new content (no GitHub API)."
+        },
+        "parameters": [
+            {
+                "name": "path",
+                "description": {
+                    "zh": "本地文件路径（绝对路径）",
+                    "en": "Local file path (absolute)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "content",
+                "description": {
+                    "zh": "新的文件内容",
+                    "en": "New file content."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "terminal_exec",
+        "description": {
+            "zh": "在本地终端执行命令（调用 Operit 内置终端，注意权限和安全）。",
+            "en": "Execute a command in the local terminal (uses Operit built-in terminal)."
+        },
+        "parameters": [
+            {
+                "name": "command",
+                "description": {
+                    "zh": "要执行的 shell 命令",
+                    "en": "Shell command to execute."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "cwd",
+                "description": {
+                    "zh": "工作目录（默认当前目录）",
+                    "en": "Working directory (default: current directory)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "timeout_ms",
+                "description": {
+                    "zh": "超时毫秒数（默认 30000）",
+                    "en": "Timeout in milliseconds (default: 30000)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     }
-  ]
+]
 }
 */
 
 var __defProp = Object.defineProperty;
 var __defProps = Object.defineProperties;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
+var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getOwnPropSymbols = Object.getOwnPropertySymbols;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
 var __propIsEnum = Object.prototype.propertyIsEnumerable;
@@ -263,22 +2646,76 @@ var __spreadValues = (a, b) => {
   return a;
 };
 var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
-
-// src/utils/wrap.ts
-async function wrap(func, params, successMessage, failMessage) {
-  try {
-    const data = await func(params);
-    const result = { success: true, message: successMessage, data };
-    complete(result);
-  } catch (error) {
-    const result = {
-      success: false,
-      message: `${failMessage}: ${String(error && error.message ? error.message : error)}`,
-      error_stack: String(error && error.stack ? error.stack : "")
-    };
-    complete(result);
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
   }
-}
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/index.ts
+var index_exports = {};
+__export(index_exports, {
+  apply_local_delete: () => apply_local_delete,
+  apply_local_replace: () => apply_local_replace,
+  cancel_workflow_run: () => cancel_workflow_run,
+  comment_issue: () => comment_issue,
+  compare_refs: () => compare_refs,
+  create_branch: () => create_branch,
+  create_issue: () => create_issue,
+  create_or_update_file: () => create_or_update_file,
+  create_pull_request: () => create_pull_request,
+  create_review: () => create_review,
+  delete_file: () => delete_file,
+  fork_repository: () => fork_repository,
+  get_authenticated_user: () => get_authenticated_user,
+  get_commit: () => get_commit,
+  get_compare_diff: () => get_compare_diff,
+  get_file_content: () => get_file_content,
+  get_issue: () => get_issue,
+  get_pull_request: () => get_pull_request,
+  get_pull_request_diff: () => get_pull_request_diff,
+  get_rate_limit: () => get_rate_limit,
+  get_repository: () => get_repository,
+  get_workflow_jobs: () => get_workflow_jobs,
+  get_workflow_run: () => get_workflow_run,
+  list_branches: () => list_branches,
+  list_check_runs: () => list_check_runs,
+  list_commits: () => list_commits,
+  list_issue_comments: () => list_issue_comments,
+  list_issues: () => list_issues,
+  list_pull_request_commits: () => list_pull_request_commits,
+  list_pull_request_files: () => list_pull_request_files,
+  list_pull_request_reviews: () => list_pull_request_reviews,
+  list_pull_requests: () => list_pull_requests,
+  list_review_comments: () => list_review_comments,
+  list_workflow_runs: () => list_workflow_runs,
+  list_workflows: () => list_workflows,
+  main: () => main,
+  merge_pull_request: () => merge_pull_request,
+  overwrite_local_file: () => overwrite_local_file,
+  patch_file_in_repo: () => patch_file_in_repo,
+  reply_review_comment: () => reply_review_comment,
+  request_reviewers: () => request_reviewers,
+  rerun_workflow_run: () => rerun_workflow_run,
+  search_code: () => search_code,
+  search_issues: () => search_issues,
+  search_repositories: () => search_repositories,
+  sync_fork: () => sync_fork,
+  terminal_exec: () => terminal_exec,
+  toolImpl: () => toolImpl,
+  trigger_workflow: () => trigger_workflow,
+  update_issue: () => update_issue,
+  update_pull_request: () => update_pull_request
+});
+module.exports = __toCommonJS(index_exports);
 
 // src/github/api.ts
 function getBaseUrl() {
@@ -290,6 +2727,13 @@ function getToken() {
   const trimmed = String(token || "").trim();
   return trimmed ? trimmed : void 0;
 }
+function requireToken(operation) {
+  const token = getToken();
+  if (!token) {
+    throw new Error(`GITHUB_TOKEN is required for ${operation}.`);
+  }
+  return token;
+}
 function buildUrl(pathname, query) {
   const base = getBaseUrl().replace(/\/+$/, "");
   const path = pathname.startsWith("/") ? pathname : `/${pathname}`;
@@ -297,17 +2741,24 @@ function buildUrl(pathname, query) {
   if (query) {
     Object.keys(query).forEach((k) => {
       const v = query[k];
-      if (v === void 0 || v === null) return;
+      if (v === void 0 || v === null || v === "") return;
       qs.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
     });
   }
   return qs.length > 0 ? `${base}${path}?${qs.join("&")}` : `${base}${path}`;
 }
+function repoPath(owner, repo, suffix = "") {
+  const extra = suffix ? suffix.startsWith("/") ? suffix : `/${suffix}` : "";
+  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${extra}`;
+}
+function encodeRef(ref) {
+  return String(ref || "").split("/").map((part) => encodeURIComponent(part)).join("/");
+}
 function defaultHeaders(extra) {
   const headers = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": "Operit-Examples-GitHub"
+    "User-Agent": "Operit-GitHub"
   };
   const token = getToken();
   if (token) {
@@ -321,143 +2772,279 @@ function defaultHeaders(extra) {
   return headers;
 }
 function createHttpClient(timeoutMs = 3e4) {
-  return OkHttp.newBuilder().connectTimeout(timeoutMs).readTimeout(timeoutMs).writeTimeout(timeoutMs).build();
+  return OkHttp.newBuilder().connectTimeout(timeoutMs).readTimeout(timeoutMs).writeTimeout(timeoutMs).followRedirects(true).build();
 }
-async function requestJson(options) {
+async function requestRaw(options) {
   var _a;
   const client = createHttpClient((_a = options.timeoutMs) != null ? _a : 3e4);
   const req = client.newRequest().url(options.url).method(options.method);
-  const headers = defaultHeaders(options.headers);
-  req.headers(headers);
-  if (options.body !== void 0 && options.body !== null && options.method !== "GET") {
-    req.body(JSON.stringify(options.body), "json");
+  req.headers(defaultHeaders(options.headers));
+  if (options.method !== "GET") {
+    const payload = options.body === void 0 || options.body === null ? {} : options.body;
+    req.body(JSON.stringify(payload), "json");
   }
   const resp = await req.build().execute();
   if (!resp.isSuccessful()) {
     throw new Error(`GitHub API Error: ${resp.statusCode} ${resp.statusMessage}
 ${resp.content}`);
   }
-  return resp.json();
+  return {
+    statusCode: resp.statusCode,
+    statusMessage: resp.statusMessage,
+    headers: resp.headers || {},
+    content: typeof resp.content === "string" ? resp.content : String(resp.content || "")
+  };
 }
+async function requestJson(options) {
+  const resp = await requestRaw(options);
+  const text = String(resp.content || "").trim();
+  if (resp.statusCode === 204 || !text) {
+    return { ok: true, statusCode: resp.statusCode };
+  }
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    throw new Error(`Failed to parse GitHub JSON response (${resp.statusCode}): ${text.slice(0, 500)}`);
+  }
+}
+async function requestText(options) {
+  const resp = await requestRaw(options);
+  return {
+    text: resp.content || "",
+    statusCode: resp.statusCode,
+    headers: resp.headers
+  };
+}
+function parseJsonParam(value, fieldName) {
+  if (value === void 0 || value === null || value === "") return void 0;
+  if (typeof value === "object") return value;
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed) return void 0;
+  try {
+    return JSON.parse(trimmed);
+  } catch (e) {
+    throw new Error(`${fieldName} must be valid JSON.`);
+  }
+}
+function splitCsv(value) {
+  if (value === void 0 || value === null || value === "") return void 0;
+  if (Array.isArray(value)) {
+    const items2 = value.map((it) => String(it).trim()).filter(Boolean);
+    return items2.length > 0 ? items2 : void 0;
+  }
+  const items = String(value).split(",").map((it) => it.trim()).filter(Boolean);
+  return items.length > 0 ? items : void 0;
+}
+function compactCommit(commit) {
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k;
+  if (!commit) return commit;
+  return {
+    sha: commit.sha || ((_b = (_a = commit.commit) == null ? void 0 : _a.tree) == null ? void 0 : _b.sha),
+    html_url: commit.html_url,
+    message: ((_c = commit.commit) == null ? void 0 : _c.message) || commit.message,
+    author: ((_e = (_d = commit.commit) == null ? void 0 : _d.author) == null ? void 0 : _e.name) || ((_f = commit.author) == null ? void 0 : _f.login),
+    date: ((_h = (_g = commit.commit) == null ? void 0 : _g.author) == null ? void 0 : _h.date) || ((_j = (_i = commit.commit) == null ? void 0 : _i.committer) == null ? void 0 : _j.date),
+    login: (_k = commit.author) == null ? void 0 : _k.login
+  };
+}
+function compactFileChange(file, includePatch) {
+  if (!file) return file;
+  const item = {
+    filename: file.filename,
+    status: file.status,
+    additions: file.additions,
+    deletions: file.deletions,
+    changes: file.changes,
+    sha: file.sha,
+    blob_url: file.blob_url,
+    previous_filename: file.previous_filename
+  };
+  if (includePatch && typeof file.patch === "string") {
+    item.patch = file.patch;
+  }
+  return item;
+}
+function truncateText(text, maxChars) {
+  const src = String(text != null ? text : "");
+  const limit = maxChars > 0 ? maxChars : src.length;
+  if (src.length <= limit) {
+    return { text: src, truncated: false, original_length: src.length };
+  }
+  const headChars = Math.max(200, Math.floor(limit * 0.35));
+  const tailChars = Math.max(200, limit - headChars - 80);
+  const omitted = src.length - headChars - tailChars;
+  return {
+    text: `${src.slice(0, headChars)}
 
-// src/github/repos.ts
-async function searchRepositories(params) {
-  var _a, _b;
-  const page = (_a = params.page) != null ? _a : 1;
-  const perPage = (_b = params.per_page) != null ? _b : 30;
-  const url = buildUrl("/search/repositories", {
-    q: params.query,
-    sort: params.sort,
-    order: params.order,
-    page,
-    per_page: perPage
-  });
-  return requestJson({ method: "GET", url });
-}
-async function getRepository(params) {
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}`);
-  return requestJson({ method: "GET", url });
+... truncated ${omitted} chars ...
+
+${src.slice(-tailChars)}`,
+    truncated: true,
+    original_length: src.length
+  };
 }
 
 // src/github/issues.ts
+function compactIssue(item) {
+  var _a;
+  if (!item) return item;
+  return {
+    number: item.number,
+    title: item.title,
+    state: item.state,
+    html_url: item.html_url,
+    user: (_a = item.user) == null ? void 0 : _a.login,
+    labels: Array.isArray(item.labels) ? item.labels.map((it) => typeof it === "string" ? it : it.name) : [],
+    assignees: Array.isArray(item.assignees) ? item.assignees.map((it) => it.login) : [],
+    comments: item.comments,
+    pull_request: Boolean(item.pull_request),
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    body: item.body
+  };
+}
 async function listIssues(params) {
   var _a, _b, _c;
-  const page = (_a = params.page) != null ? _a : 1;
-  const perPage = (_b = params.per_page) != null ? _b : 30;
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues`, {
-    state: (_c = params.state) != null ? _c : "open",
+  const url = buildUrl(repoPath(params.owner, params.repo, "/issues"), {
+    state: (_a = params.state) != null ? _a : "open",
     labels: params.labels,
     creator: params.creator,
-    page,
-    per_page: perPage
+    page: (_b = params.page) != null ? _b : 1,
+    per_page: (_c = params.per_page) != null ? _c : 30
   });
   const items = await requestJson({ method: "GET", url });
   const includePRs = params.include_pull_requests === true;
-  if (includePRs) return items;
-  return items.filter((it) => !it || !it.pull_request);
+  const filtered = includePRs ? items : items.filter((it) => !it || !it.pull_request);
+  return Array.isArray(filtered) ? filtered.map(compactIssue) : [];
+}
+async function getIssue(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}`));
+  return compactIssue(await requestJson({ method: "GET", url }));
 }
 async function createIssue(params) {
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for create_issue.");
-  }
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues`);
-  return requestJson({
-    method: "POST",
-    url,
-    body: {
-      title: params.title,
-      body: params.body,
-      labels: params.labels,
-      assignees: params.assignees
-    }
-  });
+  requireToken("create_issue");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/issues"));
+  return compactIssue(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        title: params.title,
+        body: params.body,
+        labels: splitCsv(params.labels),
+        assignees: splitCsv(params.assignees)
+      }
+    })
+  );
+}
+async function updateIssue(params) {
+  requireToken("update_issue");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}`));
+  return compactIssue(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        title: params.title,
+        body: params.body,
+        state: params.state,
+        labels: splitCsv(params.labels),
+        assignees: splitCsv(params.assignees)
+      }
+    })
+  );
 }
 async function commentIssue(params) {
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for comment_issue.");
-  }
-  const url = buildUrl(
-    `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues/${params.issue_number}/comments`
-  );
-  return requestJson({ method: "POST", url, body: { body: params.body } });
+  var _a;
+  requireToken("comment_issue");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}/comments`));
+  const data = await requestJson({ method: "POST", url, body: { body: params.body } });
+  return {
+    id: data.id,
+    html_url: data.html_url,
+    user: (_a = data.user) == null ? void 0 : _a.login,
+    body: data.body,
+    created_at: data.created_at
+  };
 }
 async function listIssueComments(params) {
   var _a, _b;
-  const page = (_a = params.page) != null ? _a : 1;
-  const perPage = (_b = params.per_page) != null ? _b : 30;
-  const url = buildUrl(
-    `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues/${params.issue_number}/comments`,
-    { page, per_page: perPage }
-  );
-  return requestJson({ method: "GET", url });
+  const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}/comments`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((item) => {
+    var _a2;
+    return {
+      id: item.id,
+      html_url: item.html_url,
+      user: (_a2 = item.user) == null ? void 0 : _a2.login,
+      body: item.body,
+      created_at: item.created_at,
+      updated_at: item.updated_at
+    };
+  }) : [];
 }
 
 // src/github/pulls.ts
+function compactPull(pr) {
+  var _a, _b, _c, _d, _e, _f;
+  if (!pr) return pr;
+  return {
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    draft: pr.draft,
+    merged: pr.merged,
+    mergeable: pr.mergeable,
+    html_url: pr.html_url,
+    user: (_a = pr.user) == null ? void 0 : _a.login,
+    head: ((_b = pr.head) == null ? void 0 : _b.label) || ((_c = pr.head) == null ? void 0 : _c.ref),
+    head_sha: (_d = pr.head) == null ? void 0 : _d.sha,
+    base: ((_e = pr.base) == null ? void 0 : _e.label) || ((_f = pr.base) == null ? void 0 : _f.ref),
+    body: pr.body,
+    created_at: pr.created_at,
+    updated_at: pr.updated_at
+  };
+}
 async function listPullRequests(params) {
   var _a, _b, _c;
-  const page = (_a = params.page) != null ? _a : 1;
-  const perPage = (_b = params.per_page) != null ? _b : 30;
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls`, {
-    state: (_c = params.state) != null ? _c : "open",
+  const url = buildUrl(repoPath(params.owner, params.repo, "/pulls"), {
+    state: (_a = params.state) != null ? _a : "open",
     head: params.head,
     base: params.base,
-    page,
-    per_page: perPage
+    page: (_b = params.page) != null ? _b : 1,
+    per_page: (_c = params.per_page) != null ? _c : 30
   });
-  return requestJson({ method: "GET", url });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactPull) : [];
 }
 async function createPullRequest(params) {
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for create_pull_request.");
-  }
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls`);
-  return requestJson({
-    method: "POST",
-    url,
-    body: {
-      title: params.title,
-      head: params.head,
-      base: params.base,
-      body: params.body,
-      draft: params.draft
-    }
-  });
+  requireToken("create_pull_request");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/pulls"));
+  return compactPull(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        title: params.title,
+        head: params.head,
+        base: params.base,
+        body: params.body,
+        draft: params.draft
+      }
+    })
+  );
 }
 async function getPullRequest(params) {
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls/${params.pull_number}`);
-  return requestJson({ method: "GET", url });
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}`));
+  return compactPull(await requestJson({ method: "GET", url }));
 }
 async function mergePullRequest(params) {
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for merge_pull_request.");
-  }
-  const url = buildUrl(
-    `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls/${params.pull_number}/merge`
-  );
+  requireToken("merge_pull_request");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/merge`));
   return requestJson({
     method: "PUT",
     url,
@@ -467,6 +3054,162 @@ async function mergePullRequest(params) {
       merge_method: params.merge_method
     }
   });
+}
+async function updatePullRequest(params) {
+  requireToken("update_pull_request");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}`));
+  return compactPull(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        title: params.title,
+        body: params.body,
+        state: params.state,
+        base: params.base,
+        draft: params.draft
+      }
+    })
+  );
+}
+async function listPullRequestFiles(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/files`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 100
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((file) => compactFileChange(file, params.include_patch === true)) : [];
+}
+async function getPullRequestDiff(params) {
+  var _a;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}`));
+  const resp = await requestText({
+    method: "GET",
+    url,
+    headers: { Accept: "application/vnd.github.diff" },
+    timeoutMs: 6e4
+  });
+  const truncated = truncateText(resp.text, (_a = params.max_chars) != null ? _a : 2e4);
+  return {
+    pull_number: params.pull_number,
+    diff: truncated.text,
+    truncated: truncated.truncated,
+    original_length: truncated.original_length
+  };
+}
+async function listPullRequestCommits(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/commits`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactCommit) : [];
+}
+async function listPullRequestReviews(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/reviews`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((item) => {
+    var _a2;
+    return {
+      id: item.id,
+      user: (_a2 = item.user) == null ? void 0 : _a2.login,
+      state: item.state,
+      body: item.body,
+      submitted_at: item.submitted_at,
+      html_url: item.html_url,
+      commit_id: item.commit_id
+    };
+  }) : [];
+}
+async function listReviewComments(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/comments`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((item) => {
+    var _a2;
+    return {
+      id: item.id,
+      user: (_a2 = item.user) == null ? void 0 : _a2.login,
+      path: item.path,
+      line: item.line,
+      original_line: item.original_line,
+      side: item.side,
+      body: item.body,
+      html_url: item.html_url,
+      in_reply_to_id: item.in_reply_to_id,
+      created_at: item.created_at,
+      updated_at: item.updated_at
+    };
+  }) : [];
+}
+async function createReview(params) {
+  var _a;
+  requireToken("create_review");
+  const comments = parseJsonParam(params.comments, "comments");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/reviews`));
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      body: params.body,
+      event: params.event,
+      commit_id: params.commit_id,
+      comments
+    }
+  });
+  return {
+    id: data.id,
+    state: data.state,
+    body: data.body,
+    html_url: data.html_url,
+    user: (_a = data.user) == null ? void 0 : _a.login
+  };
+}
+async function replyReviewComment(params) {
+  var _a;
+  requireToken("reply_review_comment");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/comments/${params.comment_id}/replies`)
+  );
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: { body: params.body }
+  });
+  return {
+    id: data.id,
+    body: data.body,
+    html_url: data.html_url,
+    in_reply_to_id: data.in_reply_to_id,
+    user: (_a = data.user) == null ? void 0 : _a.login
+  };
+}
+async function requestReviewers(params) {
+  requireToken("request_reviewers");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/requested_reviewers`));
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      reviewers: splitCsv(params.reviewers),
+      team_reviewers: splitCsv(params.team_reviewers)
+    }
+  });
+  return {
+    number: data.number,
+    html_url: data.html_url,
+    requested_reviewers: Array.isArray(data.requested_reviewers) ? data.requested_reviewers.map((it) => it.login) : [],
+    requested_teams: Array.isArray(data.requested_teams) ? data.requested_teams.map((it) => it.slug || it.name) : []
+  };
 }
 
 // src/utils/base64.ts
@@ -634,10 +3377,7 @@ async function resolveFileSha(params) {
 }
 async function createOrUpdateFile(params) {
   var _a;
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for create_or_update_file.");
-  }
+  requireToken("create_or_update_file");
   const encoding = (params.content_encoding || "utf-8").toLowerCase();
   const base64Content = encoding === "base64" ? params.content : safeBtoaBase64(params.content);
   const sha = (_a = params.sha) != null ? _a : await resolveFileSha({ owner: params.owner, repo: params.repo, path: params.path, branch: params.branch });
@@ -657,10 +3397,7 @@ async function createOrUpdateFile(params) {
 }
 async function deleteFile(params) {
   var _a;
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for delete_file.");
-  }
+  requireToken("delete_file");
   const sha = (_a = params.sha) != null ? _a : await resolveFileSha({ owner: params.owner, repo: params.repo, path: params.path, branch: params.branch });
   if (!sha) {
     throw new Error("File sha is required (unable to resolve automatically).");
@@ -677,6 +3414,25 @@ async function deleteFile(params) {
       sha
     }
   });
+}
+
+// src/github/repos.ts
+async function searchRepositories(params) {
+  var _a, _b;
+  const page = (_a = params.page) != null ? _a : 1;
+  const perPage = (_b = params.per_page) != null ? _b : 30;
+  const url = buildUrl("/search/repositories", {
+    q: params.query,
+    sort: params.sort,
+    order: params.order,
+    page,
+    per_page: perPage
+  });
+  return requestJson({ method: "GET", url });
+}
+async function getRepository(params) {
+  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}`);
+  return requestJson({ method: "GET", url });
 }
 
 // src/github/branches.ts
@@ -696,10 +3452,7 @@ async function getBranchHeadSha(params) {
 }
 async function createBranch(params) {
   var _a, _b;
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for create_branch.");
-  }
+  requireToken("create_branch");
   const fromBranch = (_b = params.from_branch) != null ? _b : String(((_a = await getRepository({ owner: params.owner, repo: params.repo })) == null ? void 0 : _a.default_branch) || "main");
   const sha = await getBranchHeadSha({ owner: params.owner, repo: params.repo, branch: fromBranch });
   const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/git/refs`);
@@ -711,6 +3464,424 @@ async function createBranch(params) {
       sha
     }
   });
+}
+
+// src/github/git.ts
+async function listBranches(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/branches"), {
+    protected: params.protected_only,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((item) => {
+    var _a2;
+    return {
+      name: item.name,
+      sha: (_a2 = item.commit) == null ? void 0 : _a2.sha,
+      protected: item.protected,
+      html_url: `https://github.com/${params.owner}/${params.repo}/tree/${item.name}`
+    };
+  }) : [];
+}
+async function listCommits(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/commits"), {
+    sha: params.sha,
+    path: params.path,
+    author: params.author,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 20
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactCommit) : [];
+}
+async function getCommit(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/commits/${encodeURIComponent(params.ref)}`));
+  const data = await requestJson({ method: "GET", url });
+  return __spreadProps(__spreadValues({}, compactCommit(data)), {
+    stats: data.stats,
+    files: params.include_files === false ? void 0 : Array.isArray(data.files) ? data.files.map((file) => compactFileChange(file, false)) : []
+  });
+}
+async function compareRefs(params) {
+  const spec = `${encodeRef(params.base)}...${encodeRef(params.head)}`;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/compare/${spec}`));
+  const data = await requestJson({ method: "GET", url });
+  const includeFiles = params.include_files !== false;
+  return {
+    status: data.status,
+    ahead_by: data.ahead_by,
+    behind_by: data.behind_by,
+    total_commits: data.total_commits,
+    html_url: data.html_url,
+    permalink_url: data.permalink_url,
+    base_commit: compactCommit(data.base_commit),
+    merge_base_commit: compactCommit(data.merge_base_commit),
+    commits: Array.isArray(data.commits) ? data.commits.map(compactCommit) : [],
+    files: includeFiles ? Array.isArray(data.files) ? data.files.map((file) => compactFileChange(file, params.include_patch === true)) : [] : void 0
+  };
+}
+async function getCompareDiff(params) {
+  var _a;
+  const spec = `${encodeRef(params.base)}...${encodeRef(params.head)}`;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/compare/${spec}`));
+  const resp = await requestText({
+    method: "GET",
+    url,
+    headers: { Accept: "application/vnd.github.diff" },
+    timeoutMs: 6e4
+  });
+  const truncated = truncateText(resp.text, (_a = params.max_chars) != null ? _a : 2e4);
+  return {
+    base: params.base,
+    head: params.head,
+    diff: truncated.text,
+    truncated: truncated.truncated,
+    original_length: truncated.original_length
+  };
+}
+
+// src/github/actions.ts
+function compactWorkflow(item) {
+  if (!item) return item;
+  return {
+    id: item.id,
+    name: item.name,
+    path: item.path,
+    state: item.state,
+    html_url: item.html_url,
+    badge_url: item.badge_url,
+    created_at: item.created_at,
+    updated_at: item.updated_at
+  };
+}
+function compactRun(item) {
+  var _a, _b;
+  if (!item) return item;
+  return {
+    id: item.id,
+    name: item.name,
+    display_title: item.display_title,
+    status: item.status,
+    conclusion: item.conclusion,
+    event: item.event,
+    head_branch: item.head_branch,
+    head_sha: item.head_sha,
+    html_url: item.html_url,
+    path: item.path,
+    run_number: item.run_number,
+    run_attempt: item.run_attempt,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    actor: (_a = item.actor) == null ? void 0 : _a.login,
+    triggering_actor: (_b = item.triggering_actor) == null ? void 0 : _b.login
+  };
+}
+function compactJob(item) {
+  if (!item) return item;
+  return {
+    id: item.id,
+    run_id: item.run_id,
+    name: item.name,
+    status: item.status,
+    conclusion: item.conclusion,
+    html_url: item.html_url,
+    started_at: item.started_at,
+    completed_at: item.completed_at,
+    runner_name: item.runner_name,
+    steps: Array.isArray(item.steps) ? item.steps.map((step) => ({
+      name: step.name,
+      status: step.status,
+      conclusion: step.conclusion,
+      number: step.number,
+      started_at: step.started_at,
+      completed_at: step.completed_at
+    })) : []
+  };
+}
+async function listWorkflows(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/actions/workflows"), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const data = await requestJson({ method: "GET", url });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    workflows: Array.isArray(data == null ? void 0 : data.workflows) ? data.workflows.map(compactWorkflow) : []
+  };
+}
+async function listWorkflowRuns(params) {
+  var _a, _b;
+  const suffix = params.workflow_id ? `/actions/workflows/${encodeURIComponent(String(params.workflow_id))}/runs` : "/actions/runs";
+  const url = buildUrl(repoPath(params.owner, params.repo, suffix), {
+    branch: params.branch,
+    status: params.status,
+    event: params.event,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 20
+  });
+  const data = await requestJson({ method: "GET", url });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    workflow_runs: Array.isArray(data == null ? void 0 : data.workflow_runs) ? data.workflow_runs.map(compactRun) : []
+  };
+}
+async function getWorkflowRun(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/actions/runs/${encodeURIComponent(String(params.run_id))}`));
+  return compactRun(await requestJson({ method: "GET", url }));
+}
+async function triggerWorkflow(params) {
+  requireToken("trigger_workflow");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/actions/workflows/${encodeURIComponent(String(params.workflow_id))}/dispatches`)
+  );
+  const inputs = parseJsonParam(params.inputs, "inputs");
+  const result = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      ref: params.ref,
+      inputs
+    }
+  });
+  return {
+    ok: true,
+    workflow_id: params.workflow_id,
+    ref: params.ref,
+    inputs: inputs || {},
+    dispatch: result
+  };
+}
+async function getWorkflowJobs(params) {
+  var _a, _b, _c;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/actions/runs/${encodeURIComponent(String(params.run_id))}/jobs`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 50
+  });
+  const data = await requestJson({ method: "GET", url });
+  const jobs = Array.isArray(data == null ? void 0 : data.jobs) ? data.jobs.map(compactJob) : [];
+  const selected = params.failed_only ? jobs.filter((job) => job.conclusion && job.conclusion !== "success" && job.conclusion !== "skipped") : jobs;
+  if (!params.include_logs) {
+    return {
+      total_count: data == null ? void 0 : data.total_count,
+      jobs: selected
+    };
+  }
+  const maxLogChars = (_c = params.max_log_chars) != null ? _c : 8e3;
+  const withLogs = [];
+  for (const job of selected) {
+    try {
+      const logUrl = buildUrl(repoPath(params.owner, params.repo, `/actions/jobs/${encodeURIComponent(String(job.id))}/logs`));
+      const logResp = await requestText({ method: "GET", url: logUrl, timeoutMs: 6e4 });
+      const truncated = truncateText(logResp.text, maxLogChars);
+      withLogs.push(__spreadProps(__spreadValues({}, job), {
+        logs: truncated.text,
+        logs_truncated: truncated.truncated,
+        logs_original_length: truncated.original_length
+      }));
+    } catch (e) {
+      withLogs.push(__spreadProps(__spreadValues({}, job), {
+        logs_error: String(e && e.message ? e.message : e)
+      }));
+    }
+  }
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    jobs: withLogs
+  };
+}
+async function rerunWorkflowRun(params) {
+  requireToken("rerun_workflow_run");
+  const suffix = params.failed_jobs_only ? `/actions/runs/${encodeURIComponent(String(params.run_id))}/rerun-failed-jobs` : `/actions/runs/${encodeURIComponent(String(params.run_id))}/rerun`;
+  const url = buildUrl(repoPath(params.owner, params.repo, suffix));
+  const body = params.enable_debug_logging === void 0 ? void 0 : { enable_debug_logging: params.enable_debug_logging };
+  const result = await requestJson({ method: "POST", url, body });
+  return { ok: true, run_id: params.run_id, failed_jobs_only: Boolean(params.failed_jobs_only), result };
+}
+async function cancelWorkflowRun(params) {
+  requireToken("cancel_workflow_run");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/actions/runs/${encodeURIComponent(String(params.run_id))}/cancel`));
+  const result = await requestJson({ method: "POST", url });
+  return { ok: true, run_id: params.run_id, result };
+}
+async function listCheckRuns(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/commits/${encodeURIComponent(params.ref)}/check-runs`), {
+    status: params.status,
+    filter: params.filter,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const data = await requestJson({ method: "GET", url });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    check_runs: Array.isArray(data == null ? void 0 : data.check_runs) ? data.check_runs.map((item) => {
+      var _a2, _b2;
+      return {
+        id: item.id,
+        name: item.name,
+        status: item.status,
+        conclusion: item.conclusion,
+        html_url: item.html_url,
+        details_url: item.details_url,
+        started_at: item.started_at,
+        completed_at: item.completed_at,
+        app: ((_a2 = item.app) == null ? void 0 : _a2.slug) || ((_b2 = item.app) == null ? void 0 : _b2.name)
+      };
+    }) : []
+  };
+}
+
+// src/github/search.ts
+async function searchCode(params) {
+  var _a, _b;
+  const url = buildUrl("/search/code", {
+    q: params.query,
+    sort: params.sort,
+    order: params.order,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 20
+  });
+  const data = await requestJson({
+    method: "GET",
+    url,
+    headers: { Accept: "application/vnd.github.text-match+json" }
+  });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    incomplete_results: data == null ? void 0 : data.incomplete_results,
+    items: Array.isArray(data == null ? void 0 : data.items) ? data.items.map((item) => {
+      var _a2;
+      return {
+        name: item.name,
+        path: item.path,
+        sha: item.sha,
+        html_url: item.html_url,
+        repository: (_a2 = item.repository) == null ? void 0 : _a2.full_name,
+        score: item.score,
+        text_matches: Array.isArray(item.text_matches) ? item.text_matches.map((match) => ({
+          fragment: match.fragment,
+          property: match.property
+        })) : []
+      };
+    }) : []
+  };
+}
+async function searchIssues(params) {
+  var _a, _b;
+  const url = buildUrl("/search/issues", {
+    q: params.query,
+    sort: params.sort,
+    order: params.order,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 20
+  });
+  const data = await requestJson({ method: "GET", url });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    incomplete_results: data == null ? void 0 : data.incomplete_results,
+    items: Array.isArray(data == null ? void 0 : data.items) ? data.items.map((item) => {
+      var _a2;
+      return {
+        number: item.number,
+        title: item.title,
+        state: item.state,
+        html_url: item.html_url,
+        repository: item.repository_url,
+        user: (_a2 = item.user) == null ? void 0 : _a2.login,
+        comments: item.comments,
+        pull_request: Boolean(item.pull_request),
+        updated_at: item.updated_at
+      };
+    }) : []
+  };
+}
+
+// src/github/users.ts
+async function getAuthenticatedUser() {
+  var _a;
+  const data = await requestJson({ method: "GET", url: buildUrl("/user") });
+  return {
+    login: data.login,
+    id: data.id,
+    name: data.name,
+    html_url: data.html_url,
+    type: data.type,
+    company: data.company,
+    public_repos: data.public_repos,
+    total_private_repos: data.total_private_repos,
+    plan: (_a = data.plan) == null ? void 0 : _a.name
+  };
+}
+async function getRateLimit() {
+  var _a, _b, _c;
+  const data = await requestJson({ method: "GET", url: buildUrl("/rate_limit") });
+  const core = ((_a = data == null ? void 0 : data.resources) == null ? void 0 : _a.core) || {};
+  const search = ((_b = data == null ? void 0 : data.resources) == null ? void 0 : _b.search) || {};
+  const graphql = ((_c = data == null ? void 0 : data.resources) == null ? void 0 : _c.graphql) || {};
+  return {
+    core: {
+      limit: core.limit,
+      remaining: core.remaining,
+      reset: core.reset,
+      used: core.used
+    },
+    search: {
+      limit: search.limit,
+      remaining: search.remaining,
+      reset: search.reset,
+      used: search.used
+    },
+    graphql: {
+      limit: graphql.limit,
+      remaining: graphql.remaining,
+      reset: graphql.reset,
+      used: graphql.used
+    }
+  };
+}
+
+// src/github/forks.ts
+async function forkRepository(params) {
+  var _a, _b;
+  requireToken("fork_repository");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/forks"));
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      organization: params.organization,
+      name: params.name,
+      default_branch_only: params.default_branch_only
+    }
+  });
+  return {
+    full_name: data.full_name,
+    html_url: data.html_url,
+    default_branch: data.default_branch,
+    parent: (_a = data.parent) == null ? void 0 : _a.full_name,
+    source: (_b = data.source) == null ? void 0 : _b.full_name,
+    private: data.private
+  };
+}
+async function syncFork(params) {
+  requireToken("sync_fork");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/merge-upstream"));
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      branch: params.branch
+    }
+  });
+  return {
+    message: data.message,
+    merge_type: data.merge_type,
+    base_branch: data.base_branch
+  };
 }
 
 // src/github/patch.ts
@@ -785,7 +3956,7 @@ async function patchFileInRepo(params) {
   });
 }
 
-// src/local/fileApply.ts
+// src/github/local/fileApply.ts
 async function applyLocalReplace(params) {
   return Tools.Files.apply(params.path, "replace", params.old, params.new, params.environment);
 }
@@ -801,7 +3972,7 @@ async function overwriteLocalFile(params) {
   return Tools.Files.write(params.path, String((_a = params.content) != null ? _a : ""), false, params.environment);
 }
 
-// src/local/terminal.ts
+// src/github/local/terminal.ts
 var terminalSessionId = null;
 async function getTerminalSession(sessionName) {
   if (terminalSessionId) return terminalSessionId;
@@ -819,282 +3990,131 @@ async function terminalExec(params) {
   return result;
 }
 
-// src/tools.ts
-var toolImpl = {
-  search_repositories: (p) => wrap(searchRepositories, p, "\u641C\u7D22\u4ED3\u5E93\u6210\u529F", "\u641C\u7D22\u4ED3\u5E93\u5931\u8D25"),
-  get_repository: (p) => wrap(getRepository, p, "\u83B7\u53D6\u4ED3\u5E93\u4FE1\u606F\u6210\u529F", "\u83B7\u53D6\u4ED3\u5E93\u4FE1\u606F\u5931\u8D25"),
-  list_issues: (p) => wrap(listIssues, p, "\u83B7\u53D6 Issues \u6210\u529F", "\u83B7\u53D6 Issues \u5931\u8D25"),
-  create_issue: (p) => wrap(createIssue, p, "\u521B\u5EFA Issue \u6210\u529F", "\u521B\u5EFA Issue \u5931\u8D25"),
-  comment_issue: (p) => wrap(commentIssue, p, "\u53D1\u8868\u8BC4\u8BBA\u6210\u529F", "\u53D1\u8868\u8BC4\u8BBA\u5931\u8D25"),
-  list_issue_comments: (p) => wrap(listIssueComments, p, "\u83B7\u53D6 Issue \u8BC4\u8BBA\u6210\u529F", "\u83B7\u53D6 Issue \u8BC4\u8BBA\u5931\u8D25"),
-  list_pull_requests: (p) => wrap(listPullRequests, p, "\u83B7\u53D6 PR \u5217\u8868\u6210\u529F", "\u83B7\u53D6 PR \u5217\u8868\u5931\u8D25"),
-  create_pull_request: (p) => wrap(createPullRequest, p, "\u521B\u5EFA PR \u6210\u529F", "\u521B\u5EFA PR \u5931\u8D25"),
-  get_pull_request: (p) => wrap(getPullRequest, p, "\u83B7\u53D6 PR \u6210\u529F", "\u83B7\u53D6 PR \u5931\u8D25"),
-  merge_pull_request: (p) => wrap(mergePullRequest, p, "\u5408\u5E76 PR \u6210\u529F", "\u5408\u5E76 PR \u5931\u8D25"),
-  get_file_content: (p) => wrap(getFileContent, p, "\u8BFB\u53D6\u6587\u4EF6\u6210\u529F", "\u8BFB\u53D6\u6587\u4EF6\u5931\u8D25"),
-  create_or_update_file: (p) => wrap(createOrUpdateFile, p, "\u63D0\u4EA4\u6587\u4EF6\u6210\u529F", "\u63D0\u4EA4\u6587\u4EF6\u5931\u8D25"),
-  delete_file: (p) => wrap(deleteFile, p, "\u5220\u9664\u6587\u4EF6\u6210\u529F", "\u5220\u9664\u6587\u4EF6\u5931\u8D25"),
-  create_branch: (p) => wrap(createBranch, p, "\u521B\u5EFA\u5206\u652F\u6210\u529F", "\u521B\u5EFA\u5206\u652F\u5931\u8D25"),
-  patch_file_in_repo: (p) => wrap(patchFileInRepo, p, "\u4ED3\u5E93\u6587\u4EF6\u5DEE\u5F02\u66F4\u65B0\u6210\u529F", "\u4ED3\u5E93\u6587\u4EF6\u5DEE\u5F02\u66F4\u65B0\u5931\u8D25"),
-  apply_local_replace: (p) => wrap(applyLocalReplace, p, "\u672C\u5730\u5DEE\u5F02\u66F4\u65B0\u6210\u529F", "\u672C\u5730\u5DEE\u5F02\u66F4\u65B0\u5931\u8D25"),
-  apply_local_delete: (p) => wrap(applyLocalDelete, p, "\u672C\u5730\u5220\u9664\u7247\u6BB5\u6210\u529F", "\u672C\u5730\u5220\u9664\u7247\u6BB5\u5931\u8D25"),
-  overwrite_local_file: (p) => wrap(overwriteLocalFile, p, "\u672C\u5730\u8986\u76D6\u5199\u5165\u6210\u529F", "\u672C\u5730\u8986\u76D6\u5199\u5165\u5931\u8D25"),
-  terminal_exec: (p) => wrap(terminalExec, p, "\u7EC8\u7AEF\u6267\u884C\u6210\u529F", "\u7EC8\u7AEF\u6267\u884C\u5931\u8D25")
-};
-
-// src/index.ts
-exports.search_repositories = toolImpl.search_repositories;
-exports.get_repository = toolImpl.get_repository;
-exports.list_issues = toolImpl.list_issues;
-exports.create_issue = toolImpl.create_issue;
-exports.comment_issue = toolImpl.comment_issue;
-exports.list_issue_comments = toolImpl.list_issue_comments;
-exports.list_pull_requests = toolImpl.list_pull_requests;
-exports.create_pull_request = toolImpl.create_pull_request;
-exports.get_pull_request = toolImpl.get_pull_request;
-exports.merge_pull_request = toolImpl.merge_pull_request;
-exports.get_file_content = toolImpl.get_file_content;
-exports.create_or_update_file = toolImpl.create_or_update_file;
-exports.patch_file_in_repo = toolImpl.patch_file_in_repo;
-exports.delete_file = toolImpl.delete_file;
-exports.create_branch = toolImpl.create_branch;
-exports.apply_local_replace = toolImpl.apply_local_replace;
-exports.apply_local_delete = toolImpl.apply_local_delete;
-exports.overwrite_local_file = toolImpl.overwrite_local_file;
-exports.terminal_exec = toolImpl.terminal_exec;
-async function main(params) {
-  var _a, _b, _c;
+// src/utils/wrap.ts
+async function wrap(func, params, successMessage, failMessage) {
   try {
-    const owner = String((params == null ? void 0 : params.owner) || "octocat");
-    const repo = String((params == null ? void 0 : params.repo) || "Hello-World");
-    const query = String((params == null ? void 0 : params.query) || "operit");
-    const path = String((params == null ? void 0 : params.path) || "README.md");
-    const enableWrite = (params == null ? void 0 : params.enable_write) === true;
-    const baseUrl = getBaseUrl();
-    const token = getToken();
-    const results = {};
-    const toErrMsg = (e) => String(e && e.message ? e.message : e);
-    const toErrStack = (e) => String(e && e.stack ? e.stack : "");
-    const run = async (name, fn) => {
-      try {
-        const data = await fn();
-        return { ok: true, data };
-      } catch (e) {
-        return { ok: false, error: toErrMsg(e), error_stack: toErrStack(e) };
-      }
-    };
-    const summarizeRepo = (r) => r ? {
-      id: r.id,
-      full_name: r.full_name,
-      private: r.private,
-      default_branch: r.default_branch
-    } : r;
-    const summarizeList = (items) => ({
-      count: Array.isArray(items) ? items.length : 0,
-      first: Array.isArray(items) && items.length > 0 ? items[0] : null
-    });
-    results.get_repository = await run("get_repository", async () => summarizeRepo(await getRepository({ owner, repo })));
-    results.search_repositories = await run("search_repositories", async () => {
-      const r = await searchRepositories({ query, per_page: 5 });
-      const items = Array.isArray(r == null ? void 0 : r.items) ? r.items : [];
-      return {
-        total_count: r == null ? void 0 : r.total_count,
-        count: items.length,
-        first: items[0] ? { id: items[0].id, full_name: items[0].full_name, stargazers_count: items[0].stargazers_count } : null
-      };
-    });
-    results.list_issues = await run("list_issues", async () => summarizeList(await listIssues({ owner, repo, per_page: 5 })));
-    let issueNumber = typeof (params == null ? void 0 : params.issue_number) === "number" ? params.issue_number : void 0;
-    if (!issueNumber && results.list_issues.ok) {
-      const first = (_a = results.list_issues.data) == null ? void 0 : _a.first;
-      if (first && typeof first.number === "number") issueNumber = first.number;
-    }
-    if (issueNumber) {
-      results.list_issue_comments = await run(
-        "list_issue_comments",
-        async () => summarizeList(await listIssueComments({ owner, repo, issue_number: issueNumber, per_page: 5 }))
-      );
-    } else {
-      results.list_issue_comments = { ok: false, skipped: true, reason: "No issue_number provided and cannot infer from list_issues." };
-    }
-    results.list_pull_requests = await run("list_pull_requests", async () => summarizeList(await listPullRequests({ owner, repo, per_page: 5 })));
-    let pullNumber = typeof (params == null ? void 0 : params.pull_number) === "number" ? params.pull_number : void 0;
-    if (!pullNumber && results.list_pull_requests.ok) {
-      const first = (_b = results.list_pull_requests.data) == null ? void 0 : _b.first;
-      if (first && typeof first.number === "number") pullNumber = first.number;
-    }
-    if (pullNumber) {
-      results.get_pull_request = await run("get_pull_request", async () => {
-        var _a2, _b2;
-        const pr = await getPullRequest({ owner, repo, pull_number: pullNumber });
-        return pr ? {
-          number: pr.number,
-          title: pr.title,
-          state: pr.state,
-          merged: pr.merged,
-          head: (_a2 = pr.head) == null ? void 0 : _a2.ref,
-          base: (_b2 = pr.base) == null ? void 0 : _b2.ref
-        } : pr;
-      });
-    } else {
-      results.get_pull_request = { ok: false, skipped: true, reason: "No pull_number provided and cannot infer from list_pull_requests." };
-    }
-    const inferReadableRepoFilePath = async () => {
-      if (params == null ? void 0 : params.path) {
-        return path;
-      }
-      try {
-        const root = await getFileContent({ owner, repo, path: "" });
-        if (!Array.isArray(root)) {
-          return void 0;
-        }
-        const prefer = ["README.md", "README", "readme.md", "Readme.md", "README.MD"];
-        for (const p of prefer) {
-          const hit = root.find((it) => it && it.type === "file" && String(it.path || it.name || "") === p);
-          if (hit) return String(hit.path || hit.name);
-        }
-        const firstFile = root.find((it) => it && it.type === "file" && (typeof it.path === "string" || typeof it.name === "string"));
-        if (firstFile) return String(firstFile.path || firstFile.name);
-        return void 0;
-      } catch (e) {
-        return void 0;
-      }
-    };
-    const resolvedPath = await inferReadableRepoFilePath();
-    if (!resolvedPath) {
-      results.get_file_content = { ok: false, skipped: true, reason: "No readable file found in repo root for get_file_content test." };
-    } else {
-      results.get_file_content = await run("get_file_content", async () => {
-        const f = await getFileContent({ owner, repo, path: resolvedPath });
-        return f ? {
-          type: f.type,
-          path: f.path,
-          sha: f.sha,
-          size: f.size,
-          has_decoded_text: typeof f.decoded_text === "string" && f.decoded_text.length > 0
-        } : f;
-      });
-    }
-    const writeSkipped = (name, reason) => {
-      results[name] = { ok: false, skipped: true, reason };
-    };
-    if (!enableWrite) {
-      writeSkipped("create_issue", "Skipped: enable_write=false (write operation).");
-      writeSkipped("comment_issue", "Skipped: enable_write=false (write operation).");
-      writeSkipped("create_branch", "Skipped: enable_write=false (write operation).");
-      writeSkipped("create_or_update_file", "Skipped: enable_write=false (write operation).");
-      writeSkipped("patch_file_in_repo", "Skipped: enable_write=false (write operation).");
-      writeSkipped("delete_file", "Skipped: enable_write=false (write operation).");
-      writeSkipped("create_pull_request", "Skipped: enable_write=false (write operation).");
-      writeSkipped("merge_pull_request", "Skipped: enable_write=false (write operation).");
-    } else {
-      const ts = Date.now();
-      const testBranch = `operit-test-${ts}`;
-      const testPath = `operit_test_${ts}.txt`;
-      const baseBranch = (results.get_repository.ok ? (_c = results.get_repository.data) == null ? void 0 : _c.default_branch : void 0) || "main";
-      results.create_branch = await run(
-        "create_branch",
-        async () => createBranch({ owner, repo, new_branch: testBranch, from_branch: baseBranch })
-      );
-      results.create_or_update_file = await run(
-        "create_or_update_file",
-        async () => createOrUpdateFile({
-          owner,
-          repo,
-          path: testPath,
-          message: `operit test create file ${ts}`,
-          content: `operit github tools self-test ${ts}`,
-          content_encoding: "utf-8",
-          branch: testBranch
-        })
-      );
-      results.patch_file_in_repo = await run(
-        "patch_file_in_repo",
-        async () => patchFileInRepo({
-          owner,
-          repo,
-          path: testPath,
-          message: `operit test patch file ${ts}`,
-          patch: `[START-REPLACE]
-[OLD]
-operit github tools self-test ${ts}
-[/OLD]
-[NEW]
-operit github tools self-test ${ts} (patched)
-[/NEW]
-[END-REPLACE]`,
-          branch: testBranch
-        })
-      );
-      results.delete_file = await run("delete_file", async () => {
-        const sha = results.create_or_update_file.ok && results.create_or_update_file.data && results.create_or_update_file.data.content ? results.create_or_update_file.data.content.sha : void 0;
-        if (!sha) {
-          throw new Error("Cannot infer sha from create_or_update_file response; pass sha explicitly if needed.");
-        }
-        return deleteFile({ owner, repo, path: testPath, message: `operit test delete file ${ts}`, branch: testBranch, sha });
-      });
-      const canIssue = Boolean(token) && issueNumber !== void 0;
-      if (!token) {
-        writeSkipped("create_issue", "Skipped: GITHUB_TOKEN missing (required for write operation).");
-      } else {
-        results.create_issue = await run(
-          "create_issue",
-          async () => createIssue({ owner, repo, title: `operit self-test issue ${ts}`, body: `created by operit github tools self-test ${ts}` })
-        );
-      }
-      if (!canIssue) {
-        writeSkipped("comment_issue", "Skipped: need GITHUB_TOKEN and issue_number (or at least one issue from list_issues).");
-      } else {
-        results.comment_issue = await run(
-          "comment_issue",
-          async () => commentIssue({ owner, repo, issue_number: issueNumber, body: `operit self-test comment ${ts}` })
-        );
-      }
-      const prHead = (params == null ? void 0 : params.pr_head) ? String(params.pr_head) : "";
-      const prBase = (params == null ? void 0 : params.pr_base) ? String(params.pr_base) : "";
-      if (!token) {
-        writeSkipped("create_pull_request", "Skipped: GITHUB_TOKEN missing (required for write operation).");
-      } else if (!prHead || !prBase) {
-        writeSkipped("create_pull_request", "Skipped: pr_head/pr_base not provided (required to create PR).");
-      } else {
-        results.create_pull_request = await run(
-          "create_pull_request",
-          async () => createPullRequest({ owner, repo, title: `operit self-test PR ${ts}`, head: prHead, base: prBase, body: `created by operit self-test ${ts}` })
-        );
-      }
-      if (!token) {
-        writeSkipped("merge_pull_request", "Skipped: GITHUB_TOKEN missing (required for write operation).");
-      } else if (!pullNumber) {
-        writeSkipped("merge_pull_request", "Skipped: pull_number missing (required to merge PR).");
-      } else {
-        results.merge_pull_request = await run(
-          "merge_pull_request",
-          async () => mergePullRequest({ owner, repo, pull_number: pullNumber, merge_method: "merge" })
-        );
-      }
-    }
-    const okCount = Object.values(results).filter((r) => r.ok === true).length;
-    const failCount = Object.values(results).filter((r) => r.ok === false && !r.skipped).length;
-    const skippedCount = Object.values(results).filter((r) => r.skipped).length;
-    complete({
-      success: failCount === 0,
-      message: failCount === 0 ? "GitHub tools main test finished." : `GitHub tools main test finished with failures: failed=${failCount}, ok=${okCount}, skipped=${skippedCount}.`,
-      data: {
-        baseUrl,
-        hasToken: Boolean(token),
-        enable_write: enableWrite,
-        owner,
-        repo,
-        summary: { ok: okCount, failed: failCount, skipped: skippedCount },
-        results
-      }
-    });
+    const data = await func(params);
+    const result = { success: true, message: successMessage, data };
+    complete(result);
   } catch (error) {
-    complete({
+    const result = {
       success: false,
-      message: `GitHub tools main test failed: ${String(error && error.message ? error.message : error)}`,
+      message: `${failMessage}: ${String(error && error.message ? error.message : error)}`,
       error_stack: String(error && error.stack ? error.stack : "")
-    });
+    };
+    complete(result);
   }
 }
-exports.main = main;
+
+// src/index.ts
+var toolImpl = {
+  search_repositories: (p) => wrap(searchRepositories, p, "\u641C\u7D22\u4ED3\u5E93\u6210\u529F", "\u641C\u7D22\u4ED3\u5E93\u5931\u8D25"),
+  get_repository: (p) => wrap(searchRepositories, p, "\u83B7\u53D6\u4ED3\u5E93\u6210\u529F", "\u83B7\u53D6\u4ED3\u5E93\u5931\u8D25"),
+  list_issues: (p) => wrap(listIssues, p, "\u5217\u51FA Issues \u6210\u529F", "\u5217\u51FA Issues \u5931\u8D25"),
+  get_issue: (p) => wrap(getIssue, p, "\u83B7\u53D6 Issue \u6210\u529F", "\u83B7\u53D6 Issue \u5931\u8D25"),
+  create_issue: (p) => wrap(createIssue, p, "\u521B\u5EFA Issue \u6210\u529F", "\u521B\u5EFA Issue \u5931\u8D25"),
+  update_issue: (p) => wrap(updateIssue, p, "\u66F4\u65B0 Issue \u6210\u529F", "\u66F4\u65B0 Issue \u5931\u8D25"),
+  comment_issue: (p) => wrap(commentIssue, p, "\u8BC4\u8BBA\u6210\u529F", "\u8BC4\u8BBA\u5931\u8D25"),
+  list_issue_comments: (p) => wrap(listIssueComments, p, "\u5217\u51FA\u8BC4\u8BBA\u6210\u529F", "\u5217\u51FA\u8BC4\u8BBA\u5931\u8D25"),
+  list_pull_requests: (p) => wrap(listPullRequests, p, "\u5217\u51FA PR \u6210\u529F", "\u5217\u51FA PR \u5931\u8D25"),
+  create_pull_request: (p) => wrap(createPullRequest, p, "\u521B\u5EFA PR \u6210\u529F", "\u521B\u5EFA PR \u5931\u8D25"),
+  get_pull_request: (p) => wrap(getPullRequest, p, "\u83B7\u53D6 PR \u6210\u529F", "\u83B7\u53D6 PR \u5931\u8D25"),
+  update_pull_request: (p) => wrap(updatePullRequest, p, "\u66F4\u65B0 PR \u6210\u529F", "\u66F4\u65B0 PR \u5931\u8D25"),
+  merge_pull_request: (p) => wrap(mergePullRequest, p, "\u5408\u5E76 PR \u6210\u529F", "\u5408\u5E76 PR \u5931\u8D25"),
+  list_pull_request_files: (p) => wrap(listPullRequestFiles, p, "\u83B7\u53D6 PR \u6587\u4EF6\u6210\u529F", "\u83B7\u53D6 PR \u6587\u4EF6\u5931\u8D25"),
+  get_pull_request_diff: (p) => wrap(getPullRequestDiff, p, "\u83B7\u53D6 PR diff \u6210\u529F", "\u83B7\u53D6 PR diff \u5931\u8D25"),
+  list_pull_request_commits: (p) => wrap(listPullRequestCommits, p, "\u83B7\u53D6 PR \u63D0\u4EA4\u6210\u529F", "\u83B7\u53D6 PR \u63D0\u4EA4\u5931\u8D25"),
+  list_pull_request_reviews: (p) => wrap(listPullRequestReviews, p, "\u83B7\u53D6 PR review \u6210\u529F", "\u83B7\u53D6 PR review \u5931\u8D25"),
+  list_review_comments: (p) => wrap(listReviewComments, p, "\u83B7\u53D6\u884C\u5185\u8BC4\u8BBA\u6210\u529F", "\u83B7\u53D6\u884C\u5185\u8BC4\u8BBA\u5931\u8D25"),
+  create_review: (p) => wrap(createReview, p, "\u63D0\u4EA4 review \u6210\u529F", "\u63D0\u4EA4 review \u5931\u8D25"),
+  reply_review_comment: (p) => wrap(replyReviewComment, p, "\u56DE\u590D\u8BC4\u8BBA\u6210\u529F", "\u56DE\u590D\u8BC4\u8BBA\u5931\u8D25"),
+  request_reviewers: (p) => wrap(requestReviewers, p, "\u8BF7\u6C42 reviewer \u6210\u529F", "\u8BF7\u6C42 reviewer \u5931\u8D25"),
+  get_file_content: (p) => wrap(getFileContent, p, "\u83B7\u53D6\u6587\u4EF6\u6210\u529F", "\u83B7\u53D6\u6587\u4EF6\u5931\u8D25"),
+  create_or_update_file: (p) => wrap(createOrUpdateFile, p, "\u5199\u5165\u6587\u4EF6\u6210\u529F", "\u5199\u5165\u6587\u4EF6\u5931\u8D25"),
+  delete_file: (p) => wrap(deleteFile, p, "\u5220\u9664\u6587\u4EF6\u6210\u529F", "\u5220\u9664\u6587\u4EF6\u5931\u8D25"),
+  create_branch: (p) => wrap(createBranch, p, "\u521B\u5EFA\u5206\u652F\u6210\u529F", "\u521B\u5EFA\u5206\u652F\u5931\u8D25"),
+  list_branches: (p) => wrap(listBranches, p, "\u5217\u51FA\u5206\u652F\u6210\u529F", "\u5217\u51FA\u5206\u652F\u5931\u8D25"),
+  list_commits: (p) => wrap(listCommits, p, "\u5217\u51FA\u63D0\u4EA4\u6210\u529F", "\u5217\u51FA\u63D0\u4EA4\u5931\u8D25"),
+  get_commit: (p) => wrap(getCommit, p, "\u83B7\u53D6\u63D0\u4EA4\u6210\u529F", "\u83B7\u53D6\u63D0\u4EA4\u5931\u8D25"),
+  compare_refs: (p) => wrap(compareRefs, p, "\u6BD4\u8F83 refs \u6210\u529F", "\u6BD4\u8F83 refs \u5931\u8D25"),
+  get_compare_diff: (p) => wrap(getCompareDiff, p, "\u83B7\u53D6 diff \u6210\u529F", "\u83B7\u53D6 diff \u5931\u8D25"),
+  list_workflows: (p) => wrap(listWorkflows, p, "\u5217\u51FA workflow \u6210\u529F", "\u5217\u51FA workflow \u5931\u8D25"),
+  list_workflow_runs: (p) => wrap(listWorkflowRuns, p, "\u83B7\u53D6 workflow run \u6210\u529F", "\u83B7\u53D6 workflow run \u5931\u8D25"),
+  get_workflow_run: (p) => wrap(getWorkflowRun, p, "\u83B7\u53D6 workflow run \u6210\u529F", "\u83B7\u53D6 workflow run \u5931\u8D25"),
+  trigger_workflow: (p) => wrap(triggerWorkflow, p, "\u89E6\u53D1 workflow \u6210\u529F", "\u89E6\u53D1 workflow \u5931\u8D25"),
+  get_workflow_jobs: (p) => wrap(getWorkflowJobs, p, "\u83B7\u53D6 workflow jobs \u6210\u529F", "\u83B7\u53D6 workflow jobs \u5931\u8D25"),
+  rerun_workflow_run: (p) => wrap(rerunWorkflowRun, p, "\u91CD\u65B0\u8FD0\u884C workflow \u6210\u529F", "\u91CD\u65B0\u8FD0\u884C workflow \u5931\u8D25"),
+  cancel_workflow_run: (p) => wrap(cancelWorkflowRun, p, "\u53D6\u6D88 workflow \u6210\u529F", "\u53D6\u6D88 workflow \u5931\u8D25"),
+  list_check_runs: (p) => wrap(listCheckRuns, p, "\u5217\u51FA check runs \u6210\u529F", "\u5217\u51FA check runs \u5931\u8D25"),
+  search_code: (p) => wrap(searchCode, p, "\u641C\u7D22\u4EE3\u7801\u6210\u529F", "\u641C\u7D22\u4EE3\u7801\u5931\u8D25"),
+  search_issues: (p) => wrap(searchIssues, p, "\u641C\u7D22 Issues \u6210\u529F", "\u641C\u7D22 Issues \u5931\u8D25"),
+  get_authenticated_user: (p) => wrap(getAuthenticatedUser, p, "\u83B7\u53D6\u7528\u6237\u6210\u529F", "\u83B7\u53D6\u7528\u6237\u5931\u8D25"),
+  get_rate_limit: (p) => wrap(getRateLimit, p, "\u83B7\u53D6 rate limit \u6210\u529F", "\u83B7\u53D6 rate limit \u5931\u8D25"),
+  fork_repository: (p) => wrap(forkRepository, p, "fork \u4ED3\u5E93\u6210\u529F", "fork \u4ED3\u5E93\u5931\u8D25"),
+  sync_fork: (p) => wrap(syncFork, p, "\u540C\u6B65 fork \u6210\u529F", "\u540C\u6B65 fork \u5931\u8D25"),
+  patch_file_in_repo: (p) => wrap(patchFileInRepo, p, "patch \u6587\u4EF6\u6210\u529F", "patch \u6587\u4EF6\u5931\u8D25"),
+  apply_local_replace: (p) => wrap(applyLocalReplace, p, "\u672C\u5730\u66FF\u6362\u6210\u529F", "\u672C\u5730\u66FF\u6362\u5931\u8D25"),
+  apply_local_delete: (p) => wrap(applyLocalDelete, p, "\u672C\u5730\u5220\u9664\u6210\u529F", "\u672C\u5730\u5220\u9664\u5931\u8D25"),
+  overwrite_local_file: (p) => wrap(overwriteLocalFile, p, "\u8986\u76D6\u6587\u4EF6\u6210\u529F", "\u8986\u76D6\u6587\u4EF6\u5931\u8D25"),
+  terminal_exec: (p) => wrap(terminalExec, p, "\u7EC8\u7AEF\u6267\u884C\u6210\u529F", "\u7EC8\u7AEF\u6267\u884C\u5931\u8D25")
+};
+async function main(params) {
+  const tool = params == null ? void 0 : params.tool;
+  if (!tool) {
+    return { ok: true, message: "GitHub API package loaded", tools: Object.keys(toolImpl) };
+  }
+  const fn = toolImpl[tool];
+  if (!fn) {
+    return { success: false, message: `Unknown tool: ${tool}`, available: Object.keys(toolImpl) };
+  }
+  return fn(params);
+}
+var search_repositories = toolImpl.search_repositories;
+var get_repository = toolImpl.get_repository;
+var list_issues = toolImpl.list_issues;
+var get_issue = toolImpl.get_issue;
+var create_issue = toolImpl.create_issue;
+var update_issue = toolImpl.update_issue;
+var comment_issue = toolImpl.comment_issue;
+var list_issue_comments = toolImpl.list_issue_comments;
+var list_pull_requests = toolImpl.list_pull_requests;
+var create_pull_request = toolImpl.create_pull_request;
+var get_pull_request = toolImpl.get_pull_request;
+var update_pull_request = toolImpl.update_pull_request;
+var merge_pull_request = toolImpl.merge_pull_request;
+var list_pull_request_files = toolImpl.list_pull_request_files;
+var get_pull_request_diff = toolImpl.get_pull_request_diff;
+var list_pull_request_commits = toolImpl.list_pull_request_commits;
+var list_pull_request_reviews = toolImpl.list_pull_request_reviews;
+var list_review_comments = toolImpl.list_review_comments;
+var create_review = toolImpl.create_review;
+var reply_review_comment = toolImpl.reply_review_comment;
+var request_reviewers = toolImpl.request_reviewers;
+var get_file_content = toolImpl.get_file_content;
+var create_or_update_file = toolImpl.create_or_update_file;
+var delete_file = toolImpl.delete_file;
+var create_branch = toolImpl.create_branch;
+var list_branches = toolImpl.list_branches;
+var list_commits = toolImpl.list_commits;
+var get_commit = toolImpl.get_commit;
+var compare_refs = toolImpl.compare_refs;
+var get_compare_diff = toolImpl.get_compare_diff;
+var list_workflows = toolImpl.list_workflows;
+var list_workflow_runs = toolImpl.list_workflow_runs;
+var get_workflow_run = toolImpl.get_workflow_run;
+var trigger_workflow = toolImpl.trigger_workflow;
+var get_workflow_jobs = toolImpl.get_workflow_jobs;
+var rerun_workflow_run = toolImpl.rerun_workflow_run;
+var cancel_workflow_run = toolImpl.cancel_workflow_run;
+var list_check_runs = toolImpl.list_check_runs;
+var search_code = toolImpl.search_code;
+var search_issues = toolImpl.search_issues;
+var get_authenticated_user = toolImpl.get_authenticated_user;
+var get_rate_limit = toolImpl.get_rate_limit;
+var fork_repository = toolImpl.fork_repository;
+var sync_fork = toolImpl.sync_fork;
+var patch_file_in_repo = toolImpl.patch_file_in_repo;
+var apply_local_replace = toolImpl.apply_local_replace;
+var apply_local_delete = toolImpl.apply_local_delete;
+var overwrite_local_file = toolImpl.overwrite_local_file;
+var terminal_exec = toolImpl.terminal_exec;

--- a/app/src/main/assets/packages/github.js
+++ b/app/src/main/assets/packages/github.js
@@ -1360,6 +1360,15 @@
           },
           "type": "string",
           "required": false
+        },
+        {
+          "name": "content_encoding",
+          "description": {
+            "zh": "内容编码：utf-8（默认）或 base64",
+            "en": "Content encoding: utf-8 (default) or base64."
+          },
+          "type": "string",
+          "required": false
         }
       ]
     },
@@ -1429,8 +1438,8 @@
     {
       "name": "create_branch",
       "description": {
-        "zh": "创建分支。",
-        "en": "Create a branch."
+        "zh": "创建分支（通过 /repos/{owner}/{repo}/git/refs）。",
+        "en": "Create a branch (via /repos/{owner}/{repo}/git/refs)."
       },
       "parameters": [
         {
@@ -1452,7 +1461,7 @@
           "required": true
         },
         {
-          "name": "branch",
+          "name": "new_branch",
           "description": {
             "zh": "新分支名",
             "en": "New branch name."
@@ -1463,17 +1472,8 @@
         {
           "name": "from_branch",
           "description": {
-            "zh": "基于哪个分支创建（默认默认分支）",
-            "en": "Branch to create from (default: default branch)."
-          },
-          "type": "string",
-          "required": false
-        },
-        {
-          "name": "sha",
-          "description": {
-            "zh": "直接指定起始 commit sha（优先于 from_branch）",
-            "en": "Starting commit SHA (overrides from_branch)."
+            "zh": "基于哪个分支创建（默认仓库默认分支）",
+            "en": "Branch to create from (default: repository default branch)."
           },
           "type": "string",
           "required": false

--- a/app/src/main/assets/packages/github.js
+++ b/app/src/main/assets/packages/github.js
@@ -1447,8 +1447,8 @@
     {
       "name": "create_branch",
       "description": {
-        "zh": "创建分支（通过 /repos/{owner}/{repo}/git/refs）。",
-        "en": "Create a branch (via /repos/{owner}/{repo}/git/refs)."
+        "zh": "创建或恢复分支（POST /repos/{owner}/{repo}/git/refs）。可从已有分支或指定 commit SHA 建 ref。",
+        "en": "Create or restore a branch (POST /repos/{owner}/{repo}/git/refs). Point the new ref at an existing branch or a commit SHA."
       },
       "parameters": [
         {
@@ -1481,11 +1481,56 @@
         {
           "name": "from_branch",
           "description": {
-            "zh": "基于哪个分支创建（默认仓库默认分支）",
-            "en": "Branch to create from (default: repository default branch)."
+            "zh": "基于哪个分支创建（默认仓库默认分支；若传了 from_sha 则忽略）",
+            "en": "Branch to create from (default: repository default branch; ignored when from_sha is set)."
           },
           "type": "string",
           "required": false
+        },
+        {
+          "name": "from_sha",
+          "description": {
+            "zh": "基于哪个 commit SHA 创建（优先于 from_branch；用于从提交恢复已删分支）",
+            "en": "Commit SHA to create from (takes precedence over from_branch; use this to restore a deleted branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_branch",
+      "description": {
+        "zh": "删除非默认分支（DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}）。不会删除仓库默认分支。",
+        "en": "Delete a non-default branch (DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}). Refuses to delete the repository default branch."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "要删除的分支名（不能是仓库默认分支）",
+            "en": "Branch name to delete (cannot be the repository default branch)."
+          },
+          "type": "string",
+          "required": true
         }
       ]
     },
@@ -4524,6 +4569,7 @@ __export(index_exports, {
   create_release: () => create_release,
   create_review: () => create_review,
   create_webhook: () => create_webhook,
+  delete_branch: () => delete_branch,
   delete_branch_protection: () => delete_branch_protection,
   delete_file: () => delete_file,
   delete_label: () => delete_label,
@@ -5336,13 +5382,16 @@ async function getRepository(params) {
 }
 
 // src/github/branches.ts
+function requiredName(value, field) {
+  const name = String(value != null ? value : "").trim();
+  if (!name) {
+    throw new Error(`${field} is required`);
+  }
+  return name;
+}
 async function getBranchHeadSha(params) {
   var _a;
-  const url = buildUrl(
-    `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/git/ref/heads/${encodeURIComponent(
-      params.branch
-    )}`
-  );
+  const url = buildUrl(repoPath(params.owner, params.repo, `/git/ref/heads/${encodeRef(params.branch)}`));
   const data = await requestJson({ method: "GET", url });
   const sha = (_a = data == null ? void 0 : data.object) == null ? void 0 : _a.sha;
   if (!sha) {
@@ -5351,19 +5400,42 @@ async function getBranchHeadSha(params) {
   return sha;
 }
 async function createBranch(params) {
-  var _a, _b;
+  var _a, _b, _c;
   requireToken("create_branch");
-  const fromBranch = (_b = params.from_branch) != null ? _b : String(((_a = await getRepository({ owner: params.owner, repo: params.repo })) == null ? void 0 : _a.default_branch) || "main");
-  const sha = await getBranchHeadSha({ owner: params.owner, repo: params.repo, branch: fromBranch });
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/git/refs`);
-  return requestJson({
+  const newBranch = requiredName(params.new_branch, "new_branch");
+  const fromSha = String((_a = params.from_sha) != null ? _a : "").trim();
+  let sha = fromSha;
+  let fromBranch;
+  if (!sha) {
+    fromBranch = String((_b = params.from_branch) != null ? _b : "").trim() || String(((_c = await getRepository({ owner: params.owner, repo: params.repo })) == null ? void 0 : _c.default_branch) || "main");
+    sha = await getBranchHeadSha({ owner: params.owner, repo: params.repo, branch: fromBranch });
+  }
+  const url = buildUrl(repoPath(params.owner, params.repo, "/git/refs"));
+  const result = await requestJson({
     method: "POST",
     url,
     body: {
-      ref: `refs/heads/${params.new_branch}`,
+      ref: `refs/heads/${newBranch}`,
       sha
     }
   });
+  return __spreadProps(__spreadValues({}, result), {
+    new_branch: newBranch,
+    from_sha: sha,
+    from_branch: fromBranch
+  });
+}
+async function deleteBranch(params) {
+  requireToken("delete_branch");
+  const branch = requiredName(params.branch, "branch");
+  const repoInfo = await getRepository({ owner: params.owner, repo: params.repo });
+  const defaultBranch = String((repoInfo == null ? void 0 : repoInfo.default_branch) || "").trim();
+  if (defaultBranch && branch === defaultBranch) {
+    throw new Error(`Refusing to delete the default branch '${defaultBranch}'.`);
+  }
+  const url = buildUrl(repoPath(params.owner, params.repo, `/git/refs/heads/${encodeRef(branch)}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, branch, result };
 }
 
 // src/github/git.ts
@@ -6571,6 +6643,7 @@ var toolImpl = {
   create_or_update_file: (p) => wrap(createOrUpdateFile, p, "\u5199\u5165\u6587\u4EF6\u6210\u529F", "\u5199\u5165\u6587\u4EF6\u5931\u8D25"),
   delete_file: (p) => wrap(deleteFile, p, "\u5220\u9664\u6587\u4EF6\u6210\u529F", "\u5220\u9664\u6587\u4EF6\u5931\u8D25"),
   create_branch: (p) => wrap(createBranch, p, "\u521B\u5EFA\u5206\u652F\u6210\u529F", "\u521B\u5EFA\u5206\u652F\u5931\u8D25"),
+  delete_branch: (p) => wrap(deleteBranch, p, "\u5220\u9664\u5206\u652F\u6210\u529F", "\u5220\u9664\u5206\u652F\u5931\u8D25"),
   list_branches: (p) => wrap(listBranches, p, "\u5217\u51FA\u5206\u652F\u6210\u529F", "\u5217\u51FA\u5206\u652F\u5931\u8D25"),
   list_commits: (p) => wrap(listCommits, p, "\u5217\u51FA\u63D0\u4EA4\u6210\u529F", "\u5217\u51FA\u63D0\u4EA4\u5931\u8D25"),
   get_commit: (p) => wrap(getCommit, p, "\u83B7\u53D6\u63D0\u4EA4\u6210\u529F", "\u83B7\u53D6\u63D0\u4EA4\u5931\u8D25"),
@@ -6668,6 +6741,7 @@ var get_file_content = toolImpl.get_file_content;
 var create_or_update_file = toolImpl.create_or_update_file;
 var delete_file = toolImpl.delete_file;
 var create_branch = toolImpl.create_branch;
+var delete_branch = toolImpl.delete_branch;
 var list_branches = toolImpl.list_branches;
 var list_commits = toolImpl.list_commits;
 var get_commit = toolImpl.get_commit;

--- a/app/src/main/assets/packages/github.js
+++ b/app/src/main/assets/packages/github.js
@@ -6,8 +6,8 @@
     "en": "GitHub API"
   },
   "description": {
-    "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。",
-    "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)."
+    "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/Releases/Webhooks/协作者/Labels/Milestones/分支保护/统计/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。",
+    "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/releases/webhooks/collaborators/labels/milestones/branch protection/stats/search/fork) and local-side utilities (apply_file patch updates, terminal)."
   },
   "category": "Development",
   "env": [
@@ -27,6 +27,15 @@
       },
       "required": false,
       "defaultValue": "https://api.github.com"
+    },
+    {
+      "name": "GITHUB_UPLOADS_BASE_URL",
+      "description": {
+        "zh": "GitHub Release 资产上传基础 URL（默认 https://uploads.github.com）",
+        "en": "GitHub release asset upload base URL (default: https://uploads.github.com)."
+      },
+      "required": false,
+      "defaultValue": "https://uploads.github.com"
     }
   ],
   "enabledByDefault": false,
@@ -2656,6 +2665,1806 @@
           "required": false
         }
       ]
+    },
+    {
+      "name": "list_releases",
+      "description": {
+        "zh": "列出仓库 Releases。",
+        "en": "List repository releases."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_release",
+      "description": {
+        "zh": "获取指定 Release。",
+        "en": "Get a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_latest_release",
+      "description": {
+        "zh": "获取最新的正式 Release。",
+        "en": "Get the latest release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_release_by_tag",
+      "description": {
+        "zh": "按 tag 获取 Release。",
+        "en": "Get a release by tag."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "tag",
+          "description": {
+            "zh": "Git tag 名称",
+            "en": "Git tag name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_release",
+      "description": {
+        "zh": "创建 Release。",
+        "en": "Create a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "tag_name",
+          "description": {
+            "zh": "tag 名称",
+            "en": "Tag name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "target_commitish",
+          "description": {
+            "zh": "目标分支或 commit",
+            "en": "Target branch or commit."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Release 标题",
+            "en": "Release name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "Release 描述",
+            "en": "Release body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether draft."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "prerelease",
+          "description": {
+            "zh": "是否预发布",
+            "en": "Whether prerelease."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "generate_release_notes",
+          "description": {
+            "zh": "是否自动生成说明",
+            "en": "Whether to generate release notes."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "make_latest",
+          "description": {
+            "zh": "latest 标记：true/false/legacy",
+            "en": "Latest marker: true/false/legacy."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "discussion_category_name",
+          "description": {
+            "zh": "Discussion 分类名",
+            "en": "Discussion category name."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_release",
+      "description": {
+        "zh": "更新 Release。",
+        "en": "Update a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "tag_name",
+          "description": {
+            "zh": "tag 名称",
+            "en": "Tag name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "target_commitish",
+          "description": {
+            "zh": "目标分支或 commit",
+            "en": "Target branch or commit."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Release 标题",
+            "en": "Release name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "Release 描述",
+            "en": "Release body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether draft."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "prerelease",
+          "description": {
+            "zh": "是否预发布",
+            "en": "Whether prerelease."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "make_latest",
+          "description": {
+            "zh": "latest 标记：true/false/legacy",
+            "en": "Latest marker: true/false/legacy."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "discussion_category_name",
+          "description": {
+            "zh": "Discussion 分类名",
+            "en": "Discussion category name."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_release",
+      "description": {
+        "zh": "删除 Release。",
+        "en": "Delete a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "upload_release_asset",
+      "description": {
+        "zh": "向 Release 上传本地文件资产。",
+        "en": "Upload a local file as a release asset."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "asset_path",
+          "description": {
+            "zh": "本地资产路径",
+            "en": "Local asset path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "上传后的文件名（默认取路径文件名）",
+            "en": "Uploaded filename (defaults to the path basename)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "label",
+          "description": {
+            "zh": "资产说明",
+            "en": "Asset label."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "content_type",
+          "description": {
+            "zh": "MIME 类型（默认 application/octet-stream）",
+            "en": "MIME type (default application/octet-stream)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "文件环境：android 或 linux",
+            "en": "File environment: android or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_release_asset",
+      "description": {
+        "zh": "删除 Release 资产。",
+        "en": "Delete a release asset."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "asset_id",
+          "description": {
+            "zh": "资产 ID",
+            "en": "Asset ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_webhooks",
+      "description": {
+        "zh": "列出仓库 Webhooks。",
+        "en": "List repository webhooks."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_webhook",
+      "description": {
+        "zh": "获取仓库 Webhook。",
+        "en": "Get a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_webhook",
+      "description": {
+        "zh": "创建仓库 Webhook。",
+        "en": "Create a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "url",
+          "description": {
+            "zh": "Webhook 接收 URL",
+            "en": "Webhook receiver URL."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "content_type",
+          "description": {
+            "zh": "内容类型：json 或 form",
+            "en": "Content type: json or form."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "secret",
+          "description": {
+            "zh": "Webhook secret",
+            "en": "Webhook secret."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "insecure_ssl",
+          "description": {
+            "zh": "是否允许不安全 SSL",
+            "en": "Whether to allow insecure SSL."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "events",
+          "description": {
+            "zh": "事件列表，逗号分隔或数组",
+            "en": "Events, comma-separated or array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "active",
+          "description": {
+            "zh": "是否启用",
+            "en": "Whether active."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "config",
+          "description": {
+            "zh": "额外 config JSON",
+            "en": "Additional config JSON."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_webhook",
+      "description": {
+        "zh": "更新仓库 Webhook。",
+        "en": "Update a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "url",
+          "description": {
+            "zh": "Webhook 接收 URL",
+            "en": "Webhook receiver URL."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "content_type",
+          "description": {
+            "zh": "内容类型：json 或 form",
+            "en": "Content type: json or form."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "secret",
+          "description": {
+            "zh": "Webhook secret",
+            "en": "Webhook secret."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "insecure_ssl",
+          "description": {
+            "zh": "是否允许不安全 SSL",
+            "en": "Whether to allow insecure SSL."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "events",
+          "description": {
+            "zh": "完整事件列表，逗号分隔或数组",
+            "en": "Complete event list, comma-separated or array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "add_events",
+          "description": {
+            "zh": "追加事件列表",
+            "en": "Events to add."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "remove_events",
+          "description": {
+            "zh": "移除事件列表",
+            "en": "Events to remove."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "active",
+          "description": {
+            "zh": "是否启用",
+            "en": "Whether active."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "config",
+          "description": {
+            "zh": "额外 config JSON",
+            "en": "Additional config JSON."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_webhook",
+      "description": {
+        "zh": "删除仓库 Webhook。",
+        "en": "Delete a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ping_webhook",
+      "description": {
+        "zh": "向仓库 Webhook 发送 ping。",
+        "en": "Ping a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_collaborators",
+      "description": {
+        "zh": "列出仓库协作者。",
+        "en": "List repository collaborators."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "affiliation",
+          "description": {
+            "zh": "筛选：outside/direct/all",
+            "en": "Filter: outside/direct/all."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "permission",
+          "description": {
+            "zh": "权限筛选：pull/triage/push/maintain/admin",
+            "en": "Permission filter: pull/triage/push/maintain/admin."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "check_collaborator",
+      "description": {
+        "zh": "检查用户是否为仓库协作者。",
+        "en": "Check whether a user is a repository collaborator."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "add_collaborator",
+      "description": {
+        "zh": "添加仓库协作者。",
+        "en": "Add a repository collaborator."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "permission",
+          "description": {
+            "zh": "权限：pull/triage/push/maintain/admin",
+            "en": "Permission: pull/triage/push/maintain/admin."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "remove_collaborator",
+      "description": {
+        "zh": "移除仓库协作者。",
+        "en": "Remove a repository collaborator."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_collaborator_permission",
+      "description": {
+        "zh": "获取用户在仓库中的权限。",
+        "en": "Get repository permissions for a user."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_labels",
+      "description": {
+        "zh": "列出仓库 Labels。",
+        "en": "List repository labels."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_label",
+      "description": {
+        "zh": "获取仓库 Label。",
+        "en": "Get a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Label 名称",
+            "en": "Label name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_label",
+      "description": {
+        "zh": "创建仓库 Label。",
+        "en": "Create a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Label 名称",
+            "en": "Label name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "color",
+          "description": {
+            "zh": "六位十六进制颜色，可带 #",
+            "en": "Six-digit hexadecimal color, with optional #."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Label 描述",
+            "en": "Label description."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_label",
+      "description": {
+        "zh": "更新仓库 Label。",
+        "en": "Update a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "当前 Label 名称",
+            "en": "Current label name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "new_name",
+          "description": {
+            "zh": "新 Label 名称",
+            "en": "New label name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "color",
+          "description": {
+            "zh": "六位十六进制颜色，可带 #",
+            "en": "Six-digit hexadecimal color, with optional #."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Label 描述",
+            "en": "Label description."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_label",
+      "description": {
+        "zh": "删除仓库 Label。",
+        "en": "Delete a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Label 名称",
+            "en": "Label name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_milestones",
+      "description": {
+        "zh": "列出仓库 Milestones。",
+        "en": "List repository milestones."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "状态：open/closed/all",
+            "en": "State: open/closed/all."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序：due_on/completeness",
+            "en": "Sort: due_on/completeness."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "direction",
+          "description": {
+            "zh": "方向：asc/desc",
+            "en": "Direction: asc/desc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_milestone",
+      "description": {
+        "zh": "获取 Milestone。",
+        "en": "Get a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "milestone_number",
+          "description": {
+            "zh": "Milestone 编号",
+            "en": "Milestone number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_milestone",
+      "description": {
+        "zh": "创建 Milestone。",
+        "en": "Create a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "Milestone 标题",
+            "en": "Milestone title."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "状态：open/closed",
+            "en": "State: open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Milestone 描述",
+            "en": "Milestone description."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "due_on",
+          "description": {
+            "zh": "截止时间，ISO 8601",
+            "en": "Due date, ISO 8601."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_milestone",
+      "description": {
+        "zh": "更新 Milestone。",
+        "en": "Update a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "milestone_number",
+          "description": {
+            "zh": "Milestone 编号",
+            "en": "Milestone number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "Milestone 标题",
+            "en": "Milestone title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "状态：open/closed",
+            "en": "State: open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Milestone 描述",
+            "en": "Milestone description."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "due_on",
+          "description": {
+            "zh": "截止时间，ISO 8601",
+            "en": "Due date, ISO 8601."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_milestone",
+      "description": {
+        "zh": "删除 Milestone。",
+        "en": "Delete a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "milestone_number",
+          "description": {
+            "zh": "Milestone 编号",
+            "en": "Milestone number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_branch_protection",
+      "description": {
+        "zh": "获取分支保护规则。",
+        "en": "Get branch protection."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "分支名",
+            "en": "Branch name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "update_branch_protection",
+      "description": {
+        "zh": "更新分支保护规则。protection 需传 GitHub PUT 接口要求的完整 JSON。",
+        "en": "Update branch protection. protection must be the complete JSON body required by the GitHub PUT endpoint."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "分支名",
+            "en": "Branch name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "protection",
+          "description": {
+            "zh": "分支保护 JSON 对象或 JSON 字符串",
+            "en": "Branch protection JSON object or JSON string."
+          },
+          "type": "object",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "delete_branch_protection",
+      "description": {
+        "zh": "删除分支保护规则。",
+        "en": "Delete branch protection."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "分支名",
+            "en": "Branch name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_contributors_stats",
+      "description": {
+        "zh": "获取仓库贡献者统计。",
+        "en": "Get repository contributor statistics."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_commit_activity",
+      "description": {
+        "zh": "获取最近一年按周提交活动。",
+        "en": "Get the last year of weekly commit activity."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_code_frequency",
+      "description": {
+        "zh": "获取每周代码增删统计。",
+        "en": "Get weekly code additions and deletions."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     }
   ]
 }
@@ -2699,45 +4508,75 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 // src/index.ts
 var index_exports = {};
 __export(index_exports, {
+  add_collaborator: () => add_collaborator,
   apply_local_delete: () => apply_local_delete,
   apply_local_replace: () => apply_local_replace,
   cancel_workflow_run: () => cancel_workflow_run,
+  check_collaborator: () => check_collaborator,
   comment_issue: () => comment_issue,
   compare_refs: () => compare_refs,
   create_branch: () => create_branch,
   create_issue: () => create_issue,
+  create_label: () => create_label,
+  create_milestone: () => create_milestone,
   create_or_update_file: () => create_or_update_file,
   create_pull_request: () => create_pull_request,
+  create_release: () => create_release,
   create_review: () => create_review,
+  create_webhook: () => create_webhook,
+  delete_branch_protection: () => delete_branch_protection,
   delete_file: () => delete_file,
+  delete_label: () => delete_label,
+  delete_milestone: () => delete_milestone,
+  delete_release: () => delete_release,
+  delete_release_asset: () => delete_release_asset,
+  delete_webhook: () => delete_webhook,
   fork_repository: () => fork_repository,
   get_authenticated_user: () => get_authenticated_user,
+  get_branch_protection: () => get_branch_protection,
+  get_code_frequency: () => get_code_frequency,
+  get_collaborator_permission: () => get_collaborator_permission,
   get_commit: () => get_commit,
+  get_commit_activity: () => get_commit_activity,
   get_compare_diff: () => get_compare_diff,
+  get_contributors_stats: () => get_contributors_stats,
   get_file_content: () => get_file_content,
   get_issue: () => get_issue,
+  get_label: () => get_label,
+  get_latest_release: () => get_latest_release,
+  get_milestone: () => get_milestone,
   get_pull_request: () => get_pull_request,
   get_pull_request_diff: () => get_pull_request_diff,
   get_rate_limit: () => get_rate_limit,
+  get_release: () => get_release,
+  get_release_by_tag: () => get_release_by_tag,
   get_repository: () => get_repository,
+  get_webhook: () => get_webhook,
   get_workflow_jobs: () => get_workflow_jobs,
   get_workflow_run: () => get_workflow_run,
   list_branches: () => list_branches,
   list_check_runs: () => list_check_runs,
+  list_collaborators: () => list_collaborators,
   list_commits: () => list_commits,
   list_issue_comments: () => list_issue_comments,
   list_issues: () => list_issues,
+  list_labels: () => list_labels,
+  list_milestones: () => list_milestones,
   list_pull_request_commits: () => list_pull_request_commits,
   list_pull_request_files: () => list_pull_request_files,
   list_pull_request_reviews: () => list_pull_request_reviews,
   list_pull_requests: () => list_pull_requests,
+  list_releases: () => list_releases,
   list_review_comments: () => list_review_comments,
+  list_webhooks: () => list_webhooks,
   list_workflow_runs: () => list_workflow_runs,
   list_workflows: () => list_workflows,
   main: () => main,
   merge_pull_request: () => merge_pull_request,
   overwrite_local_file: () => overwrite_local_file,
   patch_file_in_repo: () => patch_file_in_repo,
+  ping_webhook: () => ping_webhook,
+  remove_collaborator: () => remove_collaborator,
   reply_review_comment: () => reply_review_comment,
   request_reviewers: () => request_reviewers,
   rerun_workflow_run: () => rerun_workflow_run,
@@ -2748,8 +4587,14 @@ __export(index_exports, {
   terminal_exec: () => terminal_exec,
   toolImpl: () => toolImpl,
   trigger_workflow: () => trigger_workflow,
+  update_branch_protection: () => update_branch_protection,
   update_issue: () => update_issue,
-  update_pull_request: () => update_pull_request
+  update_label: () => update_label,
+  update_milestone: () => update_milestone,
+  update_pull_request: () => update_pull_request,
+  update_release: () => update_release,
+  update_webhook: () => update_webhook,
+  upload_release_asset: () => upload_release_asset
 });
 module.exports = __toCommonJS(index_exports);
 
@@ -2757,6 +4602,25 @@ module.exports = __toCommonJS(index_exports);
 function getBaseUrl() {
   const fromEnv = (typeof getEnv === "function" ? getEnv("GITHUB_API_BASE_URL") : void 0) || "";
   return fromEnv && String(fromEnv).trim() || "https://api.github.com";
+}
+function getUploadsBaseUrl() {
+  const fromEnv = (typeof getEnv === "function" ? getEnv("GITHUB_UPLOADS_BASE_URL") : void 0) || "";
+  const trimmed = String(fromEnv || "").trim().replace(/\/+$/, "");
+  if (trimmed) return trimmed;
+  const api = getBaseUrl().replace(/\/+$/, "");
+  if (api === "https://api.github.com") return "https://uploads.github.com";
+  return api;
+}
+function parseBool(value) {
+  if (value === void 0 || value === null || value === "") return void 0;
+  if (typeof value === "boolean") return value;
+  const s = String(value).trim().toLowerCase();
+  if (s === "true" || s === "1" || s === "yes") return true;
+  if (s === "false" || s === "0" || s === "no") return false;
+  return void 0;
+}
+function shellQuote(value) {
+  return "'" + String(value != null ? value : "").replace(/'/g, "'''") + "'";
 }
 function getToken() {
   const token = (typeof getEnv === "function" ? getEnv("GITHUB_TOKEN") : void 0) || "";
@@ -4026,6 +5890,644 @@ async function terminalExec(params) {
   return result;
 }
 
+// src/github/releases.ts
+function compactAsset(item) {
+  var _a;
+  if (!item) return item;
+  return {
+    id: item.id,
+    name: item.name,
+    label: item.label,
+    size: item.size,
+    content_type: item.content_type,
+    state: item.state,
+    download_count: item.download_count,
+    browser_download_url: item.browser_download_url,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    uploader: (_a = item.uploader) == null ? void 0 : _a.login
+  };
+}
+function compactRelease(item) {
+  var _a;
+  if (!item) return item;
+  return {
+    id: item.id,
+    tag_name: item.tag_name,
+    name: item.name,
+    draft: item.draft,
+    prerelease: item.prerelease,
+    html_url: item.html_url,
+    tarball_url: item.tarball_url,
+    zipball_url: item.zipball_url,
+    target_commitish: item.target_commitish,
+    body: item.body,
+    created_at: item.created_at,
+    published_at: item.published_at,
+    author: (_a = item.author) == null ? void 0 : _a.login,
+    assets: Array.isArray(item.assets) ? item.assets.map(compactAsset) : []
+  };
+}
+async function listReleases(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/releases"), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactRelease) : [];
+}
+async function getRelease(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/${encodeURIComponent(String(params.release_id))}`));
+  return compactRelease(await requestJson({ method: "GET", url }));
+}
+async function getLatestRelease(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, "/releases/latest"));
+  return compactRelease(await requestJson({ method: "GET", url }));
+}
+async function getReleaseByTag(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/tags/${encodeURIComponent(params.tag)}`));
+  return compactRelease(await requestJson({ method: "GET", url }));
+}
+async function createRelease(params) {
+  requireToken("create_release");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/releases"));
+  return compactRelease(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        tag_name: params.tag_name,
+        target_commitish: params.target_commitish,
+        name: params.name,
+        body: params.body,
+        draft: parseBool(params.draft),
+        prerelease: parseBool(params.prerelease),
+        generate_release_notes: parseBool(params.generate_release_notes),
+        make_latest: params.make_latest,
+        discussion_category_name: params.discussion_category_name
+      }
+    })
+  );
+}
+async function updateRelease(params) {
+  requireToken("update_release");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/${encodeURIComponent(String(params.release_id))}`));
+  return compactRelease(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        tag_name: params.tag_name,
+        target_commitish: params.target_commitish,
+        name: params.name,
+        body: params.body,
+        draft: parseBool(params.draft),
+        prerelease: parseBool(params.prerelease),
+        make_latest: params.make_latest,
+        discussion_category_name: params.discussion_category_name
+      }
+    })
+  );
+}
+async function deleteRelease(params) {
+  requireToken("delete_release");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/${encodeURIComponent(String(params.release_id))}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, release_id: params.release_id, result };
+}
+function guessFileName(path) {
+  const parts = String(path || "").replace(/\\/g, "/").split("/");
+  return parts.filter(Boolean).pop() || "asset.bin";
+}
+async function uploadReleaseAsset(params) {
+  const token = requireToken("upload_release_asset");
+  const name = params.name || guessFileName(params.asset_path);
+  const contentType = params.content_type || "application/octet-stream";
+  const environment = params.environment || "android";
+  const sourcePath = String(params.asset_path || "").trim();
+  if (!sourcePath) {
+    throw new Error("asset_path is required");
+  }
+  const exists = await Tools.Files.exists(sourcePath, environment);
+  if (!exists.exists) {
+    throw new Error(`Asset file not found: ${sourcePath}`);
+  }
+  let linuxPath = sourcePath;
+  if (environment !== "linux") {
+    linuxPath = `/tmp/operit-github-asset-${Date.now()}-${name}`;
+    await Tools.Files.copy(sourcePath, linuxPath, false, environment, "linux");
+  }
+  const uploadsPath = repoPath(
+    params.owner,
+    params.repo,
+    `/releases/${encodeURIComponent(String(params.release_id))}/assets`
+  );
+  const qs = [`name=${encodeURIComponent(name)}`];
+  if (params.label) qs.push(`label=${encodeURIComponent(params.label)}`);
+  const finalUrl = `${getUploadsBaseUrl()}${uploadsPath}?${qs.join("&")}`;
+  const headerFile = `/tmp/operit-github-upload-headers-${Date.now()}`;
+  await Tools.Files.write(
+    headerFile,
+    [
+      'header = "Accept: application/vnd.github+json"',
+      `header = "Authorization: Bearer ${token}"`,
+      'header = "X-GitHub-Api-Version: 2022-11-28"',
+      `header = "Content-Type: ${contentType}"`,
+      ""
+    ].join("\n"),
+    false,
+    "linux"
+  );
+  const command = [
+    "curl",
+    "-sS",
+    "-X",
+    "POST",
+    "-K",
+    shellQuote(headerFile),
+    "--data-binary",
+    "@" + shellQuote(linuxPath),
+    "-w",
+    shellQuote("\nHTTP_STATUS:%{http_code}"),
+    shellQuote(finalUrl)
+  ].join(" ");
+  const sessionId = await getTerminalSession("github_tools_session");
+  let result;
+  try {
+    result = await Tools.System.terminal.exec(sessionId, command, 12e4);
+  } finally {
+    try {
+      await Tools.Files.deleteFile(headerFile, false, "linux");
+    } catch (e) {
+    }
+  }
+  const output = String(result.output || "");
+  const statusMatch = output.match(/HTTP_STATUS:(\d+)\s*$/);
+  const statusCode = statusMatch ? Number(statusMatch[1]) : result.exitCode === 0 ? 200 : 500;
+  const bodyText = statusMatch ? output.slice(0, statusMatch.index).trim() : output.trim();
+  if (statusCode < 200 || statusCode >= 300) {
+    throw new Error(`GitHub API Error: ${statusCode}
+${bodyText.slice(0, 800)}`);
+  }
+  try {
+    return compactAsset(JSON.parse(bodyText));
+  } catch (e) {
+    throw new Error(`Failed to parse upload response: ${bodyText.slice(0, 500)}`);
+  }
+}
+async function deleteReleaseAsset(params) {
+  requireToken("delete_release_asset");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/assets/${encodeURIComponent(String(params.asset_id))}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, asset_id: params.asset_id, result };
+}
+
+// src/github/webhooks.ts
+function compactWebhook(item) {
+  if (!item) return item;
+  const config = item.config || {};
+  return {
+    id: item.id,
+    name: item.name,
+    active: item.active,
+    events: item.events,
+    config: {
+      url: config.url,
+      content_type: config.content_type,
+      insecure_ssl: config.insecure_ssl
+    },
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    ping_url: item.ping_url,
+    test_url: item.test_url,
+    last_response: item.last_response
+  };
+}
+async function listWebhooks(params) {
+  var _a, _b;
+  requireToken("list_webhooks");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/hooks"), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactWebhook) : [];
+}
+async function getWebhook(params) {
+  requireToken("get_webhook");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}`));
+  return compactWebhook(await requestJson({ method: "GET", url }));
+}
+async function createWebhook(params) {
+  requireToken("create_webhook");
+  const parsedConfig = parseJsonParam(params.config, "config") || {};
+  const insecure = parseBool(params.insecure_ssl);
+  const url = buildUrl(repoPath(params.owner, params.repo, "/hooks"));
+  return compactWebhook(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        name: "web",
+        active: parseBool(params.active),
+        events: splitCsv(params.events),
+        config: {
+          url: params.url || parsedConfig.url,
+          content_type: params.content_type || parsedConfig.content_type || "json",
+          secret: params.secret || parsedConfig.secret,
+          insecure_ssl: insecure === void 0 ? parsedConfig.insecure_ssl : insecure ? "1" : "0"
+        }
+      }
+    })
+  );
+}
+async function updateWebhook(params) {
+  requireToken("update_webhook");
+  const parsedConfig = parseJsonParam(params.config, "config") || {};
+  const insecure = parseBool(params.insecure_ssl);
+  const config = __spreadValues({}, parsedConfig);
+  if (params.url) config.url = params.url;
+  if (params.content_type) config.content_type = params.content_type;
+  if (params.secret) config.secret = params.secret;
+  if (insecure !== void 0) config.insecure_ssl = insecure ? "1" : "0";
+  const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}`));
+  return compactWebhook(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        active: parseBool(params.active),
+        events: splitCsv(params.events),
+        add_events: splitCsv(params.add_events),
+        remove_events: splitCsv(params.remove_events),
+        config: Object.keys(config).length > 0 ? config : void 0
+      }
+    })
+  );
+}
+async function deleteWebhook(params) {
+  requireToken("delete_webhook");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, hook_id: params.hook_id, result };
+}
+async function pingWebhook(params) {
+  requireToken("ping_webhook");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}/pings`));
+  const result = await requestJson({ method: "POST", url });
+  return { ok: true, hook_id: params.hook_id, result };
+}
+
+// src/github/collaborators.ts
+function compactCollaborator(item) {
+  if (!item) return item;
+  return {
+    login: item.login,
+    id: item.id,
+    type: item.type,
+    html_url: item.html_url,
+    role_name: item.role_name,
+    permissions: item.permissions
+  };
+}
+async function listCollaborators(params) {
+  var _a, _b;
+  requireToken("list_collaborators");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/collaborators"), {
+    affiliation: params.affiliation,
+    permission: params.permission,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactCollaborator) : [];
+}
+async function addCollaborator(params) {
+  var _a, _b;
+  requireToken("add_collaborator");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}`)
+  );
+  const data = await requestJson({
+    method: "PUT",
+    url,
+    body: {
+      permission: params.permission
+    }
+  });
+  return {
+    username: params.username,
+    permission: params.permission || "push",
+    invited: Boolean(data && (data.id || data.html_url)),
+    invitation: data && data.id ? {
+      id: data.id,
+      html_url: data.html_url,
+      permissions: data.permissions,
+      invitee: (_a = data.invitee) == null ? void 0 : _a.login,
+      inviter: (_b = data.inviter) == null ? void 0 : _b.login
+    } : data
+  };
+}
+async function removeCollaborator(params) {
+  requireToken("remove_collaborator");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}`)
+  );
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, username: params.username, result };
+}
+async function getCollaboratorPermission(params) {
+  var _a;
+  requireToken("get_collaborator_permission");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}/permission`)
+  );
+  const data = await requestJson({ method: "GET", url });
+  return {
+    permission: data.permission,
+    role_name: data.role_name,
+    user: (_a = data.user) == null ? void 0 : _a.login
+  };
+}
+async function checkCollaborator(params) {
+  requireToken("check_collaborator");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}`)
+  );
+  try {
+    const resp = await requestRaw({ method: "GET", url });
+    return { username: params.username, is_collaborator: resp.statusCode === 204 || resp.statusCode === 200 };
+  } catch (e) {
+    const message = String(e && e.message ? e.message : e);
+    if (message.includes("404")) {
+      return { username: params.username, is_collaborator: false };
+    }
+    throw e;
+  }
+}
+
+// src/github/labels.ts
+function compactLabel(item) {
+  if (!item) return item;
+  return {
+    id: item.id,
+    name: item.name,
+    color: item.color,
+    description: item.description,
+    default: item.default,
+    url: item.url
+  };
+}
+async function listLabels(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/labels"), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactLabel) : [];
+}
+async function getLabel(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/labels/${encodeURIComponent(params.name)}`));
+  return compactLabel(await requestJson({ method: "GET", url }));
+}
+async function createLabel(params) {
+  requireToken("create_label");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/labels"));
+  return compactLabel(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        name: params.name,
+        color: String(params.color || "").replace(/^#/, ""),
+        description: params.description
+      }
+    })
+  );
+}
+async function updateLabel(params) {
+  requireToken("update_label");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/labels/${encodeURIComponent(params.name)}`));
+  return compactLabel(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        new_name: params.new_name,
+        color: params.color ? String(params.color).replace(/^#/, "") : void 0,
+        description: params.description
+      }
+    })
+  );
+}
+async function deleteLabel(params) {
+  requireToken("delete_label");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/labels/${encodeURIComponent(params.name)}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, name: params.name, result };
+}
+
+// src/github/milestones.ts
+function compactMilestone(item) {
+  var _a;
+  if (!item) return item;
+  return {
+    id: item.id,
+    number: item.number,
+    title: item.title,
+    description: item.description,
+    state: item.state,
+    html_url: item.html_url,
+    open_issues: item.open_issues,
+    closed_issues: item.closed_issues,
+    due_on: item.due_on,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    closed_at: item.closed_at,
+    creator: (_a = item.creator) == null ? void 0 : _a.login
+  };
+}
+async function listMilestones(params) {
+  var _a, _b, _c;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/milestones"), {
+    state: (_a = params.state) != null ? _a : "open",
+    sort: params.sort,
+    direction: params.direction,
+    page: (_b = params.page) != null ? _b : 1,
+    per_page: (_c = params.per_page) != null ? _c : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactMilestone) : [];
+}
+async function getMilestone(params) {
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/milestones/${encodeURIComponent(String(params.milestone_number))}`)
+  );
+  return compactMilestone(await requestJson({ method: "GET", url }));
+}
+async function createMilestone(params) {
+  requireToken("create_milestone");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/milestones"));
+  return compactMilestone(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        title: params.title,
+        state: params.state,
+        description: params.description,
+        due_on: params.due_on
+      }
+    })
+  );
+}
+async function updateMilestone(params) {
+  requireToken("update_milestone");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/milestones/${encodeURIComponent(String(params.milestone_number))}`)
+  );
+  return compactMilestone(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        title: params.title,
+        state: params.state,
+        description: params.description,
+        due_on: params.due_on
+      }
+    })
+  );
+}
+async function deleteMilestone(params) {
+  requireToken("delete_milestone");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/milestones/${encodeURIComponent(String(params.milestone_number))}`)
+  );
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, milestone_number: params.milestone_number, result };
+}
+
+// src/github/protection.ts
+function compactProtection(item) {
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p;
+  if (!item) return item;
+  return {
+    url: item.url,
+    required_status_checks: item.required_status_checks ? {
+      strict: item.required_status_checks.strict,
+      contexts: item.required_status_checks.contexts,
+      checks: item.required_status_checks.checks
+    } : item.required_status_checks,
+    enforce_admins: (_b = (_a = item.enforce_admins) == null ? void 0 : _a.enabled) != null ? _b : item.enforce_admins,
+    required_pull_request_reviews: item.required_pull_request_reviews ? {
+      dismiss_stale_reviews: item.required_pull_request_reviews.dismiss_stale_reviews,
+      require_code_owner_reviews: item.required_pull_request_reviews.require_code_owner_reviews,
+      required_approving_review_count: item.required_pull_request_reviews.required_approving_review_count,
+      require_last_push_approval: item.required_pull_request_reviews.require_last_push_approval
+    } : item.required_pull_request_reviews,
+    restrictions: item.restrictions ? {
+      users: Array.isArray(item.restrictions.users) ? item.restrictions.users.map((u) => u.login || u) : [],
+      teams: Array.isArray(item.restrictions.teams) ? item.restrictions.teams.map((t) => t.slug || t.name || t) : [],
+      apps: Array.isArray(item.restrictions.apps) ? item.restrictions.apps.map((a) => a.slug || a.name || a) : []
+    } : item.restrictions,
+    required_linear_history: (_d = (_c = item.required_linear_history) == null ? void 0 : _c.enabled) != null ? _d : item.required_linear_history,
+    allow_force_pushes: (_f = (_e = item.allow_force_pushes) == null ? void 0 : _e.enabled) != null ? _f : item.allow_force_pushes,
+    allow_deletions: (_h = (_g = item.allow_deletions) == null ? void 0 : _g.enabled) != null ? _h : item.allow_deletions,
+    block_creations: (_j = (_i = item.block_creations) == null ? void 0 : _i.enabled) != null ? _j : item.block_creations,
+    required_conversation_resolution: (_l = (_k = item.required_conversation_resolution) == null ? void 0 : _k.enabled) != null ? _l : item.required_conversation_resolution,
+    lock_branch: (_n = (_m = item.lock_branch) == null ? void 0 : _m.enabled) != null ? _n : item.lock_branch,
+    allow_fork_syncing: (_p = (_o = item.allow_fork_syncing) == null ? void 0 : _o.enabled) != null ? _p : item.allow_fork_syncing
+  };
+}
+async function getBranchProtection(params) {
+  requireToken("get_branch_protection");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/branches/${encodeRef(params.branch)}/protection`));
+  return compactProtection(await requestJson({ method: "GET", url }));
+}
+async function updateBranchProtection(params) {
+  requireToken("update_branch_protection");
+  const protection = parseJsonParam(params.protection, "protection");
+  if (!protection || typeof protection !== "object") {
+    throw new Error("protection must be a JSON object matching PUT /branches/{branch}/protection");
+  }
+  const url = buildUrl(repoPath(params.owner, params.repo, `/branches/${encodeRef(params.branch)}/protection`));
+  return compactProtection(
+    await requestJson({
+      method: "PUT",
+      url,
+      body: protection
+    })
+  );
+}
+async function deleteBranchProtection(params) {
+  requireToken("delete_branch_protection");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/branches/${encodeRef(params.branch)}/protection`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, branch: params.branch, result };
+}
+
+// src/github/stats.ts
+async function requestStats(url, kind) {
+  const resp = await requestRaw({ method: "GET", url });
+  if (resp.statusCode === 202) {
+    return {
+      status: "computing",
+      retry: true,
+      kind,
+      statusCode: 202,
+      message: "GitHub is computing repository statistics. Retry shortly."
+    };
+  }
+  if (resp.statusCode === 204) {
+    return {
+      status: "empty",
+      kind,
+      statusCode: 204,
+      data: []
+    };
+  }
+  const text = String(resp.content || "").trim();
+  if (!text) {
+    return { status: "empty", kind, statusCode: resp.statusCode, data: [] };
+  }
+  try {
+    return {
+      status: "ready",
+      kind,
+      statusCode: resp.statusCode,
+      data: JSON.parse(text)
+    };
+  } catch (e) {
+    throw new Error(`Failed to parse GitHub stats JSON (${resp.statusCode}): ${text.slice(0, 500)}`);
+  }
+}
+async function getContributorsStats(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, "/stats/contributors"));
+  const result = await requestStats(url, "contributors");
+  if (result.status !== "ready" || !Array.isArray(result.data)) return result;
+  return __spreadProps(__spreadValues({}, result), {
+    data: result.data.map((item) => {
+      var _a;
+      return {
+        author: (_a = item.author) == null ? void 0 : _a.login,
+        total: item.total,
+        weeks: item.weeks
+      };
+    })
+  });
+}
+async function getCommitActivity(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, "/stats/commit_activity"));
+  return requestStats(url, "commit_activity");
+}
+async function getCodeFrequency(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, "/stats/code_frequency"));
+  return requestStats(url, "code_frequency");
+}
+
 // src/utils/wrap.ts
 async function wrap(func, params, successMessage, failMessage) {
   try {
@@ -4092,7 +6594,43 @@ var toolImpl = {
   apply_local_replace: (p) => wrap(applyLocalReplace, p, "\u672C\u5730\u66FF\u6362\u6210\u529F", "\u672C\u5730\u66FF\u6362\u5931\u8D25"),
   apply_local_delete: (p) => wrap(applyLocalDelete, p, "\u672C\u5730\u5220\u9664\u6210\u529F", "\u672C\u5730\u5220\u9664\u5931\u8D25"),
   overwrite_local_file: (p) => wrap(overwriteLocalFile, p, "\u8986\u76D6\u6587\u4EF6\u6210\u529F", "\u8986\u76D6\u6587\u4EF6\u5931\u8D25"),
-  terminal_exec: (p) => wrap(terminalExec, p, "\u7EC8\u7AEF\u6267\u884C\u6210\u529F", "\u7EC8\u7AEF\u6267\u884C\u5931\u8D25")
+  terminal_exec: (p) => wrap(terminalExec, p, "\u7EC8\u7AEF\u6267\u884C\u6210\u529F", "\u7EC8\u7AEF\u6267\u884C\u5931\u8D25"),
+  list_releases: (p) => wrap(listReleases, p, "\u5217\u51FA Releases \u6210\u529F", "\u5217\u51FA Releases \u5931\u8D25"),
+  get_release: (p) => wrap(getRelease, p, "\u83B7\u53D6 Release \u6210\u529F", "\u83B7\u53D6 Release \u5931\u8D25"),
+  get_latest_release: (p) => wrap(getLatestRelease, p, "\u83B7\u53D6\u6700\u65B0 Release \u6210\u529F", "\u83B7\u53D6\u6700\u65B0 Release \u5931\u8D25"),
+  get_release_by_tag: (p) => wrap(getReleaseByTag, p, "\u6309 tag \u83B7\u53D6 Release \u6210\u529F", "\u6309 tag \u83B7\u53D6 Release \u5931\u8D25"),
+  create_release: (p) => wrap(createRelease, p, "\u521B\u5EFA Release \u6210\u529F", "\u521B\u5EFA Release \u5931\u8D25"),
+  update_release: (p) => wrap(updateRelease, p, "\u66F4\u65B0 Release \u6210\u529F", "\u66F4\u65B0 Release \u5931\u8D25"),
+  delete_release: (p) => wrap(deleteRelease, p, "\u5220\u9664 Release \u6210\u529F", "\u5220\u9664 Release \u5931\u8D25"),
+  upload_release_asset: (p) => wrap(uploadReleaseAsset, p, "\u4E0A\u4F20 Release \u8D44\u4EA7\u6210\u529F", "\u4E0A\u4F20 Release \u8D44\u4EA7\u5931\u8D25"),
+  delete_release_asset: (p) => wrap(deleteReleaseAsset, p, "\u5220\u9664 Release \u8D44\u4EA7\u6210\u529F", "\u5220\u9664 Release \u8D44\u4EA7\u5931\u8D25"),
+  list_webhooks: (p) => wrap(listWebhooks, p, "\u5217\u51FA Webhooks \u6210\u529F", "\u5217\u51FA Webhooks \u5931\u8D25"),
+  get_webhook: (p) => wrap(getWebhook, p, "\u83B7\u53D6 Webhook \u6210\u529F", "\u83B7\u53D6 Webhook \u5931\u8D25"),
+  create_webhook: (p) => wrap(createWebhook, p, "\u521B\u5EFA Webhook \u6210\u529F", "\u521B\u5EFA Webhook \u5931\u8D25"),
+  update_webhook: (p) => wrap(updateWebhook, p, "\u66F4\u65B0 Webhook \u6210\u529F", "\u66F4\u65B0 Webhook \u5931\u8D25"),
+  delete_webhook: (p) => wrap(deleteWebhook, p, "\u5220\u9664 Webhook \u6210\u529F", "\u5220\u9664 Webhook \u5931\u8D25"),
+  ping_webhook: (p) => wrap(pingWebhook, p, "ping Webhook \u6210\u529F", "ping Webhook \u5931\u8D25"),
+  list_collaborators: (p) => wrap(listCollaborators, p, "\u5217\u51FA\u534F\u4F5C\u8005\u6210\u529F", "\u5217\u51FA\u534F\u4F5C\u8005\u5931\u8D25"),
+  check_collaborator: (p) => wrap(checkCollaborator, p, "\u68C0\u67E5\u534F\u4F5C\u8005\u6210\u529F", "\u68C0\u67E5\u534F\u4F5C\u8005\u5931\u8D25"),
+  add_collaborator: (p) => wrap(addCollaborator, p, "\u6DFB\u52A0\u534F\u4F5C\u8005\u6210\u529F", "\u6DFB\u52A0\u534F\u4F5C\u8005\u5931\u8D25"),
+  remove_collaborator: (p) => wrap(removeCollaborator, p, "\u79FB\u9664\u534F\u4F5C\u8005\u6210\u529F", "\u79FB\u9664\u534F\u4F5C\u8005\u5931\u8D25"),
+  get_collaborator_permission: (p) => wrap(getCollaboratorPermission, p, "\u83B7\u53D6\u534F\u4F5C\u8005\u6743\u9650\u6210\u529F", "\u83B7\u53D6\u534F\u4F5C\u8005\u6743\u9650\u5931\u8D25"),
+  list_labels: (p) => wrap(listLabels, p, "\u5217\u51FA Labels \u6210\u529F", "\u5217\u51FA Labels \u5931\u8D25"),
+  get_label: (p) => wrap(getLabel, p, "\u83B7\u53D6 Label \u6210\u529F", "\u83B7\u53D6 Label \u5931\u8D25"),
+  create_label: (p) => wrap(createLabel, p, "\u521B\u5EFA Label \u6210\u529F", "\u521B\u5EFA Label \u5931\u8D25"),
+  update_label: (p) => wrap(updateLabel, p, "\u66F4\u65B0 Label \u6210\u529F", "\u66F4\u65B0 Label \u5931\u8D25"),
+  delete_label: (p) => wrap(deleteLabel, p, "\u5220\u9664 Label \u6210\u529F", "\u5220\u9664 Label \u5931\u8D25"),
+  list_milestones: (p) => wrap(listMilestones, p, "\u5217\u51FA Milestones \u6210\u529F", "\u5217\u51FA Milestones \u5931\u8D25"),
+  get_milestone: (p) => wrap(getMilestone, p, "\u83B7\u53D6 Milestone \u6210\u529F", "\u83B7\u53D6 Milestone \u5931\u8D25"),
+  create_milestone: (p) => wrap(createMilestone, p, "\u521B\u5EFA Milestone \u6210\u529F", "\u521B\u5EFA Milestone \u5931\u8D25"),
+  update_milestone: (p) => wrap(updateMilestone, p, "\u66F4\u65B0 Milestone \u6210\u529F", "\u66F4\u65B0 Milestone \u5931\u8D25"),
+  delete_milestone: (p) => wrap(deleteMilestone, p, "\u5220\u9664 Milestone \u6210\u529F", "\u5220\u9664 Milestone \u5931\u8D25"),
+  get_branch_protection: (p) => wrap(getBranchProtection, p, "\u83B7\u53D6\u5206\u652F\u4FDD\u62A4\u6210\u529F", "\u83B7\u53D6\u5206\u652F\u4FDD\u62A4\u5931\u8D25"),
+  update_branch_protection: (p) => wrap(updateBranchProtection, p, "\u66F4\u65B0\u5206\u652F\u4FDD\u62A4\u6210\u529F", "\u66F4\u65B0\u5206\u652F\u4FDD\u62A4\u5931\u8D25"),
+  delete_branch_protection: (p) => wrap(deleteBranchProtection, p, "\u5220\u9664\u5206\u652F\u4FDD\u62A4\u6210\u529F", "\u5220\u9664\u5206\u652F\u4FDD\u62A4\u5931\u8D25"),
+  get_contributors_stats: (p) => wrap(getContributorsStats, p, "\u83B7\u53D6\u8D21\u732E\u8005\u7EDF\u8BA1\u6210\u529F", "\u83B7\u53D6\u8D21\u732E\u8005\u7EDF\u8BA1\u5931\u8D25"),
+  get_commit_activity: (p) => wrap(getCommitActivity, p, "\u83B7\u53D6\u63D0\u4EA4\u6D3B\u52A8\u6210\u529F", "\u83B7\u53D6\u63D0\u4EA4\u6D3B\u52A8\u5931\u8D25"),
+  get_code_frequency: (p) => wrap(getCodeFrequency, p, "\u83B7\u53D6\u4EE3\u7801\u9891\u7387\u6210\u529F", "\u83B7\u53D6\u4EE3\u7801\u9891\u7387\u5931\u8D25")
 };
 async function main(params) {
   const tool = params == null ? void 0 : params.tool;
@@ -4154,3 +6692,39 @@ var apply_local_replace = toolImpl.apply_local_replace;
 var apply_local_delete = toolImpl.apply_local_delete;
 var overwrite_local_file = toolImpl.overwrite_local_file;
 var terminal_exec = toolImpl.terminal_exec;
+var list_releases = toolImpl.list_releases;
+var get_release = toolImpl.get_release;
+var get_latest_release = toolImpl.get_latest_release;
+var get_release_by_tag = toolImpl.get_release_by_tag;
+var create_release = toolImpl.create_release;
+var update_release = toolImpl.update_release;
+var delete_release = toolImpl.delete_release;
+var upload_release_asset = toolImpl.upload_release_asset;
+var delete_release_asset = toolImpl.delete_release_asset;
+var list_webhooks = toolImpl.list_webhooks;
+var get_webhook = toolImpl.get_webhook;
+var create_webhook = toolImpl.create_webhook;
+var update_webhook = toolImpl.update_webhook;
+var delete_webhook = toolImpl.delete_webhook;
+var ping_webhook = toolImpl.ping_webhook;
+var list_collaborators = toolImpl.list_collaborators;
+var check_collaborator = toolImpl.check_collaborator;
+var add_collaborator = toolImpl.add_collaborator;
+var remove_collaborator = toolImpl.remove_collaborator;
+var get_collaborator_permission = toolImpl.get_collaborator_permission;
+var list_labels = toolImpl.list_labels;
+var get_label = toolImpl.get_label;
+var create_label = toolImpl.create_label;
+var update_label = toolImpl.update_label;
+var delete_label = toolImpl.delete_label;
+var list_milestones = toolImpl.list_milestones;
+var get_milestone = toolImpl.get_milestone;
+var create_milestone = toolImpl.create_milestone;
+var update_milestone = toolImpl.update_milestone;
+var delete_milestone = toolImpl.delete_milestone;
+var get_branch_protection = toolImpl.get_branch_protection;
+var update_branch_protection = toolImpl.update_branch_protection;
+var delete_branch_protection = toolImpl.delete_branch_protection;
+var get_contributors_stats = toolImpl.get_contributors_stats;
+var get_commit_activity = toolImpl.get_commit_activity;
+var get_code_frequency = toolImpl.get_code_frequency;

--- a/app/src/main/assets/packages/github.js
+++ b/app/src/main/assets/packages/github.js
@@ -2,20 +2,29 @@
 {
   "name": "github",
   "display_name": {
-      "zh": "GitHub API",
-      "en": "GitHub API"
+    "zh": "GitHub API",
+    "en": "GitHub API"
   },
-  "description": { "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。", "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)." },
+  "description": {
+    "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。",
+    "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)."
+  },
   "category": "Development",
   "env": [
     {
       "name": "GITHUB_TOKEN",
-      "description": { "zh": "GitHub API 认证令牌", "en": "GitHub API authentication token" },
+      "description": {
+        "zh": "GitHub API 认证令牌",
+        "en": "GitHub API authentication token"
+      },
       "required": true
     },
     {
       "name": "GITHUB_API_BASE_URL",
-      "description": { "zh": "GitHub API 基础 URL", "en": "GitHub API base URL" },
+      "description": {
+        "zh": "GitHub API 基础 URL",
+        "en": "GitHub API base URL"
+      },
       "required": false,
       "defaultValue": "https://api.github.com"
     }
@@ -23,2605 +32,2632 @@
   "enabledByDefault": false,
   "tools": [
     {
-        "name": "search_repositories",
-        "description": {
-            "zh": "搜索 GitHub 仓库（/search/repositories）。",
-            "en": "Search GitHub repositories (/search/repositories)."
+      "name": "search_repositories",
+      "description": {
+        "zh": "搜索 GitHub 仓库（/search/repositories）。",
+        "en": "Search GitHub repositories (/search/repositories)."
+      },
+      "parameters": [
+        {
+          "name": "query",
+          "description": {
+            "zh": "搜索关键词（GitHub search query）",
+            "en": "Search keywords (GitHub search query)."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "query",
-                "description": {
-                    "zh": "搜索关键词（GitHub search query）",
-                    "en": "Search keywords (GitHub search query)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sort",
-                "description": {
-                    "zh": "排序字段：stars/forks/help-wanted-issues/updated",
-                    "en": "Sort field: stars/forks/help-wanted-issues/updated."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "order",
-                "description": {
-                    "zh": "排序方向：desc/asc",
-                    "en": "Sort order: desc/asc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30，最大 100）",
-                    "en": "Items per page (default: 30, max: 100)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序字段：stars/forks/help-wanted-issues/updated",
+            "en": "Sort field: stars/forks/help-wanted-issues/updated."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "order",
+          "description": {
+            "zh": "排序方向：desc/asc",
+            "en": "Sort order: desc/asc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30，最大 100）",
+            "en": "Items per page (default: 30, max: 100)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_repository",
-        "description": {
-            "zh": "获取仓库信息（/repos/{owner}/{repo}）。",
-            "en": "Get repository information (/repos/{owner}/{repo})."
+      "name": "get_repository",
+      "description": {
+        "zh": "获取仓库信息（/repos/{owner}/{repo}）。",
+        "en": "Get repository information (/repos/{owner}/{repo})."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "list_issues",
-        "description": {
-            "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。",
-            "en": "List repository issues (/repos/{owner}/{repo}/issues)."
+      "name": "list_issues",
+      "description": {
+        "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。",
+        "en": "List repository issues (/repos/{owner}/{repo}/issues)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed/all（默认 open）",
-                    "en": "open/closed/all (default: open)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "labels",
-                "description": {
-                    "zh": "labels 逗号分隔",
-                    "en": "Labels, comma-separated."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "creator",
-                "description": {
-                    "zh": "创建者 login",
-                    "en": "Creator login."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "include_pull_requests",
-                "description": {
-                    "zh": "是否保留 PR（默认 false）",
-                    "en": "Whether to include PRs (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed/all（默认 open）",
+            "en": "open/closed/all (default: open)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "labels",
+          "description": {
+            "zh": "labels 逗号分隔",
+            "en": "Labels, comma-separated."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "creator",
+          "description": {
+            "zh": "创建者 login",
+            "en": "Creator login."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "include_pull_requests",
+          "description": {
+            "zh": "是否保留 PR（默认 false）",
+            "en": "Whether to include PRs (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_issue",
-        "description": {
-            "zh": "获取单个 Issue 详情（/repos/{owner}/{repo}/issues/{issue_number}）。",
-            "en": "Get a single issue."
+      "name": "get_issue",
+      "description": {
+        "zh": "获取单个 Issue 详情（/repos/{owner}/{repo}/issues/{issue_number}）。",
+        "en": "Get a single issue."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "create_issue",
-        "description": {
-            "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。",
-            "en": "Create an issue."
+      "name": "create_issue",
+      "description": {
+        "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。",
+        "en": "Create an issue."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "Issue 标题",
-                    "en": "Issue title."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "Issue 内容",
-                    "en": "Issue body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "labels",
-                "description": {
-                    "zh": "labels 数组",
-                    "en": "Labels array."
-                },
-                "type": "array",
-                "required": false
-            },
-            {
-                "name": "assignees",
-                "description": {
-                    "zh": "assignees 数组",
-                    "en": "Assignees array."
-                },
-                "type": "array",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "Issue 标题",
+            "en": "Issue title."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "Issue 内容",
+            "en": "Issue body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "labels",
+          "description": {
+            "zh": "labels 数组",
+            "en": "Labels array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "assignees",
+          "description": {
+            "zh": "assignees 数组",
+            "en": "Assignees array."
+          },
+          "type": "array",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "update_issue",
-        "description": {
-            "zh": "更新 Issue。",
-            "en": "Update an issue."
+      "name": "update_issue",
+      "description": {
+        "zh": "更新 Issue。",
+        "en": "Update an issue."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "新标题",
-                    "en": "New title."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "新内容",
-                    "en": "New body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed",
-                    "en": "open/closed."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "labels",
-                "description": {
-                    "zh": "labels 数组",
-                    "en": "Labels array."
-                },
-                "type": "array",
-                "required": false
-            },
-            {
-                "name": "assignees",
-                "description": {
-                    "zh": "assignees 数组",
-                    "en": "Assignees array."
-                },
-                "type": "array",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "新标题",
+            "en": "New title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "新内容",
+            "en": "New body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed",
+            "en": "open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "labels",
+          "description": {
+            "zh": "labels 数组",
+            "en": "Labels array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "assignees",
+          "description": {
+            "zh": "assignees 数组",
+            "en": "Assignees array."
+          },
+          "type": "array",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "comment_issue",
-        "description": {
-            "zh": "给 Issue/PR 评论。",
-            "en": "Comment on an issue/PR."
+      "name": "comment_issue",
+      "description": {
+        "zh": "给 Issue/PR 评论。",
+        "en": "Comment on an issue/PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "评论内容",
-                    "en": "Comment body."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "评论内容",
+            "en": "Comment body."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "list_issue_comments",
-        "description": {
-            "zh": "列出 Issue/PR 的评论。",
-            "en": "List comments on an issue/PR."
+      "name": "list_issue_comments",
+      "description": {
+        "zh": "列出 Issue/PR 的评论。",
+        "en": "List comments on an issue/PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_requests",
-        "description": {
-            "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。",
-            "en": "List pull requests."
+      "name": "list_pull_requests",
+      "description": {
+        "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。",
+        "en": "List pull requests."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed/all（默认 open）",
-                    "en": "open/closed/all (default: open)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head 分支过滤，格式 user:branch",
-                    "en": "Head branch filter (user:branch)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "base 分支过滤",
-                    "en": "Base branch filter."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed/all（默认 open）",
+            "en": "open/closed/all (default: open)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head 分支过滤，格式 user:branch",
+            "en": "Head branch filter (user:branch)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "base 分支过滤",
+            "en": "Base branch filter."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_pull_request",
-        "description": {
-            "zh": "创建 PR。",
-            "en": "Create a pull request."
+      "name": "create_pull_request",
+      "description": {
+        "zh": "创建 PR。",
+        "en": "Create a pull request."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "PR 标题",
-                    "en": "PR title."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head 分支（含跨 fork 的 user:branch 格式）",
-                    "en": "Head branch (use user:branch for cross-fork)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "目标 base 分支",
-                    "en": "Target base branch."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "PR 描述",
-                    "en": "PR body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "draft",
-                "description": {
-                    "zh": "是否草稿",
-                    "en": "Whether to create as draft."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "PR 标题",
+            "en": "PR title."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head 分支（含跨 fork 的 user:branch 格式）",
+            "en": "Head branch (use user:branch for cross-fork)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "目标 base 分支",
+            "en": "Target base branch."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "PR 描述",
+            "en": "PR body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether to create as draft."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_pull_request",
-        "description": {
-            "zh": "获取单个 PR 详情。",
-            "en": "Get a single pull request."
+      "name": "get_pull_request",
+      "description": {
+        "zh": "获取单个 PR 详情。",
+        "en": "Get a single pull request."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "update_pull_request",
-        "description": {
-            "zh": "更新 PR 标题/描述/状态/base/draft。",
-            "en": "Update PR title/body/state/base/draft."
+      "name": "update_pull_request",
+      "description": {
+        "zh": "更新 PR 标题/描述/状态/base/draft。",
+        "en": "Update PR title/body/state/base/draft."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "新标题",
-                    "en": "New title."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "新描述",
-                    "en": "New body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed",
-                    "en": "open/closed."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "新 base 分支",
-                    "en": "New base branch."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "draft",
-                "description": {
-                    "zh": "是否草稿",
-                    "en": "Whether draft."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "新标题",
+            "en": "New title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "新描述",
+            "en": "New body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed",
+            "en": "open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "新 base 分支",
+            "en": "New base branch."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether draft."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "merge_pull_request",
-        "description": {
-            "zh": "合并 PR。",
-            "en": "Merge a pull request."
+      "name": "merge_pull_request",
+      "description": {
+        "zh": "合并 PR。",
+        "en": "Merge a pull request."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "commit_title",
-                "description": {
-                    "zh": "合并 commit 标题",
-                    "en": "Merge commit title."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "commit_message",
-                "description": {
-                    "zh": "合并 commit 消息",
-                    "en": "Merge commit message."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "merge_method",
-                "description": {
-                    "zh": "merge/squash/rebase（默认 merge）",
-                    "en": "merge/squash/rebase (default: merge)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "commit_title",
+          "description": {
+            "zh": "合并 commit 标题",
+            "en": "Merge commit title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "commit_message",
+          "description": {
+            "zh": "合并 commit 消息",
+            "en": "Merge commit message."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "merge_method",
+          "description": {
+            "zh": "merge/squash/rebase（默认 merge）",
+            "en": "merge/squash/rebase (default: merge)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_request_files",
-        "description": {
-            "zh": "列出 PR 变更文件。",
-            "en": "List files changed in a PR."
+      "name": "list_pull_request_files",
+      "description": {
+        "zh": "列出 PR 变更文件。",
+        "en": "List files changed in a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "include_patch",
-                "description": {
-                    "zh": "是否包含 patch 内容（默认 false）",
-                    "en": "Include patch content (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 100）",
-                    "en": "Items per page (default: 100)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "include_patch",
+          "description": {
+            "zh": "是否包含 patch 内容（默认 false）",
+            "en": "Include patch content (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 100）",
+            "en": "Items per page (default: 100)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_pull_request_diff",
-        "description": {
-            "zh": "获取 PR 的 unified diff 文本。",
-            "en": "Get PR unified diff text."
+      "name": "get_pull_request_diff",
+      "description": {
+        "zh": "获取 PR 的 unified diff 文本。",
+        "en": "Get PR unified diff text."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "max_chars",
-                "description": {
-                    "zh": "截断字符数（默认 20000）",
-                    "en": "Truncate to this many chars (default: 20000)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "max_chars",
+          "description": {
+            "zh": "截断字符数（默认 20000）",
+            "en": "Truncate to this many chars (default: 20000)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_request_commits",
-        "description": {
-            "zh": "列出 PR 的提交。",
-            "en": "List commits in a PR."
+      "name": "list_pull_request_commits",
+      "description": {
+        "zh": "列出 PR 的提交。",
+        "en": "List commits in a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_request_reviews",
-        "description": {
-            "zh": "列出 PR 的 review。",
-            "en": "List reviews on a PR."
+      "name": "list_pull_request_reviews",
+      "description": {
+        "zh": "列出 PR 的 review。",
+        "en": "List reviews on a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_review_comments",
-        "description": {
-            "zh": "列出 PR 的行内 review comments。",
-            "en": "List inline review comments on a PR."
+      "name": "list_review_comments",
+      "description": {
+        "zh": "列出 PR 的行内 review comments。",
+        "en": "List inline review comments on a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_review",
-        "description": {
-            "zh": "提交 PR review（APPROVE/REQUEST_CHANGES/COMMENT）。",
-            "en": "Submit a PR review (APPROVE/REQUEST_CHANGES/COMMENT)."
+      "name": "create_review",
+      "description": {
+        "zh": "提交 PR review（APPROVE/REQUEST_CHANGES/COMMENT）。",
+        "en": "Submit a PR review (APPROVE/REQUEST_CHANGES/COMMENT)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "review 总评内容",
-                    "en": "Review body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "event",
-                "description": {
-                    "zh": "APPROVE/REQUEST_CHANGES/COMMENT（默认 COMMENT）",
-                    "en": "APPROVE/REQUEST_CHANGES/COMMENT (default: COMMENT)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "commit_id",
-                "description": {
-                    "zh": "关联的 commit sha",
-                    "en": "Commit SHA to associate."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "comments",
-                "description": {
-                    "zh": "行内评论数组（JSON 字符串），每项含 path/line/body",
-                    "en": "Inline comments array (JSON string), each with path/line/body."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "review 总评内容",
+            "en": "Review body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "event",
+          "description": {
+            "zh": "APPROVE/REQUEST_CHANGES/COMMENT（默认 COMMENT）",
+            "en": "APPROVE/REQUEST_CHANGES/COMMENT (default: COMMENT)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "commit_id",
+          "description": {
+            "zh": "关联的 commit sha",
+            "en": "Commit SHA to associate."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "comments",
+          "description": {
+            "zh": "行内评论数组（JSON 字符串），每项含 path/line/body",
+            "en": "Inline comments array (JSON string), each with path/line/body."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "reply_review_comment",
-        "description": {
-            "zh": "回复 PR 行内 review comment。",
-            "en": "Reply to a PR inline review comment."
+      "name": "reply_review_comment",
+      "description": {
+        "zh": "回复 PR 行内 review comment。",
+        "en": "Reply to a PR inline review comment."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "comment_id",
-                "description": {
-                    "zh": "被回复的 comment id",
-                    "en": "Comment ID to reply to."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "回复内容",
-                    "en": "Reply body."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "comment_id",
+          "description": {
+            "zh": "被回复的 comment id",
+            "en": "Comment ID to reply to."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "回复内容",
+            "en": "Reply body."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "request_reviewers",
-        "description": {
-            "zh": "请求 PR reviewer。",
-            "en": "Request reviewers for a PR."
+      "name": "request_reviewers",
+      "description": {
+        "zh": "请求 PR reviewer。",
+        "en": "Request reviewers for a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "reviewers",
-                "description": {
-                    "zh": "reviewer login 列表，逗号分隔或数组",
-                    "en": "Reviewer logins, comma-separated or array."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "team_reviewers",
-                "description": {
-                    "zh": "team reviewer slug 列表，逗号分隔或数组",
-                    "en": "Team reviewer slugs, comma-separated or array."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "reviewers",
+          "description": {
+            "zh": "reviewer login 列表，逗号分隔或数组",
+            "en": "Reviewer logins, comma-separated or array."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "team_reviewers",
+          "description": {
+            "zh": "team reviewer slug 列表，逗号分隔或数组",
+            "en": "Team reviewer slugs, comma-separated or array."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_file_content",
-        "description": {
-            "zh": "获取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。",
-            "en": "Get file content from a repository."
+      "name": "get_file_content",
+      "description": {
+        "zh": "获取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。",
+        "en": "Get file content from a repository."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径（相对仓库根目录）",
-                    "en": "File path relative to repository root."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "分支/tag/commit（默认默认分支）",
-                    "en": "Branch/tag/commit (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径（相对仓库根目录）",
+            "en": "File path relative to repository root."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "分支/tag/commit（默认默认分支）",
+            "en": "Branch/tag/commit (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_or_update_file",
-        "description": {
-            "zh": "创建或更新仓库文件。更新时需传 sha。",
-            "en": "Create or update a file in the repository. Provide sha when updating."
+      "name": "create_or_update_file",
+      "description": {
+        "zh": "创建或更新仓库文件。更新时需传 sha。",
+        "en": "Create or update a file in the repository. Provide sha when updating."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径",
-                    "en": "File path."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "message",
-                "description": {
-                    "zh": "commit 消息",
-                    "en": "Commit message."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "content",
-                "description": {
-                    "zh": "文件内容（明文，会自动 base64 编码）",
-                    "en": "File content (plain text, will be base64-encoded)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "更新时必填：现有文件的 blob sha",
-                    "en": "Required when updating: existing file blob SHA."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "目标分支（默认默认分支）",
-                    "en": "Target branch (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径",
+            "en": "File path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "message",
+          "description": {
+            "zh": "commit 消息",
+            "en": "Commit message."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "content",
+          "description": {
+            "zh": "文件内容（明文，会自动 base64 编码）",
+            "en": "File content (plain text, will be base64-encoded)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "更新时必填：现有文件的 blob sha",
+            "en": "Required when updating: existing file blob SHA."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "目标分支（默认默认分支）",
+            "en": "Target branch (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "delete_file",
-        "description": {
-            "zh": "删除仓库文件。",
-            "en": "Delete a file from the repository."
+      "name": "delete_file",
+      "description": {
+        "zh": "删除仓库文件。",
+        "en": "Delete a file from the repository."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径",
-                    "en": "File path."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "message",
-                "description": {
-                    "zh": "commit 消息",
-                    "en": "Commit message."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "文件的 blob sha",
-                    "en": "File blob SHA."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "目标分支",
-                    "en": "Target branch."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径",
+            "en": "File path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "message",
+          "description": {
+            "zh": "commit 消息",
+            "en": "Commit message."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "文件的 blob sha",
+            "en": "File blob SHA."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "目标分支",
+            "en": "Target branch."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_branch",
-        "description": {
-            "zh": "创建分支。",
-            "en": "Create a branch."
+      "name": "create_branch",
+      "description": {
+        "zh": "创建分支。",
+        "en": "Create a branch."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "新分支名",
-                    "en": "New branch name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "from_branch",
-                "description": {
-                    "zh": "基于哪个分支创建（默认默认分支）",
-                    "en": "Branch to create from (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "直接指定起始 commit sha（优先于 from_branch）",
-                    "en": "Starting commit SHA (overrides from_branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "新分支名",
+            "en": "New branch name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "from_branch",
+          "description": {
+            "zh": "基于哪个分支创建（默认默认分支）",
+            "en": "Branch to create from (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "直接指定起始 commit sha（优先于 from_branch）",
+            "en": "Starting commit SHA (overrides from_branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_branches",
-        "description": {
-            "zh": "列出仓库分支。",
-            "en": "List repository branches."
+      "name": "list_branches",
+      "description": {
+        "zh": "列出仓库分支。",
+        "en": "List repository branches."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "protected_only",
-                "description": {
-                    "zh": "只返回受保护分支（默认 false）",
-                    "en": "Return only protected branches (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "protected_only",
+          "description": {
+            "zh": "只返回受保护分支（默认 false）",
+            "en": "Return only protected branches (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_commits",
-        "description": {
-            "zh": "列出仓库提交。",
-            "en": "List repository commits."
+      "name": "list_commits",
+      "description": {
+        "zh": "列出仓库提交。",
+        "en": "List repository commits."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "分支/tag/commit sha（默认默认分支）",
-                    "en": "Branch/tag/commit SHA (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "只返回修改了该路径的提交",
-                    "en": "Only commits affecting this path."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "author",
-                "description": {
-                    "zh": "作者 login 过滤",
-                    "en": "Author login filter."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "分支/tag/commit sha（默认默认分支）",
+            "en": "Branch/tag/commit SHA (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "只返回修改了该路径的提交",
+            "en": "Only commits affecting this path."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "author",
+          "description": {
+            "zh": "作者 login 过滤",
+            "en": "Author login filter."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_commit",
-        "description": {
-            "zh": "获取单个提交详情。",
-            "en": "Get a single commit."
+      "name": "get_commit",
+      "description": {
+        "zh": "获取单个提交详情。",
+        "en": "Get a single commit."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "commit sha / 分支 / tag",
-                    "en": "Commit SHA, branch, or tag."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "include_files",
-                "description": {
-                    "zh": "是否包含文件变更列表（默认 true）",
-                    "en": "Whether to include file changes (default: true)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "commit sha / 分支 / tag",
+            "en": "Commit SHA, branch, or tag."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "include_files",
+          "description": {
+            "zh": "是否包含文件变更列表（默认 true）",
+            "en": "Whether to include file changes (default: true)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "compare_refs",
-        "description": {
-            "zh": "比较两个 ref。",
-            "en": "Compare two refs."
+      "name": "compare_refs",
+      "description": {
+        "zh": "比较两个 ref。",
+        "en": "Compare two refs."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "base ref（分支/tag/sha）",
-                    "en": "Base ref (branch/tag/sha)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head ref（分支/tag/sha）",
-                    "en": "Head ref (branch/tag/sha)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "include_files",
-                "description": {
-                    "zh": "是否包含文件列表（默认 true）",
-                    "en": "Whether to include file list (default: true)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "include_patch",
-                "description": {
-                    "zh": "文件列表是否包含 patch（默认 false）",
-                    "en": "Whether file list includes patch (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "base ref（分支/tag/sha）",
+            "en": "Base ref (branch/tag/sha)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head ref（分支/tag/sha）",
+            "en": "Head ref (branch/tag/sha)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "include_files",
+          "description": {
+            "zh": "是否包含文件列表（默认 true）",
+            "en": "Whether to include file list (default: true)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "include_patch",
+          "description": {
+            "zh": "文件列表是否包含 patch（默认 false）",
+            "en": "Whether file list includes patch (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_compare_diff",
-        "description": {
-            "zh": "获取两个 ref 之间的 unified diff 文本。",
-            "en": "Get unified diff text between two refs."
+      "name": "get_compare_diff",
+      "description": {
+        "zh": "获取两个 ref 之间的 unified diff 文本。",
+        "en": "Get unified diff text between two refs."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "base ref",
-                    "en": "Base ref."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head ref",
-                    "en": "Head ref."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "max_chars",
-                "description": {
-                    "zh": "截断字符数（默认 20000）",
-                    "en": "Truncate to this many chars (default: 20000)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "base ref",
+            "en": "Base ref."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head ref",
+            "en": "Head ref."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "max_chars",
+          "description": {
+            "zh": "截断字符数（默认 20000）",
+            "en": "Truncate to this many chars (default: 20000)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_workflows",
-        "description": {
-            "zh": "列出仓库 GitHub Actions workflow。",
-            "en": "List GitHub Actions workflows."
+      "name": "list_workflows",
+      "description": {
+        "zh": "列出仓库 GitHub Actions workflow。",
+        "en": "List GitHub Actions workflows."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_workflow_runs",
-        "description": {
-            "zh": "列出 workflow run。",
-            "en": "List workflow runs."
+      "name": "list_workflow_runs",
+      "description": {
+        "zh": "列出 workflow run。",
+        "en": "List workflow runs."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "workflow_id",
-                "description": {
-                    "zh": "workflow id 或文件名（如 android-tests.yml），不传则列出所有",
-                    "en": "Workflow ID or filename (e.g. android-tests.yml); omit to list all."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "按分支过滤",
-                    "en": "Filter by branch."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "status",
-                "description": {
-                    "zh": "按状态过滤：queued/in_progress/completed/failure/success 等",
-                    "en": "Filter by status: queued/in_progress/completed/failure/success etc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "event",
-                "description": {
-                    "zh": "按触发事件过滤：push/pull_request/workflow_dispatch 等",
-                    "en": "Filter by event: push/pull_request/workflow_dispatch etc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "workflow_id",
+          "description": {
+            "zh": "workflow id 或文件名（如 android-tests.yml），不传则列出所有",
+            "en": "Workflow ID or filename (e.g. android-tests.yml); omit to list all."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "按分支过滤",
+            "en": "Filter by branch."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "status",
+          "description": {
+            "zh": "按状态过滤：queued/in_progress/completed/failure/success 等",
+            "en": "Filter by status: queued/in_progress/completed/failure/success etc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "event",
+          "description": {
+            "zh": "按触发事件过滤：push/pull_request/workflow_dispatch 等",
+            "en": "Filter by event: push/pull_request/workflow_dispatch etc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_workflow_run",
-        "description": {
-            "zh": "获取单个 workflow run 详情。",
-            "en": "Get a single workflow run."
+      "name": "get_workflow_run",
+      "description": {
+        "zh": "获取单个 workflow run 详情。",
+        "en": "Get a single workflow run."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "trigger_workflow",
-        "description": {
-            "zh": "手动触发 workflow（workflow_dispatch）。",
-            "en": "Manually trigger a workflow (workflow_dispatch)."
+      "name": "trigger_workflow",
+      "description": {
+        "zh": "手动触发 workflow（workflow_dispatch）。",
+        "en": "Manually trigger a workflow (workflow_dispatch)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "workflow_id",
-                "description": {
-                    "zh": "workflow id 或文件名（如 android-tests.yml）",
-                    "en": "Workflow ID or filename (e.g. android-tests.yml)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "触发分支或 tag",
-                    "en": "Branch or tag to trigger on."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "inputs",
-                "description": {
-                    "zh": "workflow inputs（JSON 字符串或对象）",
-                    "en": "Workflow inputs (JSON string or object)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "workflow_id",
+          "description": {
+            "zh": "workflow id 或文件名（如 android-tests.yml）",
+            "en": "Workflow ID or filename (e.g. android-tests.yml)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "触发分支或 tag",
+            "en": "Branch or tag to trigger on."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "inputs",
+          "description": {
+            "zh": "workflow inputs（JSON 字符串或对象）",
+            "en": "Workflow inputs (JSON string or object)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_workflow_jobs",
-        "description": {
-            "zh": "获取 workflow run 的 jobs（含可选日志）。",
-            "en": "Get jobs for a workflow run (with optional logs)."
+      "name": "get_workflow_jobs",
+      "description": {
+        "zh": "获取 workflow run 的 jobs（含可选日志）。",
+        "en": "Get jobs for a workflow run (with optional logs)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "include_logs",
-                "description": {
-                    "zh": "是否拉取每个 job 的日志（默认 false）",
-                    "en": "Whether to fetch logs for each job (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "failed_only",
-                "description": {
-                    "zh": "只返回失败/非成功的 job（默认 false）",
-                    "en": "Return only failed/non-success jobs (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "max_log_chars",
-                "description": {
-                    "zh": "日志截断字符数（默认 8000）",
-                    "en": "Log truncation in characters (default: 8000)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 50）",
-                    "en": "Items per page (default: 50)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "include_logs",
+          "description": {
+            "zh": "是否拉取每个 job 的日志（默认 false）",
+            "en": "Whether to fetch logs for each job (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "failed_only",
+          "description": {
+            "zh": "只返回失败/非成功的 job（默认 false）",
+            "en": "Return only failed/non-success jobs (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "max_log_chars",
+          "description": {
+            "zh": "日志截断字符数（默认 8000）",
+            "en": "Log truncation in characters (default: 8000)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 50）",
+            "en": "Items per page (default: 50)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "rerun_workflow_run",
-        "description": {
-            "zh": "重新运行 workflow run（全部或仅失败 job）。",
-            "en": "Re-run a workflow run (all jobs or failed jobs only)."
+      "name": "rerun_workflow_run",
+      "description": {
+        "zh": "重新运行 workflow run（全部或仅失败 job）。",
+        "en": "Re-run a workflow run (all jobs or failed jobs only)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "failed_jobs_only",
-                "description": {
-                    "zh": "只重跑失败 job（默认 false）",
-                    "en": "Only re-run failed jobs (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "enable_debug_logging",
-                "description": {
-                    "zh": "是否开启 debug 日志",
-                    "en": "Whether to enable debug logging."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "failed_jobs_only",
+          "description": {
+            "zh": "只重跑失败 job（默认 false）",
+            "en": "Only re-run failed jobs (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "enable_debug_logging",
+          "description": {
+            "zh": "是否开启 debug 日志",
+            "en": "Whether to enable debug logging."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "cancel_workflow_run",
-        "description": {
-            "zh": "取消 workflow run。",
-            "en": "Cancel a workflow run."
+      "name": "cancel_workflow_run",
+      "description": {
+        "zh": "取消 workflow run。",
+        "en": "Cancel a workflow run."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "list_check_runs",
-        "description": {
-            "zh": "列出某个 commit 的 check runs。",
-            "en": "List check runs for a commit."
+      "name": "list_check_runs",
+      "description": {
+        "zh": "列出某个 commit 的 check runs。",
+        "en": "List check runs for a commit."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "commit sha / 分支 / tag",
-                    "en": "Commit SHA, branch, or tag."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "status",
-                "description": {
-                    "zh": "queued/in_progress/completed 过滤",
-                    "en": "Filter by status: queued/in_progress/completed."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "filter",
-                "description": {
-                    "zh": "latest/all（默认 latest）",
-                    "en": "latest/all (default: latest)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "commit sha / 分支 / tag",
+            "en": "Commit SHA, branch, or tag."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "status",
+          "description": {
+            "zh": "queued/in_progress/completed 过滤",
+            "en": "Filter by status: queued/in_progress/completed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "filter",
+          "description": {
+            "zh": "latest/all（默认 latest）",
+            "en": "latest/all (default: latest)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "search_code",
-        "description": {
-            "zh": "搜索代码（/search/code）。",
-            "en": "Search code (/search/code)."
+      "name": "search_code",
+      "description": {
+        "zh": "搜索代码（/search/code）。",
+        "en": "Search code (/search/code)."
+      },
+      "parameters": [
+        {
+          "name": "query",
+          "description": {
+            "zh": "搜索查询（支持 GitHub code search 语法）",
+            "en": "Search query (GitHub code search syntax, e.g. repo:owner/name keyword)."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "query",
-                "description": {
-                    "zh": "搜索查询（支持 GitHub code search 语法）",
-                    "en": "Search query (GitHub code search syntax, e.g. repo:owner/name keyword)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sort",
-                "description": {
-                    "zh": "排序字段（indexed）",
-                    "en": "Sort field (indexed)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "order",
-                "description": {
-                    "zh": "排序方向：desc/asc",
-                    "en": "Sort order: desc/asc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序字段（indexed）",
+            "en": "Sort field (indexed)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "order",
+          "description": {
+            "zh": "排序方向：desc/asc",
+            "en": "Sort order: desc/asc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "search_issues",
-        "description": {
-            "zh": "搜索 Issue/PR（/search/issues）。",
-            "en": "Search issues and PRs (/search/issues)."
+      "name": "search_issues",
+      "description": {
+        "zh": "搜索 Issue/PR（/search/issues）。",
+        "en": "Search issues and PRs (/search/issues)."
+      },
+      "parameters": [
+        {
+          "name": "query",
+          "description": {
+            "zh": "搜索查询（支持 GitHub issue search 语法）",
+            "en": "Search query (GitHub issue search syntax)."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "query",
-                "description": {
-                    "zh": "搜索查询（支持 GitHub issue search 语法）",
-                    "en": "Search query (GitHub issue search syntax)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sort",
-                "description": {
-                    "zh": "排序字段：comments/reactions/created/updated 等",
-                    "en": "Sort field: comments/reactions/created/updated etc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "order",
-                "description": {
-                    "zh": "排序方向：desc/asc",
-                    "en": "Sort order: desc/asc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序字段：comments/reactions/created/updated 等",
+            "en": "Sort field: comments/reactions/created/updated etc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "order",
+          "description": {
+            "zh": "排序方向：desc/asc",
+            "en": "Sort order: desc/asc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_authenticated_user",
-        "description": {
-            "zh": "获取当前认证用户信息（/user）。",
-            "en": "Get the currently authenticated user (/user)."
-        },
-        "parameters": []
+      "name": "get_authenticated_user",
+      "description": {
+        "zh": "获取当前认证用户信息（/user）。",
+        "en": "Get the currently authenticated user (/user)."
+      },
+      "parameters": []
     },
     {
-        "name": "get_rate_limit",
-        "description": {
-            "zh": "查询 GitHub API 请求频率限制（/rate_limit）。",
-            "en": "Query GitHub API rate limit (/rate_limit)."
-        },
-        "parameters": []
+      "name": "get_rate_limit",
+      "description": {
+        "zh": "查询 GitHub API 请求频率限制（/rate_limit）。",
+        "en": "Query GitHub API rate limit (/rate_limit)."
+      },
+      "parameters": []
     },
     {
-        "name": "fork_repository",
-        "description": {
-            "zh": "fork 仓库（/repos/{owner}/{repo}/forks）。",
-            "en": "Fork a repository."
+      "name": "fork_repository",
+      "description": {
+        "zh": "fork 仓库（/repos/{owner}/{repo}/forks）。",
+        "en": "Fork a repository."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "organization",
-                "description": {
-                    "zh": "fork 到指定组织（不填则 fork 到个人账号）",
-                    "en": "Fork to a specific organization (omit for personal account)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "name",
-                "description": {
-                    "zh": "fork 后的仓库名（默认与原仓库同名）",
-                    "en": "Name for the forked repository (default: same as original)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "default_branch_only",
-                "description": {
-                    "zh": "只 fork 默认分支（默认 false）",
-                    "en": "Fork only the default branch (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "organization",
+          "description": {
+            "zh": "fork 到指定组织（不填则 fork 到个人账号）",
+            "en": "Fork to a specific organization (omit for personal account)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "fork 后的仓库名（默认与原仓库同名）",
+            "en": "Name for the forked repository (default: same as original)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "default_branch_only",
+          "description": {
+            "zh": "只 fork 默认分支（默认 false）",
+            "en": "Fork only the default branch (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "sync_fork",
-        "description": {
-            "zh": "同步 fork 到上游（/repos/{owner}/{repo}/merge-upstream）。",
-            "en": "Sync a fork with upstream."
+      "name": "sync_fork",
+      "description": {
+        "zh": "同步 fork 到上游（/repos/{owner}/{repo}/merge-upstream）。",
+        "en": "Sync a fork with upstream."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "fork 仓库的 owner",
+            "en": "Fork repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "fork 仓库的 owner",
-                    "en": "Fork repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "fork 仓库名",
-                    "en": "Fork repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "要同步的分支（默认默认分支）",
-                    "en": "Branch to sync (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "fork 仓库名",
+            "en": "Fork repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "要同步的分支（默认默认分支）",
+            "en": "Branch to sync (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "patch_file_in_repo",
-        "description": {
-            "zh": "在仓库中对文件应用 search/replace patch（先读取文件，替换内容后写回）。",
-            "en": "Apply a search/replace patch to a file in the repository (read -> replace -> write back)."
+      "name": "patch_file_in_repo",
+      "description": {
+        "zh": "在仓库中对文件应用差异块 patch（先读取文件，按 [START-REPLACE]/[START-DELETE] 块替换内容后写回）。",
+        "en": "Apply a block-based patch to a repository file (read -> apply [START-REPLACE]/[START-DELETE] blocks -> write back)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径",
-                    "en": "File path."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "search",
-                "description": {
-                    "zh": "要查找的文本（精确匹配）",
-                    "en": "Text to search for (exact match)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "replace",
-                "description": {
-                    "zh": "替换后的文本",
-                    "en": "Replacement text."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "message",
-                "description": {
-                    "zh": "commit 消息",
-                    "en": "Commit message."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "目标分支",
-                    "en": "Target branch."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径",
+            "en": "File path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "message",
+          "description": {
+            "zh": "commit 消息",
+            "en": "Commit message."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "patch",
+          "description": {
+            "zh": "差异块文本。格式：[START-REPLACE]\\n[OLD]\\n原内容\\n[/OLD]\\n[NEW]\\n新内容\\n[/NEW]\\n[END-REPLACE]，删除用 [START-DELETE] 配 [OLD] 块，可包含多个块。",
+            "en": "Patch blocks. Format: [START-REPLACE]\\n[OLD]\\nold\\n[/OLD]\\n[NEW]\\nnew\\n[/NEW]\\n[END-REPLACE]; use [START-DELETE] with an [OLD] block to delete. Multiple blocks allowed."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "目标分支",
+            "en": "Target branch."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "apply_local_replace",
-        "description": {
-            "zh": "在本地文件系统中对文件应用 search/replace（不经过 GitHub API）。",
-            "en": "Apply a search/replace patch to a local file (no GitHub API)."
+      "name": "apply_local_replace",
+      "description": {
+        "zh": "在本地文件中把 old 片段替换为 new 片段（不经过 GitHub API）。",
+        "en": "Replace an old snippet with a new snippet in a local file (no GitHub API)."
+      },
+      "parameters": [
+        {
+          "name": "path",
+          "description": {
+            "zh": "本地文件路径",
+            "en": "Local file path."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "path",
-                "description": {
-                    "zh": "本地文件路径（绝对路径）",
-                    "en": "Local file path (absolute)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "search",
-                "description": {
-                    "zh": "要查找的文本",
-                    "en": "Text to search for."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "replace",
-                "description": {
-                    "zh": "替换后的文本",
-                    "en": "Replacement text."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "old",
+          "description": {
+            "zh": "要被替换的原内容片段（精确匹配）",
+            "en": "Existing snippet to replace (exact match)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "new",
+          "description": {
+            "zh": "替换后的新内容片段",
+            "en": "Replacement snippet."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "执行环境：android（默认）或 linux",
+            "en": "Environment: android (default) or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "apply_local_delete",
-        "description": {
-            "zh": "删除本地文件（不经过 GitHub API）。",
-            "en": "Delete a local file (no GitHub API)."
+      "name": "apply_local_delete",
+      "description": {
+        "zh": "在本地文件中删除指定内容片段（不经过 GitHub API）。",
+        "en": "Delete a snippet from a local file (no GitHub API)."
+      },
+      "parameters": [
+        {
+          "name": "path",
+          "description": {
+            "zh": "本地文件路径",
+            "en": "Local file path."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "path",
-                "description": {
-                    "zh": "本地文件路径（绝对路径）",
-                    "en": "Local file path (absolute)."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "old",
+          "description": {
+            "zh": "要删除的内容片段（精确匹配）",
+            "en": "Snippet to delete (exact match)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "执行环境：android（默认）或 linux",
+            "en": "Environment: android (default) or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "overwrite_local_file",
-        "description": {
-            "zh": "用新内容完整覆盖本地文件（不经过 GitHub API）。",
-            "en": "Overwrite a local file with new content (no GitHub API)."
+      "name": "overwrite_local_file",
+      "description": {
+        "zh": "用新内容覆盖写入本地文件（不经过 GitHub API）。",
+        "en": "Overwrite a local file with new content (no GitHub API)."
+      },
+      "parameters": [
+        {
+          "name": "path",
+          "description": {
+            "zh": "本地文件路径",
+            "en": "Local file path."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "path",
-                "description": {
-                    "zh": "本地文件路径（绝对路径）",
-                    "en": "Local file path (absolute)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "content",
-                "description": {
-                    "zh": "新的文件内容",
-                    "en": "New file content."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "content",
+          "description": {
+            "zh": "写入的完整内容",
+            "en": "Full content to write."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "执行环境：android（默认）或 linux",
+            "en": "Environment: android (default) or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "terminal_exec",
-        "description": {
-            "zh": "在本地终端执行命令（调用 Operit 内置终端，注意权限和安全）。",
-            "en": "Execute a command in the local terminal (uses Operit built-in terminal)."
+      "name": "terminal_exec",
+      "description": {
+        "zh": "在 Operit 内置终端中执行命令（会话在多次调用间复用）。",
+        "en": "Execute a command in the Operit built-in terminal (session is reused across calls)."
+      },
+      "parameters": [
+        {
+          "name": "command",
+          "description": {
+            "zh": "要执行的命令",
+            "en": "Command to execute."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "command",
-                "description": {
-                    "zh": "要执行的 shell 命令",
-                    "en": "Shell command to execute."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "cwd",
-                "description": {
-                    "zh": "工作目录（默认当前目录）",
-                    "en": "Working directory (default: current directory)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "timeout_ms",
-                "description": {
-                    "zh": "超时毫秒数（默认 30000）",
-                    "en": "Timeout in milliseconds (default: 30000)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "session_name",
+          "description": {
+            "zh": "终端会话名（默认 github_tools_session）",
+            "en": "Terminal session name (default: github_tools_session)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "close",
+          "description": {
+            "zh": "执行后是否关闭会话（默认 false）",
+            "en": "Whether to close the session after execution (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     }
-]
+  ]
 }
 */
 
@@ -4009,7 +4045,7 @@ async function wrap(func, params, successMessage, failMessage) {
 // src/index.ts
 var toolImpl = {
   search_repositories: (p) => wrap(searchRepositories, p, "\u641C\u7D22\u4ED3\u5E93\u6210\u529F", "\u641C\u7D22\u4ED3\u5E93\u5931\u8D25"),
-  get_repository: (p) => wrap(searchRepositories, p, "\u83B7\u53D6\u4ED3\u5E93\u6210\u529F", "\u83B7\u53D6\u4ED3\u5E93\u5931\u8D25"),
+  get_repository: (p) => wrap(getRepository, p, "\u83B7\u53D6\u4ED3\u5E93\u6210\u529F", "\u83B7\u53D6\u4ED3\u5E93\u5931\u8D25"),
   list_issues: (p) => wrap(listIssues, p, "\u5217\u51FA Issues \u6210\u529F", "\u5217\u51FA Issues \u5931\u8D25"),
   get_issue: (p) => wrap(getIssue, p, "\u83B7\u53D6 Issue \u6210\u529F", "\u83B7\u53D6 Issue \u5931\u8D25"),
   create_issue: (p) => wrap(createIssue, p, "\u521B\u5EFA Issue \u6210\u529F", "\u521B\u5EFA Issue \u5931\u8D25"),

--- a/examples/github.js
+++ b/examples/github.js
@@ -1,12 +1,11 @@
 /* METADATA
 {
   "name": "github",
-
   "display_name": {
       "zh": "GitHub API",
       "en": "GitHub API"
   },
-  "description": { "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异提交）与本地侧（apply_file 差异更新、terminal 终端）能力。", "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs) and local-side utilities (apply_file patch updates, terminal)." },
+  "description": { "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。", "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)." },
   "category": "Development",
   "env": [
     {
@@ -24,229 +23,2613 @@
   "enabledByDefault": false,
   "tools": [
     {
-      "name": "search_repositories",
-      "description": { "zh": "搜索 GitHub 仓库（/search/repositories）。", "en": "Search GitHub repositories (/search/repositories)." },
-      "parameters": [
-        { "name": "query", "description": { "zh": "搜索关键词（GitHub search query）", "en": "Search keywords (GitHub search query)." }, "type": "string", "required": true },
-        { "name": "sort", "description": { "zh": "排序字段：stars/forks/help-wanted-issues/updated", "en": "Sort field: stars/forks/help-wanted-issues/updated." }, "type": "string", "required": false },
-        { "name": "order", "description": { "zh": "排序方向：desc/asc", "en": "Sort order: desc/asc." }, "type": "string", "required": false },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false }
-      ]
+        "name": "search_repositories",
+        "description": {
+            "zh": "搜索 GitHub 仓库（/search/repositories）。",
+            "en": "Search GitHub repositories (/search/repositories)."
+        },
+        "parameters": [
+            {
+                "name": "query",
+                "description": {
+                    "zh": "搜索关键词（GitHub search query）",
+                    "en": "Search keywords (GitHub search query)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sort",
+                "description": {
+                    "zh": "排序字段：stars/forks/help-wanted-issues/updated",
+                    "en": "Sort field: stars/forks/help-wanted-issues/updated."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "order",
+                "description": {
+                    "zh": "排序方向：desc/asc",
+                    "en": "Sort order: desc/asc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30，最大 100）",
+                    "en": "Items per page (default: 30, max: 100)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "get_repository",
-      "description": { "zh": "获取仓库信息（/repos/{owner}/{repo}）。", "en": "Get repository information (/repos/{owner}/{repo})." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true }
-      ]
+        "name": "get_repository",
+        "description": {
+            "zh": "获取仓库信息（/repos/{owner}/{repo}）。",
+            "en": "Get repository information (/repos/{owner}/{repo})."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "list_issues",
-      "description": { "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。注意：GitHub 的 issues API 默认也会包含 PR，需要时可用 include_pull_requests 控制。", "en": "List repository issues (/repos/{owner}/{repo}/issues). Note: GitHub issues API also includes PRs by default; use include_pull_requests when needed." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "state", "description": { "zh": "open/closed/all（默认 open）", "en": "open/closed/all (default: open)." }, "type": "string", "required": false },
-        { "name": "labels", "description": { "zh": "labels 逗号分隔", "en": "Labels, comma-separated." }, "type": "string", "required": false },
-        { "name": "creator", "description": { "zh": "创建者 login", "en": "Creator login." }, "type": "string", "required": false },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false },
-        { "name": "include_pull_requests", "description": { "zh": "是否保留 PR（默认 false，仅返回 issue）", "en": "Whether to include PRs (default: false; issues only)." }, "type": "boolean", "required": false }
-      ]
+        "name": "list_issues",
+        "description": {
+            "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。",
+            "en": "List repository issues (/repos/{owner}/{repo}/issues)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed/all（默认 open）",
+                    "en": "open/closed/all (default: open)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "labels",
+                "description": {
+                    "zh": "labels 逗号分隔",
+                    "en": "Labels, comma-separated."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "creator",
+                "description": {
+                    "zh": "创建者 login",
+                    "en": "Creator login."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "include_pull_requests",
+                "description": {
+                    "zh": "是否保留 PR（默认 false）",
+                    "en": "Whether to include PRs (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "create_issue",
-      "description": { "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。", "en": "Create an issue (/repos/{owner}/{repo}/issues)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "title", "description": { "zh": "Issue 标题", "en": "Issue title." }, "type": "string", "required": true },
-        { "name": "body", "description": { "zh": "Issue 内容", "en": "Issue body." }, "type": "string", "required": false },
-        { "name": "labels", "description": { "zh": "labels 数组（字符串数组）", "en": "Labels array (string array)." }, "type": "array", "required": false },
-        { "name": "assignees", "description": { "zh": "assignees 数组（字符串数组）", "en": "Assignees array (string array)." }, "type": "array", "required": false }
-      ]
+        "name": "get_issue",
+        "description": {
+            "zh": "获取单个 Issue 详情（/repos/{owner}/{repo}/issues/{issue_number}）。",
+            "en": "Get a single issue."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "comment_issue",
-      "description": { "zh": "给 Issue/PR 评论（/repos/{owner}/{repo}/issues/{issue_number}/comments）。", "en": "Comment on an issue/PR (/repos/{owner}/{repo}/issues/{issue_number}/comments)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "issue_number", "description": { "zh": "Issue 编号", "en": "Issue number." }, "type": "number", "required": true },
-        { "name": "body", "description": { "zh": "评论内容", "en": "Comment body." }, "type": "string", "required": true }
-      ]
+        "name": "create_issue",
+        "description": {
+            "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。",
+            "en": "Create an issue."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "Issue 标题",
+                    "en": "Issue title."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "Issue 内容",
+                    "en": "Issue body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "labels",
+                "description": {
+                    "zh": "labels 数组",
+                    "en": "Labels array."
+                },
+                "type": "array",
+                "required": false
+            },
+            {
+                "name": "assignees",
+                "description": {
+                    "zh": "assignees 数组",
+                    "en": "Assignees array."
+                },
+                "type": "array",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "list_issue_comments",
-      "description": { "zh": "列出 Issue/PR 的评论（/repos/{owner}/{repo}/issues/{issue_number}/comments）。", "en": "List comments on an issue/PR (/repos/{owner}/{repo}/issues/{issue_number}/comments)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "issue_number", "description": { "zh": "Issue 编号", "en": "Issue number." }, "type": "number", "required": true },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false }
-      ]
+        "name": "update_issue",
+        "description": {
+            "zh": "更新 Issue。",
+            "en": "Update an issue."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "新标题",
+                    "en": "New title."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "新内容",
+                    "en": "New body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed",
+                    "en": "open/closed."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "labels",
+                "description": {
+                    "zh": "labels 数组",
+                    "en": "Labels array."
+                },
+                "type": "array",
+                "required": false
+            },
+            {
+                "name": "assignees",
+                "description": {
+                    "zh": "assignees 数组",
+                    "en": "Assignees array."
+                },
+                "type": "array",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "list_pull_requests",
-      "description": { "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。", "en": "List pull requests (/repos/{owner}/{repo}/pulls)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "state", "description": { "zh": "open/closed/all（默认 open）", "en": "open/closed/all (default: open)." }, "type": "string", "required": false },
-        { "name": "head", "description": { "zh": "head 过滤（可选）", "en": "Head filter (optional)." }, "type": "string", "required": false },
-        { "name": "base", "description": { "zh": "base 过滤（可选）", "en": "Base filter (optional)." }, "type": "string", "required": false },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false }
-      ]
+        "name": "comment_issue",
+        "description": {
+            "zh": "给 Issue/PR 评论。",
+            "en": "Comment on an issue/PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "评论内容",
+                    "en": "Comment body."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "create_pull_request",
-      "description": { "zh": "创建 PR（/repos/{owner}/{repo}/pulls）。", "en": "Create a pull request (/repos/{owner}/{repo}/pulls)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "title", "description": { "zh": "PR 标题", "en": "PR title." }, "type": "string", "required": true },
-        { "name": "head", "description": { "zh": "源分支，例如 feature-branch 或 owner:branch", "en": "Head branch, e.g. feature-branch or owner:branch." }, "type": "string", "required": true },
-        { "name": "base", "description": { "zh": "目标分支，例如 main", "en": "Base branch, e.g. main." }, "type": "string", "required": true },
-        { "name": "body", "description": { "zh": "PR 内容", "en": "PR body." }, "type": "string", "required": false },
-        { "name": "draft", "description": { "zh": "是否为 Draft", "en": "Whether this is a draft PR." }, "type": "boolean", "required": false }
-      ]
+        "name": "list_issue_comments",
+        "description": {
+            "zh": "列出 Issue/PR 的评论。",
+            "en": "List comments on an issue/PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "get_pull_request",
-      "description": { "zh": "获取 PR 详情（/repos/{owner}/{repo}/pulls/{pull_number}）。", "en": "Get pull request details (/repos/{owner}/{repo}/pulls/{pull_number})." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "pull_number", "description": { "zh": "PR 编号", "en": "PR number." }, "type": "number", "required": true }
-      ]
+        "name": "list_pull_requests",
+        "description": {
+            "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。",
+            "en": "List pull requests."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed/all（默认 open）",
+                    "en": "open/closed/all (default: open)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head 分支过滤，格式 user:branch",
+                    "en": "Head branch filter (user:branch)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "base 分支过滤",
+                    "en": "Base branch filter."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "merge_pull_request",
-      "description": { "zh": "合并 PR（/repos/{owner}/{repo}/pulls/{pull_number}/merge）。", "en": "Merge a pull request (/repos/{owner}/{repo}/pulls/{pull_number}/merge)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "pull_number", "description": { "zh": "PR 编号", "en": "PR number." }, "type": "number", "required": true },
-        { "name": "commit_title", "description": { "zh": "可选，merge commit 标题", "en": "Optional: merge commit title." }, "type": "string", "required": false },
-        { "name": "commit_message", "description": { "zh": "可选，merge commit 内容", "en": "Optional: merge commit message." }, "type": "string", "required": false },
-        { "name": "merge_method", "description": { "zh": "merge/squash/rebase", "en": "merge/squash/rebase." }, "type": "string", "required": false }
-      ]
+        "name": "create_pull_request",
+        "description": {
+            "zh": "创建 PR。",
+            "en": "Create a pull request."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "PR 标题",
+                    "en": "PR title."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head 分支（含跨 fork 的 user:branch 格式）",
+                    "en": "Head branch (use user:branch for cross-fork)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "目标 base 分支",
+                    "en": "Target base branch."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "PR 描述",
+                    "en": "PR body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "draft",
+                "description": {
+                    "zh": "是否草稿",
+                    "en": "Whether to create as draft."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "get_file_content",
-      "description": { "zh": "读取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。若文件是 base64 返回，将自动解码为文本并返回。", "en": "Read repository file content (/repos/{owner}/{repo}/contents/{path}). If the API returns base64, it will be decoded and returned as text." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径（如 README.md）", "en": "File path (e.g. README.md)." }, "type": "string", "required": true },
-        { "name": "ref", "description": { "zh": "分支/Tag/SHA（可选）", "en": "Branch/Tag/SHA (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "get_pull_request",
+        "description": {
+            "zh": "获取单个 PR 详情。",
+            "en": "Get a single pull request."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "create_or_update_file",
-      "description": { "zh": "创建或更新仓库文件并提交（/repos/{owner}/{repo}/contents/{path}，PUT）。", "en": "Create or update a repository file and commit it (/repos/{owner}/{repo}/contents/{path}, PUT)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径", "en": "File path." }, "type": "string", "required": true },
-        { "name": "message", "description": { "zh": "提交信息", "en": "Commit message." }, "type": "string", "required": true },
-        { "name": "content", "description": { "zh": "文件内容（默认按 utf-8 文本编码为 base64）", "en": "File content (base64-encoded as utf-8 text by default)." }, "type": "string", "required": true },
-        { "name": "content_encoding", "description": { "zh": "utf-8/base64（默认 utf-8）", "en": "utf-8/base64 (default: utf-8)." }, "type": "string", "required": false },
-        { "name": "branch", "description": { "zh": "目标分支（可选）", "en": "Target branch (optional)." }, "type": "string", "required": false },
-        { "name": "sha", "description": { "zh": "可选：已知 sha（更新文件时）", "en": "Optional: known sha (when updating a file)." }, "type": "string", "required": false }
-      ]
+        "name": "update_pull_request",
+        "description": {
+            "zh": "更新 PR 标题/描述/状态/base/draft。",
+            "en": "Update PR title/body/state/base/draft."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "新标题",
+                    "en": "New title."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "新描述",
+                    "en": "New body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed",
+                    "en": "open/closed."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "新 base 分支",
+                    "en": "New base branch."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "draft",
+                "description": {
+                    "zh": "是否草稿",
+                    "en": "Whether draft."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "patch_file_in_repo",
-      "description": { "zh": "对仓库文件做差异更新（传入 [START-REPLACE]/[START-DELETE] 块），并提交。", "en": "Patch a repository file by applying diff blocks ([START-REPLACE]/[START-DELETE]) and commit." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径", "en": "File path." }, "type": "string", "required": true },
-        { "name": "message", "description": { "zh": "提交信息", "en": "Commit message." }, "type": "string", "required": true },
-        { "name": "patch", "description": { "zh": "差异块字符串（可多块）", "en": "Diff blocks string (can include multiple blocks)." }, "type": "string", "required": true },
-        { "name": "branch", "description": { "zh": "目标分支（可选）", "en": "Target branch (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "merge_pull_request",
+        "description": {
+            "zh": "合并 PR。",
+            "en": "Merge a pull request."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "commit_title",
+                "description": {
+                    "zh": "合并 commit 标题",
+                    "en": "Merge commit title."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "commit_message",
+                "description": {
+                    "zh": "合并 commit 消息",
+                    "en": "Merge commit message."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "merge_method",
+                "description": {
+                    "zh": "merge/squash/rebase（默认 merge）",
+                    "en": "merge/squash/rebase (default: merge)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "delete_file",
-      "description": { "zh": "删除仓库文件并提交（/repos/{owner}/{repo}/contents/{path}，DELETE）。", "en": "Delete a repository file and commit (/repos/{owner}/{repo}/contents/{path}, DELETE)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径", "en": "File path." }, "type": "string", "required": true },
-        { "name": "message", "description": { "zh": "提交信息", "en": "Commit message." }, "type": "string", "required": true },
-        { "name": "branch", "description": { "zh": "目标分支（可选）", "en": "Target branch (optional)." }, "type": "string", "required": false },
-        { "name": "sha", "description": { "zh": "可选：已知 sha（删除文件时）", "en": "Optional: known sha (when deleting a file)." }, "type": "string", "required": false }
-      ]
+        "name": "list_pull_request_files",
+        "description": {
+            "zh": "列出 PR 变更文件。",
+            "en": "List files changed in a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "include_patch",
+                "description": {
+                    "zh": "是否包含 patch 内容（默认 false）",
+                    "en": "Include patch content (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 100）",
+                    "en": "Items per page (default: 100)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "create_branch",
-      "description": { "zh": "基于已有分支创建新分支（/git/refs）。", "en": "Create a new branch from an existing branch (/git/refs)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "new_branch", "description": { "zh": "新分支名", "en": "New branch name." }, "type": "string", "required": true },
-        { "name": "from_branch", "description": { "zh": "源分支（可选，默认使用 default_branch）", "en": "Source branch (optional; defaults to default_branch)." }, "type": "string", "required": false }
-      ]
+        "name": "get_pull_request_diff",
+        "description": {
+            "zh": "获取 PR 的 unified diff 文本。",
+            "en": "Get PR unified diff text."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "max_chars",
+                "description": {
+                    "zh": "截断字符数（默认 20000）",
+                    "en": "Truncate to this many chars (default: 20000)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "apply_local_replace",
-      "description": { "zh": "使用 Tools.Files.apply 对本地文件做 REPLACE（结构化块）。", "en": "Run Tools.Files.apply REPLACE on a local file (structured blocks)." },
-      "parameters": [
-        { "name": "path", "description": { "zh": "本地文件路径", "en": "Local file path." }, "type": "string", "required": true },
-        { "name": "old", "description": { "zh": "要替换的旧内容片段", "en": "Old content snippet to replace." }, "type": "string", "required": true },
-        { "name": "new", "description": { "zh": "替换后的新内容片段", "en": "New content snippet." }, "type": "string", "required": true },
-        { "name": "environment", "description": { "zh": "android/linux（可选）", "en": "android/linux (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "list_pull_request_commits",
+        "description": {
+            "zh": "列出 PR 的提交。",
+            "en": "List commits in a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "apply_local_delete",
-      "description": { "zh": "使用 Tools.Files.apply 对本地文件做 DELETE（结构化块）。", "en": "Run Tools.Files.apply DELETE on a local file (structured blocks)." },
-      "parameters": [
-        { "name": "path", "description": { "zh": "本地文件路径", "en": "Local file path." }, "type": "string", "required": true },
-        { "name": "old", "description": { "zh": "要删除的旧内容片段", "en": "Old content snippet to delete." }, "type": "string", "required": true },
-        { "name": "environment", "description": { "zh": "android/linux（可选）", "en": "android/linux (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "list_pull_request_reviews",
+        "description": {
+            "zh": "列出 PR 的 review。",
+            "en": "List reviews on a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "overwrite_local_file",
-      "description": { "zh": "覆盖写入本地文件（如果存在会先删除再写入）。", "en": "Overwrite a local file (if it exists, it will be deleted before writing)." },
-      "parameters": [
-        { "name": "path", "description": { "zh": "本地文件路径", "en": "Local file path." }, "type": "string", "required": true },
-        { "name": "content", "description": { "zh": "完整文件内容", "en": "Full file content." }, "type": "string", "required": true },
-        { "name": "environment", "description": { "zh": "android/linux（可选）", "en": "android/linux (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "list_review_comments",
+        "description": {
+            "zh": "列出 PR 的行内 review comments。",
+            "en": "List inline review comments on a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "terminal_exec",
-      "description": { "zh": "在终端会话中执行命令（Tools.System.terminal）。", "en": "Execute a command in a terminal session (Tools.System.terminal)." },
-      "parameters": [
-        { "name": "command", "description": { "zh": "要执行的命令", "en": "Command to execute." }, "type": "string", "required": true },
-        { "name": "session_name", "description": { "zh": "会话名（可选，默认 github_tools_session）", "en": "Session name (optional; default: github_tools_session)." }, "type": "string", "required": false },
-        { "name": "close", "description": { "zh": "是否执行后关闭会话", "en": "Whether to close the session after execution." }, "type": "boolean", "required": false }
-      ]
+        "name": "create_review",
+        "description": {
+            "zh": "提交 PR review（APPROVE/REQUEST_CHANGES/COMMENT）。",
+            "en": "Submit a PR review (APPROVE/REQUEST_CHANGES/COMMENT)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "review 总评内容",
+                    "en": "Review body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "event",
+                "description": {
+                    "zh": "APPROVE/REQUEST_CHANGES/COMMENT（默认 COMMENT）",
+                    "en": "APPROVE/REQUEST_CHANGES/COMMENT (default: COMMENT)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "commit_id",
+                "description": {
+                    "zh": "关联的 commit sha",
+                    "en": "Commit SHA to associate."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "comments",
+                "description": {
+                    "zh": "行内评论数组（JSON 字符串），每项含 path/line/body",
+                    "en": "Inline comments array (JSON string), each with path/line/body."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "main",
-      "description": { "zh": "用于快速连通性自测：拉取一个仓库信息并做一次仓库搜索，然后返回结果。", "en": "Quick connectivity self-test: fetch a repository and run a repository search, then return results." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner（默认 octocat）", "en": "Repository owner (default: octocat)." }, "type": "string", "required": false },
-        { "name": "repo", "description": { "zh": "仓库名（默认 Hello-World）", "en": "Repository name (default: Hello-World)." }, "type": "string", "required": false },
-        { "name": "query", "description": { "zh": "搜索关键词（默认 operit）", "en": "Search keyword (default: operit)." }, "type": "string", "required": false }
-      ]
+        "name": "reply_review_comment",
+        "description": {
+            "zh": "回复 PR 行内 review comment。",
+            "en": "Reply to a PR inline review comment."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "comment_id",
+                "description": {
+                    "zh": "被回复的 comment id",
+                    "en": "Comment ID to reply to."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "回复内容",
+                    "en": "Reply body."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "request_reviewers",
+        "description": {
+            "zh": "请求 PR reviewer。",
+            "en": "Request reviewers for a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "reviewers",
+                "description": {
+                    "zh": "reviewer login 列表，逗号分隔或数组",
+                    "en": "Reviewer logins, comma-separated or array."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "team_reviewers",
+                "description": {
+                    "zh": "team reviewer slug 列表，逗号分隔或数组",
+                    "en": "Team reviewer slugs, comma-separated or array."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_file_content",
+        "description": {
+            "zh": "获取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。",
+            "en": "Get file content from a repository."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径（相对仓库根目录）",
+                    "en": "File path relative to repository root."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "分支/tag/commit（默认默认分支）",
+                    "en": "Branch/tag/commit (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "create_or_update_file",
+        "description": {
+            "zh": "创建或更新仓库文件。更新时需传 sha。",
+            "en": "Create or update a file in the repository. Provide sha when updating."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径",
+                    "en": "File path."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "message",
+                "description": {
+                    "zh": "commit 消息",
+                    "en": "Commit message."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "content",
+                "description": {
+                    "zh": "文件内容（明文，会自动 base64 编码）",
+                    "en": "File content (plain text, will be base64-encoded)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "更新时必填：现有文件的 blob sha",
+                    "en": "Required when updating: existing file blob SHA."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "目标分支（默认默认分支）",
+                    "en": "Target branch (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "delete_file",
+        "description": {
+            "zh": "删除仓库文件。",
+            "en": "Delete a file from the repository."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径",
+                    "en": "File path."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "message",
+                "description": {
+                    "zh": "commit 消息",
+                    "en": "Commit message."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "文件的 blob sha",
+                    "en": "File blob SHA."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "目标分支",
+                    "en": "Target branch."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "create_branch",
+        "description": {
+            "zh": "创建分支。",
+            "en": "Create a branch."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "新分支名",
+                    "en": "New branch name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "from_branch",
+                "description": {
+                    "zh": "基于哪个分支创建（默认默认分支）",
+                    "en": "Branch to create from (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "直接指定起始 commit sha（优先于 from_branch）",
+                    "en": "Starting commit SHA (overrides from_branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_branches",
+        "description": {
+            "zh": "列出仓库分支。",
+            "en": "List repository branches."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "protected_only",
+                "description": {
+                    "zh": "只返回受保护分支（默认 false）",
+                    "en": "Return only protected branches (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_commits",
+        "description": {
+            "zh": "列出仓库提交。",
+            "en": "List repository commits."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "分支/tag/commit sha（默认默认分支）",
+                    "en": "Branch/tag/commit SHA (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "只返回修改了该路径的提交",
+                    "en": "Only commits affecting this path."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "author",
+                "description": {
+                    "zh": "作者 login 过滤",
+                    "en": "Author login filter."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_commit",
+        "description": {
+            "zh": "获取单个提交详情。",
+            "en": "Get a single commit."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "commit sha / 分支 / tag",
+                    "en": "Commit SHA, branch, or tag."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "include_files",
+                "description": {
+                    "zh": "是否包含文件变更列表（默认 true）",
+                    "en": "Whether to include file changes (default: true)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "compare_refs",
+        "description": {
+            "zh": "比较两个 ref。",
+            "en": "Compare two refs."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "base ref（分支/tag/sha）",
+                    "en": "Base ref (branch/tag/sha)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head ref（分支/tag/sha）",
+                    "en": "Head ref (branch/tag/sha)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "include_files",
+                "description": {
+                    "zh": "是否包含文件列表（默认 true）",
+                    "en": "Whether to include file list (default: true)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "include_patch",
+                "description": {
+                    "zh": "文件列表是否包含 patch（默认 false）",
+                    "en": "Whether file list includes patch (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_compare_diff",
+        "description": {
+            "zh": "获取两个 ref 之间的 unified diff 文本。",
+            "en": "Get unified diff text between two refs."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "base ref",
+                    "en": "Base ref."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head ref",
+                    "en": "Head ref."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "max_chars",
+                "description": {
+                    "zh": "截断字符数（默认 20000）",
+                    "en": "Truncate to this many chars (default: 20000)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_workflows",
+        "description": {
+            "zh": "列出仓库 GitHub Actions workflow。",
+            "en": "List GitHub Actions workflows."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_workflow_runs",
+        "description": {
+            "zh": "列出 workflow run。",
+            "en": "List workflow runs."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "workflow_id",
+                "description": {
+                    "zh": "workflow id 或文件名（如 android-tests.yml），不传则列出所有",
+                    "en": "Workflow ID or filename (e.g. android-tests.yml); omit to list all."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "按分支过滤",
+                    "en": "Filter by branch."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "status",
+                "description": {
+                    "zh": "按状态过滤：queued/in_progress/completed/failure/success 等",
+                    "en": "Filter by status: queued/in_progress/completed/failure/success etc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "event",
+                "description": {
+                    "zh": "按触发事件过滤：push/pull_request/workflow_dispatch 等",
+                    "en": "Filter by event: push/pull_request/workflow_dispatch etc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_workflow_run",
+        "description": {
+            "zh": "获取单个 workflow run 详情。",
+            "en": "Get a single workflow run."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "trigger_workflow",
+        "description": {
+            "zh": "手动触发 workflow（workflow_dispatch）。",
+            "en": "Manually trigger a workflow (workflow_dispatch)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "workflow_id",
+                "description": {
+                    "zh": "workflow id 或文件名（如 android-tests.yml）",
+                    "en": "Workflow ID or filename (e.g. android-tests.yml)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "触发分支或 tag",
+                    "en": "Branch or tag to trigger on."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "inputs",
+                "description": {
+                    "zh": "workflow inputs（JSON 字符串或对象）",
+                    "en": "Workflow inputs (JSON string or object)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_workflow_jobs",
+        "description": {
+            "zh": "获取 workflow run 的 jobs（含可选日志）。",
+            "en": "Get jobs for a workflow run (with optional logs)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "include_logs",
+                "description": {
+                    "zh": "是否拉取每个 job 的日志（默认 false）",
+                    "en": "Whether to fetch logs for each job (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "failed_only",
+                "description": {
+                    "zh": "只返回失败/非成功的 job（默认 false）",
+                    "en": "Return only failed/non-success jobs (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "max_log_chars",
+                "description": {
+                    "zh": "日志截断字符数（默认 8000）",
+                    "en": "Log truncation in characters (default: 8000)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 50）",
+                    "en": "Items per page (default: 50)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "rerun_workflow_run",
+        "description": {
+            "zh": "重新运行 workflow run（全部或仅失败 job）。",
+            "en": "Re-run a workflow run (all jobs or failed jobs only)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "failed_jobs_only",
+                "description": {
+                    "zh": "只重跑失败 job（默认 false）",
+                    "en": "Only re-run failed jobs (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "enable_debug_logging",
+                "description": {
+                    "zh": "是否开启 debug 日志",
+                    "en": "Whether to enable debug logging."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "cancel_workflow_run",
+        "description": {
+            "zh": "取消 workflow run。",
+            "en": "Cancel a workflow run."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "list_check_runs",
+        "description": {
+            "zh": "列出某个 commit 的 check runs。",
+            "en": "List check runs for a commit."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "commit sha / 分支 / tag",
+                    "en": "Commit SHA, branch, or tag."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "status",
+                "description": {
+                    "zh": "queued/in_progress/completed 过滤",
+                    "en": "Filter by status: queued/in_progress/completed."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "filter",
+                "description": {
+                    "zh": "latest/all（默认 latest）",
+                    "en": "latest/all (default: latest)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "search_code",
+        "description": {
+            "zh": "搜索代码（/search/code）。",
+            "en": "Search code (/search/code)."
+        },
+        "parameters": [
+            {
+                "name": "query",
+                "description": {
+                    "zh": "搜索查询（支持 GitHub code search 语法）",
+                    "en": "Search query (GitHub code search syntax, e.g. repo:owner/name keyword)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sort",
+                "description": {
+                    "zh": "排序字段（indexed）",
+                    "en": "Sort field (indexed)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "order",
+                "description": {
+                    "zh": "排序方向：desc/asc",
+                    "en": "Sort order: desc/asc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "search_issues",
+        "description": {
+            "zh": "搜索 Issue/PR（/search/issues）。",
+            "en": "Search issues and PRs (/search/issues)."
+        },
+        "parameters": [
+            {
+                "name": "query",
+                "description": {
+                    "zh": "搜索查询（支持 GitHub issue search 语法）",
+                    "en": "Search query (GitHub issue search syntax)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sort",
+                "description": {
+                    "zh": "排序字段：comments/reactions/created/updated 等",
+                    "en": "Sort field: comments/reactions/created/updated etc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "order",
+                "description": {
+                    "zh": "排序方向：desc/asc",
+                    "en": "Sort order: desc/asc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_authenticated_user",
+        "description": {
+            "zh": "获取当前认证用户信息（/user）。",
+            "en": "Get the currently authenticated user (/user)."
+        },
+        "parameters": []
+    },
+    {
+        "name": "get_rate_limit",
+        "description": {
+            "zh": "查询 GitHub API 请求频率限制（/rate_limit）。",
+            "en": "Query GitHub API rate limit (/rate_limit)."
+        },
+        "parameters": []
+    },
+    {
+        "name": "fork_repository",
+        "description": {
+            "zh": "fork 仓库（/repos/{owner}/{repo}/forks）。",
+            "en": "Fork a repository."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "organization",
+                "description": {
+                    "zh": "fork 到指定组织（不填则 fork 到个人账号）",
+                    "en": "Fork to a specific organization (omit for personal account)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "name",
+                "description": {
+                    "zh": "fork 后的仓库名（默认与原仓库同名）",
+                    "en": "Name for the forked repository (default: same as original)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "default_branch_only",
+                "description": {
+                    "zh": "只 fork 默认分支（默认 false）",
+                    "en": "Fork only the default branch (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "sync_fork",
+        "description": {
+            "zh": "同步 fork 到上游（/repos/{owner}/{repo}/merge-upstream）。",
+            "en": "Sync a fork with upstream."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "fork 仓库的 owner",
+                    "en": "Fork repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "fork 仓库名",
+                    "en": "Fork repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "要同步的分支（默认默认分支）",
+                    "en": "Branch to sync (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "patch_file_in_repo",
+        "description": {
+            "zh": "在仓库中对文件应用 search/replace patch（先读取文件，替换内容后写回）。",
+            "en": "Apply a search/replace patch to a file in the repository (read -> replace -> write back)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径",
+                    "en": "File path."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "search",
+                "description": {
+                    "zh": "要查找的文本（精确匹配）",
+                    "en": "Text to search for (exact match)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "replace",
+                "description": {
+                    "zh": "替换后的文本",
+                    "en": "Replacement text."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "message",
+                "description": {
+                    "zh": "commit 消息",
+                    "en": "Commit message."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "目标分支",
+                    "en": "Target branch."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "apply_local_replace",
+        "description": {
+            "zh": "在本地文件系统中对文件应用 search/replace（不经过 GitHub API）。",
+            "en": "Apply a search/replace patch to a local file (no GitHub API)."
+        },
+        "parameters": [
+            {
+                "name": "path",
+                "description": {
+                    "zh": "本地文件路径（绝对路径）",
+                    "en": "Local file path (absolute)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "search",
+                "description": {
+                    "zh": "要查找的文本",
+                    "en": "Text to search for."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "replace",
+                "description": {
+                    "zh": "替换后的文本",
+                    "en": "Replacement text."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "apply_local_delete",
+        "description": {
+            "zh": "删除本地文件（不经过 GitHub API）。",
+            "en": "Delete a local file (no GitHub API)."
+        },
+        "parameters": [
+            {
+                "name": "path",
+                "description": {
+                    "zh": "本地文件路径（绝对路径）",
+                    "en": "Local file path (absolute)."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "overwrite_local_file",
+        "description": {
+            "zh": "用新内容完整覆盖本地文件（不经过 GitHub API）。",
+            "en": "Overwrite a local file with new content (no GitHub API)."
+        },
+        "parameters": [
+            {
+                "name": "path",
+                "description": {
+                    "zh": "本地文件路径（绝对路径）",
+                    "en": "Local file path (absolute)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "content",
+                "description": {
+                    "zh": "新的文件内容",
+                    "en": "New file content."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "terminal_exec",
+        "description": {
+            "zh": "在本地终端执行命令（调用 Operit 内置终端，注意权限和安全）。",
+            "en": "Execute a command in the local terminal (uses Operit built-in terminal)."
+        },
+        "parameters": [
+            {
+                "name": "command",
+                "description": {
+                    "zh": "要执行的 shell 命令",
+                    "en": "Shell command to execute."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "cwd",
+                "description": {
+                    "zh": "工作目录（默认当前目录）",
+                    "en": "Working directory (default: current directory)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "timeout_ms",
+                "description": {
+                    "zh": "超时毫秒数（默认 30000）",
+                    "en": "Timeout in milliseconds (default: 30000)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     }
-  ]
+]
 }
 */
 
 var __defProp = Object.defineProperty;
 var __defProps = Object.defineProperties;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
+var __getOwnPropNames = Object.getOwnPropertyNames;
 var __getOwnPropSymbols = Object.getOwnPropertySymbols;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
 var __propIsEnum = Object.prototype.propertyIsEnumerable;
@@ -263,22 +2646,76 @@ var __spreadValues = (a, b) => {
   return a;
 };
 var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
-
-// src/utils/wrap.ts
-async function wrap(func, params, successMessage, failMessage) {
-  try {
-    const data = await func(params);
-    const result = { success: true, message: successMessage, data };
-    complete(result);
-  } catch (error) {
-    const result = {
-      success: false,
-      message: `${failMessage}: ${String(error && error.message ? error.message : error)}`,
-      error_stack: String(error && error.stack ? error.stack : "")
-    };
-    complete(result);
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
   }
-}
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/index.ts
+var index_exports = {};
+__export(index_exports, {
+  apply_local_delete: () => apply_local_delete,
+  apply_local_replace: () => apply_local_replace,
+  cancel_workflow_run: () => cancel_workflow_run,
+  comment_issue: () => comment_issue,
+  compare_refs: () => compare_refs,
+  create_branch: () => create_branch,
+  create_issue: () => create_issue,
+  create_or_update_file: () => create_or_update_file,
+  create_pull_request: () => create_pull_request,
+  create_review: () => create_review,
+  delete_file: () => delete_file,
+  fork_repository: () => fork_repository,
+  get_authenticated_user: () => get_authenticated_user,
+  get_commit: () => get_commit,
+  get_compare_diff: () => get_compare_diff,
+  get_file_content: () => get_file_content,
+  get_issue: () => get_issue,
+  get_pull_request: () => get_pull_request,
+  get_pull_request_diff: () => get_pull_request_diff,
+  get_rate_limit: () => get_rate_limit,
+  get_repository: () => get_repository,
+  get_workflow_jobs: () => get_workflow_jobs,
+  get_workflow_run: () => get_workflow_run,
+  list_branches: () => list_branches,
+  list_check_runs: () => list_check_runs,
+  list_commits: () => list_commits,
+  list_issue_comments: () => list_issue_comments,
+  list_issues: () => list_issues,
+  list_pull_request_commits: () => list_pull_request_commits,
+  list_pull_request_files: () => list_pull_request_files,
+  list_pull_request_reviews: () => list_pull_request_reviews,
+  list_pull_requests: () => list_pull_requests,
+  list_review_comments: () => list_review_comments,
+  list_workflow_runs: () => list_workflow_runs,
+  list_workflows: () => list_workflows,
+  main: () => main,
+  merge_pull_request: () => merge_pull_request,
+  overwrite_local_file: () => overwrite_local_file,
+  patch_file_in_repo: () => patch_file_in_repo,
+  reply_review_comment: () => reply_review_comment,
+  request_reviewers: () => request_reviewers,
+  rerun_workflow_run: () => rerun_workflow_run,
+  search_code: () => search_code,
+  search_issues: () => search_issues,
+  search_repositories: () => search_repositories,
+  sync_fork: () => sync_fork,
+  terminal_exec: () => terminal_exec,
+  toolImpl: () => toolImpl,
+  trigger_workflow: () => trigger_workflow,
+  update_issue: () => update_issue,
+  update_pull_request: () => update_pull_request
+});
+module.exports = __toCommonJS(index_exports);
 
 // src/github/api.ts
 function getBaseUrl() {
@@ -290,6 +2727,13 @@ function getToken() {
   const trimmed = String(token || "").trim();
   return trimmed ? trimmed : void 0;
 }
+function requireToken(operation) {
+  const token = getToken();
+  if (!token) {
+    throw new Error(`GITHUB_TOKEN is required for ${operation}.`);
+  }
+  return token;
+}
 function buildUrl(pathname, query) {
   const base = getBaseUrl().replace(/\/+$/, "");
   const path = pathname.startsWith("/") ? pathname : `/${pathname}`;
@@ -297,17 +2741,24 @@ function buildUrl(pathname, query) {
   if (query) {
     Object.keys(query).forEach((k) => {
       const v = query[k];
-      if (v === void 0 || v === null) return;
+      if (v === void 0 || v === null || v === "") return;
       qs.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
     });
   }
   return qs.length > 0 ? `${base}${path}?${qs.join("&")}` : `${base}${path}`;
 }
+function repoPath(owner, repo, suffix = "") {
+  const extra = suffix ? suffix.startsWith("/") ? suffix : `/${suffix}` : "";
+  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${extra}`;
+}
+function encodeRef(ref) {
+  return String(ref || "").split("/").map((part) => encodeURIComponent(part)).join("/");
+}
 function defaultHeaders(extra) {
   const headers = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": "Operit-Examples-GitHub"
+    "User-Agent": "Operit-GitHub"
   };
   const token = getToken();
   if (token) {
@@ -321,143 +2772,279 @@ function defaultHeaders(extra) {
   return headers;
 }
 function createHttpClient(timeoutMs = 3e4) {
-  return OkHttp.newBuilder().connectTimeout(timeoutMs).readTimeout(timeoutMs).writeTimeout(timeoutMs).build();
+  return OkHttp.newBuilder().connectTimeout(timeoutMs).readTimeout(timeoutMs).writeTimeout(timeoutMs).followRedirects(true).build();
 }
-async function requestJson(options) {
+async function requestRaw(options) {
   var _a;
   const client = createHttpClient((_a = options.timeoutMs) != null ? _a : 3e4);
   const req = client.newRequest().url(options.url).method(options.method);
-  const headers = defaultHeaders(options.headers);
-  req.headers(headers);
-  if (options.body !== void 0 && options.body !== null && options.method !== "GET") {
-    req.body(JSON.stringify(options.body), "json");
+  req.headers(defaultHeaders(options.headers));
+  if (options.method !== "GET") {
+    const payload = options.body === void 0 || options.body === null ? {} : options.body;
+    req.body(JSON.stringify(payload), "json");
   }
   const resp = await req.build().execute();
   if (!resp.isSuccessful()) {
     throw new Error(`GitHub API Error: ${resp.statusCode} ${resp.statusMessage}
 ${resp.content}`);
   }
-  return resp.json();
+  return {
+    statusCode: resp.statusCode,
+    statusMessage: resp.statusMessage,
+    headers: resp.headers || {},
+    content: typeof resp.content === "string" ? resp.content : String(resp.content || "")
+  };
 }
+async function requestJson(options) {
+  const resp = await requestRaw(options);
+  const text = String(resp.content || "").trim();
+  if (resp.statusCode === 204 || !text) {
+    return { ok: true, statusCode: resp.statusCode };
+  }
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    throw new Error(`Failed to parse GitHub JSON response (${resp.statusCode}): ${text.slice(0, 500)}`);
+  }
+}
+async function requestText(options) {
+  const resp = await requestRaw(options);
+  return {
+    text: resp.content || "",
+    statusCode: resp.statusCode,
+    headers: resp.headers
+  };
+}
+function parseJsonParam(value, fieldName) {
+  if (value === void 0 || value === null || value === "") return void 0;
+  if (typeof value === "object") return value;
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed) return void 0;
+  try {
+    return JSON.parse(trimmed);
+  } catch (e) {
+    throw new Error(`${fieldName} must be valid JSON.`);
+  }
+}
+function splitCsv(value) {
+  if (value === void 0 || value === null || value === "") return void 0;
+  if (Array.isArray(value)) {
+    const items2 = value.map((it) => String(it).trim()).filter(Boolean);
+    return items2.length > 0 ? items2 : void 0;
+  }
+  const items = String(value).split(",").map((it) => it.trim()).filter(Boolean);
+  return items.length > 0 ? items : void 0;
+}
+function compactCommit(commit) {
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k;
+  if (!commit) return commit;
+  return {
+    sha: commit.sha || ((_b = (_a = commit.commit) == null ? void 0 : _a.tree) == null ? void 0 : _b.sha),
+    html_url: commit.html_url,
+    message: ((_c = commit.commit) == null ? void 0 : _c.message) || commit.message,
+    author: ((_e = (_d = commit.commit) == null ? void 0 : _d.author) == null ? void 0 : _e.name) || ((_f = commit.author) == null ? void 0 : _f.login),
+    date: ((_h = (_g = commit.commit) == null ? void 0 : _g.author) == null ? void 0 : _h.date) || ((_j = (_i = commit.commit) == null ? void 0 : _i.committer) == null ? void 0 : _j.date),
+    login: (_k = commit.author) == null ? void 0 : _k.login
+  };
+}
+function compactFileChange(file, includePatch) {
+  if (!file) return file;
+  const item = {
+    filename: file.filename,
+    status: file.status,
+    additions: file.additions,
+    deletions: file.deletions,
+    changes: file.changes,
+    sha: file.sha,
+    blob_url: file.blob_url,
+    previous_filename: file.previous_filename
+  };
+  if (includePatch && typeof file.patch === "string") {
+    item.patch = file.patch;
+  }
+  return item;
+}
+function truncateText(text, maxChars) {
+  const src = String(text != null ? text : "");
+  const limit = maxChars > 0 ? maxChars : src.length;
+  if (src.length <= limit) {
+    return { text: src, truncated: false, original_length: src.length };
+  }
+  const headChars = Math.max(200, Math.floor(limit * 0.35));
+  const tailChars = Math.max(200, limit - headChars - 80);
+  const omitted = src.length - headChars - tailChars;
+  return {
+    text: `${src.slice(0, headChars)}
 
-// src/github/repos.ts
-async function searchRepositories(params) {
-  var _a, _b;
-  const page = (_a = params.page) != null ? _a : 1;
-  const perPage = (_b = params.per_page) != null ? _b : 30;
-  const url = buildUrl("/search/repositories", {
-    q: params.query,
-    sort: params.sort,
-    order: params.order,
-    page,
-    per_page: perPage
-  });
-  return requestJson({ method: "GET", url });
-}
-async function getRepository(params) {
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}`);
-  return requestJson({ method: "GET", url });
+... truncated ${omitted} chars ...
+
+${src.slice(-tailChars)}`,
+    truncated: true,
+    original_length: src.length
+  };
 }
 
 // src/github/issues.ts
+function compactIssue(item) {
+  var _a;
+  if (!item) return item;
+  return {
+    number: item.number,
+    title: item.title,
+    state: item.state,
+    html_url: item.html_url,
+    user: (_a = item.user) == null ? void 0 : _a.login,
+    labels: Array.isArray(item.labels) ? item.labels.map((it) => typeof it === "string" ? it : it.name) : [],
+    assignees: Array.isArray(item.assignees) ? item.assignees.map((it) => it.login) : [],
+    comments: item.comments,
+    pull_request: Boolean(item.pull_request),
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    body: item.body
+  };
+}
 async function listIssues(params) {
   var _a, _b, _c;
-  const page = (_a = params.page) != null ? _a : 1;
-  const perPage = (_b = params.per_page) != null ? _b : 30;
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues`, {
-    state: (_c = params.state) != null ? _c : "open",
+  const url = buildUrl(repoPath(params.owner, params.repo, "/issues"), {
+    state: (_a = params.state) != null ? _a : "open",
     labels: params.labels,
     creator: params.creator,
-    page,
-    per_page: perPage
+    page: (_b = params.page) != null ? _b : 1,
+    per_page: (_c = params.per_page) != null ? _c : 30
   });
   const items = await requestJson({ method: "GET", url });
   const includePRs = params.include_pull_requests === true;
-  if (includePRs) return items;
-  return items.filter((it) => !it || !it.pull_request);
+  const filtered = includePRs ? items : items.filter((it) => !it || !it.pull_request);
+  return Array.isArray(filtered) ? filtered.map(compactIssue) : [];
+}
+async function getIssue(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}`));
+  return compactIssue(await requestJson({ method: "GET", url }));
 }
 async function createIssue(params) {
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for create_issue.");
-  }
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues`);
-  return requestJson({
-    method: "POST",
-    url,
-    body: {
-      title: params.title,
-      body: params.body,
-      labels: params.labels,
-      assignees: params.assignees
-    }
-  });
+  requireToken("create_issue");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/issues"));
+  return compactIssue(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        title: params.title,
+        body: params.body,
+        labels: splitCsv(params.labels),
+        assignees: splitCsv(params.assignees)
+      }
+    })
+  );
+}
+async function updateIssue(params) {
+  requireToken("update_issue");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}`));
+  return compactIssue(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        title: params.title,
+        body: params.body,
+        state: params.state,
+        labels: splitCsv(params.labels),
+        assignees: splitCsv(params.assignees)
+      }
+    })
+  );
 }
 async function commentIssue(params) {
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for comment_issue.");
-  }
-  const url = buildUrl(
-    `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues/${params.issue_number}/comments`
-  );
-  return requestJson({ method: "POST", url, body: { body: params.body } });
+  var _a;
+  requireToken("comment_issue");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}/comments`));
+  const data = await requestJson({ method: "POST", url, body: { body: params.body } });
+  return {
+    id: data.id,
+    html_url: data.html_url,
+    user: (_a = data.user) == null ? void 0 : _a.login,
+    body: data.body,
+    created_at: data.created_at
+  };
 }
 async function listIssueComments(params) {
   var _a, _b;
-  const page = (_a = params.page) != null ? _a : 1;
-  const perPage = (_b = params.per_page) != null ? _b : 30;
-  const url = buildUrl(
-    `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues/${params.issue_number}/comments`,
-    { page, per_page: perPage }
-  );
-  return requestJson({ method: "GET", url });
+  const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}/comments`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((item) => {
+    var _a2;
+    return {
+      id: item.id,
+      html_url: item.html_url,
+      user: (_a2 = item.user) == null ? void 0 : _a2.login,
+      body: item.body,
+      created_at: item.created_at,
+      updated_at: item.updated_at
+    };
+  }) : [];
 }
 
 // src/github/pulls.ts
+function compactPull(pr) {
+  var _a, _b, _c, _d, _e, _f;
+  if (!pr) return pr;
+  return {
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    draft: pr.draft,
+    merged: pr.merged,
+    mergeable: pr.mergeable,
+    html_url: pr.html_url,
+    user: (_a = pr.user) == null ? void 0 : _a.login,
+    head: ((_b = pr.head) == null ? void 0 : _b.label) || ((_c = pr.head) == null ? void 0 : _c.ref),
+    head_sha: (_d = pr.head) == null ? void 0 : _d.sha,
+    base: ((_e = pr.base) == null ? void 0 : _e.label) || ((_f = pr.base) == null ? void 0 : _f.ref),
+    body: pr.body,
+    created_at: pr.created_at,
+    updated_at: pr.updated_at
+  };
+}
 async function listPullRequests(params) {
   var _a, _b, _c;
-  const page = (_a = params.page) != null ? _a : 1;
-  const perPage = (_b = params.per_page) != null ? _b : 30;
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls`, {
-    state: (_c = params.state) != null ? _c : "open",
+  const url = buildUrl(repoPath(params.owner, params.repo, "/pulls"), {
+    state: (_a = params.state) != null ? _a : "open",
     head: params.head,
     base: params.base,
-    page,
-    per_page: perPage
+    page: (_b = params.page) != null ? _b : 1,
+    per_page: (_c = params.per_page) != null ? _c : 30
   });
-  return requestJson({ method: "GET", url });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactPull) : [];
 }
 async function createPullRequest(params) {
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for create_pull_request.");
-  }
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls`);
-  return requestJson({
-    method: "POST",
-    url,
-    body: {
-      title: params.title,
-      head: params.head,
-      base: params.base,
-      body: params.body,
-      draft: params.draft
-    }
-  });
+  requireToken("create_pull_request");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/pulls"));
+  return compactPull(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        title: params.title,
+        head: params.head,
+        base: params.base,
+        body: params.body,
+        draft: params.draft
+      }
+    })
+  );
 }
 async function getPullRequest(params) {
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls/${params.pull_number}`);
-  return requestJson({ method: "GET", url });
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}`));
+  return compactPull(await requestJson({ method: "GET", url }));
 }
 async function mergePullRequest(params) {
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for merge_pull_request.");
-  }
-  const url = buildUrl(
-    `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls/${params.pull_number}/merge`
-  );
+  requireToken("merge_pull_request");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/merge`));
   return requestJson({
     method: "PUT",
     url,
@@ -467,6 +3054,162 @@ async function mergePullRequest(params) {
       merge_method: params.merge_method
     }
   });
+}
+async function updatePullRequest(params) {
+  requireToken("update_pull_request");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}`));
+  return compactPull(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        title: params.title,
+        body: params.body,
+        state: params.state,
+        base: params.base,
+        draft: params.draft
+      }
+    })
+  );
+}
+async function listPullRequestFiles(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/files`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 100
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((file) => compactFileChange(file, params.include_patch === true)) : [];
+}
+async function getPullRequestDiff(params) {
+  var _a;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}`));
+  const resp = await requestText({
+    method: "GET",
+    url,
+    headers: { Accept: "application/vnd.github.diff" },
+    timeoutMs: 6e4
+  });
+  const truncated = truncateText(resp.text, (_a = params.max_chars) != null ? _a : 2e4);
+  return {
+    pull_number: params.pull_number,
+    diff: truncated.text,
+    truncated: truncated.truncated,
+    original_length: truncated.original_length
+  };
+}
+async function listPullRequestCommits(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/commits`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactCommit) : [];
+}
+async function listPullRequestReviews(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/reviews`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((item) => {
+    var _a2;
+    return {
+      id: item.id,
+      user: (_a2 = item.user) == null ? void 0 : _a2.login,
+      state: item.state,
+      body: item.body,
+      submitted_at: item.submitted_at,
+      html_url: item.html_url,
+      commit_id: item.commit_id
+    };
+  }) : [];
+}
+async function listReviewComments(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/comments`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((item) => {
+    var _a2;
+    return {
+      id: item.id,
+      user: (_a2 = item.user) == null ? void 0 : _a2.login,
+      path: item.path,
+      line: item.line,
+      original_line: item.original_line,
+      side: item.side,
+      body: item.body,
+      html_url: item.html_url,
+      in_reply_to_id: item.in_reply_to_id,
+      created_at: item.created_at,
+      updated_at: item.updated_at
+    };
+  }) : [];
+}
+async function createReview(params) {
+  var _a;
+  requireToken("create_review");
+  const comments = parseJsonParam(params.comments, "comments");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/reviews`));
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      body: params.body,
+      event: params.event,
+      commit_id: params.commit_id,
+      comments
+    }
+  });
+  return {
+    id: data.id,
+    state: data.state,
+    body: data.body,
+    html_url: data.html_url,
+    user: (_a = data.user) == null ? void 0 : _a.login
+  };
+}
+async function replyReviewComment(params) {
+  var _a;
+  requireToken("reply_review_comment");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/comments/${params.comment_id}/replies`)
+  );
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: { body: params.body }
+  });
+  return {
+    id: data.id,
+    body: data.body,
+    html_url: data.html_url,
+    in_reply_to_id: data.in_reply_to_id,
+    user: (_a = data.user) == null ? void 0 : _a.login
+  };
+}
+async function requestReviewers(params) {
+  requireToken("request_reviewers");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/requested_reviewers`));
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      reviewers: splitCsv(params.reviewers),
+      team_reviewers: splitCsv(params.team_reviewers)
+    }
+  });
+  return {
+    number: data.number,
+    html_url: data.html_url,
+    requested_reviewers: Array.isArray(data.requested_reviewers) ? data.requested_reviewers.map((it) => it.login) : [],
+    requested_teams: Array.isArray(data.requested_teams) ? data.requested_teams.map((it) => it.slug || it.name) : []
+  };
 }
 
 // src/utils/base64.ts
@@ -634,10 +3377,7 @@ async function resolveFileSha(params) {
 }
 async function createOrUpdateFile(params) {
   var _a;
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for create_or_update_file.");
-  }
+  requireToken("create_or_update_file");
   const encoding = (params.content_encoding || "utf-8").toLowerCase();
   const base64Content = encoding === "base64" ? params.content : safeBtoaBase64(params.content);
   const sha = (_a = params.sha) != null ? _a : await resolveFileSha({ owner: params.owner, repo: params.repo, path: params.path, branch: params.branch });
@@ -657,10 +3397,7 @@ async function createOrUpdateFile(params) {
 }
 async function deleteFile(params) {
   var _a;
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for delete_file.");
-  }
+  requireToken("delete_file");
   const sha = (_a = params.sha) != null ? _a : await resolveFileSha({ owner: params.owner, repo: params.repo, path: params.path, branch: params.branch });
   if (!sha) {
     throw new Error("File sha is required (unable to resolve automatically).");
@@ -677,6 +3414,25 @@ async function deleteFile(params) {
       sha
     }
   });
+}
+
+// src/github/repos.ts
+async function searchRepositories(params) {
+  var _a, _b;
+  const page = (_a = params.page) != null ? _a : 1;
+  const perPage = (_b = params.per_page) != null ? _b : 30;
+  const url = buildUrl("/search/repositories", {
+    q: params.query,
+    sort: params.sort,
+    order: params.order,
+    page,
+    per_page: perPage
+  });
+  return requestJson({ method: "GET", url });
+}
+async function getRepository(params) {
+  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}`);
+  return requestJson({ method: "GET", url });
 }
 
 // src/github/branches.ts
@@ -696,10 +3452,7 @@ async function getBranchHeadSha(params) {
 }
 async function createBranch(params) {
   var _a, _b;
-  const token = getToken();
-  if (!token) {
-    throw new Error("GITHUB_TOKEN is required for create_branch.");
-  }
+  requireToken("create_branch");
   const fromBranch = (_b = params.from_branch) != null ? _b : String(((_a = await getRepository({ owner: params.owner, repo: params.repo })) == null ? void 0 : _a.default_branch) || "main");
   const sha = await getBranchHeadSha({ owner: params.owner, repo: params.repo, branch: fromBranch });
   const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/git/refs`);
@@ -711,6 +3464,424 @@ async function createBranch(params) {
       sha
     }
   });
+}
+
+// src/github/git.ts
+async function listBranches(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/branches"), {
+    protected: params.protected_only,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map((item) => {
+    var _a2;
+    return {
+      name: item.name,
+      sha: (_a2 = item.commit) == null ? void 0 : _a2.sha,
+      protected: item.protected,
+      html_url: `https://github.com/${params.owner}/${params.repo}/tree/${item.name}`
+    };
+  }) : [];
+}
+async function listCommits(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/commits"), {
+    sha: params.sha,
+    path: params.path,
+    author: params.author,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 20
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactCommit) : [];
+}
+async function getCommit(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/commits/${encodeURIComponent(params.ref)}`));
+  const data = await requestJson({ method: "GET", url });
+  return __spreadProps(__spreadValues({}, compactCommit(data)), {
+    stats: data.stats,
+    files: params.include_files === false ? void 0 : Array.isArray(data.files) ? data.files.map((file) => compactFileChange(file, false)) : []
+  });
+}
+async function compareRefs(params) {
+  const spec = `${encodeRef(params.base)}...${encodeRef(params.head)}`;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/compare/${spec}`));
+  const data = await requestJson({ method: "GET", url });
+  const includeFiles = params.include_files !== false;
+  return {
+    status: data.status,
+    ahead_by: data.ahead_by,
+    behind_by: data.behind_by,
+    total_commits: data.total_commits,
+    html_url: data.html_url,
+    permalink_url: data.permalink_url,
+    base_commit: compactCommit(data.base_commit),
+    merge_base_commit: compactCommit(data.merge_base_commit),
+    commits: Array.isArray(data.commits) ? data.commits.map(compactCommit) : [],
+    files: includeFiles ? Array.isArray(data.files) ? data.files.map((file) => compactFileChange(file, params.include_patch === true)) : [] : void 0
+  };
+}
+async function getCompareDiff(params) {
+  var _a;
+  const spec = `${encodeRef(params.base)}...${encodeRef(params.head)}`;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/compare/${spec}`));
+  const resp = await requestText({
+    method: "GET",
+    url,
+    headers: { Accept: "application/vnd.github.diff" },
+    timeoutMs: 6e4
+  });
+  const truncated = truncateText(resp.text, (_a = params.max_chars) != null ? _a : 2e4);
+  return {
+    base: params.base,
+    head: params.head,
+    diff: truncated.text,
+    truncated: truncated.truncated,
+    original_length: truncated.original_length
+  };
+}
+
+// src/github/actions.ts
+function compactWorkflow(item) {
+  if (!item) return item;
+  return {
+    id: item.id,
+    name: item.name,
+    path: item.path,
+    state: item.state,
+    html_url: item.html_url,
+    badge_url: item.badge_url,
+    created_at: item.created_at,
+    updated_at: item.updated_at
+  };
+}
+function compactRun(item) {
+  var _a, _b;
+  if (!item) return item;
+  return {
+    id: item.id,
+    name: item.name,
+    display_title: item.display_title,
+    status: item.status,
+    conclusion: item.conclusion,
+    event: item.event,
+    head_branch: item.head_branch,
+    head_sha: item.head_sha,
+    html_url: item.html_url,
+    path: item.path,
+    run_number: item.run_number,
+    run_attempt: item.run_attempt,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    actor: (_a = item.actor) == null ? void 0 : _a.login,
+    triggering_actor: (_b = item.triggering_actor) == null ? void 0 : _b.login
+  };
+}
+function compactJob(item) {
+  if (!item) return item;
+  return {
+    id: item.id,
+    run_id: item.run_id,
+    name: item.name,
+    status: item.status,
+    conclusion: item.conclusion,
+    html_url: item.html_url,
+    started_at: item.started_at,
+    completed_at: item.completed_at,
+    runner_name: item.runner_name,
+    steps: Array.isArray(item.steps) ? item.steps.map((step) => ({
+      name: step.name,
+      status: step.status,
+      conclusion: step.conclusion,
+      number: step.number,
+      started_at: step.started_at,
+      completed_at: step.completed_at
+    })) : []
+  };
+}
+async function listWorkflows(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/actions/workflows"), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const data = await requestJson({ method: "GET", url });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    workflows: Array.isArray(data == null ? void 0 : data.workflows) ? data.workflows.map(compactWorkflow) : []
+  };
+}
+async function listWorkflowRuns(params) {
+  var _a, _b;
+  const suffix = params.workflow_id ? `/actions/workflows/${encodeURIComponent(String(params.workflow_id))}/runs` : "/actions/runs";
+  const url = buildUrl(repoPath(params.owner, params.repo, suffix), {
+    branch: params.branch,
+    status: params.status,
+    event: params.event,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 20
+  });
+  const data = await requestJson({ method: "GET", url });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    workflow_runs: Array.isArray(data == null ? void 0 : data.workflow_runs) ? data.workflow_runs.map(compactRun) : []
+  };
+}
+async function getWorkflowRun(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/actions/runs/${encodeURIComponent(String(params.run_id))}`));
+  return compactRun(await requestJson({ method: "GET", url }));
+}
+async function triggerWorkflow(params) {
+  requireToken("trigger_workflow");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/actions/workflows/${encodeURIComponent(String(params.workflow_id))}/dispatches`)
+  );
+  const inputs = parseJsonParam(params.inputs, "inputs");
+  const result = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      ref: params.ref,
+      inputs
+    }
+  });
+  return {
+    ok: true,
+    workflow_id: params.workflow_id,
+    ref: params.ref,
+    inputs: inputs || {},
+    dispatch: result
+  };
+}
+async function getWorkflowJobs(params) {
+  var _a, _b, _c;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/actions/runs/${encodeURIComponent(String(params.run_id))}/jobs`), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 50
+  });
+  const data = await requestJson({ method: "GET", url });
+  const jobs = Array.isArray(data == null ? void 0 : data.jobs) ? data.jobs.map(compactJob) : [];
+  const selected = params.failed_only ? jobs.filter((job) => job.conclusion && job.conclusion !== "success" && job.conclusion !== "skipped") : jobs;
+  if (!params.include_logs) {
+    return {
+      total_count: data == null ? void 0 : data.total_count,
+      jobs: selected
+    };
+  }
+  const maxLogChars = (_c = params.max_log_chars) != null ? _c : 8e3;
+  const withLogs = [];
+  for (const job of selected) {
+    try {
+      const logUrl = buildUrl(repoPath(params.owner, params.repo, `/actions/jobs/${encodeURIComponent(String(job.id))}/logs`));
+      const logResp = await requestText({ method: "GET", url: logUrl, timeoutMs: 6e4 });
+      const truncated = truncateText(logResp.text, maxLogChars);
+      withLogs.push(__spreadProps(__spreadValues({}, job), {
+        logs: truncated.text,
+        logs_truncated: truncated.truncated,
+        logs_original_length: truncated.original_length
+      }));
+    } catch (e) {
+      withLogs.push(__spreadProps(__spreadValues({}, job), {
+        logs_error: String(e && e.message ? e.message : e)
+      }));
+    }
+  }
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    jobs: withLogs
+  };
+}
+async function rerunWorkflowRun(params) {
+  requireToken("rerun_workflow_run");
+  const suffix = params.failed_jobs_only ? `/actions/runs/${encodeURIComponent(String(params.run_id))}/rerun-failed-jobs` : `/actions/runs/${encodeURIComponent(String(params.run_id))}/rerun`;
+  const url = buildUrl(repoPath(params.owner, params.repo, suffix));
+  const body = params.enable_debug_logging === void 0 ? void 0 : { enable_debug_logging: params.enable_debug_logging };
+  const result = await requestJson({ method: "POST", url, body });
+  return { ok: true, run_id: params.run_id, failed_jobs_only: Boolean(params.failed_jobs_only), result };
+}
+async function cancelWorkflowRun(params) {
+  requireToken("cancel_workflow_run");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/actions/runs/${encodeURIComponent(String(params.run_id))}/cancel`));
+  const result = await requestJson({ method: "POST", url });
+  return { ok: true, run_id: params.run_id, result };
+}
+async function listCheckRuns(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, `/commits/${encodeURIComponent(params.ref)}/check-runs`), {
+    status: params.status,
+    filter: params.filter,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const data = await requestJson({ method: "GET", url });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    check_runs: Array.isArray(data == null ? void 0 : data.check_runs) ? data.check_runs.map((item) => {
+      var _a2, _b2;
+      return {
+        id: item.id,
+        name: item.name,
+        status: item.status,
+        conclusion: item.conclusion,
+        html_url: item.html_url,
+        details_url: item.details_url,
+        started_at: item.started_at,
+        completed_at: item.completed_at,
+        app: ((_a2 = item.app) == null ? void 0 : _a2.slug) || ((_b2 = item.app) == null ? void 0 : _b2.name)
+      };
+    }) : []
+  };
+}
+
+// src/github/search.ts
+async function searchCode(params) {
+  var _a, _b;
+  const url = buildUrl("/search/code", {
+    q: params.query,
+    sort: params.sort,
+    order: params.order,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 20
+  });
+  const data = await requestJson({
+    method: "GET",
+    url,
+    headers: { Accept: "application/vnd.github.text-match+json" }
+  });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    incomplete_results: data == null ? void 0 : data.incomplete_results,
+    items: Array.isArray(data == null ? void 0 : data.items) ? data.items.map((item) => {
+      var _a2;
+      return {
+        name: item.name,
+        path: item.path,
+        sha: item.sha,
+        html_url: item.html_url,
+        repository: (_a2 = item.repository) == null ? void 0 : _a2.full_name,
+        score: item.score,
+        text_matches: Array.isArray(item.text_matches) ? item.text_matches.map((match) => ({
+          fragment: match.fragment,
+          property: match.property
+        })) : []
+      };
+    }) : []
+  };
+}
+async function searchIssues(params) {
+  var _a, _b;
+  const url = buildUrl("/search/issues", {
+    q: params.query,
+    sort: params.sort,
+    order: params.order,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 20
+  });
+  const data = await requestJson({ method: "GET", url });
+  return {
+    total_count: data == null ? void 0 : data.total_count,
+    incomplete_results: data == null ? void 0 : data.incomplete_results,
+    items: Array.isArray(data == null ? void 0 : data.items) ? data.items.map((item) => {
+      var _a2;
+      return {
+        number: item.number,
+        title: item.title,
+        state: item.state,
+        html_url: item.html_url,
+        repository: item.repository_url,
+        user: (_a2 = item.user) == null ? void 0 : _a2.login,
+        comments: item.comments,
+        pull_request: Boolean(item.pull_request),
+        updated_at: item.updated_at
+      };
+    }) : []
+  };
+}
+
+// src/github/users.ts
+async function getAuthenticatedUser() {
+  var _a;
+  const data = await requestJson({ method: "GET", url: buildUrl("/user") });
+  return {
+    login: data.login,
+    id: data.id,
+    name: data.name,
+    html_url: data.html_url,
+    type: data.type,
+    company: data.company,
+    public_repos: data.public_repos,
+    total_private_repos: data.total_private_repos,
+    plan: (_a = data.plan) == null ? void 0 : _a.name
+  };
+}
+async function getRateLimit() {
+  var _a, _b, _c;
+  const data = await requestJson({ method: "GET", url: buildUrl("/rate_limit") });
+  const core = ((_a = data == null ? void 0 : data.resources) == null ? void 0 : _a.core) || {};
+  const search = ((_b = data == null ? void 0 : data.resources) == null ? void 0 : _b.search) || {};
+  const graphql = ((_c = data == null ? void 0 : data.resources) == null ? void 0 : _c.graphql) || {};
+  return {
+    core: {
+      limit: core.limit,
+      remaining: core.remaining,
+      reset: core.reset,
+      used: core.used
+    },
+    search: {
+      limit: search.limit,
+      remaining: search.remaining,
+      reset: search.reset,
+      used: search.used
+    },
+    graphql: {
+      limit: graphql.limit,
+      remaining: graphql.remaining,
+      reset: graphql.reset,
+      used: graphql.used
+    }
+  };
+}
+
+// src/github/forks.ts
+async function forkRepository(params) {
+  var _a, _b;
+  requireToken("fork_repository");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/forks"));
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      organization: params.organization,
+      name: params.name,
+      default_branch_only: params.default_branch_only
+    }
+  });
+  return {
+    full_name: data.full_name,
+    html_url: data.html_url,
+    default_branch: data.default_branch,
+    parent: (_a = data.parent) == null ? void 0 : _a.full_name,
+    source: (_b = data.source) == null ? void 0 : _b.full_name,
+    private: data.private
+  };
+}
+async function syncFork(params) {
+  requireToken("sync_fork");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/merge-upstream"));
+  const data = await requestJson({
+    method: "POST",
+    url,
+    body: {
+      branch: params.branch
+    }
+  });
+  return {
+    message: data.message,
+    merge_type: data.merge_type,
+    base_branch: data.base_branch
+  };
 }
 
 // src/github/patch.ts
@@ -785,7 +3956,7 @@ async function patchFileInRepo(params) {
   });
 }
 
-// src/local/fileApply.ts
+// src/github/local/fileApply.ts
 async function applyLocalReplace(params) {
   return Tools.Files.apply(params.path, "replace", params.old, params.new, params.environment);
 }
@@ -801,7 +3972,7 @@ async function overwriteLocalFile(params) {
   return Tools.Files.write(params.path, String((_a = params.content) != null ? _a : ""), false, params.environment);
 }
 
-// src/local/terminal.ts
+// src/github/local/terminal.ts
 var terminalSessionId = null;
 async function getTerminalSession(sessionName) {
   if (terminalSessionId) return terminalSessionId;
@@ -819,282 +3990,131 @@ async function terminalExec(params) {
   return result;
 }
 
-// src/tools.ts
-var toolImpl = {
-  search_repositories: (p) => wrap(searchRepositories, p, "\u641C\u7D22\u4ED3\u5E93\u6210\u529F", "\u641C\u7D22\u4ED3\u5E93\u5931\u8D25"),
-  get_repository: (p) => wrap(getRepository, p, "\u83B7\u53D6\u4ED3\u5E93\u4FE1\u606F\u6210\u529F", "\u83B7\u53D6\u4ED3\u5E93\u4FE1\u606F\u5931\u8D25"),
-  list_issues: (p) => wrap(listIssues, p, "\u83B7\u53D6 Issues \u6210\u529F", "\u83B7\u53D6 Issues \u5931\u8D25"),
-  create_issue: (p) => wrap(createIssue, p, "\u521B\u5EFA Issue \u6210\u529F", "\u521B\u5EFA Issue \u5931\u8D25"),
-  comment_issue: (p) => wrap(commentIssue, p, "\u53D1\u8868\u8BC4\u8BBA\u6210\u529F", "\u53D1\u8868\u8BC4\u8BBA\u5931\u8D25"),
-  list_issue_comments: (p) => wrap(listIssueComments, p, "\u83B7\u53D6 Issue \u8BC4\u8BBA\u6210\u529F", "\u83B7\u53D6 Issue \u8BC4\u8BBA\u5931\u8D25"),
-  list_pull_requests: (p) => wrap(listPullRequests, p, "\u83B7\u53D6 PR \u5217\u8868\u6210\u529F", "\u83B7\u53D6 PR \u5217\u8868\u5931\u8D25"),
-  create_pull_request: (p) => wrap(createPullRequest, p, "\u521B\u5EFA PR \u6210\u529F", "\u521B\u5EFA PR \u5931\u8D25"),
-  get_pull_request: (p) => wrap(getPullRequest, p, "\u83B7\u53D6 PR \u6210\u529F", "\u83B7\u53D6 PR \u5931\u8D25"),
-  merge_pull_request: (p) => wrap(mergePullRequest, p, "\u5408\u5E76 PR \u6210\u529F", "\u5408\u5E76 PR \u5931\u8D25"),
-  get_file_content: (p) => wrap(getFileContent, p, "\u8BFB\u53D6\u6587\u4EF6\u6210\u529F", "\u8BFB\u53D6\u6587\u4EF6\u5931\u8D25"),
-  create_or_update_file: (p) => wrap(createOrUpdateFile, p, "\u63D0\u4EA4\u6587\u4EF6\u6210\u529F", "\u63D0\u4EA4\u6587\u4EF6\u5931\u8D25"),
-  delete_file: (p) => wrap(deleteFile, p, "\u5220\u9664\u6587\u4EF6\u6210\u529F", "\u5220\u9664\u6587\u4EF6\u5931\u8D25"),
-  create_branch: (p) => wrap(createBranch, p, "\u521B\u5EFA\u5206\u652F\u6210\u529F", "\u521B\u5EFA\u5206\u652F\u5931\u8D25"),
-  patch_file_in_repo: (p) => wrap(patchFileInRepo, p, "\u4ED3\u5E93\u6587\u4EF6\u5DEE\u5F02\u66F4\u65B0\u6210\u529F", "\u4ED3\u5E93\u6587\u4EF6\u5DEE\u5F02\u66F4\u65B0\u5931\u8D25"),
-  apply_local_replace: (p) => wrap(applyLocalReplace, p, "\u672C\u5730\u5DEE\u5F02\u66F4\u65B0\u6210\u529F", "\u672C\u5730\u5DEE\u5F02\u66F4\u65B0\u5931\u8D25"),
-  apply_local_delete: (p) => wrap(applyLocalDelete, p, "\u672C\u5730\u5220\u9664\u7247\u6BB5\u6210\u529F", "\u672C\u5730\u5220\u9664\u7247\u6BB5\u5931\u8D25"),
-  overwrite_local_file: (p) => wrap(overwriteLocalFile, p, "\u672C\u5730\u8986\u76D6\u5199\u5165\u6210\u529F", "\u672C\u5730\u8986\u76D6\u5199\u5165\u5931\u8D25"),
-  terminal_exec: (p) => wrap(terminalExec, p, "\u7EC8\u7AEF\u6267\u884C\u6210\u529F", "\u7EC8\u7AEF\u6267\u884C\u5931\u8D25")
-};
-
-// src/index.ts
-exports.search_repositories = toolImpl.search_repositories;
-exports.get_repository = toolImpl.get_repository;
-exports.list_issues = toolImpl.list_issues;
-exports.create_issue = toolImpl.create_issue;
-exports.comment_issue = toolImpl.comment_issue;
-exports.list_issue_comments = toolImpl.list_issue_comments;
-exports.list_pull_requests = toolImpl.list_pull_requests;
-exports.create_pull_request = toolImpl.create_pull_request;
-exports.get_pull_request = toolImpl.get_pull_request;
-exports.merge_pull_request = toolImpl.merge_pull_request;
-exports.get_file_content = toolImpl.get_file_content;
-exports.create_or_update_file = toolImpl.create_or_update_file;
-exports.patch_file_in_repo = toolImpl.patch_file_in_repo;
-exports.delete_file = toolImpl.delete_file;
-exports.create_branch = toolImpl.create_branch;
-exports.apply_local_replace = toolImpl.apply_local_replace;
-exports.apply_local_delete = toolImpl.apply_local_delete;
-exports.overwrite_local_file = toolImpl.overwrite_local_file;
-exports.terminal_exec = toolImpl.terminal_exec;
-async function main(params) {
-  var _a, _b, _c;
+// src/utils/wrap.ts
+async function wrap(func, params, successMessage, failMessage) {
   try {
-    const owner = String((params == null ? void 0 : params.owner) || "octocat");
-    const repo = String((params == null ? void 0 : params.repo) || "Hello-World");
-    const query = String((params == null ? void 0 : params.query) || "operit");
-    const path = String((params == null ? void 0 : params.path) || "README.md");
-    const enableWrite = (params == null ? void 0 : params.enable_write) === true;
-    const baseUrl = getBaseUrl();
-    const token = getToken();
-    const results = {};
-    const toErrMsg = (e) => String(e && e.message ? e.message : e);
-    const toErrStack = (e) => String(e && e.stack ? e.stack : "");
-    const run = async (name, fn) => {
-      try {
-        const data = await fn();
-        return { ok: true, data };
-      } catch (e) {
-        return { ok: false, error: toErrMsg(e), error_stack: toErrStack(e) };
-      }
-    };
-    const summarizeRepo = (r) => r ? {
-      id: r.id,
-      full_name: r.full_name,
-      private: r.private,
-      default_branch: r.default_branch
-    } : r;
-    const summarizeList = (items) => ({
-      count: Array.isArray(items) ? items.length : 0,
-      first: Array.isArray(items) && items.length > 0 ? items[0] : null
-    });
-    results.get_repository = await run("get_repository", async () => summarizeRepo(await getRepository({ owner, repo })));
-    results.search_repositories = await run("search_repositories", async () => {
-      const r = await searchRepositories({ query, per_page: 5 });
-      const items = Array.isArray(r == null ? void 0 : r.items) ? r.items : [];
-      return {
-        total_count: r == null ? void 0 : r.total_count,
-        count: items.length,
-        first: items[0] ? { id: items[0].id, full_name: items[0].full_name, stargazers_count: items[0].stargazers_count } : null
-      };
-    });
-    results.list_issues = await run("list_issues", async () => summarizeList(await listIssues({ owner, repo, per_page: 5 })));
-    let issueNumber = typeof (params == null ? void 0 : params.issue_number) === "number" ? params.issue_number : void 0;
-    if (!issueNumber && results.list_issues.ok) {
-      const first = (_a = results.list_issues.data) == null ? void 0 : _a.first;
-      if (first && typeof first.number === "number") issueNumber = first.number;
-    }
-    if (issueNumber) {
-      results.list_issue_comments = await run(
-        "list_issue_comments",
-        async () => summarizeList(await listIssueComments({ owner, repo, issue_number: issueNumber, per_page: 5 }))
-      );
-    } else {
-      results.list_issue_comments = { ok: false, skipped: true, reason: "No issue_number provided and cannot infer from list_issues." };
-    }
-    results.list_pull_requests = await run("list_pull_requests", async () => summarizeList(await listPullRequests({ owner, repo, per_page: 5 })));
-    let pullNumber = typeof (params == null ? void 0 : params.pull_number) === "number" ? params.pull_number : void 0;
-    if (!pullNumber && results.list_pull_requests.ok) {
-      const first = (_b = results.list_pull_requests.data) == null ? void 0 : _b.first;
-      if (first && typeof first.number === "number") pullNumber = first.number;
-    }
-    if (pullNumber) {
-      results.get_pull_request = await run("get_pull_request", async () => {
-        var _a2, _b2;
-        const pr = await getPullRequest({ owner, repo, pull_number: pullNumber });
-        return pr ? {
-          number: pr.number,
-          title: pr.title,
-          state: pr.state,
-          merged: pr.merged,
-          head: (_a2 = pr.head) == null ? void 0 : _a2.ref,
-          base: (_b2 = pr.base) == null ? void 0 : _b2.ref
-        } : pr;
-      });
-    } else {
-      results.get_pull_request = { ok: false, skipped: true, reason: "No pull_number provided and cannot infer from list_pull_requests." };
-    }
-    const inferReadableRepoFilePath = async () => {
-      if (params == null ? void 0 : params.path) {
-        return path;
-      }
-      try {
-        const root = await getFileContent({ owner, repo, path: "" });
-        if (!Array.isArray(root)) {
-          return void 0;
-        }
-        const prefer = ["README.md", "README", "readme.md", "Readme.md", "README.MD"];
-        for (const p of prefer) {
-          const hit = root.find((it) => it && it.type === "file" && String(it.path || it.name || "") === p);
-          if (hit) return String(hit.path || hit.name);
-        }
-        const firstFile = root.find((it) => it && it.type === "file" && (typeof it.path === "string" || typeof it.name === "string"));
-        if (firstFile) return String(firstFile.path || firstFile.name);
-        return void 0;
-      } catch (e) {
-        return void 0;
-      }
-    };
-    const resolvedPath = await inferReadableRepoFilePath();
-    if (!resolvedPath) {
-      results.get_file_content = { ok: false, skipped: true, reason: "No readable file found in repo root for get_file_content test." };
-    } else {
-      results.get_file_content = await run("get_file_content", async () => {
-        const f = await getFileContent({ owner, repo, path: resolvedPath });
-        return f ? {
-          type: f.type,
-          path: f.path,
-          sha: f.sha,
-          size: f.size,
-          has_decoded_text: typeof f.decoded_text === "string" && f.decoded_text.length > 0
-        } : f;
-      });
-    }
-    const writeSkipped = (name, reason) => {
-      results[name] = { ok: false, skipped: true, reason };
-    };
-    if (!enableWrite) {
-      writeSkipped("create_issue", "Skipped: enable_write=false (write operation).");
-      writeSkipped("comment_issue", "Skipped: enable_write=false (write operation).");
-      writeSkipped("create_branch", "Skipped: enable_write=false (write operation).");
-      writeSkipped("create_or_update_file", "Skipped: enable_write=false (write operation).");
-      writeSkipped("patch_file_in_repo", "Skipped: enable_write=false (write operation).");
-      writeSkipped("delete_file", "Skipped: enable_write=false (write operation).");
-      writeSkipped("create_pull_request", "Skipped: enable_write=false (write operation).");
-      writeSkipped("merge_pull_request", "Skipped: enable_write=false (write operation).");
-    } else {
-      const ts = Date.now();
-      const testBranch = `operit-test-${ts}`;
-      const testPath = `operit_test_${ts}.txt`;
-      const baseBranch = (results.get_repository.ok ? (_c = results.get_repository.data) == null ? void 0 : _c.default_branch : void 0) || "main";
-      results.create_branch = await run(
-        "create_branch",
-        async () => createBranch({ owner, repo, new_branch: testBranch, from_branch: baseBranch })
-      );
-      results.create_or_update_file = await run(
-        "create_or_update_file",
-        async () => createOrUpdateFile({
-          owner,
-          repo,
-          path: testPath,
-          message: `operit test create file ${ts}`,
-          content: `operit github tools self-test ${ts}`,
-          content_encoding: "utf-8",
-          branch: testBranch
-        })
-      );
-      results.patch_file_in_repo = await run(
-        "patch_file_in_repo",
-        async () => patchFileInRepo({
-          owner,
-          repo,
-          path: testPath,
-          message: `operit test patch file ${ts}`,
-          patch: `[START-REPLACE]
-[OLD]
-operit github tools self-test ${ts}
-[/OLD]
-[NEW]
-operit github tools self-test ${ts} (patched)
-[/NEW]
-[END-REPLACE]`,
-          branch: testBranch
-        })
-      );
-      results.delete_file = await run("delete_file", async () => {
-        const sha = results.create_or_update_file.ok && results.create_or_update_file.data && results.create_or_update_file.data.content ? results.create_or_update_file.data.content.sha : void 0;
-        if (!sha) {
-          throw new Error("Cannot infer sha from create_or_update_file response; pass sha explicitly if needed.");
-        }
-        return deleteFile({ owner, repo, path: testPath, message: `operit test delete file ${ts}`, branch: testBranch, sha });
-      });
-      const canIssue = Boolean(token) && issueNumber !== void 0;
-      if (!token) {
-        writeSkipped("create_issue", "Skipped: GITHUB_TOKEN missing (required for write operation).");
-      } else {
-        results.create_issue = await run(
-          "create_issue",
-          async () => createIssue({ owner, repo, title: `operit self-test issue ${ts}`, body: `created by operit github tools self-test ${ts}` })
-        );
-      }
-      if (!canIssue) {
-        writeSkipped("comment_issue", "Skipped: need GITHUB_TOKEN and issue_number (or at least one issue from list_issues).");
-      } else {
-        results.comment_issue = await run(
-          "comment_issue",
-          async () => commentIssue({ owner, repo, issue_number: issueNumber, body: `operit self-test comment ${ts}` })
-        );
-      }
-      const prHead = (params == null ? void 0 : params.pr_head) ? String(params.pr_head) : "";
-      const prBase = (params == null ? void 0 : params.pr_base) ? String(params.pr_base) : "";
-      if (!token) {
-        writeSkipped("create_pull_request", "Skipped: GITHUB_TOKEN missing (required for write operation).");
-      } else if (!prHead || !prBase) {
-        writeSkipped("create_pull_request", "Skipped: pr_head/pr_base not provided (required to create PR).");
-      } else {
-        results.create_pull_request = await run(
-          "create_pull_request",
-          async () => createPullRequest({ owner, repo, title: `operit self-test PR ${ts}`, head: prHead, base: prBase, body: `created by operit self-test ${ts}` })
-        );
-      }
-      if (!token) {
-        writeSkipped("merge_pull_request", "Skipped: GITHUB_TOKEN missing (required for write operation).");
-      } else if (!pullNumber) {
-        writeSkipped("merge_pull_request", "Skipped: pull_number missing (required to merge PR).");
-      } else {
-        results.merge_pull_request = await run(
-          "merge_pull_request",
-          async () => mergePullRequest({ owner, repo, pull_number: pullNumber, merge_method: "merge" })
-        );
-      }
-    }
-    const okCount = Object.values(results).filter((r) => r.ok === true).length;
-    const failCount = Object.values(results).filter((r) => r.ok === false && !r.skipped).length;
-    const skippedCount = Object.values(results).filter((r) => r.skipped).length;
-    complete({
-      success: failCount === 0,
-      message: failCount === 0 ? "GitHub tools main test finished." : `GitHub tools main test finished with failures: failed=${failCount}, ok=${okCount}, skipped=${skippedCount}.`,
-      data: {
-        baseUrl,
-        hasToken: Boolean(token),
-        enable_write: enableWrite,
-        owner,
-        repo,
-        summary: { ok: okCount, failed: failCount, skipped: skippedCount },
-        results
-      }
-    });
+    const data = await func(params);
+    const result = { success: true, message: successMessage, data };
+    complete(result);
   } catch (error) {
-    complete({
+    const result = {
       success: false,
-      message: `GitHub tools main test failed: ${String(error && error.message ? error.message : error)}`,
+      message: `${failMessage}: ${String(error && error.message ? error.message : error)}`,
       error_stack: String(error && error.stack ? error.stack : "")
-    });
+    };
+    complete(result);
   }
 }
-exports.main = main;
+
+// src/index.ts
+var toolImpl = {
+  search_repositories: (p) => wrap(searchRepositories, p, "\u641C\u7D22\u4ED3\u5E93\u6210\u529F", "\u641C\u7D22\u4ED3\u5E93\u5931\u8D25"),
+  get_repository: (p) => wrap(searchRepositories, p, "\u83B7\u53D6\u4ED3\u5E93\u6210\u529F", "\u83B7\u53D6\u4ED3\u5E93\u5931\u8D25"),
+  list_issues: (p) => wrap(listIssues, p, "\u5217\u51FA Issues \u6210\u529F", "\u5217\u51FA Issues \u5931\u8D25"),
+  get_issue: (p) => wrap(getIssue, p, "\u83B7\u53D6 Issue \u6210\u529F", "\u83B7\u53D6 Issue \u5931\u8D25"),
+  create_issue: (p) => wrap(createIssue, p, "\u521B\u5EFA Issue \u6210\u529F", "\u521B\u5EFA Issue \u5931\u8D25"),
+  update_issue: (p) => wrap(updateIssue, p, "\u66F4\u65B0 Issue \u6210\u529F", "\u66F4\u65B0 Issue \u5931\u8D25"),
+  comment_issue: (p) => wrap(commentIssue, p, "\u8BC4\u8BBA\u6210\u529F", "\u8BC4\u8BBA\u5931\u8D25"),
+  list_issue_comments: (p) => wrap(listIssueComments, p, "\u5217\u51FA\u8BC4\u8BBA\u6210\u529F", "\u5217\u51FA\u8BC4\u8BBA\u5931\u8D25"),
+  list_pull_requests: (p) => wrap(listPullRequests, p, "\u5217\u51FA PR \u6210\u529F", "\u5217\u51FA PR \u5931\u8D25"),
+  create_pull_request: (p) => wrap(createPullRequest, p, "\u521B\u5EFA PR \u6210\u529F", "\u521B\u5EFA PR \u5931\u8D25"),
+  get_pull_request: (p) => wrap(getPullRequest, p, "\u83B7\u53D6 PR \u6210\u529F", "\u83B7\u53D6 PR \u5931\u8D25"),
+  update_pull_request: (p) => wrap(updatePullRequest, p, "\u66F4\u65B0 PR \u6210\u529F", "\u66F4\u65B0 PR \u5931\u8D25"),
+  merge_pull_request: (p) => wrap(mergePullRequest, p, "\u5408\u5E76 PR \u6210\u529F", "\u5408\u5E76 PR \u5931\u8D25"),
+  list_pull_request_files: (p) => wrap(listPullRequestFiles, p, "\u83B7\u53D6 PR \u6587\u4EF6\u6210\u529F", "\u83B7\u53D6 PR \u6587\u4EF6\u5931\u8D25"),
+  get_pull_request_diff: (p) => wrap(getPullRequestDiff, p, "\u83B7\u53D6 PR diff \u6210\u529F", "\u83B7\u53D6 PR diff \u5931\u8D25"),
+  list_pull_request_commits: (p) => wrap(listPullRequestCommits, p, "\u83B7\u53D6 PR \u63D0\u4EA4\u6210\u529F", "\u83B7\u53D6 PR \u63D0\u4EA4\u5931\u8D25"),
+  list_pull_request_reviews: (p) => wrap(listPullRequestReviews, p, "\u83B7\u53D6 PR review \u6210\u529F", "\u83B7\u53D6 PR review \u5931\u8D25"),
+  list_review_comments: (p) => wrap(listReviewComments, p, "\u83B7\u53D6\u884C\u5185\u8BC4\u8BBA\u6210\u529F", "\u83B7\u53D6\u884C\u5185\u8BC4\u8BBA\u5931\u8D25"),
+  create_review: (p) => wrap(createReview, p, "\u63D0\u4EA4 review \u6210\u529F", "\u63D0\u4EA4 review \u5931\u8D25"),
+  reply_review_comment: (p) => wrap(replyReviewComment, p, "\u56DE\u590D\u8BC4\u8BBA\u6210\u529F", "\u56DE\u590D\u8BC4\u8BBA\u5931\u8D25"),
+  request_reviewers: (p) => wrap(requestReviewers, p, "\u8BF7\u6C42 reviewer \u6210\u529F", "\u8BF7\u6C42 reviewer \u5931\u8D25"),
+  get_file_content: (p) => wrap(getFileContent, p, "\u83B7\u53D6\u6587\u4EF6\u6210\u529F", "\u83B7\u53D6\u6587\u4EF6\u5931\u8D25"),
+  create_or_update_file: (p) => wrap(createOrUpdateFile, p, "\u5199\u5165\u6587\u4EF6\u6210\u529F", "\u5199\u5165\u6587\u4EF6\u5931\u8D25"),
+  delete_file: (p) => wrap(deleteFile, p, "\u5220\u9664\u6587\u4EF6\u6210\u529F", "\u5220\u9664\u6587\u4EF6\u5931\u8D25"),
+  create_branch: (p) => wrap(createBranch, p, "\u521B\u5EFA\u5206\u652F\u6210\u529F", "\u521B\u5EFA\u5206\u652F\u5931\u8D25"),
+  list_branches: (p) => wrap(listBranches, p, "\u5217\u51FA\u5206\u652F\u6210\u529F", "\u5217\u51FA\u5206\u652F\u5931\u8D25"),
+  list_commits: (p) => wrap(listCommits, p, "\u5217\u51FA\u63D0\u4EA4\u6210\u529F", "\u5217\u51FA\u63D0\u4EA4\u5931\u8D25"),
+  get_commit: (p) => wrap(getCommit, p, "\u83B7\u53D6\u63D0\u4EA4\u6210\u529F", "\u83B7\u53D6\u63D0\u4EA4\u5931\u8D25"),
+  compare_refs: (p) => wrap(compareRefs, p, "\u6BD4\u8F83 refs \u6210\u529F", "\u6BD4\u8F83 refs \u5931\u8D25"),
+  get_compare_diff: (p) => wrap(getCompareDiff, p, "\u83B7\u53D6 diff \u6210\u529F", "\u83B7\u53D6 diff \u5931\u8D25"),
+  list_workflows: (p) => wrap(listWorkflows, p, "\u5217\u51FA workflow \u6210\u529F", "\u5217\u51FA workflow \u5931\u8D25"),
+  list_workflow_runs: (p) => wrap(listWorkflowRuns, p, "\u83B7\u53D6 workflow run \u6210\u529F", "\u83B7\u53D6 workflow run \u5931\u8D25"),
+  get_workflow_run: (p) => wrap(getWorkflowRun, p, "\u83B7\u53D6 workflow run \u6210\u529F", "\u83B7\u53D6 workflow run \u5931\u8D25"),
+  trigger_workflow: (p) => wrap(triggerWorkflow, p, "\u89E6\u53D1 workflow \u6210\u529F", "\u89E6\u53D1 workflow \u5931\u8D25"),
+  get_workflow_jobs: (p) => wrap(getWorkflowJobs, p, "\u83B7\u53D6 workflow jobs \u6210\u529F", "\u83B7\u53D6 workflow jobs \u5931\u8D25"),
+  rerun_workflow_run: (p) => wrap(rerunWorkflowRun, p, "\u91CD\u65B0\u8FD0\u884C workflow \u6210\u529F", "\u91CD\u65B0\u8FD0\u884C workflow \u5931\u8D25"),
+  cancel_workflow_run: (p) => wrap(cancelWorkflowRun, p, "\u53D6\u6D88 workflow \u6210\u529F", "\u53D6\u6D88 workflow \u5931\u8D25"),
+  list_check_runs: (p) => wrap(listCheckRuns, p, "\u5217\u51FA check runs \u6210\u529F", "\u5217\u51FA check runs \u5931\u8D25"),
+  search_code: (p) => wrap(searchCode, p, "\u641C\u7D22\u4EE3\u7801\u6210\u529F", "\u641C\u7D22\u4EE3\u7801\u5931\u8D25"),
+  search_issues: (p) => wrap(searchIssues, p, "\u641C\u7D22 Issues \u6210\u529F", "\u641C\u7D22 Issues \u5931\u8D25"),
+  get_authenticated_user: (p) => wrap(getAuthenticatedUser, p, "\u83B7\u53D6\u7528\u6237\u6210\u529F", "\u83B7\u53D6\u7528\u6237\u5931\u8D25"),
+  get_rate_limit: (p) => wrap(getRateLimit, p, "\u83B7\u53D6 rate limit \u6210\u529F", "\u83B7\u53D6 rate limit \u5931\u8D25"),
+  fork_repository: (p) => wrap(forkRepository, p, "fork \u4ED3\u5E93\u6210\u529F", "fork \u4ED3\u5E93\u5931\u8D25"),
+  sync_fork: (p) => wrap(syncFork, p, "\u540C\u6B65 fork \u6210\u529F", "\u540C\u6B65 fork \u5931\u8D25"),
+  patch_file_in_repo: (p) => wrap(patchFileInRepo, p, "patch \u6587\u4EF6\u6210\u529F", "patch \u6587\u4EF6\u5931\u8D25"),
+  apply_local_replace: (p) => wrap(applyLocalReplace, p, "\u672C\u5730\u66FF\u6362\u6210\u529F", "\u672C\u5730\u66FF\u6362\u5931\u8D25"),
+  apply_local_delete: (p) => wrap(applyLocalDelete, p, "\u672C\u5730\u5220\u9664\u6210\u529F", "\u672C\u5730\u5220\u9664\u5931\u8D25"),
+  overwrite_local_file: (p) => wrap(overwriteLocalFile, p, "\u8986\u76D6\u6587\u4EF6\u6210\u529F", "\u8986\u76D6\u6587\u4EF6\u5931\u8D25"),
+  terminal_exec: (p) => wrap(terminalExec, p, "\u7EC8\u7AEF\u6267\u884C\u6210\u529F", "\u7EC8\u7AEF\u6267\u884C\u5931\u8D25")
+};
+async function main(params) {
+  const tool = params == null ? void 0 : params.tool;
+  if (!tool) {
+    return { ok: true, message: "GitHub API package loaded", tools: Object.keys(toolImpl) };
+  }
+  const fn = toolImpl[tool];
+  if (!fn) {
+    return { success: false, message: `Unknown tool: ${tool}`, available: Object.keys(toolImpl) };
+  }
+  return fn(params);
+}
+var search_repositories = toolImpl.search_repositories;
+var get_repository = toolImpl.get_repository;
+var list_issues = toolImpl.list_issues;
+var get_issue = toolImpl.get_issue;
+var create_issue = toolImpl.create_issue;
+var update_issue = toolImpl.update_issue;
+var comment_issue = toolImpl.comment_issue;
+var list_issue_comments = toolImpl.list_issue_comments;
+var list_pull_requests = toolImpl.list_pull_requests;
+var create_pull_request = toolImpl.create_pull_request;
+var get_pull_request = toolImpl.get_pull_request;
+var update_pull_request = toolImpl.update_pull_request;
+var merge_pull_request = toolImpl.merge_pull_request;
+var list_pull_request_files = toolImpl.list_pull_request_files;
+var get_pull_request_diff = toolImpl.get_pull_request_diff;
+var list_pull_request_commits = toolImpl.list_pull_request_commits;
+var list_pull_request_reviews = toolImpl.list_pull_request_reviews;
+var list_review_comments = toolImpl.list_review_comments;
+var create_review = toolImpl.create_review;
+var reply_review_comment = toolImpl.reply_review_comment;
+var request_reviewers = toolImpl.request_reviewers;
+var get_file_content = toolImpl.get_file_content;
+var create_or_update_file = toolImpl.create_or_update_file;
+var delete_file = toolImpl.delete_file;
+var create_branch = toolImpl.create_branch;
+var list_branches = toolImpl.list_branches;
+var list_commits = toolImpl.list_commits;
+var get_commit = toolImpl.get_commit;
+var compare_refs = toolImpl.compare_refs;
+var get_compare_diff = toolImpl.get_compare_diff;
+var list_workflows = toolImpl.list_workflows;
+var list_workflow_runs = toolImpl.list_workflow_runs;
+var get_workflow_run = toolImpl.get_workflow_run;
+var trigger_workflow = toolImpl.trigger_workflow;
+var get_workflow_jobs = toolImpl.get_workflow_jobs;
+var rerun_workflow_run = toolImpl.rerun_workflow_run;
+var cancel_workflow_run = toolImpl.cancel_workflow_run;
+var list_check_runs = toolImpl.list_check_runs;
+var search_code = toolImpl.search_code;
+var search_issues = toolImpl.search_issues;
+var get_authenticated_user = toolImpl.get_authenticated_user;
+var get_rate_limit = toolImpl.get_rate_limit;
+var fork_repository = toolImpl.fork_repository;
+var sync_fork = toolImpl.sync_fork;
+var patch_file_in_repo = toolImpl.patch_file_in_repo;
+var apply_local_replace = toolImpl.apply_local_replace;
+var apply_local_delete = toolImpl.apply_local_delete;
+var overwrite_local_file = toolImpl.overwrite_local_file;
+var terminal_exec = toolImpl.terminal_exec;

--- a/examples/github.js
+++ b/examples/github.js
@@ -1360,6 +1360,15 @@
           },
           "type": "string",
           "required": false
+        },
+        {
+          "name": "content_encoding",
+          "description": {
+            "zh": "内容编码：utf-8（默认）或 base64",
+            "en": "Content encoding: utf-8 (default) or base64."
+          },
+          "type": "string",
+          "required": false
         }
       ]
     },
@@ -1429,8 +1438,8 @@
     {
       "name": "create_branch",
       "description": {
-        "zh": "创建分支。",
-        "en": "Create a branch."
+        "zh": "创建分支（通过 /repos/{owner}/{repo}/git/refs）。",
+        "en": "Create a branch (via /repos/{owner}/{repo}/git/refs)."
       },
       "parameters": [
         {
@@ -1452,7 +1461,7 @@
           "required": true
         },
         {
-          "name": "branch",
+          "name": "new_branch",
           "description": {
             "zh": "新分支名",
             "en": "New branch name."
@@ -1463,17 +1472,8 @@
         {
           "name": "from_branch",
           "description": {
-            "zh": "基于哪个分支创建（默认默认分支）",
-            "en": "Branch to create from (default: default branch)."
-          },
-          "type": "string",
-          "required": false
-        },
-        {
-          "name": "sha",
-          "description": {
-            "zh": "直接指定起始 commit sha（优先于 from_branch）",
-            "en": "Starting commit SHA (overrides from_branch)."
+            "zh": "基于哪个分支创建（默认仓库默认分支）",
+            "en": "Branch to create from (default: repository default branch)."
           },
           "type": "string",
           "required": false

--- a/examples/github.js
+++ b/examples/github.js
@@ -1447,8 +1447,8 @@
     {
       "name": "create_branch",
       "description": {
-        "zh": "创建分支（通过 /repos/{owner}/{repo}/git/refs）。",
-        "en": "Create a branch (via /repos/{owner}/{repo}/git/refs)."
+        "zh": "创建或恢复分支（POST /repos/{owner}/{repo}/git/refs）。可从已有分支或指定 commit SHA 建 ref。",
+        "en": "Create or restore a branch (POST /repos/{owner}/{repo}/git/refs). Point the new ref at an existing branch or a commit SHA."
       },
       "parameters": [
         {
@@ -1481,11 +1481,56 @@
         {
           "name": "from_branch",
           "description": {
-            "zh": "基于哪个分支创建（默认仓库默认分支）",
-            "en": "Branch to create from (default: repository default branch)."
+            "zh": "基于哪个分支创建（默认仓库默认分支；若传了 from_sha 则忽略）",
+            "en": "Branch to create from (default: repository default branch; ignored when from_sha is set)."
           },
           "type": "string",
           "required": false
+        },
+        {
+          "name": "from_sha",
+          "description": {
+            "zh": "基于哪个 commit SHA 创建（优先于 from_branch；用于从提交恢复已删分支）",
+            "en": "Commit SHA to create from (takes precedence over from_branch; use this to restore a deleted branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_branch",
+      "description": {
+        "zh": "删除非默认分支（DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}）。不会删除仓库默认分支。",
+        "en": "Delete a non-default branch (DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}). Refuses to delete the repository default branch."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "要删除的分支名（不能是仓库默认分支）",
+            "en": "Branch name to delete (cannot be the repository default branch)."
+          },
+          "type": "string",
+          "required": true
         }
       ]
     },
@@ -4524,6 +4569,7 @@ __export(index_exports, {
   create_release: () => create_release,
   create_review: () => create_review,
   create_webhook: () => create_webhook,
+  delete_branch: () => delete_branch,
   delete_branch_protection: () => delete_branch_protection,
   delete_file: () => delete_file,
   delete_label: () => delete_label,
@@ -5336,13 +5382,16 @@ async function getRepository(params) {
 }
 
 // src/github/branches.ts
+function requiredName(value, field) {
+  const name = String(value != null ? value : "").trim();
+  if (!name) {
+    throw new Error(`${field} is required`);
+  }
+  return name;
+}
 async function getBranchHeadSha(params) {
   var _a;
-  const url = buildUrl(
-    `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/git/ref/heads/${encodeURIComponent(
-      params.branch
-    )}`
-  );
+  const url = buildUrl(repoPath(params.owner, params.repo, `/git/ref/heads/${encodeRef(params.branch)}`));
   const data = await requestJson({ method: "GET", url });
   const sha = (_a = data == null ? void 0 : data.object) == null ? void 0 : _a.sha;
   if (!sha) {
@@ -5351,19 +5400,42 @@ async function getBranchHeadSha(params) {
   return sha;
 }
 async function createBranch(params) {
-  var _a, _b;
+  var _a, _b, _c;
   requireToken("create_branch");
-  const fromBranch = (_b = params.from_branch) != null ? _b : String(((_a = await getRepository({ owner: params.owner, repo: params.repo })) == null ? void 0 : _a.default_branch) || "main");
-  const sha = await getBranchHeadSha({ owner: params.owner, repo: params.repo, branch: fromBranch });
-  const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/git/refs`);
-  return requestJson({
+  const newBranch = requiredName(params.new_branch, "new_branch");
+  const fromSha = String((_a = params.from_sha) != null ? _a : "").trim();
+  let sha = fromSha;
+  let fromBranch;
+  if (!sha) {
+    fromBranch = String((_b = params.from_branch) != null ? _b : "").trim() || String(((_c = await getRepository({ owner: params.owner, repo: params.repo })) == null ? void 0 : _c.default_branch) || "main");
+    sha = await getBranchHeadSha({ owner: params.owner, repo: params.repo, branch: fromBranch });
+  }
+  const url = buildUrl(repoPath(params.owner, params.repo, "/git/refs"));
+  const result = await requestJson({
     method: "POST",
     url,
     body: {
-      ref: `refs/heads/${params.new_branch}`,
+      ref: `refs/heads/${newBranch}`,
       sha
     }
   });
+  return __spreadProps(__spreadValues({}, result), {
+    new_branch: newBranch,
+    from_sha: sha,
+    from_branch: fromBranch
+  });
+}
+async function deleteBranch(params) {
+  requireToken("delete_branch");
+  const branch = requiredName(params.branch, "branch");
+  const repoInfo = await getRepository({ owner: params.owner, repo: params.repo });
+  const defaultBranch = String((repoInfo == null ? void 0 : repoInfo.default_branch) || "").trim();
+  if (defaultBranch && branch === defaultBranch) {
+    throw new Error(`Refusing to delete the default branch '${defaultBranch}'.`);
+  }
+  const url = buildUrl(repoPath(params.owner, params.repo, `/git/refs/heads/${encodeRef(branch)}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, branch, result };
 }
 
 // src/github/git.ts
@@ -6571,6 +6643,7 @@ var toolImpl = {
   create_or_update_file: (p) => wrap(createOrUpdateFile, p, "\u5199\u5165\u6587\u4EF6\u6210\u529F", "\u5199\u5165\u6587\u4EF6\u5931\u8D25"),
   delete_file: (p) => wrap(deleteFile, p, "\u5220\u9664\u6587\u4EF6\u6210\u529F", "\u5220\u9664\u6587\u4EF6\u5931\u8D25"),
   create_branch: (p) => wrap(createBranch, p, "\u521B\u5EFA\u5206\u652F\u6210\u529F", "\u521B\u5EFA\u5206\u652F\u5931\u8D25"),
+  delete_branch: (p) => wrap(deleteBranch, p, "\u5220\u9664\u5206\u652F\u6210\u529F", "\u5220\u9664\u5206\u652F\u5931\u8D25"),
   list_branches: (p) => wrap(listBranches, p, "\u5217\u51FA\u5206\u652F\u6210\u529F", "\u5217\u51FA\u5206\u652F\u5931\u8D25"),
   list_commits: (p) => wrap(listCommits, p, "\u5217\u51FA\u63D0\u4EA4\u6210\u529F", "\u5217\u51FA\u63D0\u4EA4\u5931\u8D25"),
   get_commit: (p) => wrap(getCommit, p, "\u83B7\u53D6\u63D0\u4EA4\u6210\u529F", "\u83B7\u53D6\u63D0\u4EA4\u5931\u8D25"),
@@ -6668,6 +6741,7 @@ var get_file_content = toolImpl.get_file_content;
 var create_or_update_file = toolImpl.create_or_update_file;
 var delete_file = toolImpl.delete_file;
 var create_branch = toolImpl.create_branch;
+var delete_branch = toolImpl.delete_branch;
 var list_branches = toolImpl.list_branches;
 var list_commits = toolImpl.list_commits;
 var get_commit = toolImpl.get_commit;

--- a/examples/github.js
+++ b/examples/github.js
@@ -6,8 +6,8 @@
     "en": "GitHub API"
   },
   "description": {
-    "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。",
-    "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)."
+    "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/Releases/Webhooks/协作者/Labels/Milestones/分支保护/统计/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。",
+    "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/releases/webhooks/collaborators/labels/milestones/branch protection/stats/search/fork) and local-side utilities (apply_file patch updates, terminal)."
   },
   "category": "Development",
   "env": [
@@ -27,6 +27,15 @@
       },
       "required": false,
       "defaultValue": "https://api.github.com"
+    },
+    {
+      "name": "GITHUB_UPLOADS_BASE_URL",
+      "description": {
+        "zh": "GitHub Release 资产上传基础 URL（默认 https://uploads.github.com）",
+        "en": "GitHub release asset upload base URL (default: https://uploads.github.com)."
+      },
+      "required": false,
+      "defaultValue": "https://uploads.github.com"
     }
   ],
   "enabledByDefault": false,
@@ -2656,6 +2665,1806 @@
           "required": false
         }
       ]
+    },
+    {
+      "name": "list_releases",
+      "description": {
+        "zh": "列出仓库 Releases。",
+        "en": "List repository releases."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_release",
+      "description": {
+        "zh": "获取指定 Release。",
+        "en": "Get a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_latest_release",
+      "description": {
+        "zh": "获取最新的正式 Release。",
+        "en": "Get the latest release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_release_by_tag",
+      "description": {
+        "zh": "按 tag 获取 Release。",
+        "en": "Get a release by tag."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "tag",
+          "description": {
+            "zh": "Git tag 名称",
+            "en": "Git tag name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_release",
+      "description": {
+        "zh": "创建 Release。",
+        "en": "Create a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "tag_name",
+          "description": {
+            "zh": "tag 名称",
+            "en": "Tag name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "target_commitish",
+          "description": {
+            "zh": "目标分支或 commit",
+            "en": "Target branch or commit."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Release 标题",
+            "en": "Release name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "Release 描述",
+            "en": "Release body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether draft."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "prerelease",
+          "description": {
+            "zh": "是否预发布",
+            "en": "Whether prerelease."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "generate_release_notes",
+          "description": {
+            "zh": "是否自动生成说明",
+            "en": "Whether to generate release notes."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "make_latest",
+          "description": {
+            "zh": "latest 标记：true/false/legacy",
+            "en": "Latest marker: true/false/legacy."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "discussion_category_name",
+          "description": {
+            "zh": "Discussion 分类名",
+            "en": "Discussion category name."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_release",
+      "description": {
+        "zh": "更新 Release。",
+        "en": "Update a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "tag_name",
+          "description": {
+            "zh": "tag 名称",
+            "en": "Tag name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "target_commitish",
+          "description": {
+            "zh": "目标分支或 commit",
+            "en": "Target branch or commit."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Release 标题",
+            "en": "Release name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "Release 描述",
+            "en": "Release body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether draft."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "prerelease",
+          "description": {
+            "zh": "是否预发布",
+            "en": "Whether prerelease."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "make_latest",
+          "description": {
+            "zh": "latest 标记：true/false/legacy",
+            "en": "Latest marker: true/false/legacy."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "discussion_category_name",
+          "description": {
+            "zh": "Discussion 分类名",
+            "en": "Discussion category name."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_release",
+      "description": {
+        "zh": "删除 Release。",
+        "en": "Delete a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "upload_release_asset",
+      "description": {
+        "zh": "向 Release 上传本地文件资产。",
+        "en": "Upload a local file as a release asset."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "asset_path",
+          "description": {
+            "zh": "本地资产路径",
+            "en": "Local asset path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "上传后的文件名（默认取路径文件名）",
+            "en": "Uploaded filename (defaults to the path basename)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "label",
+          "description": {
+            "zh": "资产说明",
+            "en": "Asset label."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "content_type",
+          "description": {
+            "zh": "MIME 类型（默认 application/octet-stream）",
+            "en": "MIME type (default application/octet-stream)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "文件环境：android 或 linux",
+            "en": "File environment: android or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_release_asset",
+      "description": {
+        "zh": "删除 Release 资产。",
+        "en": "Delete a release asset."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "asset_id",
+          "description": {
+            "zh": "资产 ID",
+            "en": "Asset ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_webhooks",
+      "description": {
+        "zh": "列出仓库 Webhooks。",
+        "en": "List repository webhooks."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_webhook",
+      "description": {
+        "zh": "获取仓库 Webhook。",
+        "en": "Get a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_webhook",
+      "description": {
+        "zh": "创建仓库 Webhook。",
+        "en": "Create a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "url",
+          "description": {
+            "zh": "Webhook 接收 URL",
+            "en": "Webhook receiver URL."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "content_type",
+          "description": {
+            "zh": "内容类型：json 或 form",
+            "en": "Content type: json or form."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "secret",
+          "description": {
+            "zh": "Webhook secret",
+            "en": "Webhook secret."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "insecure_ssl",
+          "description": {
+            "zh": "是否允许不安全 SSL",
+            "en": "Whether to allow insecure SSL."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "events",
+          "description": {
+            "zh": "事件列表，逗号分隔或数组",
+            "en": "Events, comma-separated or array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "active",
+          "description": {
+            "zh": "是否启用",
+            "en": "Whether active."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "config",
+          "description": {
+            "zh": "额外 config JSON",
+            "en": "Additional config JSON."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_webhook",
+      "description": {
+        "zh": "更新仓库 Webhook。",
+        "en": "Update a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "url",
+          "description": {
+            "zh": "Webhook 接收 URL",
+            "en": "Webhook receiver URL."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "content_type",
+          "description": {
+            "zh": "内容类型：json 或 form",
+            "en": "Content type: json or form."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "secret",
+          "description": {
+            "zh": "Webhook secret",
+            "en": "Webhook secret."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "insecure_ssl",
+          "description": {
+            "zh": "是否允许不安全 SSL",
+            "en": "Whether to allow insecure SSL."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "events",
+          "description": {
+            "zh": "完整事件列表，逗号分隔或数组",
+            "en": "Complete event list, comma-separated or array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "add_events",
+          "description": {
+            "zh": "追加事件列表",
+            "en": "Events to add."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "remove_events",
+          "description": {
+            "zh": "移除事件列表",
+            "en": "Events to remove."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "active",
+          "description": {
+            "zh": "是否启用",
+            "en": "Whether active."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "config",
+          "description": {
+            "zh": "额外 config JSON",
+            "en": "Additional config JSON."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_webhook",
+      "description": {
+        "zh": "删除仓库 Webhook。",
+        "en": "Delete a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ping_webhook",
+      "description": {
+        "zh": "向仓库 Webhook 发送 ping。",
+        "en": "Ping a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_collaborators",
+      "description": {
+        "zh": "列出仓库协作者。",
+        "en": "List repository collaborators."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "affiliation",
+          "description": {
+            "zh": "筛选：outside/direct/all",
+            "en": "Filter: outside/direct/all."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "permission",
+          "description": {
+            "zh": "权限筛选：pull/triage/push/maintain/admin",
+            "en": "Permission filter: pull/triage/push/maintain/admin."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "check_collaborator",
+      "description": {
+        "zh": "检查用户是否为仓库协作者。",
+        "en": "Check whether a user is a repository collaborator."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "add_collaborator",
+      "description": {
+        "zh": "添加仓库协作者。",
+        "en": "Add a repository collaborator."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "permission",
+          "description": {
+            "zh": "权限：pull/triage/push/maintain/admin",
+            "en": "Permission: pull/triage/push/maintain/admin."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "remove_collaborator",
+      "description": {
+        "zh": "移除仓库协作者。",
+        "en": "Remove a repository collaborator."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_collaborator_permission",
+      "description": {
+        "zh": "获取用户在仓库中的权限。",
+        "en": "Get repository permissions for a user."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_labels",
+      "description": {
+        "zh": "列出仓库 Labels。",
+        "en": "List repository labels."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_label",
+      "description": {
+        "zh": "获取仓库 Label。",
+        "en": "Get a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Label 名称",
+            "en": "Label name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_label",
+      "description": {
+        "zh": "创建仓库 Label。",
+        "en": "Create a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Label 名称",
+            "en": "Label name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "color",
+          "description": {
+            "zh": "六位十六进制颜色，可带 #",
+            "en": "Six-digit hexadecimal color, with optional #."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Label 描述",
+            "en": "Label description."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_label",
+      "description": {
+        "zh": "更新仓库 Label。",
+        "en": "Update a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "当前 Label 名称",
+            "en": "Current label name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "new_name",
+          "description": {
+            "zh": "新 Label 名称",
+            "en": "New label name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "color",
+          "description": {
+            "zh": "六位十六进制颜色，可带 #",
+            "en": "Six-digit hexadecimal color, with optional #."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Label 描述",
+            "en": "Label description."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_label",
+      "description": {
+        "zh": "删除仓库 Label。",
+        "en": "Delete a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Label 名称",
+            "en": "Label name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_milestones",
+      "description": {
+        "zh": "列出仓库 Milestones。",
+        "en": "List repository milestones."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "状态：open/closed/all",
+            "en": "State: open/closed/all."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序：due_on/completeness",
+            "en": "Sort: due_on/completeness."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "direction",
+          "description": {
+            "zh": "方向：asc/desc",
+            "en": "Direction: asc/desc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_milestone",
+      "description": {
+        "zh": "获取 Milestone。",
+        "en": "Get a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "milestone_number",
+          "description": {
+            "zh": "Milestone 编号",
+            "en": "Milestone number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_milestone",
+      "description": {
+        "zh": "创建 Milestone。",
+        "en": "Create a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "Milestone 标题",
+            "en": "Milestone title."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "状态：open/closed",
+            "en": "State: open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Milestone 描述",
+            "en": "Milestone description."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "due_on",
+          "description": {
+            "zh": "截止时间，ISO 8601",
+            "en": "Due date, ISO 8601."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_milestone",
+      "description": {
+        "zh": "更新 Milestone。",
+        "en": "Update a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "milestone_number",
+          "description": {
+            "zh": "Milestone 编号",
+            "en": "Milestone number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "Milestone 标题",
+            "en": "Milestone title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "状态：open/closed",
+            "en": "State: open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Milestone 描述",
+            "en": "Milestone description."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "due_on",
+          "description": {
+            "zh": "截止时间，ISO 8601",
+            "en": "Due date, ISO 8601."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_milestone",
+      "description": {
+        "zh": "删除 Milestone。",
+        "en": "Delete a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "milestone_number",
+          "description": {
+            "zh": "Milestone 编号",
+            "en": "Milestone number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_branch_protection",
+      "description": {
+        "zh": "获取分支保护规则。",
+        "en": "Get branch protection."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "分支名",
+            "en": "Branch name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "update_branch_protection",
+      "description": {
+        "zh": "更新分支保护规则。protection 需传 GitHub PUT 接口要求的完整 JSON。",
+        "en": "Update branch protection. protection must be the complete JSON body required by the GitHub PUT endpoint."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "分支名",
+            "en": "Branch name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "protection",
+          "description": {
+            "zh": "分支保护 JSON 对象或 JSON 字符串",
+            "en": "Branch protection JSON object or JSON string."
+          },
+          "type": "object",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "delete_branch_protection",
+      "description": {
+        "zh": "删除分支保护规则。",
+        "en": "Delete branch protection."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "分支名",
+            "en": "Branch name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_contributors_stats",
+      "description": {
+        "zh": "获取仓库贡献者统计。",
+        "en": "Get repository contributor statistics."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_commit_activity",
+      "description": {
+        "zh": "获取最近一年按周提交活动。",
+        "en": "Get the last year of weekly commit activity."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_code_frequency",
+      "description": {
+        "zh": "获取每周代码增删统计。",
+        "en": "Get weekly code additions and deletions."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     }
   ]
 }
@@ -2699,45 +4508,75 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 // src/index.ts
 var index_exports = {};
 __export(index_exports, {
+  add_collaborator: () => add_collaborator,
   apply_local_delete: () => apply_local_delete,
   apply_local_replace: () => apply_local_replace,
   cancel_workflow_run: () => cancel_workflow_run,
+  check_collaborator: () => check_collaborator,
   comment_issue: () => comment_issue,
   compare_refs: () => compare_refs,
   create_branch: () => create_branch,
   create_issue: () => create_issue,
+  create_label: () => create_label,
+  create_milestone: () => create_milestone,
   create_or_update_file: () => create_or_update_file,
   create_pull_request: () => create_pull_request,
+  create_release: () => create_release,
   create_review: () => create_review,
+  create_webhook: () => create_webhook,
+  delete_branch_protection: () => delete_branch_protection,
   delete_file: () => delete_file,
+  delete_label: () => delete_label,
+  delete_milestone: () => delete_milestone,
+  delete_release: () => delete_release,
+  delete_release_asset: () => delete_release_asset,
+  delete_webhook: () => delete_webhook,
   fork_repository: () => fork_repository,
   get_authenticated_user: () => get_authenticated_user,
+  get_branch_protection: () => get_branch_protection,
+  get_code_frequency: () => get_code_frequency,
+  get_collaborator_permission: () => get_collaborator_permission,
   get_commit: () => get_commit,
+  get_commit_activity: () => get_commit_activity,
   get_compare_diff: () => get_compare_diff,
+  get_contributors_stats: () => get_contributors_stats,
   get_file_content: () => get_file_content,
   get_issue: () => get_issue,
+  get_label: () => get_label,
+  get_latest_release: () => get_latest_release,
+  get_milestone: () => get_milestone,
   get_pull_request: () => get_pull_request,
   get_pull_request_diff: () => get_pull_request_diff,
   get_rate_limit: () => get_rate_limit,
+  get_release: () => get_release,
+  get_release_by_tag: () => get_release_by_tag,
   get_repository: () => get_repository,
+  get_webhook: () => get_webhook,
   get_workflow_jobs: () => get_workflow_jobs,
   get_workflow_run: () => get_workflow_run,
   list_branches: () => list_branches,
   list_check_runs: () => list_check_runs,
+  list_collaborators: () => list_collaborators,
   list_commits: () => list_commits,
   list_issue_comments: () => list_issue_comments,
   list_issues: () => list_issues,
+  list_labels: () => list_labels,
+  list_milestones: () => list_milestones,
   list_pull_request_commits: () => list_pull_request_commits,
   list_pull_request_files: () => list_pull_request_files,
   list_pull_request_reviews: () => list_pull_request_reviews,
   list_pull_requests: () => list_pull_requests,
+  list_releases: () => list_releases,
   list_review_comments: () => list_review_comments,
+  list_webhooks: () => list_webhooks,
   list_workflow_runs: () => list_workflow_runs,
   list_workflows: () => list_workflows,
   main: () => main,
   merge_pull_request: () => merge_pull_request,
   overwrite_local_file: () => overwrite_local_file,
   patch_file_in_repo: () => patch_file_in_repo,
+  ping_webhook: () => ping_webhook,
+  remove_collaborator: () => remove_collaborator,
   reply_review_comment: () => reply_review_comment,
   request_reviewers: () => request_reviewers,
   rerun_workflow_run: () => rerun_workflow_run,
@@ -2748,8 +4587,14 @@ __export(index_exports, {
   terminal_exec: () => terminal_exec,
   toolImpl: () => toolImpl,
   trigger_workflow: () => trigger_workflow,
+  update_branch_protection: () => update_branch_protection,
   update_issue: () => update_issue,
-  update_pull_request: () => update_pull_request
+  update_label: () => update_label,
+  update_milestone: () => update_milestone,
+  update_pull_request: () => update_pull_request,
+  update_release: () => update_release,
+  update_webhook: () => update_webhook,
+  upload_release_asset: () => upload_release_asset
 });
 module.exports = __toCommonJS(index_exports);
 
@@ -2757,6 +4602,25 @@ module.exports = __toCommonJS(index_exports);
 function getBaseUrl() {
   const fromEnv = (typeof getEnv === "function" ? getEnv("GITHUB_API_BASE_URL") : void 0) || "";
   return fromEnv && String(fromEnv).trim() || "https://api.github.com";
+}
+function getUploadsBaseUrl() {
+  const fromEnv = (typeof getEnv === "function" ? getEnv("GITHUB_UPLOADS_BASE_URL") : void 0) || "";
+  const trimmed = String(fromEnv || "").trim().replace(/\/+$/, "");
+  if (trimmed) return trimmed;
+  const api = getBaseUrl().replace(/\/+$/, "");
+  if (api === "https://api.github.com") return "https://uploads.github.com";
+  return api;
+}
+function parseBool(value) {
+  if (value === void 0 || value === null || value === "") return void 0;
+  if (typeof value === "boolean") return value;
+  const s = String(value).trim().toLowerCase();
+  if (s === "true" || s === "1" || s === "yes") return true;
+  if (s === "false" || s === "0" || s === "no") return false;
+  return void 0;
+}
+function shellQuote(value) {
+  return "'" + String(value != null ? value : "").replace(/'/g, "'''") + "'";
 }
 function getToken() {
   const token = (typeof getEnv === "function" ? getEnv("GITHUB_TOKEN") : void 0) || "";
@@ -4026,6 +5890,644 @@ async function terminalExec(params) {
   return result;
 }
 
+// src/github/releases.ts
+function compactAsset(item) {
+  var _a;
+  if (!item) return item;
+  return {
+    id: item.id,
+    name: item.name,
+    label: item.label,
+    size: item.size,
+    content_type: item.content_type,
+    state: item.state,
+    download_count: item.download_count,
+    browser_download_url: item.browser_download_url,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    uploader: (_a = item.uploader) == null ? void 0 : _a.login
+  };
+}
+function compactRelease(item) {
+  var _a;
+  if (!item) return item;
+  return {
+    id: item.id,
+    tag_name: item.tag_name,
+    name: item.name,
+    draft: item.draft,
+    prerelease: item.prerelease,
+    html_url: item.html_url,
+    tarball_url: item.tarball_url,
+    zipball_url: item.zipball_url,
+    target_commitish: item.target_commitish,
+    body: item.body,
+    created_at: item.created_at,
+    published_at: item.published_at,
+    author: (_a = item.author) == null ? void 0 : _a.login,
+    assets: Array.isArray(item.assets) ? item.assets.map(compactAsset) : []
+  };
+}
+async function listReleases(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/releases"), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactRelease) : [];
+}
+async function getRelease(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/${encodeURIComponent(String(params.release_id))}`));
+  return compactRelease(await requestJson({ method: "GET", url }));
+}
+async function getLatestRelease(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, "/releases/latest"));
+  return compactRelease(await requestJson({ method: "GET", url }));
+}
+async function getReleaseByTag(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/tags/${encodeURIComponent(params.tag)}`));
+  return compactRelease(await requestJson({ method: "GET", url }));
+}
+async function createRelease(params) {
+  requireToken("create_release");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/releases"));
+  return compactRelease(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        tag_name: params.tag_name,
+        target_commitish: params.target_commitish,
+        name: params.name,
+        body: params.body,
+        draft: parseBool(params.draft),
+        prerelease: parseBool(params.prerelease),
+        generate_release_notes: parseBool(params.generate_release_notes),
+        make_latest: params.make_latest,
+        discussion_category_name: params.discussion_category_name
+      }
+    })
+  );
+}
+async function updateRelease(params) {
+  requireToken("update_release");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/${encodeURIComponent(String(params.release_id))}`));
+  return compactRelease(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        tag_name: params.tag_name,
+        target_commitish: params.target_commitish,
+        name: params.name,
+        body: params.body,
+        draft: parseBool(params.draft),
+        prerelease: parseBool(params.prerelease),
+        make_latest: params.make_latest,
+        discussion_category_name: params.discussion_category_name
+      }
+    })
+  );
+}
+async function deleteRelease(params) {
+  requireToken("delete_release");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/${encodeURIComponent(String(params.release_id))}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, release_id: params.release_id, result };
+}
+function guessFileName(path) {
+  const parts = String(path || "").replace(/\\/g, "/").split("/");
+  return parts.filter(Boolean).pop() || "asset.bin";
+}
+async function uploadReleaseAsset(params) {
+  const token = requireToken("upload_release_asset");
+  const name = params.name || guessFileName(params.asset_path);
+  const contentType = params.content_type || "application/octet-stream";
+  const environment = params.environment || "android";
+  const sourcePath = String(params.asset_path || "").trim();
+  if (!sourcePath) {
+    throw new Error("asset_path is required");
+  }
+  const exists = await Tools.Files.exists(sourcePath, environment);
+  if (!exists.exists) {
+    throw new Error(`Asset file not found: ${sourcePath}`);
+  }
+  let linuxPath = sourcePath;
+  if (environment !== "linux") {
+    linuxPath = `/tmp/operit-github-asset-${Date.now()}-${name}`;
+    await Tools.Files.copy(sourcePath, linuxPath, false, environment, "linux");
+  }
+  const uploadsPath = repoPath(
+    params.owner,
+    params.repo,
+    `/releases/${encodeURIComponent(String(params.release_id))}/assets`
+  );
+  const qs = [`name=${encodeURIComponent(name)}`];
+  if (params.label) qs.push(`label=${encodeURIComponent(params.label)}`);
+  const finalUrl = `${getUploadsBaseUrl()}${uploadsPath}?${qs.join("&")}`;
+  const headerFile = `/tmp/operit-github-upload-headers-${Date.now()}`;
+  await Tools.Files.write(
+    headerFile,
+    [
+      'header = "Accept: application/vnd.github+json"',
+      `header = "Authorization: Bearer ${token}"`,
+      'header = "X-GitHub-Api-Version: 2022-11-28"',
+      `header = "Content-Type: ${contentType}"`,
+      ""
+    ].join("\n"),
+    false,
+    "linux"
+  );
+  const command = [
+    "curl",
+    "-sS",
+    "-X",
+    "POST",
+    "-K",
+    shellQuote(headerFile),
+    "--data-binary",
+    "@" + shellQuote(linuxPath),
+    "-w",
+    shellQuote("\nHTTP_STATUS:%{http_code}"),
+    shellQuote(finalUrl)
+  ].join(" ");
+  const sessionId = await getTerminalSession("github_tools_session");
+  let result;
+  try {
+    result = await Tools.System.terminal.exec(sessionId, command, 12e4);
+  } finally {
+    try {
+      await Tools.Files.deleteFile(headerFile, false, "linux");
+    } catch (e) {
+    }
+  }
+  const output = String(result.output || "");
+  const statusMatch = output.match(/HTTP_STATUS:(\d+)\s*$/);
+  const statusCode = statusMatch ? Number(statusMatch[1]) : result.exitCode === 0 ? 200 : 500;
+  const bodyText = statusMatch ? output.slice(0, statusMatch.index).trim() : output.trim();
+  if (statusCode < 200 || statusCode >= 300) {
+    throw new Error(`GitHub API Error: ${statusCode}
+${bodyText.slice(0, 800)}`);
+  }
+  try {
+    return compactAsset(JSON.parse(bodyText));
+  } catch (e) {
+    throw new Error(`Failed to parse upload response: ${bodyText.slice(0, 500)}`);
+  }
+}
+async function deleteReleaseAsset(params) {
+  requireToken("delete_release_asset");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/releases/assets/${encodeURIComponent(String(params.asset_id))}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, asset_id: params.asset_id, result };
+}
+
+// src/github/webhooks.ts
+function compactWebhook(item) {
+  if (!item) return item;
+  const config = item.config || {};
+  return {
+    id: item.id,
+    name: item.name,
+    active: item.active,
+    events: item.events,
+    config: {
+      url: config.url,
+      content_type: config.content_type,
+      insecure_ssl: config.insecure_ssl
+    },
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    ping_url: item.ping_url,
+    test_url: item.test_url,
+    last_response: item.last_response
+  };
+}
+async function listWebhooks(params) {
+  var _a, _b;
+  requireToken("list_webhooks");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/hooks"), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactWebhook) : [];
+}
+async function getWebhook(params) {
+  requireToken("get_webhook");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}`));
+  return compactWebhook(await requestJson({ method: "GET", url }));
+}
+async function createWebhook(params) {
+  requireToken("create_webhook");
+  const parsedConfig = parseJsonParam(params.config, "config") || {};
+  const insecure = parseBool(params.insecure_ssl);
+  const url = buildUrl(repoPath(params.owner, params.repo, "/hooks"));
+  return compactWebhook(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        name: "web",
+        active: parseBool(params.active),
+        events: splitCsv(params.events),
+        config: {
+          url: params.url || parsedConfig.url,
+          content_type: params.content_type || parsedConfig.content_type || "json",
+          secret: params.secret || parsedConfig.secret,
+          insecure_ssl: insecure === void 0 ? parsedConfig.insecure_ssl : insecure ? "1" : "0"
+        }
+      }
+    })
+  );
+}
+async function updateWebhook(params) {
+  requireToken("update_webhook");
+  const parsedConfig = parseJsonParam(params.config, "config") || {};
+  const insecure = parseBool(params.insecure_ssl);
+  const config = __spreadValues({}, parsedConfig);
+  if (params.url) config.url = params.url;
+  if (params.content_type) config.content_type = params.content_type;
+  if (params.secret) config.secret = params.secret;
+  if (insecure !== void 0) config.insecure_ssl = insecure ? "1" : "0";
+  const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}`));
+  return compactWebhook(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        active: parseBool(params.active),
+        events: splitCsv(params.events),
+        add_events: splitCsv(params.add_events),
+        remove_events: splitCsv(params.remove_events),
+        config: Object.keys(config).length > 0 ? config : void 0
+      }
+    })
+  );
+}
+async function deleteWebhook(params) {
+  requireToken("delete_webhook");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, hook_id: params.hook_id, result };
+}
+async function pingWebhook(params) {
+  requireToken("ping_webhook");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}/pings`));
+  const result = await requestJson({ method: "POST", url });
+  return { ok: true, hook_id: params.hook_id, result };
+}
+
+// src/github/collaborators.ts
+function compactCollaborator(item) {
+  if (!item) return item;
+  return {
+    login: item.login,
+    id: item.id,
+    type: item.type,
+    html_url: item.html_url,
+    role_name: item.role_name,
+    permissions: item.permissions
+  };
+}
+async function listCollaborators(params) {
+  var _a, _b;
+  requireToken("list_collaborators");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/collaborators"), {
+    affiliation: params.affiliation,
+    permission: params.permission,
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactCollaborator) : [];
+}
+async function addCollaborator(params) {
+  var _a, _b;
+  requireToken("add_collaborator");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}`)
+  );
+  const data = await requestJson({
+    method: "PUT",
+    url,
+    body: {
+      permission: params.permission
+    }
+  });
+  return {
+    username: params.username,
+    permission: params.permission || "push",
+    invited: Boolean(data && (data.id || data.html_url)),
+    invitation: data && data.id ? {
+      id: data.id,
+      html_url: data.html_url,
+      permissions: data.permissions,
+      invitee: (_a = data.invitee) == null ? void 0 : _a.login,
+      inviter: (_b = data.inviter) == null ? void 0 : _b.login
+    } : data
+  };
+}
+async function removeCollaborator(params) {
+  requireToken("remove_collaborator");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}`)
+  );
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, username: params.username, result };
+}
+async function getCollaboratorPermission(params) {
+  var _a;
+  requireToken("get_collaborator_permission");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}/permission`)
+  );
+  const data = await requestJson({ method: "GET", url });
+  return {
+    permission: data.permission,
+    role_name: data.role_name,
+    user: (_a = data.user) == null ? void 0 : _a.login
+  };
+}
+async function checkCollaborator(params) {
+  requireToken("check_collaborator");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}`)
+  );
+  try {
+    const resp = await requestRaw({ method: "GET", url });
+    return { username: params.username, is_collaborator: resp.statusCode === 204 || resp.statusCode === 200 };
+  } catch (e) {
+    const message = String(e && e.message ? e.message : e);
+    if (message.includes("404")) {
+      return { username: params.username, is_collaborator: false };
+    }
+    throw e;
+  }
+}
+
+// src/github/labels.ts
+function compactLabel(item) {
+  if (!item) return item;
+  return {
+    id: item.id,
+    name: item.name,
+    color: item.color,
+    description: item.description,
+    default: item.default,
+    url: item.url
+  };
+}
+async function listLabels(params) {
+  var _a, _b;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/labels"), {
+    page: (_a = params.page) != null ? _a : 1,
+    per_page: (_b = params.per_page) != null ? _b : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactLabel) : [];
+}
+async function getLabel(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, `/labels/${encodeURIComponent(params.name)}`));
+  return compactLabel(await requestJson({ method: "GET", url }));
+}
+async function createLabel(params) {
+  requireToken("create_label");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/labels"));
+  return compactLabel(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        name: params.name,
+        color: String(params.color || "").replace(/^#/, ""),
+        description: params.description
+      }
+    })
+  );
+}
+async function updateLabel(params) {
+  requireToken("update_label");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/labels/${encodeURIComponent(params.name)}`));
+  return compactLabel(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        new_name: params.new_name,
+        color: params.color ? String(params.color).replace(/^#/, "") : void 0,
+        description: params.description
+      }
+    })
+  );
+}
+async function deleteLabel(params) {
+  requireToken("delete_label");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/labels/${encodeURIComponent(params.name)}`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, name: params.name, result };
+}
+
+// src/github/milestones.ts
+function compactMilestone(item) {
+  var _a;
+  if (!item) return item;
+  return {
+    id: item.id,
+    number: item.number,
+    title: item.title,
+    description: item.description,
+    state: item.state,
+    html_url: item.html_url,
+    open_issues: item.open_issues,
+    closed_issues: item.closed_issues,
+    due_on: item.due_on,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    closed_at: item.closed_at,
+    creator: (_a = item.creator) == null ? void 0 : _a.login
+  };
+}
+async function listMilestones(params) {
+  var _a, _b, _c;
+  const url = buildUrl(repoPath(params.owner, params.repo, "/milestones"), {
+    state: (_a = params.state) != null ? _a : "open",
+    sort: params.sort,
+    direction: params.direction,
+    page: (_b = params.page) != null ? _b : 1,
+    per_page: (_c = params.per_page) != null ? _c : 30
+  });
+  const items = await requestJson({ method: "GET", url });
+  return Array.isArray(items) ? items.map(compactMilestone) : [];
+}
+async function getMilestone(params) {
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/milestones/${encodeURIComponent(String(params.milestone_number))}`)
+  );
+  return compactMilestone(await requestJson({ method: "GET", url }));
+}
+async function createMilestone(params) {
+  requireToken("create_milestone");
+  const url = buildUrl(repoPath(params.owner, params.repo, "/milestones"));
+  return compactMilestone(
+    await requestJson({
+      method: "POST",
+      url,
+      body: {
+        title: params.title,
+        state: params.state,
+        description: params.description,
+        due_on: params.due_on
+      }
+    })
+  );
+}
+async function updateMilestone(params) {
+  requireToken("update_milestone");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/milestones/${encodeURIComponent(String(params.milestone_number))}`)
+  );
+  return compactMilestone(
+    await requestJson({
+      method: "PATCH",
+      url,
+      body: {
+        title: params.title,
+        state: params.state,
+        description: params.description,
+        due_on: params.due_on
+      }
+    })
+  );
+}
+async function deleteMilestone(params) {
+  requireToken("delete_milestone");
+  const url = buildUrl(
+    repoPath(params.owner, params.repo, `/milestones/${encodeURIComponent(String(params.milestone_number))}`)
+  );
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, milestone_number: params.milestone_number, result };
+}
+
+// src/github/protection.ts
+function compactProtection(item) {
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p;
+  if (!item) return item;
+  return {
+    url: item.url,
+    required_status_checks: item.required_status_checks ? {
+      strict: item.required_status_checks.strict,
+      contexts: item.required_status_checks.contexts,
+      checks: item.required_status_checks.checks
+    } : item.required_status_checks,
+    enforce_admins: (_b = (_a = item.enforce_admins) == null ? void 0 : _a.enabled) != null ? _b : item.enforce_admins,
+    required_pull_request_reviews: item.required_pull_request_reviews ? {
+      dismiss_stale_reviews: item.required_pull_request_reviews.dismiss_stale_reviews,
+      require_code_owner_reviews: item.required_pull_request_reviews.require_code_owner_reviews,
+      required_approving_review_count: item.required_pull_request_reviews.required_approving_review_count,
+      require_last_push_approval: item.required_pull_request_reviews.require_last_push_approval
+    } : item.required_pull_request_reviews,
+    restrictions: item.restrictions ? {
+      users: Array.isArray(item.restrictions.users) ? item.restrictions.users.map((u) => u.login || u) : [],
+      teams: Array.isArray(item.restrictions.teams) ? item.restrictions.teams.map((t) => t.slug || t.name || t) : [],
+      apps: Array.isArray(item.restrictions.apps) ? item.restrictions.apps.map((a) => a.slug || a.name || a) : []
+    } : item.restrictions,
+    required_linear_history: (_d = (_c = item.required_linear_history) == null ? void 0 : _c.enabled) != null ? _d : item.required_linear_history,
+    allow_force_pushes: (_f = (_e = item.allow_force_pushes) == null ? void 0 : _e.enabled) != null ? _f : item.allow_force_pushes,
+    allow_deletions: (_h = (_g = item.allow_deletions) == null ? void 0 : _g.enabled) != null ? _h : item.allow_deletions,
+    block_creations: (_j = (_i = item.block_creations) == null ? void 0 : _i.enabled) != null ? _j : item.block_creations,
+    required_conversation_resolution: (_l = (_k = item.required_conversation_resolution) == null ? void 0 : _k.enabled) != null ? _l : item.required_conversation_resolution,
+    lock_branch: (_n = (_m = item.lock_branch) == null ? void 0 : _m.enabled) != null ? _n : item.lock_branch,
+    allow_fork_syncing: (_p = (_o = item.allow_fork_syncing) == null ? void 0 : _o.enabled) != null ? _p : item.allow_fork_syncing
+  };
+}
+async function getBranchProtection(params) {
+  requireToken("get_branch_protection");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/branches/${encodeRef(params.branch)}/protection`));
+  return compactProtection(await requestJson({ method: "GET", url }));
+}
+async function updateBranchProtection(params) {
+  requireToken("update_branch_protection");
+  const protection = parseJsonParam(params.protection, "protection");
+  if (!protection || typeof protection !== "object") {
+    throw new Error("protection must be a JSON object matching PUT /branches/{branch}/protection");
+  }
+  const url = buildUrl(repoPath(params.owner, params.repo, `/branches/${encodeRef(params.branch)}/protection`));
+  return compactProtection(
+    await requestJson({
+      method: "PUT",
+      url,
+      body: protection
+    })
+  );
+}
+async function deleteBranchProtection(params) {
+  requireToken("delete_branch_protection");
+  const url = buildUrl(repoPath(params.owner, params.repo, `/branches/${encodeRef(params.branch)}/protection`));
+  const result = await requestJson({ method: "DELETE", url });
+  return { ok: true, branch: params.branch, result };
+}
+
+// src/github/stats.ts
+async function requestStats(url, kind) {
+  const resp = await requestRaw({ method: "GET", url });
+  if (resp.statusCode === 202) {
+    return {
+      status: "computing",
+      retry: true,
+      kind,
+      statusCode: 202,
+      message: "GitHub is computing repository statistics. Retry shortly."
+    };
+  }
+  if (resp.statusCode === 204) {
+    return {
+      status: "empty",
+      kind,
+      statusCode: 204,
+      data: []
+    };
+  }
+  const text = String(resp.content || "").trim();
+  if (!text) {
+    return { status: "empty", kind, statusCode: resp.statusCode, data: [] };
+  }
+  try {
+    return {
+      status: "ready",
+      kind,
+      statusCode: resp.statusCode,
+      data: JSON.parse(text)
+    };
+  } catch (e) {
+    throw new Error(`Failed to parse GitHub stats JSON (${resp.statusCode}): ${text.slice(0, 500)}`);
+  }
+}
+async function getContributorsStats(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, "/stats/contributors"));
+  const result = await requestStats(url, "contributors");
+  if (result.status !== "ready" || !Array.isArray(result.data)) return result;
+  return __spreadProps(__spreadValues({}, result), {
+    data: result.data.map((item) => {
+      var _a;
+      return {
+        author: (_a = item.author) == null ? void 0 : _a.login,
+        total: item.total,
+        weeks: item.weeks
+      };
+    })
+  });
+}
+async function getCommitActivity(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, "/stats/commit_activity"));
+  return requestStats(url, "commit_activity");
+}
+async function getCodeFrequency(params) {
+  const url = buildUrl(repoPath(params.owner, params.repo, "/stats/code_frequency"));
+  return requestStats(url, "code_frequency");
+}
+
 // src/utils/wrap.ts
 async function wrap(func, params, successMessage, failMessage) {
   try {
@@ -4092,7 +6594,43 @@ var toolImpl = {
   apply_local_replace: (p) => wrap(applyLocalReplace, p, "\u672C\u5730\u66FF\u6362\u6210\u529F", "\u672C\u5730\u66FF\u6362\u5931\u8D25"),
   apply_local_delete: (p) => wrap(applyLocalDelete, p, "\u672C\u5730\u5220\u9664\u6210\u529F", "\u672C\u5730\u5220\u9664\u5931\u8D25"),
   overwrite_local_file: (p) => wrap(overwriteLocalFile, p, "\u8986\u76D6\u6587\u4EF6\u6210\u529F", "\u8986\u76D6\u6587\u4EF6\u5931\u8D25"),
-  terminal_exec: (p) => wrap(terminalExec, p, "\u7EC8\u7AEF\u6267\u884C\u6210\u529F", "\u7EC8\u7AEF\u6267\u884C\u5931\u8D25")
+  terminal_exec: (p) => wrap(terminalExec, p, "\u7EC8\u7AEF\u6267\u884C\u6210\u529F", "\u7EC8\u7AEF\u6267\u884C\u5931\u8D25"),
+  list_releases: (p) => wrap(listReleases, p, "\u5217\u51FA Releases \u6210\u529F", "\u5217\u51FA Releases \u5931\u8D25"),
+  get_release: (p) => wrap(getRelease, p, "\u83B7\u53D6 Release \u6210\u529F", "\u83B7\u53D6 Release \u5931\u8D25"),
+  get_latest_release: (p) => wrap(getLatestRelease, p, "\u83B7\u53D6\u6700\u65B0 Release \u6210\u529F", "\u83B7\u53D6\u6700\u65B0 Release \u5931\u8D25"),
+  get_release_by_tag: (p) => wrap(getReleaseByTag, p, "\u6309 tag \u83B7\u53D6 Release \u6210\u529F", "\u6309 tag \u83B7\u53D6 Release \u5931\u8D25"),
+  create_release: (p) => wrap(createRelease, p, "\u521B\u5EFA Release \u6210\u529F", "\u521B\u5EFA Release \u5931\u8D25"),
+  update_release: (p) => wrap(updateRelease, p, "\u66F4\u65B0 Release \u6210\u529F", "\u66F4\u65B0 Release \u5931\u8D25"),
+  delete_release: (p) => wrap(deleteRelease, p, "\u5220\u9664 Release \u6210\u529F", "\u5220\u9664 Release \u5931\u8D25"),
+  upload_release_asset: (p) => wrap(uploadReleaseAsset, p, "\u4E0A\u4F20 Release \u8D44\u4EA7\u6210\u529F", "\u4E0A\u4F20 Release \u8D44\u4EA7\u5931\u8D25"),
+  delete_release_asset: (p) => wrap(deleteReleaseAsset, p, "\u5220\u9664 Release \u8D44\u4EA7\u6210\u529F", "\u5220\u9664 Release \u8D44\u4EA7\u5931\u8D25"),
+  list_webhooks: (p) => wrap(listWebhooks, p, "\u5217\u51FA Webhooks \u6210\u529F", "\u5217\u51FA Webhooks \u5931\u8D25"),
+  get_webhook: (p) => wrap(getWebhook, p, "\u83B7\u53D6 Webhook \u6210\u529F", "\u83B7\u53D6 Webhook \u5931\u8D25"),
+  create_webhook: (p) => wrap(createWebhook, p, "\u521B\u5EFA Webhook \u6210\u529F", "\u521B\u5EFA Webhook \u5931\u8D25"),
+  update_webhook: (p) => wrap(updateWebhook, p, "\u66F4\u65B0 Webhook \u6210\u529F", "\u66F4\u65B0 Webhook \u5931\u8D25"),
+  delete_webhook: (p) => wrap(deleteWebhook, p, "\u5220\u9664 Webhook \u6210\u529F", "\u5220\u9664 Webhook \u5931\u8D25"),
+  ping_webhook: (p) => wrap(pingWebhook, p, "ping Webhook \u6210\u529F", "ping Webhook \u5931\u8D25"),
+  list_collaborators: (p) => wrap(listCollaborators, p, "\u5217\u51FA\u534F\u4F5C\u8005\u6210\u529F", "\u5217\u51FA\u534F\u4F5C\u8005\u5931\u8D25"),
+  check_collaborator: (p) => wrap(checkCollaborator, p, "\u68C0\u67E5\u534F\u4F5C\u8005\u6210\u529F", "\u68C0\u67E5\u534F\u4F5C\u8005\u5931\u8D25"),
+  add_collaborator: (p) => wrap(addCollaborator, p, "\u6DFB\u52A0\u534F\u4F5C\u8005\u6210\u529F", "\u6DFB\u52A0\u534F\u4F5C\u8005\u5931\u8D25"),
+  remove_collaborator: (p) => wrap(removeCollaborator, p, "\u79FB\u9664\u534F\u4F5C\u8005\u6210\u529F", "\u79FB\u9664\u534F\u4F5C\u8005\u5931\u8D25"),
+  get_collaborator_permission: (p) => wrap(getCollaboratorPermission, p, "\u83B7\u53D6\u534F\u4F5C\u8005\u6743\u9650\u6210\u529F", "\u83B7\u53D6\u534F\u4F5C\u8005\u6743\u9650\u5931\u8D25"),
+  list_labels: (p) => wrap(listLabels, p, "\u5217\u51FA Labels \u6210\u529F", "\u5217\u51FA Labels \u5931\u8D25"),
+  get_label: (p) => wrap(getLabel, p, "\u83B7\u53D6 Label \u6210\u529F", "\u83B7\u53D6 Label \u5931\u8D25"),
+  create_label: (p) => wrap(createLabel, p, "\u521B\u5EFA Label \u6210\u529F", "\u521B\u5EFA Label \u5931\u8D25"),
+  update_label: (p) => wrap(updateLabel, p, "\u66F4\u65B0 Label \u6210\u529F", "\u66F4\u65B0 Label \u5931\u8D25"),
+  delete_label: (p) => wrap(deleteLabel, p, "\u5220\u9664 Label \u6210\u529F", "\u5220\u9664 Label \u5931\u8D25"),
+  list_milestones: (p) => wrap(listMilestones, p, "\u5217\u51FA Milestones \u6210\u529F", "\u5217\u51FA Milestones \u5931\u8D25"),
+  get_milestone: (p) => wrap(getMilestone, p, "\u83B7\u53D6 Milestone \u6210\u529F", "\u83B7\u53D6 Milestone \u5931\u8D25"),
+  create_milestone: (p) => wrap(createMilestone, p, "\u521B\u5EFA Milestone \u6210\u529F", "\u521B\u5EFA Milestone \u5931\u8D25"),
+  update_milestone: (p) => wrap(updateMilestone, p, "\u66F4\u65B0 Milestone \u6210\u529F", "\u66F4\u65B0 Milestone \u5931\u8D25"),
+  delete_milestone: (p) => wrap(deleteMilestone, p, "\u5220\u9664 Milestone \u6210\u529F", "\u5220\u9664 Milestone \u5931\u8D25"),
+  get_branch_protection: (p) => wrap(getBranchProtection, p, "\u83B7\u53D6\u5206\u652F\u4FDD\u62A4\u6210\u529F", "\u83B7\u53D6\u5206\u652F\u4FDD\u62A4\u5931\u8D25"),
+  update_branch_protection: (p) => wrap(updateBranchProtection, p, "\u66F4\u65B0\u5206\u652F\u4FDD\u62A4\u6210\u529F", "\u66F4\u65B0\u5206\u652F\u4FDD\u62A4\u5931\u8D25"),
+  delete_branch_protection: (p) => wrap(deleteBranchProtection, p, "\u5220\u9664\u5206\u652F\u4FDD\u62A4\u6210\u529F", "\u5220\u9664\u5206\u652F\u4FDD\u62A4\u5931\u8D25"),
+  get_contributors_stats: (p) => wrap(getContributorsStats, p, "\u83B7\u53D6\u8D21\u732E\u8005\u7EDF\u8BA1\u6210\u529F", "\u83B7\u53D6\u8D21\u732E\u8005\u7EDF\u8BA1\u5931\u8D25"),
+  get_commit_activity: (p) => wrap(getCommitActivity, p, "\u83B7\u53D6\u63D0\u4EA4\u6D3B\u52A8\u6210\u529F", "\u83B7\u53D6\u63D0\u4EA4\u6D3B\u52A8\u5931\u8D25"),
+  get_code_frequency: (p) => wrap(getCodeFrequency, p, "\u83B7\u53D6\u4EE3\u7801\u9891\u7387\u6210\u529F", "\u83B7\u53D6\u4EE3\u7801\u9891\u7387\u5931\u8D25")
 };
 async function main(params) {
   const tool = params == null ? void 0 : params.tool;
@@ -4154,3 +6692,39 @@ var apply_local_replace = toolImpl.apply_local_replace;
 var apply_local_delete = toolImpl.apply_local_delete;
 var overwrite_local_file = toolImpl.overwrite_local_file;
 var terminal_exec = toolImpl.terminal_exec;
+var list_releases = toolImpl.list_releases;
+var get_release = toolImpl.get_release;
+var get_latest_release = toolImpl.get_latest_release;
+var get_release_by_tag = toolImpl.get_release_by_tag;
+var create_release = toolImpl.create_release;
+var update_release = toolImpl.update_release;
+var delete_release = toolImpl.delete_release;
+var upload_release_asset = toolImpl.upload_release_asset;
+var delete_release_asset = toolImpl.delete_release_asset;
+var list_webhooks = toolImpl.list_webhooks;
+var get_webhook = toolImpl.get_webhook;
+var create_webhook = toolImpl.create_webhook;
+var update_webhook = toolImpl.update_webhook;
+var delete_webhook = toolImpl.delete_webhook;
+var ping_webhook = toolImpl.ping_webhook;
+var list_collaborators = toolImpl.list_collaborators;
+var check_collaborator = toolImpl.check_collaborator;
+var add_collaborator = toolImpl.add_collaborator;
+var remove_collaborator = toolImpl.remove_collaborator;
+var get_collaborator_permission = toolImpl.get_collaborator_permission;
+var list_labels = toolImpl.list_labels;
+var get_label = toolImpl.get_label;
+var create_label = toolImpl.create_label;
+var update_label = toolImpl.update_label;
+var delete_label = toolImpl.delete_label;
+var list_milestones = toolImpl.list_milestones;
+var get_milestone = toolImpl.get_milestone;
+var create_milestone = toolImpl.create_milestone;
+var update_milestone = toolImpl.update_milestone;
+var delete_milestone = toolImpl.delete_milestone;
+var get_branch_protection = toolImpl.get_branch_protection;
+var update_branch_protection = toolImpl.update_branch_protection;
+var delete_branch_protection = toolImpl.delete_branch_protection;
+var get_contributors_stats = toolImpl.get_contributors_stats;
+var get_commit_activity = toolImpl.get_commit_activity;
+var get_code_frequency = toolImpl.get_code_frequency;

--- a/examples/github.js
+++ b/examples/github.js
@@ -2,20 +2,29 @@
 {
   "name": "github",
   "display_name": {
-      "zh": "GitHub API",
-      "en": "GitHub API"
+    "zh": "GitHub API",
+    "en": "GitHub API"
   },
-  "description": { "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。", "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)." },
+  "description": {
+    "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。",
+    "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)."
+  },
   "category": "Development",
   "env": [
     {
       "name": "GITHUB_TOKEN",
-      "description": { "zh": "GitHub API 认证令牌", "en": "GitHub API authentication token" },
+      "description": {
+        "zh": "GitHub API 认证令牌",
+        "en": "GitHub API authentication token"
+      },
       "required": true
     },
     {
       "name": "GITHUB_API_BASE_URL",
-      "description": { "zh": "GitHub API 基础 URL", "en": "GitHub API base URL" },
+      "description": {
+        "zh": "GitHub API 基础 URL",
+        "en": "GitHub API base URL"
+      },
       "required": false,
       "defaultValue": "https://api.github.com"
     }
@@ -23,2605 +32,2632 @@
   "enabledByDefault": false,
   "tools": [
     {
-        "name": "search_repositories",
-        "description": {
-            "zh": "搜索 GitHub 仓库（/search/repositories）。",
-            "en": "Search GitHub repositories (/search/repositories)."
+      "name": "search_repositories",
+      "description": {
+        "zh": "搜索 GitHub 仓库（/search/repositories）。",
+        "en": "Search GitHub repositories (/search/repositories)."
+      },
+      "parameters": [
+        {
+          "name": "query",
+          "description": {
+            "zh": "搜索关键词（GitHub search query）",
+            "en": "Search keywords (GitHub search query)."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "query",
-                "description": {
-                    "zh": "搜索关键词（GitHub search query）",
-                    "en": "Search keywords (GitHub search query)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sort",
-                "description": {
-                    "zh": "排序字段：stars/forks/help-wanted-issues/updated",
-                    "en": "Sort field: stars/forks/help-wanted-issues/updated."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "order",
-                "description": {
-                    "zh": "排序方向：desc/asc",
-                    "en": "Sort order: desc/asc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30，最大 100）",
-                    "en": "Items per page (default: 30, max: 100)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序字段：stars/forks/help-wanted-issues/updated",
+            "en": "Sort field: stars/forks/help-wanted-issues/updated."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "order",
+          "description": {
+            "zh": "排序方向：desc/asc",
+            "en": "Sort order: desc/asc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30，最大 100）",
+            "en": "Items per page (default: 30, max: 100)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_repository",
-        "description": {
-            "zh": "获取仓库信息（/repos/{owner}/{repo}）。",
-            "en": "Get repository information (/repos/{owner}/{repo})."
+      "name": "get_repository",
+      "description": {
+        "zh": "获取仓库信息（/repos/{owner}/{repo}）。",
+        "en": "Get repository information (/repos/{owner}/{repo})."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "list_issues",
-        "description": {
-            "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。",
-            "en": "List repository issues (/repos/{owner}/{repo}/issues)."
+      "name": "list_issues",
+      "description": {
+        "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。",
+        "en": "List repository issues (/repos/{owner}/{repo}/issues)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed/all（默认 open）",
-                    "en": "open/closed/all (default: open)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "labels",
-                "description": {
-                    "zh": "labels 逗号分隔",
-                    "en": "Labels, comma-separated."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "creator",
-                "description": {
-                    "zh": "创建者 login",
-                    "en": "Creator login."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "include_pull_requests",
-                "description": {
-                    "zh": "是否保留 PR（默认 false）",
-                    "en": "Whether to include PRs (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed/all（默认 open）",
+            "en": "open/closed/all (default: open)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "labels",
+          "description": {
+            "zh": "labels 逗号分隔",
+            "en": "Labels, comma-separated."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "creator",
+          "description": {
+            "zh": "创建者 login",
+            "en": "Creator login."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "include_pull_requests",
+          "description": {
+            "zh": "是否保留 PR（默认 false）",
+            "en": "Whether to include PRs (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_issue",
-        "description": {
-            "zh": "获取单个 Issue 详情（/repos/{owner}/{repo}/issues/{issue_number}）。",
-            "en": "Get a single issue."
+      "name": "get_issue",
+      "description": {
+        "zh": "获取单个 Issue 详情（/repos/{owner}/{repo}/issues/{issue_number}）。",
+        "en": "Get a single issue."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "create_issue",
-        "description": {
-            "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。",
-            "en": "Create an issue."
+      "name": "create_issue",
+      "description": {
+        "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。",
+        "en": "Create an issue."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "Issue 标题",
-                    "en": "Issue title."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "Issue 内容",
-                    "en": "Issue body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "labels",
-                "description": {
-                    "zh": "labels 数组",
-                    "en": "Labels array."
-                },
-                "type": "array",
-                "required": false
-            },
-            {
-                "name": "assignees",
-                "description": {
-                    "zh": "assignees 数组",
-                    "en": "Assignees array."
-                },
-                "type": "array",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "Issue 标题",
+            "en": "Issue title."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "Issue 内容",
+            "en": "Issue body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "labels",
+          "description": {
+            "zh": "labels 数组",
+            "en": "Labels array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "assignees",
+          "description": {
+            "zh": "assignees 数组",
+            "en": "Assignees array."
+          },
+          "type": "array",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "update_issue",
-        "description": {
-            "zh": "更新 Issue。",
-            "en": "Update an issue."
+      "name": "update_issue",
+      "description": {
+        "zh": "更新 Issue。",
+        "en": "Update an issue."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "新标题",
-                    "en": "New title."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "新内容",
-                    "en": "New body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed",
-                    "en": "open/closed."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "labels",
-                "description": {
-                    "zh": "labels 数组",
-                    "en": "Labels array."
-                },
-                "type": "array",
-                "required": false
-            },
-            {
-                "name": "assignees",
-                "description": {
-                    "zh": "assignees 数组",
-                    "en": "Assignees array."
-                },
-                "type": "array",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "新标题",
+            "en": "New title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "新内容",
+            "en": "New body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed",
+            "en": "open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "labels",
+          "description": {
+            "zh": "labels 数组",
+            "en": "Labels array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "assignees",
+          "description": {
+            "zh": "assignees 数组",
+            "en": "Assignees array."
+          },
+          "type": "array",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "comment_issue",
-        "description": {
-            "zh": "给 Issue/PR 评论。",
-            "en": "Comment on an issue/PR."
+      "name": "comment_issue",
+      "description": {
+        "zh": "给 Issue/PR 评论。",
+        "en": "Comment on an issue/PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "评论内容",
-                    "en": "Comment body."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "评论内容",
+            "en": "Comment body."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "list_issue_comments",
-        "description": {
-            "zh": "列出 Issue/PR 的评论。",
-            "en": "List comments on an issue/PR."
+      "name": "list_issue_comments",
+      "description": {
+        "zh": "列出 Issue/PR 的评论。",
+        "en": "List comments on an issue/PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_requests",
-        "description": {
-            "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。",
-            "en": "List pull requests."
+      "name": "list_pull_requests",
+      "description": {
+        "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。",
+        "en": "List pull requests."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed/all（默认 open）",
-                    "en": "open/closed/all (default: open)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head 分支过滤，格式 user:branch",
-                    "en": "Head branch filter (user:branch)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "base 分支过滤",
-                    "en": "Base branch filter."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed/all（默认 open）",
+            "en": "open/closed/all (default: open)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head 分支过滤，格式 user:branch",
+            "en": "Head branch filter (user:branch)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "base 分支过滤",
+            "en": "Base branch filter."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_pull_request",
-        "description": {
-            "zh": "创建 PR。",
-            "en": "Create a pull request."
+      "name": "create_pull_request",
+      "description": {
+        "zh": "创建 PR。",
+        "en": "Create a pull request."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "PR 标题",
-                    "en": "PR title."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head 分支（含跨 fork 的 user:branch 格式）",
-                    "en": "Head branch (use user:branch for cross-fork)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "目标 base 分支",
-                    "en": "Target base branch."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "PR 描述",
-                    "en": "PR body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "draft",
-                "description": {
-                    "zh": "是否草稿",
-                    "en": "Whether to create as draft."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "PR 标题",
+            "en": "PR title."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head 分支（含跨 fork 的 user:branch 格式）",
+            "en": "Head branch (use user:branch for cross-fork)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "目标 base 分支",
+            "en": "Target base branch."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "PR 描述",
+            "en": "PR body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether to create as draft."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_pull_request",
-        "description": {
-            "zh": "获取单个 PR 详情。",
-            "en": "Get a single pull request."
+      "name": "get_pull_request",
+      "description": {
+        "zh": "获取单个 PR 详情。",
+        "en": "Get a single pull request."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "update_pull_request",
-        "description": {
-            "zh": "更新 PR 标题/描述/状态/base/draft。",
-            "en": "Update PR title/body/state/base/draft."
+      "name": "update_pull_request",
+      "description": {
+        "zh": "更新 PR 标题/描述/状态/base/draft。",
+        "en": "Update PR title/body/state/base/draft."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "新标题",
-                    "en": "New title."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "新描述",
-                    "en": "New body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed",
-                    "en": "open/closed."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "新 base 分支",
-                    "en": "New base branch."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "draft",
-                "description": {
-                    "zh": "是否草稿",
-                    "en": "Whether draft."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "新标题",
+            "en": "New title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "新描述",
+            "en": "New body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed",
+            "en": "open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "新 base 分支",
+            "en": "New base branch."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether draft."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "merge_pull_request",
-        "description": {
-            "zh": "合并 PR。",
-            "en": "Merge a pull request."
+      "name": "merge_pull_request",
+      "description": {
+        "zh": "合并 PR。",
+        "en": "Merge a pull request."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "commit_title",
-                "description": {
-                    "zh": "合并 commit 标题",
-                    "en": "Merge commit title."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "commit_message",
-                "description": {
-                    "zh": "合并 commit 消息",
-                    "en": "Merge commit message."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "merge_method",
-                "description": {
-                    "zh": "merge/squash/rebase（默认 merge）",
-                    "en": "merge/squash/rebase (default: merge)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "commit_title",
+          "description": {
+            "zh": "合并 commit 标题",
+            "en": "Merge commit title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "commit_message",
+          "description": {
+            "zh": "合并 commit 消息",
+            "en": "Merge commit message."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "merge_method",
+          "description": {
+            "zh": "merge/squash/rebase（默认 merge）",
+            "en": "merge/squash/rebase (default: merge)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_request_files",
-        "description": {
-            "zh": "列出 PR 变更文件。",
-            "en": "List files changed in a PR."
+      "name": "list_pull_request_files",
+      "description": {
+        "zh": "列出 PR 变更文件。",
+        "en": "List files changed in a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "include_patch",
-                "description": {
-                    "zh": "是否包含 patch 内容（默认 false）",
-                    "en": "Include patch content (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 100）",
-                    "en": "Items per page (default: 100)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "include_patch",
+          "description": {
+            "zh": "是否包含 patch 内容（默认 false）",
+            "en": "Include patch content (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 100）",
+            "en": "Items per page (default: 100)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_pull_request_diff",
-        "description": {
-            "zh": "获取 PR 的 unified diff 文本。",
-            "en": "Get PR unified diff text."
+      "name": "get_pull_request_diff",
+      "description": {
+        "zh": "获取 PR 的 unified diff 文本。",
+        "en": "Get PR unified diff text."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "max_chars",
-                "description": {
-                    "zh": "截断字符数（默认 20000）",
-                    "en": "Truncate to this many chars (default: 20000)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "max_chars",
+          "description": {
+            "zh": "截断字符数（默认 20000）",
+            "en": "Truncate to this many chars (default: 20000)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_request_commits",
-        "description": {
-            "zh": "列出 PR 的提交。",
-            "en": "List commits in a PR."
+      "name": "list_pull_request_commits",
+      "description": {
+        "zh": "列出 PR 的提交。",
+        "en": "List commits in a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_request_reviews",
-        "description": {
-            "zh": "列出 PR 的 review。",
-            "en": "List reviews on a PR."
+      "name": "list_pull_request_reviews",
+      "description": {
+        "zh": "列出 PR 的 review。",
+        "en": "List reviews on a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_review_comments",
-        "description": {
-            "zh": "列出 PR 的行内 review comments。",
-            "en": "List inline review comments on a PR."
+      "name": "list_review_comments",
+      "description": {
+        "zh": "列出 PR 的行内 review comments。",
+        "en": "List inline review comments on a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_review",
-        "description": {
-            "zh": "提交 PR review（APPROVE/REQUEST_CHANGES/COMMENT）。",
-            "en": "Submit a PR review (APPROVE/REQUEST_CHANGES/COMMENT)."
+      "name": "create_review",
+      "description": {
+        "zh": "提交 PR review（APPROVE/REQUEST_CHANGES/COMMENT）。",
+        "en": "Submit a PR review (APPROVE/REQUEST_CHANGES/COMMENT)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "review 总评内容",
-                    "en": "Review body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "event",
-                "description": {
-                    "zh": "APPROVE/REQUEST_CHANGES/COMMENT（默认 COMMENT）",
-                    "en": "APPROVE/REQUEST_CHANGES/COMMENT (default: COMMENT)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "commit_id",
-                "description": {
-                    "zh": "关联的 commit sha",
-                    "en": "Commit SHA to associate."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "comments",
-                "description": {
-                    "zh": "行内评论数组（JSON 字符串），每项含 path/line/body",
-                    "en": "Inline comments array (JSON string), each with path/line/body."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "review 总评内容",
+            "en": "Review body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "event",
+          "description": {
+            "zh": "APPROVE/REQUEST_CHANGES/COMMENT（默认 COMMENT）",
+            "en": "APPROVE/REQUEST_CHANGES/COMMENT (default: COMMENT)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "commit_id",
+          "description": {
+            "zh": "关联的 commit sha",
+            "en": "Commit SHA to associate."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "comments",
+          "description": {
+            "zh": "行内评论数组（JSON 字符串），每项含 path/line/body",
+            "en": "Inline comments array (JSON string), each with path/line/body."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "reply_review_comment",
-        "description": {
-            "zh": "回复 PR 行内 review comment。",
-            "en": "Reply to a PR inline review comment."
+      "name": "reply_review_comment",
+      "description": {
+        "zh": "回复 PR 行内 review comment。",
+        "en": "Reply to a PR inline review comment."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "comment_id",
-                "description": {
-                    "zh": "被回复的 comment id",
-                    "en": "Comment ID to reply to."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "回复内容",
-                    "en": "Reply body."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "comment_id",
+          "description": {
+            "zh": "被回复的 comment id",
+            "en": "Comment ID to reply to."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "回复内容",
+            "en": "Reply body."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "request_reviewers",
-        "description": {
-            "zh": "请求 PR reviewer。",
-            "en": "Request reviewers for a PR."
+      "name": "request_reviewers",
+      "description": {
+        "zh": "请求 PR reviewer。",
+        "en": "Request reviewers for a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "reviewers",
-                "description": {
-                    "zh": "reviewer login 列表，逗号分隔或数组",
-                    "en": "Reviewer logins, comma-separated or array."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "team_reviewers",
-                "description": {
-                    "zh": "team reviewer slug 列表，逗号分隔或数组",
-                    "en": "Team reviewer slugs, comma-separated or array."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "reviewers",
+          "description": {
+            "zh": "reviewer login 列表，逗号分隔或数组",
+            "en": "Reviewer logins, comma-separated or array."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "team_reviewers",
+          "description": {
+            "zh": "team reviewer slug 列表，逗号分隔或数组",
+            "en": "Team reviewer slugs, comma-separated or array."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_file_content",
-        "description": {
-            "zh": "获取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。",
-            "en": "Get file content from a repository."
+      "name": "get_file_content",
+      "description": {
+        "zh": "获取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。",
+        "en": "Get file content from a repository."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径（相对仓库根目录）",
-                    "en": "File path relative to repository root."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "分支/tag/commit（默认默认分支）",
-                    "en": "Branch/tag/commit (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径（相对仓库根目录）",
+            "en": "File path relative to repository root."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "分支/tag/commit（默认默认分支）",
+            "en": "Branch/tag/commit (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_or_update_file",
-        "description": {
-            "zh": "创建或更新仓库文件。更新时需传 sha。",
-            "en": "Create or update a file in the repository. Provide sha when updating."
+      "name": "create_or_update_file",
+      "description": {
+        "zh": "创建或更新仓库文件。更新时需传 sha。",
+        "en": "Create or update a file in the repository. Provide sha when updating."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径",
-                    "en": "File path."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "message",
-                "description": {
-                    "zh": "commit 消息",
-                    "en": "Commit message."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "content",
-                "description": {
-                    "zh": "文件内容（明文，会自动 base64 编码）",
-                    "en": "File content (plain text, will be base64-encoded)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "更新时必填：现有文件的 blob sha",
-                    "en": "Required when updating: existing file blob SHA."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "目标分支（默认默认分支）",
-                    "en": "Target branch (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径",
+            "en": "File path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "message",
+          "description": {
+            "zh": "commit 消息",
+            "en": "Commit message."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "content",
+          "description": {
+            "zh": "文件内容（明文，会自动 base64 编码）",
+            "en": "File content (plain text, will be base64-encoded)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "更新时必填：现有文件的 blob sha",
+            "en": "Required when updating: existing file blob SHA."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "目标分支（默认默认分支）",
+            "en": "Target branch (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "delete_file",
-        "description": {
-            "zh": "删除仓库文件。",
-            "en": "Delete a file from the repository."
+      "name": "delete_file",
+      "description": {
+        "zh": "删除仓库文件。",
+        "en": "Delete a file from the repository."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径",
-                    "en": "File path."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "message",
-                "description": {
-                    "zh": "commit 消息",
-                    "en": "Commit message."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "文件的 blob sha",
-                    "en": "File blob SHA."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "目标分支",
-                    "en": "Target branch."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径",
+            "en": "File path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "message",
+          "description": {
+            "zh": "commit 消息",
+            "en": "Commit message."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "文件的 blob sha",
+            "en": "File blob SHA."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "目标分支",
+            "en": "Target branch."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_branch",
-        "description": {
-            "zh": "创建分支。",
-            "en": "Create a branch."
+      "name": "create_branch",
+      "description": {
+        "zh": "创建分支。",
+        "en": "Create a branch."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "新分支名",
-                    "en": "New branch name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "from_branch",
-                "description": {
-                    "zh": "基于哪个分支创建（默认默认分支）",
-                    "en": "Branch to create from (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "直接指定起始 commit sha（优先于 from_branch）",
-                    "en": "Starting commit SHA (overrides from_branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "新分支名",
+            "en": "New branch name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "from_branch",
+          "description": {
+            "zh": "基于哪个分支创建（默认默认分支）",
+            "en": "Branch to create from (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "直接指定起始 commit sha（优先于 from_branch）",
+            "en": "Starting commit SHA (overrides from_branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_branches",
-        "description": {
-            "zh": "列出仓库分支。",
-            "en": "List repository branches."
+      "name": "list_branches",
+      "description": {
+        "zh": "列出仓库分支。",
+        "en": "List repository branches."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "protected_only",
-                "description": {
-                    "zh": "只返回受保护分支（默认 false）",
-                    "en": "Return only protected branches (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "protected_only",
+          "description": {
+            "zh": "只返回受保护分支（默认 false）",
+            "en": "Return only protected branches (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_commits",
-        "description": {
-            "zh": "列出仓库提交。",
-            "en": "List repository commits."
+      "name": "list_commits",
+      "description": {
+        "zh": "列出仓库提交。",
+        "en": "List repository commits."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "分支/tag/commit sha（默认默认分支）",
-                    "en": "Branch/tag/commit SHA (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "只返回修改了该路径的提交",
-                    "en": "Only commits affecting this path."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "author",
-                "description": {
-                    "zh": "作者 login 过滤",
-                    "en": "Author login filter."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "分支/tag/commit sha（默认默认分支）",
+            "en": "Branch/tag/commit SHA (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "只返回修改了该路径的提交",
+            "en": "Only commits affecting this path."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "author",
+          "description": {
+            "zh": "作者 login 过滤",
+            "en": "Author login filter."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_commit",
-        "description": {
-            "zh": "获取单个提交详情。",
-            "en": "Get a single commit."
+      "name": "get_commit",
+      "description": {
+        "zh": "获取单个提交详情。",
+        "en": "Get a single commit."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "commit sha / 分支 / tag",
-                    "en": "Commit SHA, branch, or tag."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "include_files",
-                "description": {
-                    "zh": "是否包含文件变更列表（默认 true）",
-                    "en": "Whether to include file changes (default: true)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "commit sha / 分支 / tag",
+            "en": "Commit SHA, branch, or tag."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "include_files",
+          "description": {
+            "zh": "是否包含文件变更列表（默认 true）",
+            "en": "Whether to include file changes (default: true)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "compare_refs",
-        "description": {
-            "zh": "比较两个 ref。",
-            "en": "Compare two refs."
+      "name": "compare_refs",
+      "description": {
+        "zh": "比较两个 ref。",
+        "en": "Compare two refs."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "base ref（分支/tag/sha）",
-                    "en": "Base ref (branch/tag/sha)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head ref（分支/tag/sha）",
-                    "en": "Head ref (branch/tag/sha)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "include_files",
-                "description": {
-                    "zh": "是否包含文件列表（默认 true）",
-                    "en": "Whether to include file list (default: true)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "include_patch",
-                "description": {
-                    "zh": "文件列表是否包含 patch（默认 false）",
-                    "en": "Whether file list includes patch (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "base ref（分支/tag/sha）",
+            "en": "Base ref (branch/tag/sha)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head ref（分支/tag/sha）",
+            "en": "Head ref (branch/tag/sha)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "include_files",
+          "description": {
+            "zh": "是否包含文件列表（默认 true）",
+            "en": "Whether to include file list (default: true)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "include_patch",
+          "description": {
+            "zh": "文件列表是否包含 patch（默认 false）",
+            "en": "Whether file list includes patch (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_compare_diff",
-        "description": {
-            "zh": "获取两个 ref 之间的 unified diff 文本。",
-            "en": "Get unified diff text between two refs."
+      "name": "get_compare_diff",
+      "description": {
+        "zh": "获取两个 ref 之间的 unified diff 文本。",
+        "en": "Get unified diff text between two refs."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "base ref",
-                    "en": "Base ref."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head ref",
-                    "en": "Head ref."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "max_chars",
-                "description": {
-                    "zh": "截断字符数（默认 20000）",
-                    "en": "Truncate to this many chars (default: 20000)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "base ref",
+            "en": "Base ref."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head ref",
+            "en": "Head ref."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "max_chars",
+          "description": {
+            "zh": "截断字符数（默认 20000）",
+            "en": "Truncate to this many chars (default: 20000)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_workflows",
-        "description": {
-            "zh": "列出仓库 GitHub Actions workflow。",
-            "en": "List GitHub Actions workflows."
+      "name": "list_workflows",
+      "description": {
+        "zh": "列出仓库 GitHub Actions workflow。",
+        "en": "List GitHub Actions workflows."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_workflow_runs",
-        "description": {
-            "zh": "列出 workflow run。",
-            "en": "List workflow runs."
+      "name": "list_workflow_runs",
+      "description": {
+        "zh": "列出 workflow run。",
+        "en": "List workflow runs."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "workflow_id",
-                "description": {
-                    "zh": "workflow id 或文件名（如 android-tests.yml），不传则列出所有",
-                    "en": "Workflow ID or filename (e.g. android-tests.yml); omit to list all."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "按分支过滤",
-                    "en": "Filter by branch."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "status",
-                "description": {
-                    "zh": "按状态过滤：queued/in_progress/completed/failure/success 等",
-                    "en": "Filter by status: queued/in_progress/completed/failure/success etc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "event",
-                "description": {
-                    "zh": "按触发事件过滤：push/pull_request/workflow_dispatch 等",
-                    "en": "Filter by event: push/pull_request/workflow_dispatch etc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "workflow_id",
+          "description": {
+            "zh": "workflow id 或文件名（如 android-tests.yml），不传则列出所有",
+            "en": "Workflow ID or filename (e.g. android-tests.yml); omit to list all."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "按分支过滤",
+            "en": "Filter by branch."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "status",
+          "description": {
+            "zh": "按状态过滤：queued/in_progress/completed/failure/success 等",
+            "en": "Filter by status: queued/in_progress/completed/failure/success etc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "event",
+          "description": {
+            "zh": "按触发事件过滤：push/pull_request/workflow_dispatch 等",
+            "en": "Filter by event: push/pull_request/workflow_dispatch etc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_workflow_run",
-        "description": {
-            "zh": "获取单个 workflow run 详情。",
-            "en": "Get a single workflow run."
+      "name": "get_workflow_run",
+      "description": {
+        "zh": "获取单个 workflow run 详情。",
+        "en": "Get a single workflow run."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "trigger_workflow",
-        "description": {
-            "zh": "手动触发 workflow（workflow_dispatch）。",
-            "en": "Manually trigger a workflow (workflow_dispatch)."
+      "name": "trigger_workflow",
+      "description": {
+        "zh": "手动触发 workflow（workflow_dispatch）。",
+        "en": "Manually trigger a workflow (workflow_dispatch)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "workflow_id",
-                "description": {
-                    "zh": "workflow id 或文件名（如 android-tests.yml）",
-                    "en": "Workflow ID or filename (e.g. android-tests.yml)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "触发分支或 tag",
-                    "en": "Branch or tag to trigger on."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "inputs",
-                "description": {
-                    "zh": "workflow inputs（JSON 字符串或对象）",
-                    "en": "Workflow inputs (JSON string or object)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "workflow_id",
+          "description": {
+            "zh": "workflow id 或文件名（如 android-tests.yml）",
+            "en": "Workflow ID or filename (e.g. android-tests.yml)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "触发分支或 tag",
+            "en": "Branch or tag to trigger on."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "inputs",
+          "description": {
+            "zh": "workflow inputs（JSON 字符串或对象）",
+            "en": "Workflow inputs (JSON string or object)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_workflow_jobs",
-        "description": {
-            "zh": "获取 workflow run 的 jobs（含可选日志）。",
-            "en": "Get jobs for a workflow run (with optional logs)."
+      "name": "get_workflow_jobs",
+      "description": {
+        "zh": "获取 workflow run 的 jobs（含可选日志）。",
+        "en": "Get jobs for a workflow run (with optional logs)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "include_logs",
-                "description": {
-                    "zh": "是否拉取每个 job 的日志（默认 false）",
-                    "en": "Whether to fetch logs for each job (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "failed_only",
-                "description": {
-                    "zh": "只返回失败/非成功的 job（默认 false）",
-                    "en": "Return only failed/non-success jobs (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "max_log_chars",
-                "description": {
-                    "zh": "日志截断字符数（默认 8000）",
-                    "en": "Log truncation in characters (default: 8000)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 50）",
-                    "en": "Items per page (default: 50)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "include_logs",
+          "description": {
+            "zh": "是否拉取每个 job 的日志（默认 false）",
+            "en": "Whether to fetch logs for each job (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "failed_only",
+          "description": {
+            "zh": "只返回失败/非成功的 job（默认 false）",
+            "en": "Return only failed/non-success jobs (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "max_log_chars",
+          "description": {
+            "zh": "日志截断字符数（默认 8000）",
+            "en": "Log truncation in characters (default: 8000)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 50）",
+            "en": "Items per page (default: 50)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "rerun_workflow_run",
-        "description": {
-            "zh": "重新运行 workflow run（全部或仅失败 job）。",
-            "en": "Re-run a workflow run (all jobs or failed jobs only)."
+      "name": "rerun_workflow_run",
+      "description": {
+        "zh": "重新运行 workflow run（全部或仅失败 job）。",
+        "en": "Re-run a workflow run (all jobs or failed jobs only)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "failed_jobs_only",
-                "description": {
-                    "zh": "只重跑失败 job（默认 false）",
-                    "en": "Only re-run failed jobs (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "enable_debug_logging",
-                "description": {
-                    "zh": "是否开启 debug 日志",
-                    "en": "Whether to enable debug logging."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "failed_jobs_only",
+          "description": {
+            "zh": "只重跑失败 job（默认 false）",
+            "en": "Only re-run failed jobs (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "enable_debug_logging",
+          "description": {
+            "zh": "是否开启 debug 日志",
+            "en": "Whether to enable debug logging."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "cancel_workflow_run",
-        "description": {
-            "zh": "取消 workflow run。",
-            "en": "Cancel a workflow run."
+      "name": "cancel_workflow_run",
+      "description": {
+        "zh": "取消 workflow run。",
+        "en": "Cancel a workflow run."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "list_check_runs",
-        "description": {
-            "zh": "列出某个 commit 的 check runs。",
-            "en": "List check runs for a commit."
+      "name": "list_check_runs",
+      "description": {
+        "zh": "列出某个 commit 的 check runs。",
+        "en": "List check runs for a commit."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "commit sha / 分支 / tag",
-                    "en": "Commit SHA, branch, or tag."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "status",
-                "description": {
-                    "zh": "queued/in_progress/completed 过滤",
-                    "en": "Filter by status: queued/in_progress/completed."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "filter",
-                "description": {
-                    "zh": "latest/all（默认 latest）",
-                    "en": "latest/all (default: latest)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "commit sha / 分支 / tag",
+            "en": "Commit SHA, branch, or tag."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "status",
+          "description": {
+            "zh": "queued/in_progress/completed 过滤",
+            "en": "Filter by status: queued/in_progress/completed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "filter",
+          "description": {
+            "zh": "latest/all（默认 latest）",
+            "en": "latest/all (default: latest)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "search_code",
-        "description": {
-            "zh": "搜索代码（/search/code）。",
-            "en": "Search code (/search/code)."
+      "name": "search_code",
+      "description": {
+        "zh": "搜索代码（/search/code）。",
+        "en": "Search code (/search/code)."
+      },
+      "parameters": [
+        {
+          "name": "query",
+          "description": {
+            "zh": "搜索查询（支持 GitHub code search 语法）",
+            "en": "Search query (GitHub code search syntax, e.g. repo:owner/name keyword)."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "query",
-                "description": {
-                    "zh": "搜索查询（支持 GitHub code search 语法）",
-                    "en": "Search query (GitHub code search syntax, e.g. repo:owner/name keyword)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sort",
-                "description": {
-                    "zh": "排序字段（indexed）",
-                    "en": "Sort field (indexed)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "order",
-                "description": {
-                    "zh": "排序方向：desc/asc",
-                    "en": "Sort order: desc/asc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序字段（indexed）",
+            "en": "Sort field (indexed)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "order",
+          "description": {
+            "zh": "排序方向：desc/asc",
+            "en": "Sort order: desc/asc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "search_issues",
-        "description": {
-            "zh": "搜索 Issue/PR（/search/issues）。",
-            "en": "Search issues and PRs (/search/issues)."
+      "name": "search_issues",
+      "description": {
+        "zh": "搜索 Issue/PR（/search/issues）。",
+        "en": "Search issues and PRs (/search/issues)."
+      },
+      "parameters": [
+        {
+          "name": "query",
+          "description": {
+            "zh": "搜索查询（支持 GitHub issue search 语法）",
+            "en": "Search query (GitHub issue search syntax)."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "query",
-                "description": {
-                    "zh": "搜索查询（支持 GitHub issue search 语法）",
-                    "en": "Search query (GitHub issue search syntax)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sort",
-                "description": {
-                    "zh": "排序字段：comments/reactions/created/updated 等",
-                    "en": "Sort field: comments/reactions/created/updated etc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "order",
-                "description": {
-                    "zh": "排序方向：desc/asc",
-                    "en": "Sort order: desc/asc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序字段：comments/reactions/created/updated 等",
+            "en": "Sort field: comments/reactions/created/updated etc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "order",
+          "description": {
+            "zh": "排序方向：desc/asc",
+            "en": "Sort order: desc/asc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_authenticated_user",
-        "description": {
-            "zh": "获取当前认证用户信息（/user）。",
-            "en": "Get the currently authenticated user (/user)."
-        },
-        "parameters": []
+      "name": "get_authenticated_user",
+      "description": {
+        "zh": "获取当前认证用户信息（/user）。",
+        "en": "Get the currently authenticated user (/user)."
+      },
+      "parameters": []
     },
     {
-        "name": "get_rate_limit",
-        "description": {
-            "zh": "查询 GitHub API 请求频率限制（/rate_limit）。",
-            "en": "Query GitHub API rate limit (/rate_limit)."
-        },
-        "parameters": []
+      "name": "get_rate_limit",
+      "description": {
+        "zh": "查询 GitHub API 请求频率限制（/rate_limit）。",
+        "en": "Query GitHub API rate limit (/rate_limit)."
+      },
+      "parameters": []
     },
     {
-        "name": "fork_repository",
-        "description": {
-            "zh": "fork 仓库（/repos/{owner}/{repo}/forks）。",
-            "en": "Fork a repository."
+      "name": "fork_repository",
+      "description": {
+        "zh": "fork 仓库（/repos/{owner}/{repo}/forks）。",
+        "en": "Fork a repository."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "organization",
-                "description": {
-                    "zh": "fork 到指定组织（不填则 fork 到个人账号）",
-                    "en": "Fork to a specific organization (omit for personal account)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "name",
-                "description": {
-                    "zh": "fork 后的仓库名（默认与原仓库同名）",
-                    "en": "Name for the forked repository (default: same as original)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "default_branch_only",
-                "description": {
-                    "zh": "只 fork 默认分支（默认 false）",
-                    "en": "Fork only the default branch (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "organization",
+          "description": {
+            "zh": "fork 到指定组织（不填则 fork 到个人账号）",
+            "en": "Fork to a specific organization (omit for personal account)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "fork 后的仓库名（默认与原仓库同名）",
+            "en": "Name for the forked repository (default: same as original)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "default_branch_only",
+          "description": {
+            "zh": "只 fork 默认分支（默认 false）",
+            "en": "Fork only the default branch (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "sync_fork",
-        "description": {
-            "zh": "同步 fork 到上游（/repos/{owner}/{repo}/merge-upstream）。",
-            "en": "Sync a fork with upstream."
+      "name": "sync_fork",
+      "description": {
+        "zh": "同步 fork 到上游（/repos/{owner}/{repo}/merge-upstream）。",
+        "en": "Sync a fork with upstream."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "fork 仓库的 owner",
+            "en": "Fork repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "fork 仓库的 owner",
-                    "en": "Fork repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "fork 仓库名",
-                    "en": "Fork repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "要同步的分支（默认默认分支）",
-                    "en": "Branch to sync (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "fork 仓库名",
+            "en": "Fork repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "要同步的分支（默认默认分支）",
+            "en": "Branch to sync (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "patch_file_in_repo",
-        "description": {
-            "zh": "在仓库中对文件应用 search/replace patch（先读取文件，替换内容后写回）。",
-            "en": "Apply a search/replace patch to a file in the repository (read -> replace -> write back)."
+      "name": "patch_file_in_repo",
+      "description": {
+        "zh": "在仓库中对文件应用差异块 patch（先读取文件，按 [START-REPLACE]/[START-DELETE] 块替换内容后写回）。",
+        "en": "Apply a block-based patch to a repository file (read -> apply [START-REPLACE]/[START-DELETE] blocks -> write back)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径",
-                    "en": "File path."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "search",
-                "description": {
-                    "zh": "要查找的文本（精确匹配）",
-                    "en": "Text to search for (exact match)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "replace",
-                "description": {
-                    "zh": "替换后的文本",
-                    "en": "Replacement text."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "message",
-                "description": {
-                    "zh": "commit 消息",
-                    "en": "Commit message."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "目标分支",
-                    "en": "Target branch."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径",
+            "en": "File path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "message",
+          "description": {
+            "zh": "commit 消息",
+            "en": "Commit message."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "patch",
+          "description": {
+            "zh": "差异块文本。格式：[START-REPLACE]\\n[OLD]\\n原内容\\n[/OLD]\\n[NEW]\\n新内容\\n[/NEW]\\n[END-REPLACE]，删除用 [START-DELETE] 配 [OLD] 块，可包含多个块。",
+            "en": "Patch blocks. Format: [START-REPLACE]\\n[OLD]\\nold\\n[/OLD]\\n[NEW]\\nnew\\n[/NEW]\\n[END-REPLACE]; use [START-DELETE] with an [OLD] block to delete. Multiple blocks allowed."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "目标分支",
+            "en": "Target branch."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "apply_local_replace",
-        "description": {
-            "zh": "在本地文件系统中对文件应用 search/replace（不经过 GitHub API）。",
-            "en": "Apply a search/replace patch to a local file (no GitHub API)."
+      "name": "apply_local_replace",
+      "description": {
+        "zh": "在本地文件中把 old 片段替换为 new 片段（不经过 GitHub API）。",
+        "en": "Replace an old snippet with a new snippet in a local file (no GitHub API)."
+      },
+      "parameters": [
+        {
+          "name": "path",
+          "description": {
+            "zh": "本地文件路径",
+            "en": "Local file path."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "path",
-                "description": {
-                    "zh": "本地文件路径（绝对路径）",
-                    "en": "Local file path (absolute)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "search",
-                "description": {
-                    "zh": "要查找的文本",
-                    "en": "Text to search for."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "replace",
-                "description": {
-                    "zh": "替换后的文本",
-                    "en": "Replacement text."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "old",
+          "description": {
+            "zh": "要被替换的原内容片段（精确匹配）",
+            "en": "Existing snippet to replace (exact match)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "new",
+          "description": {
+            "zh": "替换后的新内容片段",
+            "en": "Replacement snippet."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "执行环境：android（默认）或 linux",
+            "en": "Environment: android (default) or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "apply_local_delete",
-        "description": {
-            "zh": "删除本地文件（不经过 GitHub API）。",
-            "en": "Delete a local file (no GitHub API)."
+      "name": "apply_local_delete",
+      "description": {
+        "zh": "在本地文件中删除指定内容片段（不经过 GitHub API）。",
+        "en": "Delete a snippet from a local file (no GitHub API)."
+      },
+      "parameters": [
+        {
+          "name": "path",
+          "description": {
+            "zh": "本地文件路径",
+            "en": "Local file path."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "path",
-                "description": {
-                    "zh": "本地文件路径（绝对路径）",
-                    "en": "Local file path (absolute)."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "old",
+          "description": {
+            "zh": "要删除的内容片段（精确匹配）",
+            "en": "Snippet to delete (exact match)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "执行环境：android（默认）或 linux",
+            "en": "Environment: android (default) or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "overwrite_local_file",
-        "description": {
-            "zh": "用新内容完整覆盖本地文件（不经过 GitHub API）。",
-            "en": "Overwrite a local file with new content (no GitHub API)."
+      "name": "overwrite_local_file",
+      "description": {
+        "zh": "用新内容覆盖写入本地文件（不经过 GitHub API）。",
+        "en": "Overwrite a local file with new content (no GitHub API)."
+      },
+      "parameters": [
+        {
+          "name": "path",
+          "description": {
+            "zh": "本地文件路径",
+            "en": "Local file path."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "path",
-                "description": {
-                    "zh": "本地文件路径（绝对路径）",
-                    "en": "Local file path (absolute)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "content",
-                "description": {
-                    "zh": "新的文件内容",
-                    "en": "New file content."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "content",
+          "description": {
+            "zh": "写入的完整内容",
+            "en": "Full content to write."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "执行环境：android（默认）或 linux",
+            "en": "Environment: android (default) or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "terminal_exec",
-        "description": {
-            "zh": "在本地终端执行命令（调用 Operit 内置终端，注意权限和安全）。",
-            "en": "Execute a command in the local terminal (uses Operit built-in terminal)."
+      "name": "terminal_exec",
+      "description": {
+        "zh": "在 Operit 内置终端中执行命令（会话在多次调用间复用）。",
+        "en": "Execute a command in the Operit built-in terminal (session is reused across calls)."
+      },
+      "parameters": [
+        {
+          "name": "command",
+          "description": {
+            "zh": "要执行的命令",
+            "en": "Command to execute."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "command",
-                "description": {
-                    "zh": "要执行的 shell 命令",
-                    "en": "Shell command to execute."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "cwd",
-                "description": {
-                    "zh": "工作目录（默认当前目录）",
-                    "en": "Working directory (default: current directory)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "timeout_ms",
-                "description": {
-                    "zh": "超时毫秒数（默认 30000）",
-                    "en": "Timeout in milliseconds (default: 30000)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "session_name",
+          "description": {
+            "zh": "终端会话名（默认 github_tools_session）",
+            "en": "Terminal session name (default: github_tools_session)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "close",
+          "description": {
+            "zh": "执行后是否关闭会话（默认 false）",
+            "en": "Whether to close the session after execution (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     }
-]
+  ]
 }
 */
 
@@ -4009,7 +4045,7 @@ async function wrap(func, params, successMessage, failMessage) {
 // src/index.ts
 var toolImpl = {
   search_repositories: (p) => wrap(searchRepositories, p, "\u641C\u7D22\u4ED3\u5E93\u6210\u529F", "\u641C\u7D22\u4ED3\u5E93\u5931\u8D25"),
-  get_repository: (p) => wrap(searchRepositories, p, "\u83B7\u53D6\u4ED3\u5E93\u6210\u529F", "\u83B7\u53D6\u4ED3\u5E93\u5931\u8D25"),
+  get_repository: (p) => wrap(getRepository, p, "\u83B7\u53D6\u4ED3\u5E93\u6210\u529F", "\u83B7\u53D6\u4ED3\u5E93\u5931\u8D25"),
   list_issues: (p) => wrap(listIssues, p, "\u5217\u51FA Issues \u6210\u529F", "\u5217\u51FA Issues \u5931\u8D25"),
   get_issue: (p) => wrap(getIssue, p, "\u83B7\u53D6 Issue \u6210\u529F", "\u83B7\u53D6 Issue \u5931\u8D25"),
   create_issue: (p) => wrap(createIssue, p, "\u521B\u5EFA Issue \u6210\u529F", "\u521B\u5EFA Issue \u5931\u8D25"),

--- a/examples/github/src/github/actions.ts
+++ b/examples/github/src/github/actions.ts
@@ -1,0 +1,250 @@
+import { buildUrl, compactCommit, parseJsonParam, repoPath, requestJson, requestText, requireToken, truncateText } from './api';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+function compactWorkflow(item: any) {
+    if (!item) return item;
+    return {
+        id: item.id,
+        name: item.name,
+        path: item.path,
+        state: item.state,
+        html_url: item.html_url,
+        badge_url: item.badge_url,
+        created_at: item.created_at,
+        updated_at: item.updated_at
+    };
+}
+
+function compactRun(item: any) {
+    if (!item) return item;
+    return {
+        id: item.id,
+        name: item.name,
+        display_title: item.display_title,
+        status: item.status,
+        conclusion: item.conclusion,
+        event: item.event,
+        head_branch: item.head_branch,
+        head_sha: item.head_sha,
+        html_url: item.html_url,
+        path: item.path,
+        run_number: item.run_number,
+        run_attempt: item.run_attempt,
+        created_at: item.created_at,
+        updated_at: item.updated_at,
+        actor: item.actor?.login,
+        triggering_actor: item.triggering_actor?.login
+    };
+}
+
+function compactJob(item: any) {
+    if (!item) return item;
+    return {
+        id: item.id,
+        run_id: item.run_id,
+        name: item.name,
+        status: item.status,
+        conclusion: item.conclusion,
+        html_url: item.html_url,
+        started_at: item.started_at,
+        completed_at: item.completed_at,
+        runner_name: item.runner_name,
+        steps: Array.isArray(item.steps)
+            ? item.steps.map((step: any) => ({
+                  name: step.name,
+                  status: step.status,
+                  conclusion: step.conclusion,
+                  number: step.number,
+                  started_at: step.started_at,
+                  completed_at: step.completed_at
+              }))
+            : []
+    };
+}
+
+export async function listWorkflows(params: RepoIdParams & { page?: number; per_page?: number }): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/actions/workflows'), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const data = await requestJson<any>({ method: 'GET', url });
+    return {
+        total_count: data?.total_count,
+        workflows: Array.isArray(data?.workflows) ? data.workflows.map(compactWorkflow) : []
+    };
+}
+
+export async function listWorkflowRuns(
+    params: RepoIdParams & {
+        workflow_id?: string | number;
+        branch?: string;
+        status?: string;
+        event?: string;
+        page?: number;
+        per_page?: number;
+    }
+): Promise<any> {
+    const suffix = params.workflow_id
+        ? `/actions/workflows/${encodeURIComponent(String(params.workflow_id))}/runs`
+        : '/actions/runs';
+    const url = buildUrl(repoPath(params.owner, params.repo, suffix), {
+        branch: params.branch,
+        status: params.status,
+        event: params.event,
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 20
+    });
+    const data = await requestJson<any>({ method: 'GET', url });
+    return {
+        total_count: data?.total_count,
+        workflow_runs: Array.isArray(data?.workflow_runs) ? data.workflow_runs.map(compactRun) : []
+    };
+}
+
+export async function getWorkflowRun(params: RepoIdParams & { run_id: number | string }): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/actions/runs/${encodeURIComponent(String(params.run_id))}`));
+    return compactRun(await requestJson<any>({ method: 'GET', url }));
+}
+
+export async function triggerWorkflow(
+    params: RepoIdParams & {
+        workflow_id: string | number;
+        ref: string;
+        inputs?: any;
+    }
+): Promise<any> {
+    requireToken('trigger_workflow');
+    const url = buildUrl(
+        repoPath(params.owner, params.repo, `/actions/workflows/${encodeURIComponent(String(params.workflow_id))}/dispatches`)
+    );
+    const inputs = parseJsonParam<Record<string, any>>(params.inputs, 'inputs');
+    const result = await requestJson<any>({
+        method: 'POST',
+        url,
+        body: {
+            ref: params.ref,
+            inputs
+        }
+    });
+    return {
+        ok: true,
+        workflow_id: params.workflow_id,
+        ref: params.ref,
+        inputs: inputs || {},
+        dispatch: result
+    };
+}
+
+export async function getWorkflowJobs(
+    params: RepoIdParams & {
+        run_id: number | string;
+        include_logs?: boolean;
+        failed_only?: boolean;
+        max_log_chars?: number;
+        page?: number;
+        per_page?: number;
+    }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/actions/runs/${encodeURIComponent(String(params.run_id))}/jobs`), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 50
+    });
+    const data = await requestJson<any>({ method: 'GET', url });
+    const jobs = Array.isArray(data?.jobs) ? data.jobs.map(compactJob) : [];
+    const selected = params.failed_only
+        ? jobs.filter((job: any) => job.conclusion && job.conclusion !== 'success' && job.conclusion !== 'skipped')
+        : jobs;
+
+    if (!params.include_logs) {
+        return {
+            total_count: data?.total_count,
+            jobs: selected
+        };
+    }
+
+    const maxLogChars = params.max_log_chars ?? 8000;
+    const withLogs = [];
+    for (const job of selected) {
+        try {
+            const logUrl = buildUrl(repoPath(params.owner, params.repo, `/actions/jobs/${encodeURIComponent(String(job.id))}/logs`));
+            const logResp = await requestText({ method: 'GET', url: logUrl, timeoutMs: 60000 });
+            const truncated = truncateText(logResp.text, maxLogChars);
+            withLogs.push({
+                ...job,
+                logs: truncated.text,
+                logs_truncated: truncated.truncated,
+                logs_original_length: truncated.original_length
+            });
+        } catch (e: any) {
+            withLogs.push({
+                ...job,
+                logs_error: String(e && e.message ? e.message : e)
+            });
+        }
+    }
+
+    return {
+        total_count: data?.total_count,
+        jobs: withLogs
+    };
+}
+
+export async function rerunWorkflowRun(
+    params: RepoIdParams & { run_id: number | string; failed_jobs_only?: boolean; enable_debug_logging?: boolean }
+): Promise<any> {
+    requireToken('rerun_workflow_run');
+    const suffix = params.failed_jobs_only
+        ? `/actions/runs/${encodeURIComponent(String(params.run_id))}/rerun-failed-jobs`
+        : `/actions/runs/${encodeURIComponent(String(params.run_id))}/rerun`;
+    const url = buildUrl(repoPath(params.owner, params.repo, suffix));
+    const body = params.enable_debug_logging === undefined ? undefined : { enable_debug_logging: params.enable_debug_logging };
+    const result = await requestJson<any>({ method: 'POST', url, body });
+    return { ok: true, run_id: params.run_id, failed_jobs_only: Boolean(params.failed_jobs_only), result };
+}
+
+export async function cancelWorkflowRun(params: RepoIdParams & { run_id: number | string }): Promise<any> {
+    requireToken('cancel_workflow_run');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/actions/runs/${encodeURIComponent(String(params.run_id))}/cancel`));
+    const result = await requestJson<any>({ method: 'POST', url });
+    return { ok: true, run_id: params.run_id, result };
+}
+
+export async function listCheckRuns(
+    params: RepoIdParams & {
+        ref: string;
+        status?: string;
+        filter?: string;
+        page?: number;
+        per_page?: number;
+    }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/commits/${encodeURIComponent(params.ref)}/check-runs`), {
+        status: params.status,
+        filter: params.filter,
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const data = await requestJson<any>({ method: 'GET', url });
+    return {
+        total_count: data?.total_count,
+        check_runs: Array.isArray(data?.check_runs)
+            ? data.check_runs.map((item: any) => ({
+                  id: item.id,
+                  name: item.name,
+                  status: item.status,
+                  conclusion: item.conclusion,
+                  html_url: item.html_url,
+                  details_url: item.details_url,
+                  started_at: item.started_at,
+                  completed_at: item.completed_at,
+                  app: item.app?.slug || item.app?.name
+              }))
+            : []
+    };
+}
+
+export { compactCommit };

--- a/examples/github/src/github/api.ts
+++ b/examples/github/src/github/api.ts
@@ -3,6 +3,15 @@ export type GithubApiOptions = {
     token?: string;
 };
 
+export type GithubHttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export type GithubRawResponse = {
+    statusCode: number;
+    statusMessage: string;
+    headers: Record<string, string>;
+    content: string;
+};
+
 export function getBaseUrl(): string {
     const fromEnv = (typeof getEnv === 'function' ? getEnv('GITHUB_API_BASE_URL') : undefined) || '';
     return (fromEnv && String(fromEnv).trim()) || 'https://api.github.com';
@@ -14,6 +23,14 @@ export function getToken(): string | undefined {
     return trimmed ? trimmed : undefined;
 }
 
+export function requireToken(operation: string): string {
+    const token = getToken();
+    if (!token) {
+        throw new Error(`GITHUB_TOKEN is required for ${operation}.`);
+    }
+    return token;
+}
+
 export function buildUrl(pathname: string, query?: Record<string, string | number | boolean | undefined>): string {
     const base = getBaseUrl().replace(/\/+$/, '');
     const path = pathname.startsWith('/') ? pathname : `/${pathname}`;
@@ -22,7 +39,7 @@ export function buildUrl(pathname: string, query?: Record<string, string | numbe
     if (query) {
         Object.keys(query).forEach((k) => {
             const v = query[k];
-            if (v === undefined || v === null) return;
+            if (v === undefined || v === null || v === '') return;
             qs.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
         });
     }
@@ -30,11 +47,23 @@ export function buildUrl(pathname: string, query?: Record<string, string | numbe
     return qs.length > 0 ? `${base}${path}?${qs.join('&')}` : `${base}${path}`;
 }
 
+export function repoPath(owner: string, repo: string, suffix = ''): string {
+    const extra = suffix ? (suffix.startsWith('/') ? suffix : `/${suffix}`) : '';
+    return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${extra}`;
+}
+
+export function encodeRef(ref: string): string {
+    return String(ref || '')
+        .split('/')
+        .map((part) => encodeURIComponent(part))
+        .join('/');
+}
+
 export function defaultHeaders(extra?: Record<string, string>): Record<string, string> {
     const headers: Record<string, string> = {
         Accept: 'application/vnd.github+json',
         'X-GitHub-Api-Version': '2022-11-28',
-        'User-Agent': 'Operit-Examples-GitHub'
+        'User-Agent': 'Operit-GitHub'
     };
 
     const token = getToken();
@@ -52,31 +81,148 @@ export function defaultHeaders(extra?: Record<string, string>): Record<string, s
 }
 
 export function createHttpClient(timeoutMs: number = 30000): OkHttpClient {
-    return OkHttp.newBuilder().connectTimeout(timeoutMs).readTimeout(timeoutMs).writeTimeout(timeoutMs).build();
+    return OkHttp.newBuilder()
+        .connectTimeout(timeoutMs)
+        .readTimeout(timeoutMs)
+        .writeTimeout(timeoutMs)
+        .followRedirects(true)
+        .build();
+}
+
+export async function requestRaw(options: {
+    method: GithubHttpMethod;
+    url: string;
+    headers?: Record<string, string>;
+    body?: any;
+    timeoutMs?: number;
+}): Promise<GithubRawResponse> {
+    const client = createHttpClient(options.timeoutMs ?? 30000);
+    const req = client.newRequest().url(options.url).method(options.method);
+    req.headers(defaultHeaders(options.headers));
+
+    if (options.method !== 'GET') {
+        const payload = options.body === undefined || options.body === null ? {} : options.body;
+        req.body(JSON.stringify(payload), 'json');
+    }
+
+    const resp: OkHttpResponse = await req.build().execute();
+    if (!resp.isSuccessful()) {
+        throw new Error(`GitHub API Error: ${resp.statusCode} ${resp.statusMessage}\n${resp.content}`);
+    }
+
+    return {
+        statusCode: resp.statusCode,
+        statusMessage: resp.statusMessage,
+        headers: resp.headers || {},
+        content: typeof resp.content === 'string' ? resp.content : String(resp.content || '')
+    };
 }
 
 export async function requestJson<T>(options: {
-    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+    method: GithubHttpMethod;
     url: string;
     headers?: Record<string, string>;
     body?: any;
     timeoutMs?: number;
 }): Promise<T> {
-    const client = createHttpClient(options.timeoutMs ?? 30000);
-    const req = client.newRequest().url(options.url).method(options.method);
-
-    const headers = defaultHeaders(options.headers);
-    req.headers(headers);
-
-    if (options.body !== undefined && options.body !== null && options.method !== 'GET') {
-        req.body(JSON.stringify(options.body), 'json');
+    const resp = await requestRaw(options);
+    const text = String(resp.content || '').trim();
+    if (resp.statusCode === 204 || !text) {
+        return { ok: true, statusCode: resp.statusCode } as T;
     }
-
-    const resp: OkHttpResponse = await req.build().execute();
-
-    if (!resp.isSuccessful()) {
-        throw new Error(`GitHub API Error: ${resp.statusCode} ${resp.statusMessage}\n${resp.content}`);
+    try {
+        return JSON.parse(text) as T;
+    } catch (e) {
+        throw new Error(`Failed to parse GitHub JSON response (${resp.statusCode}): ${text.slice(0, 500)}`);
     }
+}
 
-    return resp.json() as T;
+export async function requestText(options: {
+    method: GithubHttpMethod;
+    url: string;
+    headers?: Record<string, string>;
+    body?: any;
+    timeoutMs?: number;
+}): Promise<{ text: string; statusCode: number; headers: Record<string, string> }> {
+    const resp = await requestRaw(options);
+    return {
+        text: resp.content || '',
+        statusCode: resp.statusCode,
+        headers: resp.headers
+    };
+}
+
+export function parseJsonParam<T = any>(value: any, fieldName: string): T | undefined {
+    if (value === undefined || value === null || value === '') return undefined;
+    if (typeof value === 'object') return value as T;
+    if (typeof value !== 'string') return value as T;
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    try {
+        return JSON.parse(trimmed) as T;
+    } catch (e) {
+        throw new Error(`${fieldName} must be valid JSON.`);
+    }
+}
+
+export function splitCsv(value?: string | string[]): string[] | undefined {
+    if (value === undefined || value === null || value === '') return undefined;
+    if (Array.isArray(value)) {
+        const items = value.map((it) => String(it).trim()).filter(Boolean);
+        return items.length > 0 ? items : undefined;
+    }
+    const items = String(value)
+        .split(',')
+        .map((it) => it.trim())
+        .filter(Boolean);
+    return items.length > 0 ? items : undefined;
+}
+
+export function compactCommit(commit: any) {
+    if (!commit) return commit;
+    return {
+        sha: commit.sha || commit.commit?.tree?.sha,
+        html_url: commit.html_url,
+        message: commit.commit?.message || commit.message,
+        author: commit.commit?.author?.name || commit.author?.login,
+        date: commit.commit?.author?.date || commit.commit?.committer?.date,
+        login: commit.author?.login
+    };
+}
+
+export function compactFileChange(file: any, includePatch: boolean) {
+    if (!file) return file;
+    const item: any = {
+        filename: file.filename,
+        status: file.status,
+        additions: file.additions,
+        deletions: file.deletions,
+        changes: file.changes,
+        sha: file.sha,
+        blob_url: file.blob_url,
+        previous_filename: file.previous_filename
+    };
+    if (includePatch && typeof file.patch === 'string') {
+        item.patch = file.patch;
+    }
+    return item;
+}
+
+export function truncateText(
+    text: string,
+    maxChars: number
+): { text: string; truncated: boolean; original_length: number } {
+    const src = String(text ?? '');
+    const limit = maxChars > 0 ? maxChars : src.length;
+    if (src.length <= limit) {
+        return { text: src, truncated: false, original_length: src.length };
+    }
+    const headChars = Math.max(200, Math.floor(limit * 0.35));
+    const tailChars = Math.max(200, limit - headChars - 80);
+    const omitted = src.length - headChars - tailChars;
+    return {
+        text: `${src.slice(0, headChars)}\n\n... truncated ${omitted} chars ...\n\n${src.slice(-tailChars)}`,
+        truncated: true,
+        original_length: src.length
+    };
 }

--- a/examples/github/src/github/api.ts
+++ b/examples/github/src/github/api.ts
@@ -17,6 +17,28 @@ export function getBaseUrl(): string {
     return (fromEnv && String(fromEnv).trim()) || 'https://api.github.com';
 }
 
+export function getUploadsBaseUrl(): string {
+    const fromEnv = (typeof getEnv === 'function' ? getEnv('GITHUB_UPLOADS_BASE_URL') : undefined) || '';
+    const trimmed = String(fromEnv || '').trim().replace(/\/+$/, '');
+    if (trimmed) return trimmed;
+    const api = getBaseUrl().replace(/\/+$/, '');
+    if (api === 'https://api.github.com') return 'https://uploads.github.com';
+    return api;
+}
+
+export function parseBool(value: any): boolean | undefined {
+    if (value === undefined || value === null || value === '') return undefined;
+    if (typeof value === 'boolean') return value;
+    const s = String(value).trim().toLowerCase();
+    if (s === 'true' || s === '1' || s === 'yes') return true;
+    if (s === 'false' || s === '0' || s === 'no') return false;
+    return undefined;
+}
+
+export function shellQuote(value: string): string {
+    return "'" + String(value ?? '').replace(/'/g, "'\''") + "'";
+}
+
 export function getToken(): string | undefined {
     const token = (typeof getEnv === 'function' ? getEnv('GITHUB_TOKEN') : undefined) || '';
     const trimmed = String(token || '').trim();

--- a/examples/github/src/github/branches.ts
+++ b/examples/github/src/github/branches.ts
@@ -1,4 +1,4 @@
-import { buildUrl, requestJson, requireToken } from './api';
+import { buildUrl, encodeRef, repoPath, requestJson, requireToken } from './api';
 import { getRepository } from './repos';
 
 export type RepoIdParams = {
@@ -9,15 +9,23 @@ export type RepoIdParams = {
 export type CreateBranchParams = RepoIdParams & {
     new_branch: string;
     from_branch?: string;
+    from_sha?: string;
 };
 
-async function getBranchHeadSha(params: RepoIdParams & { branch: string }): Promise<string> {
-    const url = buildUrl(
-        `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/git/ref/heads/${encodeURIComponent(
-            params.branch
-        )}`
-    );
+export type DeleteBranchParams = RepoIdParams & {
+    branch: string;
+};
 
+function requiredName(value: unknown, field: string): string {
+    const name = String(value ?? '').trim();
+    if (!name) {
+        throw new Error(`${field} is required`);
+    }
+    return name;
+}
+
+async function getBranchHeadSha(params: RepoIdParams & { branch: string }): Promise<string> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/git/ref/heads/${encodeRef(params.branch)}`));
     const data = await requestJson<any>({ method: 'GET', url });
     const sha = data?.object?.sha;
     if (!sha) {
@@ -29,17 +37,46 @@ async function getBranchHeadSha(params: RepoIdParams & { branch: string }): Prom
 export async function createBranch(params: CreateBranchParams): Promise<any> {
     requireToken('create_branch');
 
-    const fromBranch = params.from_branch ?? String((await getRepository({ owner: params.owner, repo: params.repo }))?.default_branch || 'main');
+    const newBranch = requiredName(params.new_branch, 'new_branch');
+    const fromSha = String(params.from_sha ?? '').trim();
+    let sha = fromSha;
+    let fromBranch: string | undefined;
 
-    const sha = await getBranchHeadSha({ owner: params.owner, repo: params.repo, branch: fromBranch });
+    if (!sha) {
+        fromBranch =
+            String(params.from_branch ?? '').trim() ||
+            String((await getRepository({ owner: params.owner, repo: params.repo }))?.default_branch || 'main');
+        sha = await getBranchHeadSha({ owner: params.owner, repo: params.repo, branch: fromBranch });
+    }
 
-    const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/git/refs`);
-    return requestJson<any>({
+    const url = buildUrl(repoPath(params.owner, params.repo, '/git/refs'));
+    const result = await requestJson<any>({
         method: 'POST',
         url,
         body: {
-            ref: `refs/heads/${params.new_branch}`,
+            ref: `refs/heads/${newBranch}`,
             sha
         }
     });
+    return {
+        ...result,
+        new_branch: newBranch,
+        from_sha: sha,
+        from_branch: fromBranch
+    };
+}
+
+export async function deleteBranch(params: DeleteBranchParams): Promise<any> {
+    requireToken('delete_branch');
+
+    const branch = requiredName(params.branch, 'branch');
+    const repoInfo = await getRepository({ owner: params.owner, repo: params.repo });
+    const defaultBranch = String(repoInfo?.default_branch || '').trim();
+    if (defaultBranch && branch === defaultBranch) {
+        throw new Error(`Refusing to delete the default branch '${defaultBranch}'.`);
+    }
+
+    const url = buildUrl(repoPath(params.owner, params.repo, `/git/refs/heads/${encodeRef(branch)}`));
+    const result = await requestJson<any>({ method: 'DELETE', url });
+    return { ok: true, branch, result };
 }

--- a/examples/github/src/github/branches.ts
+++ b/examples/github/src/github/branches.ts
@@ -1,4 +1,4 @@
-import { buildUrl, requestJson, getToken } from './api';
+import { buildUrl, requestJson, requireToken } from './api';
 import { getRepository } from './repos';
 
 export type RepoIdParams = {
@@ -27,10 +27,7 @@ async function getBranchHeadSha(params: RepoIdParams & { branch: string }): Prom
 }
 
 export async function createBranch(params: CreateBranchParams): Promise<any> {
-    const token = getToken();
-    if (!token) {
-        throw new Error('GITHUB_TOKEN is required for create_branch.');
-    }
+    requireToken('create_branch');
 
     const fromBranch = params.from_branch ?? String((await getRepository({ owner: params.owner, repo: params.repo }))?.default_branch || 'main');
 

--- a/examples/github/src/github/collaborators.ts
+++ b/examples/github/src/github/collaborators.ts
@@ -1,0 +1,101 @@
+import { buildUrl, repoPath, requestJson, requestRaw, requireToken } from './api';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+function compactCollaborator(item: any) {
+    if (!item) return item;
+    return {
+        login: item.login,
+        id: item.id,
+        type: item.type,
+        html_url: item.html_url,
+        role_name: item.role_name,
+        permissions: item.permissions
+    };
+}
+
+export async function listCollaborators(
+    params: RepoIdParams & { affiliation?: string; permission?: string; page?: number; per_page?: number }
+): Promise<any> {
+    requireToken('list_collaborators');
+    const url = buildUrl(repoPath(params.owner, params.repo, '/collaborators'), {
+        affiliation: params.affiliation,
+        permission: params.permission,
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items) ? items.map(compactCollaborator) : [];
+}
+
+export async function addCollaborator(
+    params: RepoIdParams & { username: string; permission?: string }
+): Promise<any> {
+    requireToken('add_collaborator');
+    const url = buildUrl(
+        repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}`)
+    );
+    const data = await requestJson<any>({
+        method: 'PUT',
+        url,
+        body: {
+            permission: params.permission
+        }
+    });
+    return {
+        username: params.username,
+        permission: params.permission || 'push',
+        invited: Boolean(data && (data.id || data.html_url)),
+        invitation: data && data.id
+            ? {
+                  id: data.id,
+                  html_url: data.html_url,
+                  permissions: data.permissions,
+                  invitee: data.invitee?.login,
+                  inviter: data.inviter?.login
+              }
+            : data
+    };
+}
+
+export async function removeCollaborator(params: RepoIdParams & { username: string }): Promise<any> {
+    requireToken('remove_collaborator');
+    const url = buildUrl(
+        repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}`)
+    );
+    const result = await requestJson<any>({ method: 'DELETE', url });
+    return { ok: true, username: params.username, result };
+}
+
+export async function getCollaboratorPermission(params: RepoIdParams & { username: string }): Promise<any> {
+    requireToken('get_collaborator_permission');
+    const url = buildUrl(
+        repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}/permission`)
+    );
+    const data = await requestJson<any>({ method: 'GET', url });
+    return {
+        permission: data.permission,
+        role_name: data.role_name,
+        user: data.user?.login
+    };
+}
+
+export async function checkCollaborator(params: RepoIdParams & { username: string }): Promise<any> {
+    requireToken('check_collaborator');
+    const url = buildUrl(
+        repoPath(params.owner, params.repo, `/collaborators/${encodeURIComponent(params.username)}`)
+    );
+    try {
+        const resp = await requestRaw({ method: 'GET', url });
+        return { username: params.username, is_collaborator: resp.statusCode === 204 || resp.statusCode === 200 };
+    } catch (e: any) {
+        const message = String(e && e.message ? e.message : e);
+        if (message.includes('404')) {
+            return { username: params.username, is_collaborator: false };
+        }
+        throw e;
+    }
+}

--- a/examples/github/src/github/contents.ts
+++ b/examples/github/src/github/contents.ts
@@ -1,4 +1,4 @@
-import { buildUrl, requestJson, getToken } from './api';
+import { buildUrl, requestJson, requireToken } from './api';
 import { safeAtobBase64, safeBtoaBase64 } from '../utils/base64';
 
 export type RepoIdParams = {
@@ -66,10 +66,7 @@ async function resolveFileSha(params: RepoIdParams & { path: string; branch?: st
 }
 
 export async function createOrUpdateFile(params: CreateOrUpdateFileParams): Promise<any> {
-    const token = getToken();
-    if (!token) {
-        throw new Error('GITHUB_TOKEN is required for create_or_update_file.');
-    }
+    requireToken('create_or_update_file');
 
     const encoding = (params.content_encoding || 'utf-8').toLowerCase();
     const base64Content = encoding === 'base64' ? params.content : safeBtoaBase64(params.content);
@@ -96,10 +93,7 @@ export async function createOrUpdateFile(params: CreateOrUpdateFileParams): Prom
 }
 
 export async function deleteFile(params: DeleteFileParams): Promise<any> {
-    const token = getToken();
-    if (!token) {
-        throw new Error('GITHUB_TOKEN is required for delete_file.');
-    }
+    requireToken('delete_file');
 
     const sha = params.sha ?? (await resolveFileSha({ owner: params.owner, repo: params.repo, path: params.path, branch: params.branch }));
     if (!sha) {

--- a/examples/github/src/github/forks.ts
+++ b/examples/github/src/github/forks.ts
@@ -1,0 +1,45 @@
+import { buildUrl, repoPath, requestJson, requireToken } from './api';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+export async function forkRepository(params: RepoIdParams & { organization?: string; name?: string; default_branch_only?: boolean }): Promise<any> {
+    requireToken('fork_repository');
+    const url = buildUrl(repoPath(params.owner, params.repo, '/forks'));
+    const data = await requestJson<any>({
+        method: 'POST',
+        url,
+        body: {
+            organization: params.organization,
+            name: params.name,
+            default_branch_only: params.default_branch_only
+        }
+    });
+    return {
+        full_name: data.full_name,
+        html_url: data.html_url,
+        default_branch: data.default_branch,
+        parent: data.parent?.full_name,
+        source: data.source?.full_name,
+        private: data.private
+    };
+}
+
+export async function syncFork(params: RepoIdParams & { branch?: string }): Promise<any> {
+    requireToken('sync_fork');
+    const url = buildUrl(repoPath(params.owner, params.repo, '/merge-upstream'));
+    const data = await requestJson<any>({
+        method: 'POST',
+        url,
+        body: {
+            branch: params.branch
+        }
+    });
+    return {
+        message: data.message,
+        merge_type: data.merge_type,
+        base_branch: data.base_branch
+    };
+}

--- a/examples/github/src/github/git.ts
+++ b/examples/github/src/github/git.ts
@@ -1,0 +1,95 @@
+import { buildUrl, compactCommit, compactFileChange, encodeRef, repoPath, requestJson, requestText, truncateText } from './api';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+export async function listBranches(
+    params: RepoIdParams & { protected_only?: boolean; page?: number; per_page?: number }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/branches'), {
+        protected: params.protected_only,
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items)
+        ? items.map((item) => ({
+              name: item.name,
+              sha: item.commit?.sha,
+              protected: item.protected,
+              html_url: `https://github.com/${params.owner}/${params.repo}/tree/${item.name}`
+          }))
+        : [];
+}
+
+export async function listCommits(
+    params: RepoIdParams & { sha?: string; path?: string; author?: string; page?: number; per_page?: number }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/commits'), {
+        sha: params.sha,
+        path: params.path,
+        author: params.author,
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 20
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items) ? items.map(compactCommit) : [];
+}
+
+export async function getCommit(params: RepoIdParams & { ref: string; include_files?: boolean }): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/commits/${encodeURIComponent(params.ref)}`));
+    const data = await requestJson<any>({ method: 'GET', url });
+    return {
+        ...compactCommit(data),
+        stats: data.stats,
+        files: params.include_files === false ? undefined : (Array.isArray(data.files) ? data.files.map((file: any) => compactFileChange(file, false)) : [])
+    };
+}
+
+export async function compareRefs(
+    params: RepoIdParams & { base: string; head: string; include_files?: boolean; include_patch?: boolean }
+): Promise<any> {
+    const spec = `${encodeRef(params.base)}...${encodeRef(params.head)}`;
+    const url = buildUrl(repoPath(params.owner, params.repo, `/compare/${spec}`));
+    const data = await requestJson<any>({ method: 'GET', url });
+    const includeFiles = params.include_files !== false;
+    return {
+        status: data.status,
+        ahead_by: data.ahead_by,
+        behind_by: data.behind_by,
+        total_commits: data.total_commits,
+        html_url: data.html_url,
+        permalink_url: data.permalink_url,
+        base_commit: compactCommit(data.base_commit),
+        merge_base_commit: compactCommit(data.merge_base_commit),
+        commits: Array.isArray(data.commits) ? data.commits.map(compactCommit) : [],
+        files: includeFiles
+            ? Array.isArray(data.files)
+                ? data.files.map((file: any) => compactFileChange(file, params.include_patch === true))
+                : []
+            : undefined
+    };
+}
+
+export async function getCompareDiff(
+    params: RepoIdParams & { base: string; head: string; max_chars?: number }
+): Promise<any> {
+    const spec = `${encodeRef(params.base)}...${encodeRef(params.head)}`;
+    const url = buildUrl(repoPath(params.owner, params.repo, `/compare/${spec}`));
+    const resp = await requestText({
+        method: 'GET',
+        url,
+        headers: { Accept: 'application/vnd.github.diff' },
+        timeoutMs: 60000
+    });
+    const truncated = truncateText(resp.text, params.max_chars ?? 20000);
+    return {
+        base: params.base,
+        head: params.head,
+        diff: truncated.text,
+        truncated: truncated.truncated,
+        original_length: truncated.original_length
+    };
+}

--- a/examples/github/src/github/issues.ts
+++ b/examples/github/src/github/issues.ts
@@ -1,4 +1,4 @@
-import { buildUrl, requestJson, getToken } from './api';
+import { buildUrl, repoPath, requestJson, requireToken, splitCsv } from './api';
 
 export type RepoIdParams = {
     owner: string;
@@ -17,8 +17,8 @@ export type ListIssuesParams = RepoIdParams & {
 export type CreateIssueParams = RepoIdParams & {
     title: string;
     body?: string;
-    labels?: string[];
-    assignees?: string[];
+    labels?: string[] | string;
+    assignees?: string[] | string;
 };
 
 export type CommentIssueParams = RepoIdParams & {
@@ -32,65 +32,114 @@ export type ListIssueCommentsParams = RepoIdParams & {
     per_page?: number;
 };
 
-export async function listIssues(params: ListIssuesParams): Promise<any[]> {
-    const page = params.page ?? 1;
-    const perPage = params.per_page ?? 30;
+function compactIssue(item: any) {
+    if (!item) return item;
+    return {
+        number: item.number,
+        title: item.title,
+        state: item.state,
+        html_url: item.html_url,
+        user: item.user?.login,
+        labels: Array.isArray(item.labels) ? item.labels.map((it: any) => (typeof it === 'string' ? it : it.name)) : [],
+        assignees: Array.isArray(item.assignees) ? item.assignees.map((it: any) => it.login) : [],
+        comments: item.comments,
+        pull_request: Boolean(item.pull_request),
+        created_at: item.created_at,
+        updated_at: item.updated_at,
+        body: item.body
+    };
+}
 
-    const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues`, {
+export async function listIssues(params: ListIssuesParams): Promise<any[]> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/issues'), {
         state: params.state ?? 'open',
         labels: params.labels,
         creator: params.creator,
-        page,
-        per_page: perPage
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
     });
-
     const items = await requestJson<any[]>({ method: 'GET', url });
-
     const includePRs = params.include_pull_requests === true;
-    if (includePRs) return items;
-    return items.filter((it) => !it || !it.pull_request);
+    const filtered = includePRs ? items : items.filter((it) => !it || !it.pull_request);
+    return Array.isArray(filtered) ? filtered.map(compactIssue) : [];
+}
+
+export async function getIssue(params: RepoIdParams & { issue_number: number }): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}`));
+    return compactIssue(await requestJson<any>({ method: 'GET', url }));
 }
 
 export async function createIssue(params: CreateIssueParams): Promise<any> {
-    const token = getToken();
-    if (!token) {
-        throw new Error('GITHUB_TOKEN is required for create_issue.');
-    }
+    requireToken('create_issue');
+    const url = buildUrl(repoPath(params.owner, params.repo, '/issues'));
+    return compactIssue(
+        await requestJson<any>({
+            method: 'POST',
+            url,
+            body: {
+                title: params.title,
+                body: params.body,
+                labels: splitCsv(params.labels),
+                assignees: splitCsv(params.assignees)
+            }
+        })
+    );
+}
 
-    const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues`);
-    return requestJson<any>({
-        method: 'POST',
-        url,
-        body: {
-            title: params.title,
-            body: params.body,
-            labels: params.labels,
-            assignees: params.assignees
-        }
-    });
+export async function updateIssue(
+    params: RepoIdParams & {
+        issue_number: number;
+        title?: string;
+        body?: string;
+        state?: string;
+        labels?: string[] | string;
+        assignees?: string[] | string;
+    }
+): Promise<any> {
+    requireToken('update_issue');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}`));
+    return compactIssue(
+        await requestJson<any>({
+            method: 'PATCH',
+            url,
+            body: {
+                title: params.title,
+                body: params.body,
+                state: params.state,
+                labels: splitCsv(params.labels),
+                assignees: splitCsv(params.assignees)
+            }
+        })
+    );
 }
 
 export async function commentIssue(params: CommentIssueParams): Promise<any> {
-    const token = getToken();
-    if (!token) {
-        throw new Error('GITHUB_TOKEN is required for comment_issue.');
-    }
-
-    const url = buildUrl(
-        `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues/${params.issue_number}/comments`
-    );
-
-    return requestJson<any>({ method: 'POST', url, body: { body: params.body } });
+    requireToken('comment_issue');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}/comments`));
+    const data = await requestJson<any>({ method: 'POST', url, body: { body: params.body } });
+    return {
+        id: data.id,
+        html_url: data.html_url,
+        user: data.user?.login,
+        body: data.body,
+        created_at: data.created_at
+    };
 }
 
 export async function listIssueComments(params: ListIssueCommentsParams): Promise<any[]> {
-    const page = params.page ?? 1;
-    const perPage = params.per_page ?? 30;
-
-    const url = buildUrl(
-        `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/issues/${params.issue_number}/comments`,
-        { page, per_page: perPage }
-    );
-
-    return requestJson<any[]>({ method: 'GET', url });
+    const url = buildUrl(repoPath(params.owner, params.repo, `/issues/${params.issue_number}/comments`), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items)
+        ? items.map((item) => ({
+              id: item.id,
+              html_url: item.html_url,
+              user: item.user?.login,
+              body: item.body,
+              created_at: item.created_at,
+              updated_at: item.updated_at
+          }))
+        : [];
 }

--- a/examples/github/src/github/labels.ts
+++ b/examples/github/src/github/labels.ts
@@ -1,0 +1,75 @@
+import { buildUrl, repoPath, requestJson, requireToken } from './api';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+function compactLabel(item: any) {
+    if (!item) return item;
+    return {
+        id: item.id,
+        name: item.name,
+        color: item.color,
+        description: item.description,
+        default: item.default,
+        url: item.url
+    };
+}
+
+export async function listLabels(params: RepoIdParams & { page?: number; per_page?: number }): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/labels'), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items) ? items.map(compactLabel) : [];
+}
+
+export async function getLabel(params: RepoIdParams & { name: string }): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/labels/${encodeURIComponent(params.name)}`));
+    return compactLabel(await requestJson<any>({ method: 'GET', url }));
+}
+
+export async function createLabel(
+    params: RepoIdParams & { name: string; color: string; description?: string }
+): Promise<any> {
+    requireToken('create_label');
+    const url = buildUrl(repoPath(params.owner, params.repo, '/labels'));
+    return compactLabel(
+        await requestJson<any>({
+            method: 'POST',
+            url,
+            body: {
+                name: params.name,
+                color: String(params.color || '').replace(/^#/, ''),
+                description: params.description
+            }
+        })
+    );
+}
+
+export async function updateLabel(
+    params: RepoIdParams & { name: string; new_name?: string; color?: string; description?: string }
+): Promise<any> {
+    requireToken('update_label');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/labels/${encodeURIComponent(params.name)}`));
+    return compactLabel(
+        await requestJson<any>({
+            method: 'PATCH',
+            url,
+            body: {
+                new_name: params.new_name,
+                color: params.color ? String(params.color).replace(/^#/, '') : undefined,
+                description: params.description
+            }
+        })
+    );
+}
+
+export async function deleteLabel(params: RepoIdParams & { name: string }): Promise<any> {
+    requireToken('delete_label');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/labels/${encodeURIComponent(params.name)}`));
+    const result = await requestJson<any>({ method: 'DELETE', url });
+    return { ok: true, name: params.name, result };
+}

--- a/examples/github/src/github/local/fileApply.ts
+++ b/examples/github/src/github/local/fileApply.ts
@@ -1,0 +1,17 @@
+export type FileEnvironment = 'android' | 'linux';
+
+export async function applyLocalReplace(params: { path: string; old: string; new: string; environment?: FileEnvironment }): Promise<any> {
+    return Tools.Files.apply(params.path, 'replace', params.old, params.new, params.environment);
+}
+
+export async function applyLocalDelete(params: { path: string; old: string; environment?: FileEnvironment }): Promise<any> {
+    return Tools.Files.apply(params.path, 'delete', params.old, undefined, params.environment);
+}
+
+export async function overwriteLocalFile(params: { path: string; content: string; environment?: FileEnvironment }): Promise<any> {
+    const exists = await Tools.Files.exists(params.path, params.environment);
+    if (exists.exists) {
+        await Tools.Files.deleteFile(params.path, true, params.environment);
+    }
+    return Tools.Files.write(params.path, String(params.content ?? ''), false, params.environment);
+}

--- a/examples/github/src/github/local/terminal.ts
+++ b/examples/github/src/github/local/terminal.ts
@@ -1,0 +1,18 @@
+let terminalSessionId: string | null = null;
+
+export async function getTerminalSession(sessionName?: string): Promise<string> {
+    if (terminalSessionId) return terminalSessionId;
+    const session = await Tools.System.terminal.create(sessionName || 'github_tools_session');
+    terminalSessionId = session.sessionId;
+    return terminalSessionId;
+}
+
+export async function terminalExec(params: { command: string; session_name?: string; close?: boolean }): Promise<any> {
+    const sessionId = await getTerminalSession(params.session_name);
+    const result = await Tools.System.terminal.exec(sessionId, params.command);
+    if (params.close) {
+        await Tools.System.terminal.close(sessionId);
+        terminalSessionId = null;
+    }
+    return result;
+}

--- a/examples/github/src/github/milestones.ts
+++ b/examples/github/src/github/milestones.ts
@@ -1,0 +1,101 @@
+import { buildUrl, repoPath, requestJson, requireToken } from './api';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+function compactMilestone(item: any) {
+    if (!item) return item;
+    return {
+        id: item.id,
+        number: item.number,
+        title: item.title,
+        description: item.description,
+        state: item.state,
+        html_url: item.html_url,
+        open_issues: item.open_issues,
+        closed_issues: item.closed_issues,
+        due_on: item.due_on,
+        created_at: item.created_at,
+        updated_at: item.updated_at,
+        closed_at: item.closed_at,
+        creator: item.creator?.login
+    };
+}
+
+export async function listMilestones(
+    params: RepoIdParams & { state?: string; sort?: string; direction?: string; page?: number; per_page?: number }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/milestones'), {
+        state: params.state ?? 'open',
+        sort: params.sort,
+        direction: params.direction,
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items) ? items.map(compactMilestone) : [];
+}
+
+export async function getMilestone(params: RepoIdParams & { milestone_number: number | string }): Promise<any> {
+    const url = buildUrl(
+        repoPath(params.owner, params.repo, `/milestones/${encodeURIComponent(String(params.milestone_number))}`)
+    );
+    return compactMilestone(await requestJson<any>({ method: 'GET', url }));
+}
+
+export async function createMilestone(
+    params: RepoIdParams & { title: string; state?: string; description?: string; due_on?: string }
+): Promise<any> {
+    requireToken('create_milestone');
+    const url = buildUrl(repoPath(params.owner, params.repo, '/milestones'));
+    return compactMilestone(
+        await requestJson<any>({
+            method: 'POST',
+            url,
+            body: {
+                title: params.title,
+                state: params.state,
+                description: params.description,
+                due_on: params.due_on
+            }
+        })
+    );
+}
+
+export async function updateMilestone(
+    params: RepoIdParams & {
+        milestone_number: number | string;
+        title?: string;
+        state?: string;
+        description?: string;
+        due_on?: string;
+    }
+): Promise<any> {
+    requireToken('update_milestone');
+    const url = buildUrl(
+        repoPath(params.owner, params.repo, `/milestones/${encodeURIComponent(String(params.milestone_number))}`)
+    );
+    return compactMilestone(
+        await requestJson<any>({
+            method: 'PATCH',
+            url,
+            body: {
+                title: params.title,
+                state: params.state,
+                description: params.description,
+                due_on: params.due_on
+            }
+        })
+    );
+}
+
+export async function deleteMilestone(params: RepoIdParams & { milestone_number: number | string }): Promise<any> {
+    requireToken('delete_milestone');
+    const url = buildUrl(
+        repoPath(params.owner, params.repo, `/milestones/${encodeURIComponent(String(params.milestone_number))}`)
+    );
+    const result = await requestJson<any>({ method: 'DELETE', url });
+    return { ok: true, milestone_number: params.milestone_number, result };
+}

--- a/examples/github/src/github/protection.ts
+++ b/examples/github/src/github/protection.ts
@@ -1,0 +1,74 @@
+import { buildUrl, encodeRef, parseJsonParam, repoPath, requestJson, requireToken } from './api';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+function compactProtection(item: any) {
+    if (!item) return item;
+    return {
+        url: item.url,
+        required_status_checks: item.required_status_checks
+            ? {
+                  strict: item.required_status_checks.strict,
+                  contexts: item.required_status_checks.contexts,
+                  checks: item.required_status_checks.checks
+              }
+            : item.required_status_checks,
+        enforce_admins: item.enforce_admins?.enabled ?? item.enforce_admins,
+        required_pull_request_reviews: item.required_pull_request_reviews
+            ? {
+                  dismiss_stale_reviews: item.required_pull_request_reviews.dismiss_stale_reviews,
+                  require_code_owner_reviews: item.required_pull_request_reviews.require_code_owner_reviews,
+                  required_approving_review_count: item.required_pull_request_reviews.required_approving_review_count,
+                  require_last_push_approval: item.required_pull_request_reviews.require_last_push_approval
+              }
+            : item.required_pull_request_reviews,
+        restrictions: item.restrictions
+            ? {
+                  users: Array.isArray(item.restrictions.users) ? item.restrictions.users.map((u: any) => u.login || u) : [],
+                  teams: Array.isArray(item.restrictions.teams) ? item.restrictions.teams.map((t: any) => t.slug || t.name || t) : [],
+                  apps: Array.isArray(item.restrictions.apps) ? item.restrictions.apps.map((a: any) => a.slug || a.name || a) : []
+              }
+            : item.restrictions,
+        required_linear_history: item.required_linear_history?.enabled ?? item.required_linear_history,
+        allow_force_pushes: item.allow_force_pushes?.enabled ?? item.allow_force_pushes,
+        allow_deletions: item.allow_deletions?.enabled ?? item.allow_deletions,
+        block_creations: item.block_creations?.enabled ?? item.block_creations,
+        required_conversation_resolution: item.required_conversation_resolution?.enabled ?? item.required_conversation_resolution,
+        lock_branch: item.lock_branch?.enabled ?? item.lock_branch,
+        allow_fork_syncing: item.allow_fork_syncing?.enabled ?? item.allow_fork_syncing
+    };
+}
+
+export async function getBranchProtection(params: RepoIdParams & { branch: string }): Promise<any> {
+    requireToken('get_branch_protection');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/branches/${encodeRef(params.branch)}/protection`));
+    return compactProtection(await requestJson<any>({ method: 'GET', url }));
+}
+
+export async function updateBranchProtection(
+    params: RepoIdParams & { branch: string; protection: any }
+): Promise<any> {
+    requireToken('update_branch_protection');
+    const protection = parseJsonParam<Record<string, any>>(params.protection, 'protection');
+    if (!protection || typeof protection !== 'object') {
+        throw new Error('protection must be a JSON object matching PUT /branches/{branch}/protection');
+    }
+    const url = buildUrl(repoPath(params.owner, params.repo, `/branches/${encodeRef(params.branch)}/protection`));
+    return compactProtection(
+        await requestJson<any>({
+            method: 'PUT',
+            url,
+            body: protection
+        })
+    );
+}
+
+export async function deleteBranchProtection(params: RepoIdParams & { branch: string }): Promise<any> {
+    requireToken('delete_branch_protection');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/branches/${encodeRef(params.branch)}/protection`));
+    const result = await requestJson<any>({ method: 'DELETE', url });
+    return { ok: true, branch: params.branch, result };
+}

--- a/examples/github/src/github/pulls.ts
+++ b/examples/github/src/github/pulls.ts
@@ -1,4 +1,4 @@
-import { buildUrl, requestJson, getToken } from './api';
+import { buildUrl, compactCommit, compactFileChange, parseJsonParam, repoPath, requestJson, requestText, requireToken, splitCsv, truncateText } from './api';
 
 export type RepoIdParams = {
     owner: string;
@@ -32,56 +32,64 @@ export type MergePullRequestParams = RepoIdParams & {
     merge_method?: 'merge' | 'squash' | 'rebase' | string;
 };
 
-export async function listPullRequests(params: ListPullRequestsParams): Promise<any[]> {
-    const page = params.page ?? 1;
-    const perPage = params.per_page ?? 30;
+function compactPull(pr: any) {
+    if (!pr) return pr;
+    return {
+        number: pr.number,
+        title: pr.title,
+        state: pr.state,
+        draft: pr.draft,
+        merged: pr.merged,
+        mergeable: pr.mergeable,
+        html_url: pr.html_url,
+        user: pr.user?.login,
+        head: pr.head?.label || pr.head?.ref,
+        head_sha: pr.head?.sha,
+        base: pr.base?.label || pr.base?.ref,
+        body: pr.body,
+        created_at: pr.created_at,
+        updated_at: pr.updated_at
+    };
+}
 
-    const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls`, {
+export async function listPullRequests(params: ListPullRequestsParams): Promise<any[]> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/pulls'), {
         state: params.state ?? 'open',
         head: params.head,
         base: params.base,
-        page,
-        per_page: perPage
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
     });
-
-    return requestJson<any[]>({ method: 'GET', url });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items) ? items.map(compactPull) : [];
 }
 
 export async function createPullRequest(params: CreatePullRequestParams): Promise<any> {
-    const token = getToken();
-    if (!token) {
-        throw new Error('GITHUB_TOKEN is required for create_pull_request.');
-    }
-
-    const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls`);
-    return requestJson<any>({
-        method: 'POST',
-        url,
-        body: {
-            title: params.title,
-            head: params.head,
-            base: params.base,
-            body: params.body,
-            draft: params.draft
-        }
-    });
+    requireToken('create_pull_request');
+    const url = buildUrl(repoPath(params.owner, params.repo, '/pulls'));
+    return compactPull(
+        await requestJson<any>({
+            method: 'POST',
+            url,
+            body: {
+                title: params.title,
+                head: params.head,
+                base: params.base,
+                body: params.body,
+                draft: params.draft
+            }
+        })
+    );
 }
 
 export async function getPullRequest(params: GetPullRequestParams): Promise<any> {
-    const url = buildUrl(`/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls/${params.pull_number}`);
-    return requestJson<any>({ method: 'GET', url });
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}`));
+    return compactPull(await requestJson<any>({ method: 'GET', url }));
 }
 
 export async function mergePullRequest(params: MergePullRequestParams): Promise<any> {
-    const token = getToken();
-    if (!token) {
-        throw new Error('GITHUB_TOKEN is required for merge_pull_request.');
-    }
-
-    const url = buildUrl(
-        `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.repo)}/pulls/${params.pull_number}/merge`
-    );
-
+    requireToken('merge_pull_request');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/merge`));
     return requestJson<any>({
         method: 'PUT',
         url,
@@ -91,4 +99,191 @@ export async function mergePullRequest(params: MergePullRequestParams): Promise<
             merge_method: params.merge_method
         }
     });
+}
+
+export async function updatePullRequest(
+    params: RepoIdParams & {
+        pull_number: number;
+        title?: string;
+        body?: string;
+        state?: string;
+        base?: string;
+        draft?: boolean;
+    }
+): Promise<any> {
+    requireToken('update_pull_request');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}`));
+    return compactPull(
+        await requestJson<any>({
+            method: 'PATCH',
+            url,
+            body: {
+                title: params.title,
+                body: params.body,
+                state: params.state,
+                base: params.base,
+                draft: params.draft
+            }
+        })
+    );
+}
+
+export async function listPullRequestFiles(
+    params: RepoIdParams & { pull_number: number; include_patch?: boolean; page?: number; per_page?: number }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/files`), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 100
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items) ? items.map((file) => compactFileChange(file, params.include_patch === true)) : [];
+}
+
+export async function getPullRequestDiff(
+    params: RepoIdParams & { pull_number: number; max_chars?: number }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}`));
+    const resp = await requestText({
+        method: 'GET',
+        url,
+        headers: { Accept: 'application/vnd.github.diff' },
+        timeoutMs: 60000
+    });
+    const truncated = truncateText(resp.text, params.max_chars ?? 20000);
+    return {
+        pull_number: params.pull_number,
+        diff: truncated.text,
+        truncated: truncated.truncated,
+        original_length: truncated.original_length
+    };
+}
+
+export async function listPullRequestCommits(
+    params: RepoIdParams & { pull_number: number; page?: number; per_page?: number }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/commits`), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items) ? items.map(compactCommit) : [];
+}
+
+export async function listPullRequestReviews(
+    params: RepoIdParams & { pull_number: number; page?: number; per_page?: number }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/reviews`), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items)
+        ? items.map((item) => ({
+              id: item.id,
+              user: item.user?.login,
+              state: item.state,
+              body: item.body,
+              submitted_at: item.submitted_at,
+              html_url: item.html_url,
+              commit_id: item.commit_id
+          }))
+        : [];
+}
+
+export async function listReviewComments(
+    params: RepoIdParams & { pull_number: number; page?: number; per_page?: number }
+): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/comments`), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items)
+        ? items.map((item) => ({
+              id: item.id,
+              user: item.user?.login,
+              path: item.path,
+              line: item.line,
+              original_line: item.original_line,
+              side: item.side,
+              body: item.body,
+              html_url: item.html_url,
+              in_reply_to_id: item.in_reply_to_id,
+              created_at: item.created_at,
+              updated_at: item.updated_at
+          }))
+        : [];
+}
+
+export async function createReview(
+    params: RepoIdParams & {
+        pull_number: number;
+        body?: string;
+        event?: string;
+        commit_id?: string;
+        comments?: any;
+    }
+): Promise<any> {
+    requireToken('create_review');
+    const comments = parseJsonParam<any[]>(params.comments, 'comments');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/reviews`));
+    const data = await requestJson<any>({
+        method: 'POST',
+        url,
+        body: {
+            body: params.body,
+            event: params.event,
+            commit_id: params.commit_id,
+            comments
+        }
+    });
+    return {
+        id: data.id,
+        state: data.state,
+        body: data.body,
+        html_url: data.html_url,
+        user: data.user?.login
+    };
+}
+
+export async function replyReviewComment(
+    params: RepoIdParams & { pull_number: number; comment_id: number; body: string }
+): Promise<any> {
+    requireToken('reply_review_comment');
+    const url = buildUrl(
+        repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/comments/${params.comment_id}/replies`)
+    );
+    const data = await requestJson<any>({
+        method: 'POST',
+        url,
+        body: { body: params.body }
+    });
+    return {
+        id: data.id,
+        body: data.body,
+        html_url: data.html_url,
+        in_reply_to_id: data.in_reply_to_id,
+        user: data.user?.login
+    };
+}
+
+export async function requestReviewers(
+    params: RepoIdParams & { pull_number: number; reviewers?: string | string[]; team_reviewers?: string | string[] }
+): Promise<any> {
+    requireToken('request_reviewers');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/pulls/${params.pull_number}/requested_reviewers`));
+    const data = await requestJson<any>({
+        method: 'POST',
+        url,
+        body: {
+            reviewers: splitCsv(params.reviewers),
+            team_reviewers: splitCsv(params.team_reviewers)
+        }
+    });
+    return {
+        number: data.number,
+        html_url: data.html_url,
+        requested_reviewers: Array.isArray(data.requested_reviewers) ? data.requested_reviewers.map((it: any) => it.login) : [],
+        requested_teams: Array.isArray(data.requested_teams) ? data.requested_teams.map((it: any) => it.slug || it.name) : []
+    };
 }

--- a/examples/github/src/github/releases.ts
+++ b/examples/github/src/github/releases.ts
@@ -1,0 +1,241 @@
+import { buildUrl, getUploadsBaseUrl, parseBool, repoPath, requestJson, requireToken, shellQuote } from './api';
+import { getTerminalSession } from './local/terminal';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+function compactAsset(item: any) {
+    if (!item) return item;
+    return {
+        id: item.id,
+        name: item.name,
+        label: item.label,
+        size: item.size,
+        content_type: item.content_type,
+        state: item.state,
+        download_count: item.download_count,
+        browser_download_url: item.browser_download_url,
+        created_at: item.created_at,
+        updated_at: item.updated_at,
+        uploader: item.uploader?.login
+    };
+}
+
+function compactRelease(item: any) {
+    if (!item) return item;
+    return {
+        id: item.id,
+        tag_name: item.tag_name,
+        name: item.name,
+        draft: item.draft,
+        prerelease: item.prerelease,
+        html_url: item.html_url,
+        tarball_url: item.tarball_url,
+        zipball_url: item.zipball_url,
+        target_commitish: item.target_commitish,
+        body: item.body,
+        created_at: item.created_at,
+        published_at: item.published_at,
+        author: item.author?.login,
+        assets: Array.isArray(item.assets) ? item.assets.map(compactAsset) : []
+    };
+}
+
+export async function listReleases(params: RepoIdParams & { page?: number; per_page?: number }): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/releases'), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items) ? items.map(compactRelease) : [];
+}
+
+export async function getRelease(params: RepoIdParams & { release_id: number | string }): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/releases/${encodeURIComponent(String(params.release_id))}`));
+    return compactRelease(await requestJson<any>({ method: 'GET', url }));
+}
+
+export async function getLatestRelease(params: RepoIdParams): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/releases/latest'));
+    return compactRelease(await requestJson<any>({ method: 'GET', url }));
+}
+
+export async function getReleaseByTag(params: RepoIdParams & { tag: string }): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, `/releases/tags/${encodeURIComponent(params.tag)}`));
+    return compactRelease(await requestJson<any>({ method: 'GET', url }));
+}
+
+export async function createRelease(
+    params: RepoIdParams & {
+        tag_name: string;
+        target_commitish?: string;
+        name?: string;
+        body?: string;
+        draft?: boolean | string;
+        prerelease?: boolean | string;
+        generate_release_notes?: boolean | string;
+        make_latest?: string;
+        discussion_category_name?: string;
+    }
+): Promise<any> {
+    requireToken('create_release');
+    const url = buildUrl(repoPath(params.owner, params.repo, '/releases'));
+    return compactRelease(
+        await requestJson<any>({
+            method: 'POST',
+            url,
+            body: {
+                tag_name: params.tag_name,
+                target_commitish: params.target_commitish,
+                name: params.name,
+                body: params.body,
+                draft: parseBool(params.draft),
+                prerelease: parseBool(params.prerelease),
+                generate_release_notes: parseBool(params.generate_release_notes),
+                make_latest: params.make_latest,
+                discussion_category_name: params.discussion_category_name
+            }
+        })
+    );
+}
+
+export async function updateRelease(
+    params: RepoIdParams & {
+        release_id: number | string;
+        tag_name?: string;
+        target_commitish?: string;
+        name?: string;
+        body?: string;
+        draft?: boolean | string;
+        prerelease?: boolean | string;
+        make_latest?: string;
+        discussion_category_name?: string;
+    }
+): Promise<any> {
+    requireToken('update_release');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/releases/${encodeURIComponent(String(params.release_id))}`));
+    return compactRelease(
+        await requestJson<any>({
+            method: 'PATCH',
+            url,
+            body: {
+                tag_name: params.tag_name,
+                target_commitish: params.target_commitish,
+                name: params.name,
+                body: params.body,
+                draft: parseBool(params.draft),
+                prerelease: parseBool(params.prerelease),
+                make_latest: params.make_latest,
+                discussion_category_name: params.discussion_category_name
+            }
+        })
+    );
+}
+
+export async function deleteRelease(params: RepoIdParams & { release_id: number | string }): Promise<any> {
+    requireToken('delete_release');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/releases/${encodeURIComponent(String(params.release_id))}`));
+    const result = await requestJson<any>({ method: 'DELETE', url });
+    return { ok: true, release_id: params.release_id, result };
+}
+
+function guessFileName(path: string): string {
+    const parts = String(path || '').replace(/\\/g, '/').split('/');
+    return parts.filter(Boolean).pop() || 'asset.bin';
+}
+
+export async function uploadReleaseAsset(
+    params: RepoIdParams & {
+        release_id: number | string;
+        asset_path: string;
+        name?: string;
+        label?: string;
+        content_type?: string;
+        environment?: 'android' | 'linux' | string;
+    }
+): Promise<any> {
+    const token = requireToken('upload_release_asset');
+    const name = params.name || guessFileName(params.asset_path);
+    const contentType = params.content_type || 'application/octet-stream';
+    const environment = (params.environment || 'android') as 'android' | 'linux';
+    const sourcePath = String(params.asset_path || '').trim();
+    if (!sourcePath) {
+        throw new Error('asset_path is required');
+    }
+
+    const exists = await Tools.Files.exists(sourcePath, environment);
+    if (!exists.exists) {
+        throw new Error(`Asset file not found: ${sourcePath}`);
+    }
+
+    let linuxPath = sourcePath;
+    if (environment !== 'linux') {
+        linuxPath = `/tmp/operit-github-asset-${Date.now()}-${name}`;
+        await Tools.Files.copy(sourcePath, linuxPath, false, environment, 'linux');
+    }
+
+    const uploadsPath = repoPath(
+        params.owner,
+        params.repo,
+        `/releases/${encodeURIComponent(String(params.release_id))}/assets`
+    );
+    const qs: string[] = [`name=${encodeURIComponent(name)}`];
+    if (params.label) qs.push(`label=${encodeURIComponent(params.label)}`);
+    const finalUrl = `${getUploadsBaseUrl()}${uploadsPath}?${qs.join('&')}`;
+
+    const headerFile = `/tmp/operit-github-upload-headers-${Date.now()}`;
+    await Tools.Files.write(
+        headerFile,
+        [
+            'header = "Accept: application/vnd.github+json"',
+            `header = "Authorization: Bearer ${token}"`,
+            'header = "X-GitHub-Api-Version: 2022-11-28"',
+            `header = "Content-Type: ${contentType}"`,
+            ''
+        ].join('\n'),
+        false,
+        'linux'
+    );
+
+    const command = [
+        'curl', '-sS', '-X', 'POST',
+        '-K', shellQuote(headerFile),
+        '--data-binary', '@' + shellQuote(linuxPath),
+        '-w', shellQuote('\nHTTP_STATUS:%{http_code}'),
+        shellQuote(finalUrl)
+    ].join(' ');
+
+    const sessionId = await getTerminalSession('github_tools_session');
+    let result: any;
+    try {
+        result = await Tools.System.terminal.exec(sessionId, command, 120000);
+    } finally {
+        try {
+            await Tools.Files.deleteFile(headerFile, false, 'linux');
+        } catch (e) {
+            // ignore cleanup errors
+        }
+    }
+    const output = String(result.output || '');
+    const statusMatch = output.match(/HTTP_STATUS:(\d+)\s*$/);
+    const statusCode = statusMatch ? Number(statusMatch[1]) : result.exitCode === 0 ? 200 : 500;
+    const bodyText = statusMatch ? output.slice(0, statusMatch.index).trim() : output.trim();
+
+    if (statusCode < 200 || statusCode >= 300) {
+        throw new Error(`GitHub API Error: ${statusCode}\n${bodyText.slice(0, 800)}`);
+    }
+    try {
+        return compactAsset(JSON.parse(bodyText));
+    } catch (e) {
+        throw new Error(`Failed to parse upload response: ${bodyText.slice(0, 500)}`);
+    }
+}
+
+export async function deleteReleaseAsset(params: RepoIdParams & { asset_id: number | string }): Promise<any> {
+    requireToken('delete_release_asset');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/releases/assets/${encodeURIComponent(String(params.asset_id))}`));
+    const result = await requestJson<any>({ method: 'DELETE', url });
+    return { ok: true, asset_id: params.asset_id, result };
+}

--- a/examples/github/src/github/search.ts
+++ b/examples/github/src/github/search.ts
@@ -1,0 +1,76 @@
+import { buildUrl, requestJson } from './api';
+
+export async function searchCode(params: {
+    query: string;
+    sort?: string;
+    order?: string;
+    page?: number;
+    per_page?: number;
+}): Promise<any> {
+    const url = buildUrl('/search/code', {
+        q: params.query,
+        sort: params.sort,
+        order: params.order,
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 20
+    });
+    const data = await requestJson<any>({
+        method: 'GET',
+        url,
+        headers: { Accept: 'application/vnd.github.text-match+json' }
+    });
+    return {
+        total_count: data?.total_count,
+        incomplete_results: data?.incomplete_results,
+        items: Array.isArray(data?.items)
+            ? data.items.map((item: any) => ({
+                  name: item.name,
+                  path: item.path,
+                  sha: item.sha,
+                  html_url: item.html_url,
+                  repository: item.repository?.full_name,
+                  score: item.score,
+                  text_matches: Array.isArray(item.text_matches)
+                      ? item.text_matches.map((match: any) => ({
+                            fragment: match.fragment,
+                            property: match.property
+                        }))
+                      : []
+              }))
+            : []
+    };
+}
+
+export async function searchIssues(params: {
+    query: string;
+    sort?: string;
+    order?: string;
+    page?: number;
+    per_page?: number;
+}): Promise<any> {
+    const url = buildUrl('/search/issues', {
+        q: params.query,
+        sort: params.sort,
+        order: params.order,
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 20
+    });
+    const data = await requestJson<any>({ method: 'GET', url });
+    return {
+        total_count: data?.total_count,
+        incomplete_results: data?.incomplete_results,
+        items: Array.isArray(data?.items)
+            ? data.items.map((item: any) => ({
+                  number: item.number,
+                  title: item.title,
+                  state: item.state,
+                  html_url: item.html_url,
+                  repository: item.repository_url,
+                  user: item.user?.login,
+                  comments: item.comments,
+                  pull_request: Boolean(item.pull_request),
+                  updated_at: item.updated_at
+              }))
+            : []
+    };
+}

--- a/examples/github/src/github/stats.ts
+++ b/examples/github/src/github/stats.ts
@@ -1,0 +1,65 @@
+import { buildUrl, repoPath, requestRaw } from './api';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+async function requestStats(url: string, kind: string): Promise<any> {
+    const resp = await requestRaw({ method: 'GET', url });
+    if (resp.statusCode === 202) {
+        return {
+            status: 'computing',
+            retry: true,
+            kind,
+            statusCode: 202,
+            message: 'GitHub is computing repository statistics. Retry shortly.'
+        };
+    }
+    if (resp.statusCode === 204) {
+        return {
+            status: 'empty',
+            kind,
+            statusCode: 204,
+            data: []
+        };
+    }
+    const text = String(resp.content || '').trim();
+    if (!text) {
+        return { status: 'empty', kind, statusCode: resp.statusCode, data: [] };
+    }
+    try {
+        return {
+            status: 'ready',
+            kind,
+            statusCode: resp.statusCode,
+            data: JSON.parse(text)
+        };
+    } catch (e) {
+        throw new Error(`Failed to parse GitHub stats JSON (${resp.statusCode}): ${text.slice(0, 500)}`);
+    }
+}
+
+export async function getContributorsStats(params: RepoIdParams): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/stats/contributors'));
+    const result = await requestStats(url, 'contributors');
+    if (result.status !== 'ready' || !Array.isArray(result.data)) return result;
+    return {
+        ...result,
+        data: result.data.map((item: any) => ({
+            author: item.author?.login,
+            total: item.total,
+            weeks: item.weeks
+        }))
+    };
+}
+
+export async function getCommitActivity(params: RepoIdParams): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/stats/commit_activity'));
+    return requestStats(url, 'commit_activity');
+}
+
+export async function getCodeFrequency(params: RepoIdParams): Promise<any> {
+    const url = buildUrl(repoPath(params.owner, params.repo, '/stats/code_frequency'));
+    return requestStats(url, 'code_frequency');
+}

--- a/examples/github/src/github/users.ts
+++ b/examples/github/src/github/users.ts
@@ -1,0 +1,43 @@
+import { buildUrl, requestJson } from './api';
+
+export async function getAuthenticatedUser(): Promise<any> {
+    const data = await requestJson<any>({ method: 'GET', url: buildUrl('/user') });
+    return {
+        login: data.login,
+        id: data.id,
+        name: data.name,
+        html_url: data.html_url,
+        type: data.type,
+        company: data.company,
+        public_repos: data.public_repos,
+        total_private_repos: data.total_private_repos,
+        plan: data.plan?.name
+    };
+}
+
+export async function getRateLimit(): Promise<any> {
+    const data = await requestJson<any>({ method: 'GET', url: buildUrl('/rate_limit') });
+    const core = data?.resources?.core || {};
+    const search = data?.resources?.search || {};
+    const graphql = data?.resources?.graphql || {};
+    return {
+        core: {
+            limit: core.limit,
+            remaining: core.remaining,
+            reset: core.reset,
+            used: core.used
+        },
+        search: {
+            limit: search.limit,
+            remaining: search.remaining,
+            reset: search.reset,
+            used: search.used
+        },
+        graphql: {
+            limit: graphql.limit,
+            remaining: graphql.remaining,
+            reset: graphql.reset,
+            used: graphql.used
+        }
+    };
+}

--- a/examples/github/src/github/webhooks.ts
+++ b/examples/github/src/github/webhooks.ts
@@ -1,0 +1,130 @@
+import { buildUrl, parseBool, parseJsonParam, repoPath, requestJson, requireToken, splitCsv } from './api';
+
+export type RepoIdParams = {
+    owner: string;
+    repo: string;
+};
+
+function compactWebhook(item: any) {
+    if (!item) return item;
+    const config = item.config || {};
+    return {
+        id: item.id,
+        name: item.name,
+        active: item.active,
+        events: item.events,
+        config: {
+            url: config.url,
+            content_type: config.content_type,
+            insecure_ssl: config.insecure_ssl
+        },
+        created_at: item.created_at,
+        updated_at: item.updated_at,
+        ping_url: item.ping_url,
+        test_url: item.test_url,
+        last_response: item.last_response
+    };
+}
+
+export async function listWebhooks(params: RepoIdParams & { page?: number; per_page?: number }): Promise<any> {
+    requireToken('list_webhooks');
+    const url = buildUrl(repoPath(params.owner, params.repo, '/hooks'), {
+        page: params.page ?? 1,
+        per_page: params.per_page ?? 30
+    });
+    const items = await requestJson<any[]>({ method: 'GET', url });
+    return Array.isArray(items) ? items.map(compactWebhook) : [];
+}
+
+export async function getWebhook(params: RepoIdParams & { hook_id: number | string }): Promise<any> {
+    requireToken('get_webhook');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}`));
+    return compactWebhook(await requestJson<any>({ method: 'GET', url }));
+}
+
+export async function createWebhook(
+    params: RepoIdParams & {
+        url: string;
+        content_type?: string;
+        secret?: string;
+        insecure_ssl?: boolean | string;
+        events?: string | string[];
+        active?: boolean | string;
+        config?: any;
+    }
+): Promise<any> {
+    requireToken('create_webhook');
+    const parsedConfig = parseJsonParam<Record<string, any>>(params.config, 'config') || {};
+    const insecure = parseBool(params.insecure_ssl);
+    const url = buildUrl(repoPath(params.owner, params.repo, '/hooks'));
+    return compactWebhook(
+        await requestJson<any>({
+            method: 'POST',
+            url,
+            body: {
+                name: 'web',
+                active: parseBool(params.active),
+                events: splitCsv(params.events),
+                config: {
+                    url: params.url || parsedConfig.url,
+                    content_type: params.content_type || parsedConfig.content_type || 'json',
+                    secret: params.secret || parsedConfig.secret,
+                    insecure_ssl: insecure === undefined ? parsedConfig.insecure_ssl : insecure ? '1' : '0'
+                }
+            }
+        })
+    );
+}
+
+export async function updateWebhook(
+    params: RepoIdParams & {
+        hook_id: number | string;
+        url?: string;
+        content_type?: string;
+        secret?: string;
+        insecure_ssl?: boolean | string;
+        events?: string | string[];
+        add_events?: string | string[];
+        remove_events?: string | string[];
+        active?: boolean | string;
+        config?: any;
+    }
+): Promise<any> {
+    requireToken('update_webhook');
+    const parsedConfig = parseJsonParam<Record<string, any>>(params.config, 'config') || {};
+    const insecure = parseBool(params.insecure_ssl);
+    const config: Record<string, any> = { ...parsedConfig };
+    if (params.url) config.url = params.url;
+    if (params.content_type) config.content_type = params.content_type;
+    if (params.secret) config.secret = params.secret;
+    if (insecure !== undefined) config.insecure_ssl = insecure ? '1' : '0';
+
+    const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}`));
+    return compactWebhook(
+        await requestJson<any>({
+            method: 'PATCH',
+            url,
+            body: {
+                active: parseBool(params.active),
+                events: splitCsv(params.events),
+                add_events: splitCsv(params.add_events),
+                remove_events: splitCsv(params.remove_events),
+                config: Object.keys(config).length > 0 ? config : undefined
+            }
+        })
+    );
+}
+
+export async function deleteWebhook(params: RepoIdParams & { hook_id: number | string }): Promise<any> {
+    requireToken('delete_webhook');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}`));
+    const result = await requestJson<any>({ method: 'DELETE', url });
+    return { ok: true, hook_id: params.hook_id, result };
+}
+
+export async function pingWebhook(params: RepoIdParams & { hook_id: number | string }): Promise<any> {
+    requireToken('ping_webhook');
+    const url = buildUrl(repoPath(params.owner, params.repo, `/hooks/${encodeURIComponent(String(params.hook_id))}/pings`));
+    const result = await requestJson<any>({ method: 'POST', url });
+    return { ok: true, hook_id: params.hook_id, result };
+}

--- a/examples/github/src/index.ts
+++ b/examples/github/src/index.ts
@@ -1,12 +1,11 @@
 /* METADATA
 {
   "name": "github",
-
   "display_name": {
       "zh": "GitHub API",
       "en": "GitHub API"
   },
-  "description": { "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异提交）与本地侧（apply_file 差异更新、terminal 终端）能力。", "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs) and local-side utilities (apply_file patch updates, terminal)." },
+  "description": { "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。", "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)." },
   "category": "Development",
   "env": [
     {
@@ -24,538 +23,2733 @@
   "enabledByDefault": false,
   "tools": [
     {
-      "name": "search_repositories",
-      "description": { "zh": "搜索 GitHub 仓库（/search/repositories）。", "en": "Search GitHub repositories (/search/repositories)." },
-      "parameters": [
-        { "name": "query", "description": { "zh": "搜索关键词（GitHub search query）", "en": "Search keywords (GitHub search query)." }, "type": "string", "required": true },
-        { "name": "sort", "description": { "zh": "排序字段：stars/forks/help-wanted-issues/updated", "en": "Sort field: stars/forks/help-wanted-issues/updated." }, "type": "string", "required": false },
-        { "name": "order", "description": { "zh": "排序方向：desc/asc", "en": "Sort order: desc/asc." }, "type": "string", "required": false },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false }
-      ]
+        "name": "search_repositories",
+        "description": {
+            "zh": "搜索 GitHub 仓库（/search/repositories）。",
+            "en": "Search GitHub repositories (/search/repositories)."
+        },
+        "parameters": [
+            {
+                "name": "query",
+                "description": {
+                    "zh": "搜索关键词（GitHub search query）",
+                    "en": "Search keywords (GitHub search query)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sort",
+                "description": {
+                    "zh": "排序字段：stars/forks/help-wanted-issues/updated",
+                    "en": "Sort field: stars/forks/help-wanted-issues/updated."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "order",
+                "description": {
+                    "zh": "排序方向：desc/asc",
+                    "en": "Sort order: desc/asc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30，最大 100）",
+                    "en": "Items per page (default: 30, max: 100)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "get_repository",
-      "description": { "zh": "获取仓库信息（/repos/{owner}/{repo}）。", "en": "Get repository information (/repos/{owner}/{repo})." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true }
-      ]
+        "name": "get_repository",
+        "description": {
+            "zh": "获取仓库信息（/repos/{owner}/{repo}）。",
+            "en": "Get repository information (/repos/{owner}/{repo})."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "list_issues",
-      "description": { "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。注意：GitHub 的 issues API 默认也会包含 PR，需要时可用 include_pull_requests 控制。", "en": "List repository issues (/repos/{owner}/{repo}/issues). Note: GitHub issues API also includes PRs by default; use include_pull_requests when needed." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "state", "description": { "zh": "open/closed/all（默认 open）", "en": "open/closed/all (default: open)." }, "type": "string", "required": false },
-        { "name": "labels", "description": { "zh": "labels 逗号分隔", "en": "Labels, comma-separated." }, "type": "string", "required": false },
-        { "name": "creator", "description": { "zh": "创建者 login", "en": "Creator login." }, "type": "string", "required": false },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false },
-        { "name": "include_pull_requests", "description": { "zh": "是否保留 PR（默认 false，仅返回 issue）", "en": "Whether to include PRs (default: false; issues only)." }, "type": "boolean", "required": false }
-      ]
+        "name": "list_issues",
+        "description": {
+            "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。",
+            "en": "List repository issues (/repos/{owner}/{repo}/issues)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed/all（默认 open）",
+                    "en": "open/closed/all (default: open)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "labels",
+                "description": {
+                    "zh": "labels 逗号分隔",
+                    "en": "Labels, comma-separated."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "creator",
+                "description": {
+                    "zh": "创建者 login",
+                    "en": "Creator login."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "include_pull_requests",
+                "description": {
+                    "zh": "是否保留 PR（默认 false）",
+                    "en": "Whether to include PRs (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "create_issue",
-      "description": { "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。", "en": "Create an issue (/repos/{owner}/{repo}/issues)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "title", "description": { "zh": "Issue 标题", "en": "Issue title." }, "type": "string", "required": true },
-        { "name": "body", "description": { "zh": "Issue 内容", "en": "Issue body." }, "type": "string", "required": false },
-        { "name": "labels", "description": { "zh": "labels 数组（字符串数组）", "en": "Labels array (string array)." }, "type": "array", "required": false },
-        { "name": "assignees", "description": { "zh": "assignees 数组（字符串数组）", "en": "Assignees array (string array)." }, "type": "array", "required": false }
-      ]
+        "name": "get_issue",
+        "description": {
+            "zh": "获取单个 Issue 详情（/repos/{owner}/{repo}/issues/{issue_number}）。",
+            "en": "Get a single issue."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "comment_issue",
-      "description": { "zh": "给 Issue/PR 评论（/repos/{owner}/{repo}/issues/{issue_number}/comments）。", "en": "Comment on an issue/PR (/repos/{owner}/{repo}/issues/{issue_number}/comments)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "issue_number", "description": { "zh": "Issue 编号", "en": "Issue number." }, "type": "number", "required": true },
-        { "name": "body", "description": { "zh": "评论内容", "en": "Comment body." }, "type": "string", "required": true }
-      ]
+        "name": "create_issue",
+        "description": {
+            "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。",
+            "en": "Create an issue."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "Issue 标题",
+                    "en": "Issue title."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "Issue 内容",
+                    "en": "Issue body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "labels",
+                "description": {
+                    "zh": "labels 数组",
+                    "en": "Labels array."
+                },
+                "type": "array",
+                "required": false
+            },
+            {
+                "name": "assignees",
+                "description": {
+                    "zh": "assignees 数组",
+                    "en": "Assignees array."
+                },
+                "type": "array",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "list_issue_comments",
-      "description": { "zh": "列出 Issue/PR 的评论（/repos/{owner}/{repo}/issues/{issue_number}/comments）。", "en": "List comments on an issue/PR (/repos/{owner}/{repo}/issues/{issue_number}/comments)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "issue_number", "description": { "zh": "Issue 编号", "en": "Issue number." }, "type": "number", "required": true },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false }
-      ]
+        "name": "update_issue",
+        "description": {
+            "zh": "更新 Issue。",
+            "en": "Update an issue."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "新标题",
+                    "en": "New title."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "新内容",
+                    "en": "New body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed",
+                    "en": "open/closed."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "labels",
+                "description": {
+                    "zh": "labels 数组",
+                    "en": "Labels array."
+                },
+                "type": "array",
+                "required": false
+            },
+            {
+                "name": "assignees",
+                "description": {
+                    "zh": "assignees 数组",
+                    "en": "Assignees array."
+                },
+                "type": "array",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "list_pull_requests",
-      "description": { "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。", "en": "List pull requests (/repos/{owner}/{repo}/pulls)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "state", "description": { "zh": "open/closed/all（默认 open）", "en": "open/closed/all (default: open)." }, "type": "string", "required": false },
-        { "name": "head", "description": { "zh": "head 过滤（可选）", "en": "Head filter (optional)." }, "type": "string", "required": false },
-        { "name": "base", "description": { "zh": "base 过滤（可选）", "en": "Base filter (optional)." }, "type": "string", "required": false },
-        { "name": "page", "description": { "zh": "页码（默认 1）", "en": "Page number (default: 1)." }, "type": "number", "required": false },
-        { "name": "per_page", "description": { "zh": "每页数量（默认 30，最大 100）", "en": "Items per page (default: 30, max: 100)." }, "type": "number", "required": false }
-      ]
+        "name": "comment_issue",
+        "description": {
+            "zh": "给 Issue/PR 评论。",
+            "en": "Comment on an issue/PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "评论内容",
+                    "en": "Comment body."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "create_pull_request",
-      "description": { "zh": "创建 PR（/repos/{owner}/{repo}/pulls）。", "en": "Create a pull request (/repos/{owner}/{repo}/pulls)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "title", "description": { "zh": "PR 标题", "en": "PR title." }, "type": "string", "required": true },
-        { "name": "head", "description": { "zh": "源分支，例如 feature-branch 或 owner:branch", "en": "Head branch, e.g. feature-branch or owner:branch." }, "type": "string", "required": true },
-        { "name": "base", "description": { "zh": "目标分支，例如 main", "en": "Base branch, e.g. main." }, "type": "string", "required": true },
-        { "name": "body", "description": { "zh": "PR 内容", "en": "PR body." }, "type": "string", "required": false },
-        { "name": "draft", "description": { "zh": "是否为 Draft", "en": "Whether this is a draft PR." }, "type": "boolean", "required": false }
-      ]
+        "name": "list_issue_comments",
+        "description": {
+            "zh": "列出 Issue/PR 的评论。",
+            "en": "List comments on an issue/PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "issue_number",
+                "description": {
+                    "zh": "Issue 编号",
+                    "en": "Issue number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "get_pull_request",
-      "description": { "zh": "获取 PR 详情（/repos/{owner}/{repo}/pulls/{pull_number}）。", "en": "Get pull request details (/repos/{owner}/{repo}/pulls/{pull_number})." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "pull_number", "description": { "zh": "PR 编号", "en": "PR number." }, "type": "number", "required": true }
-      ]
+        "name": "list_pull_requests",
+        "description": {
+            "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。",
+            "en": "List pull requests."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed/all（默认 open）",
+                    "en": "open/closed/all (default: open)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head 分支过滤，格式 user:branch",
+                    "en": "Head branch filter (user:branch)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "base 分支过滤",
+                    "en": "Base branch filter."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "merge_pull_request",
-      "description": { "zh": "合并 PR（/repos/{owner}/{repo}/pulls/{pull_number}/merge）。", "en": "Merge a pull request (/repos/{owner}/{repo}/pulls/{pull_number}/merge)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "pull_number", "description": { "zh": "PR 编号", "en": "PR number." }, "type": "number", "required": true },
-        { "name": "commit_title", "description": { "zh": "可选，merge commit 标题", "en": "Optional: merge commit title." }, "type": "string", "required": false },
-        { "name": "commit_message", "description": { "zh": "可选，merge commit 内容", "en": "Optional: merge commit message." }, "type": "string", "required": false },
-        { "name": "merge_method", "description": { "zh": "merge/squash/rebase", "en": "merge/squash/rebase." }, "type": "string", "required": false }
-      ]
+        "name": "create_pull_request",
+        "description": {
+            "zh": "创建 PR。",
+            "en": "Create a pull request."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "PR 标题",
+                    "en": "PR title."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head 分支（含跨 fork 的 user:branch 格式）",
+                    "en": "Head branch (use user:branch for cross-fork)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "目标 base 分支",
+                    "en": "Target base branch."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "PR 描述",
+                    "en": "PR body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "draft",
+                "description": {
+                    "zh": "是否草稿",
+                    "en": "Whether to create as draft."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "get_file_content",
-      "description": { "zh": "读取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。若文件是 base64 返回，将自动解码为文本并返回。", "en": "Read repository file content (/repos/{owner}/{repo}/contents/{path}). If the API returns base64, it will be decoded and returned as text." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径（如 README.md）", "en": "File path (e.g. README.md)." }, "type": "string", "required": true },
-        { "name": "ref", "description": { "zh": "分支/Tag/SHA（可选）", "en": "Branch/Tag/SHA (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "get_pull_request",
+        "description": {
+            "zh": "获取单个 PR 详情。",
+            "en": "Get a single pull request."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
     },
     {
-      "name": "create_or_update_file",
-      "description": { "zh": "创建或更新仓库文件并提交（/repos/{owner}/{repo}/contents/{path}，PUT）。", "en": "Create or update a repository file and commit it (/repos/{owner}/{repo}/contents/{path}, PUT)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径", "en": "File path." }, "type": "string", "required": true },
-        { "name": "message", "description": { "zh": "提交信息", "en": "Commit message." }, "type": "string", "required": true },
-        { "name": "content", "description": { "zh": "文件内容（默认按 utf-8 文本编码为 base64）", "en": "File content (base64-encoded as utf-8 text by default)." }, "type": "string", "required": true },
-        { "name": "content_encoding", "description": { "zh": "utf-8/base64（默认 utf-8）", "en": "utf-8/base64 (default: utf-8)." }, "type": "string", "required": false },
-        { "name": "branch", "description": { "zh": "目标分支（可选）", "en": "Target branch (optional)." }, "type": "string", "required": false },
-        { "name": "sha", "description": { "zh": "可选：已知 sha（更新文件时）", "en": "Optional: known sha (when updating a file)." }, "type": "string", "required": false }
-      ]
+        "name": "update_pull_request",
+        "description": {
+            "zh": "更新 PR 标题/描述/状态/base/draft。",
+            "en": "Update PR title/body/state/base/draft."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "title",
+                "description": {
+                    "zh": "新标题",
+                    "en": "New title."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "新描述",
+                    "en": "New body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "state",
+                "description": {
+                    "zh": "open/closed",
+                    "en": "open/closed."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "新 base 分支",
+                    "en": "New base branch."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "draft",
+                "description": {
+                    "zh": "是否草稿",
+                    "en": "Whether draft."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "patch_file_in_repo",
-      "description": { "zh": "对仓库文件做差异更新（传入 [START-REPLACE]/[START-DELETE] 块），并提交。", "en": "Patch a repository file by applying diff blocks ([START-REPLACE]/[START-DELETE]) and commit." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径", "en": "File path." }, "type": "string", "required": true },
-        { "name": "message", "description": { "zh": "提交信息", "en": "Commit message." }, "type": "string", "required": true },
-        { "name": "patch", "description": { "zh": "差异块字符串（可多块）", "en": "Diff blocks string (can include multiple blocks)." }, "type": "string", "required": true },
-        { "name": "branch", "description": { "zh": "目标分支（可选）", "en": "Target branch (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "merge_pull_request",
+        "description": {
+            "zh": "合并 PR。",
+            "en": "Merge a pull request."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "commit_title",
+                "description": {
+                    "zh": "合并 commit 标题",
+                    "en": "Merge commit title."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "commit_message",
+                "description": {
+                    "zh": "合并 commit 消息",
+                    "en": "Merge commit message."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "merge_method",
+                "description": {
+                    "zh": "merge/squash/rebase（默认 merge）",
+                    "en": "merge/squash/rebase (default: merge)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "delete_file",
-      "description": { "zh": "删除仓库文件并提交（/repos/{owner}/{repo}/contents/{path}，DELETE）。", "en": "Delete a repository file and commit (/repos/{owner}/{repo}/contents/{path}, DELETE)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "path", "description": { "zh": "文件路径", "en": "File path." }, "type": "string", "required": true },
-        { "name": "message", "description": { "zh": "提交信息", "en": "Commit message." }, "type": "string", "required": true },
-        { "name": "branch", "description": { "zh": "目标分支（可选）", "en": "Target branch (optional)." }, "type": "string", "required": false },
-        { "name": "sha", "description": { "zh": "可选：已知 sha（删除文件时）", "en": "Optional: known sha (when deleting a file)." }, "type": "string", "required": false }
-      ]
+        "name": "list_pull_request_files",
+        "description": {
+            "zh": "列出 PR 变更文件。",
+            "en": "List files changed in a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "include_patch",
+                "description": {
+                    "zh": "是否包含 patch 内容（默认 false）",
+                    "en": "Include patch content (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 100）",
+                    "en": "Items per page (default: 100)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "create_branch",
-      "description": { "zh": "基于已有分支创建新分支（/git/refs）。", "en": "Create a new branch from an existing branch (/git/refs)." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner", "en": "Repository owner." }, "type": "string", "required": true },
-        { "name": "repo", "description": { "zh": "仓库名", "en": "Repository name." }, "type": "string", "required": true },
-        { "name": "new_branch", "description": { "zh": "新分支名", "en": "New branch name." }, "type": "string", "required": true },
-        { "name": "from_branch", "description": { "zh": "源分支（可选，默认使用 default_branch）", "en": "Source branch (optional; defaults to default_branch)." }, "type": "string", "required": false }
-      ]
+        "name": "get_pull_request_diff",
+        "description": {
+            "zh": "获取 PR 的 unified diff 文本。",
+            "en": "Get PR unified diff text."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "max_chars",
+                "description": {
+                    "zh": "截断字符数（默认 20000）",
+                    "en": "Truncate to this many chars (default: 20000)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "apply_local_replace",
-      "description": { "zh": "使用 Tools.Files.apply 对本地文件做 REPLACE（结构化块）。", "en": "Run Tools.Files.apply REPLACE on a local file (structured blocks)." },
-      "parameters": [
-        { "name": "path", "description": { "zh": "本地文件路径", "en": "Local file path." }, "type": "string", "required": true },
-        { "name": "old", "description": { "zh": "要替换的旧内容片段", "en": "Old content snippet to replace." }, "type": "string", "required": true },
-        { "name": "new", "description": { "zh": "替换后的新内容片段", "en": "New content snippet." }, "type": "string", "required": true },
-        { "name": "environment", "description": { "zh": "android/linux（可选）", "en": "android/linux (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "list_pull_request_commits",
+        "description": {
+            "zh": "列出 PR 的提交。",
+            "en": "List commits in a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "apply_local_delete",
-      "description": { "zh": "使用 Tools.Files.apply 对本地文件做 DELETE（结构化块）。", "en": "Run Tools.Files.apply DELETE on a local file (structured blocks)." },
-      "parameters": [
-        { "name": "path", "description": { "zh": "本地文件路径", "en": "Local file path." }, "type": "string", "required": true },
-        { "name": "old", "description": { "zh": "要删除的旧内容片段", "en": "Old content snippet to delete." }, "type": "string", "required": true },
-        { "name": "environment", "description": { "zh": "android/linux（可选）", "en": "android/linux (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "list_pull_request_reviews",
+        "description": {
+            "zh": "列出 PR 的 review。",
+            "en": "List reviews on a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "overwrite_local_file",
-      "description": { "zh": "覆盖写入本地文件（如果存在会先删除再写入）。", "en": "Overwrite a local file (if it exists, it will be deleted before writing)." },
-      "parameters": [
-        { "name": "path", "description": { "zh": "本地文件路径", "en": "Local file path." }, "type": "string", "required": true },
-        { "name": "content", "description": { "zh": "完整文件内容", "en": "Full file content." }, "type": "string", "required": true },
-        { "name": "environment", "description": { "zh": "android/linux（可选）", "en": "android/linux (optional)." }, "type": "string", "required": false }
-      ]
+        "name": "list_review_comments",
+        "description": {
+            "zh": "列出 PR 的行内 review comments。",
+            "en": "List inline review comments on a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "terminal_exec",
-      "description": { "zh": "在终端会话中执行命令（Tools.System.terminal）。", "en": "Execute a command in a terminal session (Tools.System.terminal)." },
-      "parameters": [
-        { "name": "command", "description": { "zh": "要执行的命令", "en": "Command to execute." }, "type": "string", "required": true },
-        { "name": "session_name", "description": { "zh": "会话名（可选，默认 github_tools_session）", "en": "Session name (optional; default: github_tools_session)." }, "type": "string", "required": false },
-        { "name": "close", "description": { "zh": "是否执行后关闭会话", "en": "Whether to close the session after execution." }, "type": "boolean", "required": false }
-      ]
+        "name": "create_review",
+        "description": {
+            "zh": "提交 PR review（APPROVE/REQUEST_CHANGES/COMMENT）。",
+            "en": "Submit a PR review (APPROVE/REQUEST_CHANGES/COMMENT)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "review 总评内容",
+                    "en": "Review body."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "event",
+                "description": {
+                    "zh": "APPROVE/REQUEST_CHANGES/COMMENT（默认 COMMENT）",
+                    "en": "APPROVE/REQUEST_CHANGES/COMMENT (default: COMMENT)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "commit_id",
+                "description": {
+                    "zh": "关联的 commit sha",
+                    "en": "Commit SHA to associate."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "comments",
+                "description": {
+                    "zh": "行内评论数组（JSON 字符串），每项含 path/line/body",
+                    "en": "Inline comments array (JSON string), each with path/line/body."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
     },
     {
-      "name": "main",
-      "description": { "zh": "用于快速连通性自测：拉取一个仓库信息并做一次仓库搜索，然后返回结果。", "en": "Quick connectivity self-test: fetch a repository and run a repository search, then return results." },
-      "parameters": [
-        { "name": "owner", "description": { "zh": "仓库 owner（默认 octocat）", "en": "Repository owner (default: octocat)." }, "type": "string", "required": false },
-        { "name": "repo", "description": { "zh": "仓库名（默认 Hello-World）", "en": "Repository name (default: Hello-World)." }, "type": "string", "required": false },
-        { "name": "query", "description": { "zh": "搜索关键词（默认 operit）", "en": "Search keyword (default: operit)." }, "type": "string", "required": false }
-      ]
+        "name": "reply_review_comment",
+        "description": {
+            "zh": "回复 PR 行内 review comment。",
+            "en": "Reply to a PR inline review comment."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "comment_id",
+                "description": {
+                    "zh": "被回复的 comment id",
+                    "en": "Comment ID to reply to."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "body",
+                "description": {
+                    "zh": "回复内容",
+                    "en": "Reply body."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "request_reviewers",
+        "description": {
+            "zh": "请求 PR reviewer。",
+            "en": "Request reviewers for a PR."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "pull_number",
+                "description": {
+                    "zh": "PR 编号",
+                    "en": "PR number."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "reviewers",
+                "description": {
+                    "zh": "reviewer login 列表，逗号分隔或数组",
+                    "en": "Reviewer logins, comma-separated or array."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "team_reviewers",
+                "description": {
+                    "zh": "team reviewer slug 列表，逗号分隔或数组",
+                    "en": "Team reviewer slugs, comma-separated or array."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_file_content",
+        "description": {
+            "zh": "获取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。",
+            "en": "Get file content from a repository."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径（相对仓库根目录）",
+                    "en": "File path relative to repository root."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "分支/tag/commit（默认默认分支）",
+                    "en": "Branch/tag/commit (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "create_or_update_file",
+        "description": {
+            "zh": "创建或更新仓库文件。更新时需传 sha。",
+            "en": "Create or update a file in the repository. Provide sha when updating."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径",
+                    "en": "File path."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "message",
+                "description": {
+                    "zh": "commit 消息",
+                    "en": "Commit message."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "content",
+                "description": {
+                    "zh": "文件内容（明文，会自动 base64 编码）",
+                    "en": "File content (plain text, will be base64-encoded)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "更新时必填：现有文件的 blob sha",
+                    "en": "Required when updating: existing file blob SHA."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "目标分支（默认默认分支）",
+                    "en": "Target branch (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "delete_file",
+        "description": {
+            "zh": "删除仓库文件。",
+            "en": "Delete a file from the repository."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径",
+                    "en": "File path."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "message",
+                "description": {
+                    "zh": "commit 消息",
+                    "en": "Commit message."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "文件的 blob sha",
+                    "en": "File blob SHA."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "目标分支",
+                    "en": "Target branch."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "create_branch",
+        "description": {
+            "zh": "创建分支。",
+            "en": "Create a branch."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "新分支名",
+                    "en": "New branch name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "from_branch",
+                "description": {
+                    "zh": "基于哪个分支创建（默认默认分支）",
+                    "en": "Branch to create from (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "直接指定起始 commit sha（优先于 from_branch）",
+                    "en": "Starting commit SHA (overrides from_branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_branches",
+        "description": {
+            "zh": "列出仓库分支。",
+            "en": "List repository branches."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "protected_only",
+                "description": {
+                    "zh": "只返回受保护分支（默认 false）",
+                    "en": "Return only protected branches (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_commits",
+        "description": {
+            "zh": "列出仓库提交。",
+            "en": "List repository commits."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sha",
+                "description": {
+                    "zh": "分支/tag/commit sha（默认默认分支）",
+                    "en": "Branch/tag/commit SHA (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "只返回修改了该路径的提交",
+                    "en": "Only commits affecting this path."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "author",
+                "description": {
+                    "zh": "作者 login 过滤",
+                    "en": "Author login filter."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_commit",
+        "description": {
+            "zh": "获取单个提交详情。",
+            "en": "Get a single commit."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "commit sha / 分支 / tag",
+                    "en": "Commit SHA, branch, or tag."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "include_files",
+                "description": {
+                    "zh": "是否包含文件变更列表（默认 true）",
+                    "en": "Whether to include file changes (default: true)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "compare_refs",
+        "description": {
+            "zh": "比较两个 ref。",
+            "en": "Compare two refs."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "base ref（分支/tag/sha）",
+                    "en": "Base ref (branch/tag/sha)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head ref（分支/tag/sha）",
+                    "en": "Head ref (branch/tag/sha)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "include_files",
+                "description": {
+                    "zh": "是否包含文件列表（默认 true）",
+                    "en": "Whether to include file list (default: true)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "include_patch",
+                "description": {
+                    "zh": "文件列表是否包含 patch（默认 false）",
+                    "en": "Whether file list includes patch (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_compare_diff",
+        "description": {
+            "zh": "获取两个 ref 之间的 unified diff 文本。",
+            "en": "Get unified diff text between two refs."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "base",
+                "description": {
+                    "zh": "base ref",
+                    "en": "Base ref."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "head",
+                "description": {
+                    "zh": "head ref",
+                    "en": "Head ref."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "max_chars",
+                "description": {
+                    "zh": "截断字符数（默认 20000）",
+                    "en": "Truncate to this many chars (default: 20000)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_workflows",
+        "description": {
+            "zh": "列出仓库 GitHub Actions workflow。",
+            "en": "List GitHub Actions workflows."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "list_workflow_runs",
+        "description": {
+            "zh": "列出 workflow run。",
+            "en": "List workflow runs."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "workflow_id",
+                "description": {
+                    "zh": "workflow id 或文件名（如 android-tests.yml），不传则列出所有",
+                    "en": "Workflow ID or filename (e.g. android-tests.yml); omit to list all."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "按分支过滤",
+                    "en": "Filter by branch."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "status",
+                "description": {
+                    "zh": "按状态过滤：queued/in_progress/completed/failure/success 等",
+                    "en": "Filter by status: queued/in_progress/completed/failure/success etc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "event",
+                "description": {
+                    "zh": "按触发事件过滤：push/pull_request/workflow_dispatch 等",
+                    "en": "Filter by event: push/pull_request/workflow_dispatch etc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_workflow_run",
+        "description": {
+            "zh": "获取单个 workflow run 详情。",
+            "en": "Get a single workflow run."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "trigger_workflow",
+        "description": {
+            "zh": "手动触发 workflow（workflow_dispatch）。",
+            "en": "Manually trigger a workflow (workflow_dispatch)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "workflow_id",
+                "description": {
+                    "zh": "workflow id 或文件名（如 android-tests.yml）",
+                    "en": "Workflow ID or filename (e.g. android-tests.yml)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "触发分支或 tag",
+                    "en": "Branch or tag to trigger on."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "inputs",
+                "description": {
+                    "zh": "workflow inputs（JSON 字符串或对象）",
+                    "en": "Workflow inputs (JSON string or object)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_workflow_jobs",
+        "description": {
+            "zh": "获取 workflow run 的 jobs（含可选日志）。",
+            "en": "Get jobs for a workflow run (with optional logs)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "include_logs",
+                "description": {
+                    "zh": "是否拉取每个 job 的日志（默认 false）",
+                    "en": "Whether to fetch logs for each job (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "failed_only",
+                "description": {
+                    "zh": "只返回失败/非成功的 job（默认 false）",
+                    "en": "Return only failed/non-success jobs (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "max_log_chars",
+                "description": {
+                    "zh": "日志截断字符数（默认 8000）",
+                    "en": "Log truncation in characters (default: 8000)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 50）",
+                    "en": "Items per page (default: 50)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "rerun_workflow_run",
+        "description": {
+            "zh": "重新运行 workflow run（全部或仅失败 job）。",
+            "en": "Re-run a workflow run (all jobs or failed jobs only)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            },
+            {
+                "name": "failed_jobs_only",
+                "description": {
+                    "zh": "只重跑失败 job（默认 false）",
+                    "en": "Only re-run failed jobs (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            },
+            {
+                "name": "enable_debug_logging",
+                "description": {
+                    "zh": "是否开启 debug 日志",
+                    "en": "Whether to enable debug logging."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "cancel_workflow_run",
+        "description": {
+            "zh": "取消 workflow run。",
+            "en": "Cancel a workflow run."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "run_id",
+                "description": {
+                    "zh": "workflow run id",
+                    "en": "Workflow run ID."
+                },
+                "type": "number",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "list_check_runs",
+        "description": {
+            "zh": "列出某个 commit 的 check runs。",
+            "en": "List check runs for a commit."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "ref",
+                "description": {
+                    "zh": "commit sha / 分支 / tag",
+                    "en": "Commit SHA, branch, or tag."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "status",
+                "description": {
+                    "zh": "queued/in_progress/completed 过滤",
+                    "en": "Filter by status: queued/in_progress/completed."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "filter",
+                "description": {
+                    "zh": "latest/all（默认 latest）",
+                    "en": "latest/all (default: latest)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 30）",
+                    "en": "Items per page (default: 30)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "search_code",
+        "description": {
+            "zh": "搜索代码（/search/code）。",
+            "en": "Search code (/search/code)."
+        },
+        "parameters": [
+            {
+                "name": "query",
+                "description": {
+                    "zh": "搜索查询（支持 GitHub code search 语法）",
+                    "en": "Search query (GitHub code search syntax, e.g. repo:owner/name keyword)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sort",
+                "description": {
+                    "zh": "排序字段（indexed）",
+                    "en": "Sort field (indexed)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "order",
+                "description": {
+                    "zh": "排序方向：desc/asc",
+                    "en": "Sort order: desc/asc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "search_issues",
+        "description": {
+            "zh": "搜索 Issue/PR（/search/issues）。",
+            "en": "Search issues and PRs (/search/issues)."
+        },
+        "parameters": [
+            {
+                "name": "query",
+                "description": {
+                    "zh": "搜索查询（支持 GitHub issue search 语法）",
+                    "en": "Search query (GitHub issue search syntax)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "sort",
+                "description": {
+                    "zh": "排序字段：comments/reactions/created/updated 等",
+                    "en": "Sort field: comments/reactions/created/updated etc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "order",
+                "description": {
+                    "zh": "排序方向：desc/asc",
+                    "en": "Sort order: desc/asc."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "page",
+                "description": {
+                    "zh": "页码（默认 1）",
+                    "en": "Page number (default: 1)."
+                },
+                "type": "number",
+                "required": false
+            },
+            {
+                "name": "per_page",
+                "description": {
+                    "zh": "每页数量（默认 20）",
+                    "en": "Items per page (default: 20)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "get_authenticated_user",
+        "description": {
+            "zh": "获取当前认证用户信息（/user）。",
+            "en": "Get the currently authenticated user (/user)."
+        },
+        "parameters": []
+    },
+    {
+        "name": "get_rate_limit",
+        "description": {
+            "zh": "查询 GitHub API 请求频率限制（/rate_limit）。",
+            "en": "Query GitHub API rate limit (/rate_limit)."
+        },
+        "parameters": []
+    },
+    {
+        "name": "fork_repository",
+        "description": {
+            "zh": "fork 仓库（/repos/{owner}/{repo}/forks）。",
+            "en": "Fork a repository."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "organization",
+                "description": {
+                    "zh": "fork 到指定组织（不填则 fork 到个人账号）",
+                    "en": "Fork to a specific organization (omit for personal account)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "name",
+                "description": {
+                    "zh": "fork 后的仓库名（默认与原仓库同名）",
+                    "en": "Name for the forked repository (default: same as original)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "default_branch_only",
+                "description": {
+                    "zh": "只 fork 默认分支（默认 false）",
+                    "en": "Fork only the default branch (default: false)."
+                },
+                "type": "boolean",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "sync_fork",
+        "description": {
+            "zh": "同步 fork 到上游（/repos/{owner}/{repo}/merge-upstream）。",
+            "en": "Sync a fork with upstream."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "fork 仓库的 owner",
+                    "en": "Fork repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "fork 仓库名",
+                    "en": "Fork repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "要同步的分支（默认默认分支）",
+                    "en": "Branch to sync (default: default branch)."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "patch_file_in_repo",
+        "description": {
+            "zh": "在仓库中对文件应用 search/replace patch（先读取文件，替换内容后写回）。",
+            "en": "Apply a search/replace patch to a file in the repository (read -> replace -> write back)."
+        },
+        "parameters": [
+            {
+                "name": "owner",
+                "description": {
+                    "zh": "仓库 owner",
+                    "en": "Repository owner."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "repo",
+                "description": {
+                    "zh": "仓库名",
+                    "en": "Repository name."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "path",
+                "description": {
+                    "zh": "文件路径",
+                    "en": "File path."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "search",
+                "description": {
+                    "zh": "要查找的文本（精确匹配）",
+                    "en": "Text to search for (exact match)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "replace",
+                "description": {
+                    "zh": "替换后的文本",
+                    "en": "Replacement text."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "message",
+                "description": {
+                    "zh": "commit 消息",
+                    "en": "Commit message."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "branch",
+                "description": {
+                    "zh": "目标分支",
+                    "en": "Target branch."
+                },
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "name": "apply_local_replace",
+        "description": {
+            "zh": "在本地文件系统中对文件应用 search/replace（不经过 GitHub API）。",
+            "en": "Apply a search/replace patch to a local file (no GitHub API)."
+        },
+        "parameters": [
+            {
+                "name": "path",
+                "description": {
+                    "zh": "本地文件路径（绝对路径）",
+                    "en": "Local file path (absolute)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "search",
+                "description": {
+                    "zh": "要查找的文本",
+                    "en": "Text to search for."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "replace",
+                "description": {
+                    "zh": "替换后的文本",
+                    "en": "Replacement text."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "apply_local_delete",
+        "description": {
+            "zh": "删除本地文件（不经过 GitHub API）。",
+            "en": "Delete a local file (no GitHub API)."
+        },
+        "parameters": [
+            {
+                "name": "path",
+                "description": {
+                    "zh": "本地文件路径（绝对路径）",
+                    "en": "Local file path (absolute)."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "overwrite_local_file",
+        "description": {
+            "zh": "用新内容完整覆盖本地文件（不经过 GitHub API）。",
+            "en": "Overwrite a local file with new content (no GitHub API)."
+        },
+        "parameters": [
+            {
+                "name": "path",
+                "description": {
+                    "zh": "本地文件路径（绝对路径）",
+                    "en": "Local file path (absolute)."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "content",
+                "description": {
+                    "zh": "新的文件内容",
+                    "en": "New file content."
+                },
+                "type": "string",
+                "required": true
+            }
+        ]
+    },
+    {
+        "name": "terminal_exec",
+        "description": {
+            "zh": "在本地终端执行命令（调用 Operit 内置终端，注意权限和安全）。",
+            "en": "Execute a command in the local terminal (uses Operit built-in terminal)."
+        },
+        "parameters": [
+            {
+                "name": "command",
+                "description": {
+                    "zh": "要执行的 shell 命令",
+                    "en": "Shell command to execute."
+                },
+                "type": "string",
+                "required": true
+            },
+            {
+                "name": "cwd",
+                "description": {
+                    "zh": "工作目录（默认当前目录）",
+                    "en": "Working directory (default: current directory)."
+                },
+                "type": "string",
+                "required": false
+            },
+            {
+                "name": "timeout_ms",
+                "description": {
+                    "zh": "超时毫秒数（默认 30000）",
+                    "en": "Timeout in milliseconds (default: 30000)."
+                },
+                "type": "number",
+                "required": false
+            }
+        ]
     }
-  ]
+]
 }
 */
 
-/// <reference path="../../types/index.d.ts" />
-import { toolImpl } from './tools';
-import { getRepository, searchRepositories } from './github/repos';
-import { listIssues, listIssueComments, createIssue, commentIssue } from './github/issues';
-import { listPullRequests, getPullRequest, createPullRequest, mergePullRequest } from './github/pulls';
+import { listIssues, getIssue, createIssue, updateIssue, commentIssue, listIssueComments } from './github/issues';
+import { listPullRequests, createPullRequest, getPullRequest, updatePullRequest, mergePullRequest, listPullRequestFiles, getPullRequestDiff, listPullRequestCommits, listPullRequestReviews, listReviewComments, createReview, replyReviewComment, requestReviewers } from './github/pulls';
 import { getFileContent, createOrUpdateFile, deleteFile } from './github/contents';
 import { createBranch } from './github/branches';
+import { listBranches, listCommits, getCommit, compareRefs, getCompareDiff } from './github/git';
+import { listWorkflows, listWorkflowRuns, getWorkflowRun, triggerWorkflow, getWorkflowJobs, rerunWorkflowRun, cancelWorkflowRun, listCheckRuns } from './github/actions';
+import { searchRepositories } from './github/repos';
+import { searchCode, searchIssues } from './github/search';
+import { getAuthenticatedUser, getRateLimit } from './github/users';
+import { forkRepository, syncFork } from './github/forks';
 import { patchFileInRepo } from './github/patch';
-import { getBaseUrl, getToken } from './github/api';
+import { applyLocalReplace, applyLocalDelete, overwriteLocalFile } from './github/local/fileApply';
+import { terminalExec } from './github/local/terminal';
+import { wrap } from './utils/wrap';
 
-exports.search_repositories = toolImpl.search_repositories;
-exports.get_repository = toolImpl.get_repository;
-exports.list_issues = toolImpl.list_issues;
-exports.create_issue = toolImpl.create_issue;
-exports.comment_issue = toolImpl.comment_issue;
-exports.list_issue_comments = toolImpl.list_issue_comments;
+export const toolImpl: Record<string, (params: any) => Promise<any>> = {
+    search_repositories: (p) => wrap(searchRepositories as any, p, '搜索仓库成功', '搜索仓库失败'),
+    get_repository: (p) => wrap(searchRepositories as any, p, '获取仓库成功', '获取仓库失败'),
+    list_issues: (p) => wrap(listIssues as any, p, '列出 Issues 成功', '列出 Issues 失败'),
+    get_issue: (p) => wrap(getIssue as any, p, '获取 Issue 成功', '获取 Issue 失败'),
+    create_issue: (p) => wrap(createIssue as any, p, '创建 Issue 成功', '创建 Issue 失败'),
+    update_issue: (p) => wrap(updateIssue as any, p, '更新 Issue 成功', '更新 Issue 失败'),
+    comment_issue: (p) => wrap(commentIssue as any, p, '评论成功', '评论失败'),
+    list_issue_comments: (p) => wrap(listIssueComments as any, p, '列出评论成功', '列出评论失败'),
+    list_pull_requests: (p) => wrap(listPullRequests as any, p, '列出 PR 成功', '列出 PR 失败'),
+    create_pull_request: (p) => wrap(createPullRequest as any, p, '创建 PR 成功', '创建 PR 失败'),
+    get_pull_request: (p) => wrap(getPullRequest as any, p, '获取 PR 成功', '获取 PR 失败'),
+    update_pull_request: (p) => wrap(updatePullRequest as any, p, '更新 PR 成功', '更新 PR 失败'),
+    merge_pull_request: (p) => wrap(mergePullRequest as any, p, '合并 PR 成功', '合并 PR 失败'),
+    list_pull_request_files: (p) => wrap(listPullRequestFiles as any, p, '获取 PR 文件成功', '获取 PR 文件失败'),
+    get_pull_request_diff: (p) => wrap(getPullRequestDiff as any, p, '获取 PR diff 成功', '获取 PR diff 失败'),
+    list_pull_request_commits: (p) => wrap(listPullRequestCommits as any, p, '获取 PR 提交成功', '获取 PR 提交失败'),
+    list_pull_request_reviews: (p) => wrap(listPullRequestReviews as any, p, '获取 PR review 成功', '获取 PR review 失败'),
+    list_review_comments: (p) => wrap(listReviewComments as any, p, '获取行内评论成功', '获取行内评论失败'),
+    create_review: (p) => wrap(createReview as any, p, '提交 review 成功', '提交 review 失败'),
+    reply_review_comment: (p) => wrap(replyReviewComment as any, p, '回复评论成功', '回复评论失败'),
+    request_reviewers: (p) => wrap(requestReviewers as any, p, '请求 reviewer 成功', '请求 reviewer 失败'),
+    get_file_content: (p) => wrap(getFileContent as any, p, '获取文件成功', '获取文件失败'),
+    create_or_update_file: (p) => wrap(createOrUpdateFile as any, p, '写入文件成功', '写入文件失败'),
+    delete_file: (p) => wrap(deleteFile as any, p, '删除文件成功', '删除文件失败'),
+    create_branch: (p) => wrap(createBranch as any, p, '创建分支成功', '创建分支失败'),
+    list_branches: (p) => wrap(listBranches as any, p, '列出分支成功', '列出分支失败'),
+    list_commits: (p) => wrap(listCommits as any, p, '列出提交成功', '列出提交失败'),
+    get_commit: (p) => wrap(getCommit as any, p, '获取提交成功', '获取提交失败'),
+    compare_refs: (p) => wrap(compareRefs as any, p, '比较 refs 成功', '比较 refs 失败'),
+    get_compare_diff: (p) => wrap(getCompareDiff as any, p, '获取 diff 成功', '获取 diff 失败'),
+    list_workflows: (p) => wrap(listWorkflows as any, p, '列出 workflow 成功', '列出 workflow 失败'),
+    list_workflow_runs: (p) => wrap(listWorkflowRuns as any, p, '获取 workflow run 成功', '获取 workflow run 失败'),
+    get_workflow_run: (p) => wrap(getWorkflowRun as any, p, '获取 workflow run 成功', '获取 workflow run 失败'),
+    trigger_workflow: (p) => wrap(triggerWorkflow as any, p, '触发 workflow 成功', '触发 workflow 失败'),
+    get_workflow_jobs: (p) => wrap(getWorkflowJobs as any, p, '获取 workflow jobs 成功', '获取 workflow jobs 失败'),
+    rerun_workflow_run: (p) => wrap(rerunWorkflowRun as any, p, '重新运行 workflow 成功', '重新运行 workflow 失败'),
+    cancel_workflow_run: (p) => wrap(cancelWorkflowRun as any, p, '取消 workflow 成功', '取消 workflow 失败'),
+    list_check_runs: (p) => wrap(listCheckRuns as any, p, '列出 check runs 成功', '列出 check runs 失败'),
+    search_code: (p) => wrap(searchCode as any, p, '搜索代码成功', '搜索代码失败'),
+    search_issues: (p) => wrap(searchIssues as any, p, '搜索 Issues 成功', '搜索 Issues 失败'),
+    get_authenticated_user: (p) => wrap(getAuthenticatedUser as any, p, '获取用户成功', '获取用户失败'),
+    get_rate_limit: (p) => wrap(getRateLimit as any, p, '获取 rate limit 成功', '获取 rate limit 失败'),
+    fork_repository: (p) => wrap(forkRepository as any, p, 'fork 仓库成功', 'fork 仓库失败'),
+    sync_fork: (p) => wrap(syncFork as any, p, '同步 fork 成功', '同步 fork 失败'),
+    patch_file_in_repo: (p) => wrap(patchFileInRepo as any, p, 'patch 文件成功', 'patch 文件失败'),
+    apply_local_replace: (p) => wrap(applyLocalReplace as any, p, '本地替换成功', '本地替换失败'),
+    apply_local_delete: (p) => wrap(applyLocalDelete as any, p, '本地删除成功', '本地删除失败'),
+    overwrite_local_file: (p) => wrap(overwriteLocalFile as any, p, '覆盖文件成功', '覆盖文件失败'),
+    terminal_exec: (p) => wrap(terminalExec as any, p, '终端执行成功', '终端执行失败')
+};
 
-exports.list_pull_requests = toolImpl.list_pull_requests;
-exports.create_pull_request = toolImpl.create_pull_request;
-exports.get_pull_request = toolImpl.get_pull_request;
-exports.merge_pull_request = toolImpl.merge_pull_request;
-
-exports.get_file_content = toolImpl.get_file_content;
-exports.create_or_update_file = toolImpl.create_or_update_file;
-exports.patch_file_in_repo = toolImpl.patch_file_in_repo;
-exports.delete_file = toolImpl.delete_file;
-exports.create_branch = toolImpl.create_branch;
-
-exports.apply_local_replace = toolImpl.apply_local_replace;
-exports.apply_local_delete = toolImpl.apply_local_delete;
-exports.overwrite_local_file = toolImpl.overwrite_local_file;
-exports.terminal_exec = toolImpl.terminal_exec;
-
-async function main(
-  params?: {
-    owner?: string;
-    repo?: string;
-    query?: string;
-    path?: string;
-    issue_number?: number;
-    pull_number?: number;
-    enable_write?: boolean;
-    pr_head?: string;
-    pr_base?: string;
-  }
-) {
-  try {
-    const owner = String(params?.owner || 'octocat');
-    const repo = String(params?.repo || 'Hello-World');
-    const query = String(params?.query || 'operit');
-    const path = String(params?.path || 'README.md');
-    const enableWrite = params?.enable_write === true;
-
-    const baseUrl = getBaseUrl();
-    const token = getToken();
-
-    type TestResult =
-      | { ok: true; data: any }
-      | { ok: false; error: string; error_stack: string }
-      | { ok: false; skipped: true; reason: string };
-
-    const results: Record<string, TestResult> = {};
-
-    const toErrMsg = (e: any) => String(e && e.message ? e.message : e);
-    const toErrStack = (e: any) => String(e && e.stack ? e.stack : '');
-
-    const run = async (name: string, fn: () => Promise<any>): Promise<TestResult> => {
-      try {
-        const data = await fn();
-        return { ok: true, data };
-      } catch (e: any) {
-        return { ok: false, error: toErrMsg(e), error_stack: toErrStack(e) };
-      }
-    };
-
-    const summarizeRepo = (r: any) =>
-      r
-        ? {
-          id: r.id,
-          full_name: r.full_name,
-          private: r.private,
-          default_branch: r.default_branch
-        }
-        : r;
-
-    const summarizeList = (items: any[]) => ({
-      count: Array.isArray(items) ? items.length : 0,
-      first: Array.isArray(items) && items.length > 0 ? items[0] : null
-    });
-
-    results.get_repository = await run('get_repository', async () => summarizeRepo(await getRepository({ owner, repo })));
-
-    results.search_repositories = await run('search_repositories', async () => {
-      const r = await searchRepositories({ query, per_page: 5 });
-      const items = Array.isArray(r?.items) ? r.items : [];
-      return {
-        total_count: r?.total_count,
-        count: items.length,
-        first: items[0] ? { id: items[0].id, full_name: items[0].full_name, stargazers_count: items[0].stargazers_count } : null
-      };
-    });
-
-    results.list_issues = await run('list_issues', async () => summarizeList(await listIssues({ owner, repo, per_page: 5 })));
-
-    let issueNumber: number | undefined = typeof params?.issue_number === 'number' ? params.issue_number : undefined;
-    if (!issueNumber && results.list_issues.ok) {
-      const first = results.list_issues.data?.first;
-      if (first && typeof first.number === 'number') issueNumber = first.number;
+export async function main(params: any): Promise<any> {
+    const tool = params?.tool as string | undefined;
+    if (!tool) {
+        return { ok: true, message: 'GitHub API package loaded', tools: Object.keys(toolImpl) };
     }
-
-    if (issueNumber) {
-      results.list_issue_comments = await run('list_issue_comments', async () =>
-        summarizeList(await listIssueComments({ owner, repo, issue_number: issueNumber, per_page: 5 }))
-      );
-    } else {
-      results.list_issue_comments = { ok: false, skipped: true, reason: 'No issue_number provided and cannot infer from list_issues.' };
+    const fn = toolImpl[tool];
+    if (!fn) {
+        return { success: false, message: `Unknown tool: ${tool}`, available: Object.keys(toolImpl) };
     }
-
-    results.list_pull_requests = await run('list_pull_requests', async () => summarizeList(await listPullRequests({ owner, repo, per_page: 5 })));
-
-    let pullNumber: number | undefined = typeof params?.pull_number === 'number' ? params.pull_number : undefined;
-    if (!pullNumber && results.list_pull_requests.ok) {
-      const first = results.list_pull_requests.data?.first;
-      if (first && typeof first.number === 'number') pullNumber = first.number;
-    }
-
-    if (pullNumber) {
-      results.get_pull_request = await run('get_pull_request', async () => {
-        const pr = await getPullRequest({ owner, repo, pull_number: pullNumber });
-        return pr
-          ? {
-            number: pr.number,
-            title: pr.title,
-            state: pr.state,
-            merged: pr.merged,
-            head: pr.head?.ref,
-            base: pr.base?.ref
-          }
-          : pr;
-      });
-    } else {
-      results.get_pull_request = { ok: false, skipped: true, reason: 'No pull_number provided and cannot infer from list_pull_requests.' };
-    }
-
-    const inferReadableRepoFilePath = async (): Promise<string | undefined> => {
-      if (params?.path) {
-        return path;
-      }
-
-      try {
-        const root = await getFileContent({ owner, repo, path: '' });
-        if (!Array.isArray(root)) {
-          return undefined;
-        }
-
-        const prefer = ['README.md', 'README', 'readme.md', 'Readme.md', 'README.MD'];
-        for (const p of prefer) {
-          const hit = root.find((it: any) => it && it.type === 'file' && String(it.path || it.name || '') === p);
-          if (hit) return String(hit.path || hit.name);
-        }
-
-        const firstFile = root.find((it: any) => it && it.type === 'file' && (typeof it.path === 'string' || typeof it.name === 'string'));
-        if (firstFile) return String(firstFile.path || firstFile.name);
-
-        return undefined;
-      } catch (e) {
-        return undefined;
-      }
-    };
-
-    const resolvedPath = await inferReadableRepoFilePath();
-    if (!resolvedPath) {
-      results.get_file_content = { ok: false, skipped: true, reason: 'No readable file found in repo root for get_file_content test.' };
-    } else {
-      results.get_file_content = await run('get_file_content', async () => {
-        const f = await getFileContent({ owner, repo, path: resolvedPath });
-        return f
-          ? {
-            type: f.type,
-            path: f.path,
-            sha: f.sha,
-            size: f.size,
-            has_decoded_text: typeof f.decoded_text === 'string' && f.decoded_text.length > 0
-          }
-          : f;
-      });
-    }
-
-    const writeSkipped = (name: string, reason: string) => {
-      results[name] = { ok: false, skipped: true, reason };
-    };
-
-    if (!enableWrite) {
-      writeSkipped('create_issue', 'Skipped: enable_write=false (write operation).');
-      writeSkipped('comment_issue', 'Skipped: enable_write=false (write operation).');
-      writeSkipped('create_branch', 'Skipped: enable_write=false (write operation).');
-      writeSkipped('create_or_update_file', 'Skipped: enable_write=false (write operation).');
-      writeSkipped('patch_file_in_repo', 'Skipped: enable_write=false (write operation).');
-      writeSkipped('delete_file', 'Skipped: enable_write=false (write operation).');
-      writeSkipped('create_pull_request', 'Skipped: enable_write=false (write operation).');
-      writeSkipped('merge_pull_request', 'Skipped: enable_write=false (write operation).');
-    } else {
-      const ts = Date.now();
-      const testBranch = `operit-test-${ts}`;
-      const testPath = `operit_test_${ts}.txt`;
-      const baseBranch = (results.get_repository.ok ? results.get_repository.data?.default_branch : undefined) || 'main';
-
-      results.create_branch = await run('create_branch', async () =>
-        createBranch({ owner, repo, new_branch: testBranch, from_branch: baseBranch })
-      );
-
-      results.create_or_update_file = await run('create_or_update_file', async () =>
-        createOrUpdateFile({
-          owner,
-          repo,
-          path: testPath,
-          message: `operit test create file ${ts}`,
-          content: `operit github tools self-test ${ts}`,
-          content_encoding: 'utf-8',
-          branch: testBranch
-        })
-      );
-
-      results.patch_file_in_repo = await run('patch_file_in_repo', async () =>
-        patchFileInRepo({
-          owner,
-          repo,
-          path: testPath,
-          message: `operit test patch file ${ts}`,
-          patch: `[START-REPLACE]\n[OLD]\noperit github tools self-test ${ts}\n[/OLD]\n[NEW]\noperit github tools self-test ${ts} (patched)\n[/NEW]\n[END-REPLACE]`,
-          branch: testBranch
-        })
-      );
-
-      results.delete_file = await run('delete_file', async () => {
-        const sha =
-          results.create_or_update_file.ok && results.create_or_update_file.data && results.create_or_update_file.data.content
-            ? results.create_or_update_file.data.content.sha
-            : undefined;
-        if (!sha) {
-          throw new Error('Cannot infer sha from create_or_update_file response; pass sha explicitly if needed.');
-        }
-        return deleteFile({ owner, repo, path: testPath, message: `operit test delete file ${ts}`, branch: testBranch, sha });
-      });
-
-      const canIssue = Boolean(token) && issueNumber !== undefined;
-      if (!token) {
-        writeSkipped('create_issue', 'Skipped: GITHUB_TOKEN missing (required for write operation).');
-      } else {
-        results.create_issue = await run('create_issue', async () =>
-          createIssue({ owner, repo, title: `operit self-test issue ${ts}`, body: `created by operit github tools self-test ${ts}` })
-        );
-      }
-
-      if (!canIssue) {
-        writeSkipped('comment_issue', 'Skipped: need GITHUB_TOKEN and issue_number (or at least one issue from list_issues).');
-      } else {
-        results.comment_issue = await run('comment_issue', async () =>
-          commentIssue({ owner, repo, issue_number: issueNumber!, body: `operit self-test comment ${ts}` })
-        );
-      }
-
-      const prHead = params?.pr_head ? String(params.pr_head) : '';
-      const prBase = params?.pr_base ? String(params.pr_base) : '';
-      if (!token) {
-        writeSkipped('create_pull_request', 'Skipped: GITHUB_TOKEN missing (required for write operation).');
-      } else if (!prHead || !prBase) {
-        writeSkipped('create_pull_request', 'Skipped: pr_head/pr_base not provided (required to create PR).');
-      } else {
-        results.create_pull_request = await run('create_pull_request', async () =>
-          createPullRequest({ owner, repo, title: `operit self-test PR ${ts}`, head: prHead, base: prBase, body: `created by operit self-test ${ts}` })
-        );
-      }
-
-      if (!token) {
-        writeSkipped('merge_pull_request', 'Skipped: GITHUB_TOKEN missing (required for write operation).');
-      } else if (!pullNumber) {
-        writeSkipped('merge_pull_request', 'Skipped: pull_number missing (required to merge PR).');
-      } else {
-        results.merge_pull_request = await run('merge_pull_request', async () =>
-          mergePullRequest({ owner, repo, pull_number: pullNumber!, merge_method: 'merge' })
-        );
-      }
-    }
-
-    const okCount = Object.values(results).filter((r) => (r as any).ok === true).length;
-    const failCount = Object.values(results).filter((r) => (r as any).ok === false && !(r as any).skipped).length;
-    const skippedCount = Object.values(results).filter((r) => (r as any).skipped).length;
-
-    complete({
-      success: failCount === 0,
-      message:
-        failCount === 0
-          ? 'GitHub tools main test finished.'
-          : `GitHub tools main test finished with failures: failed=${failCount}, ok=${okCount}, skipped=${skippedCount}.`,
-      data: {
-        baseUrl,
-        hasToken: Boolean(token),
-        enable_write: enableWrite,
-        owner,
-        repo,
-        summary: { ok: okCount, failed: failCount, skipped: skippedCount },
-        results
-      }
-    });
-  } catch (error: any) {
-    complete({
-      success: false,
-      message: `GitHub tools main test failed: ${String(error && error.message ? error.message : error)}`,
-      error_stack: String(error && error.stack ? error.stack : '')
-    });
-  }
+    return fn(params);
 }
 
-exports.main = main;
+export const search_repositories = toolImpl.search_repositories;
+export const get_repository = toolImpl.get_repository;
+export const list_issues = toolImpl.list_issues;
+export const get_issue = toolImpl.get_issue;
+export const create_issue = toolImpl.create_issue;
+export const update_issue = toolImpl.update_issue;
+export const comment_issue = toolImpl.comment_issue;
+export const list_issue_comments = toolImpl.list_issue_comments;
+export const list_pull_requests = toolImpl.list_pull_requests;
+export const create_pull_request = toolImpl.create_pull_request;
+export const get_pull_request = toolImpl.get_pull_request;
+export const update_pull_request = toolImpl.update_pull_request;
+export const merge_pull_request = toolImpl.merge_pull_request;
+export const list_pull_request_files = toolImpl.list_pull_request_files;
+export const get_pull_request_diff = toolImpl.get_pull_request_diff;
+export const list_pull_request_commits = toolImpl.list_pull_request_commits;
+export const list_pull_request_reviews = toolImpl.list_pull_request_reviews;
+export const list_review_comments = toolImpl.list_review_comments;
+export const create_review = toolImpl.create_review;
+export const reply_review_comment = toolImpl.reply_review_comment;
+export const request_reviewers = toolImpl.request_reviewers;
+export const get_file_content = toolImpl.get_file_content;
+export const create_or_update_file = toolImpl.create_or_update_file;
+export const delete_file = toolImpl.delete_file;
+export const create_branch = toolImpl.create_branch;
+export const list_branches = toolImpl.list_branches;
+export const list_commits = toolImpl.list_commits;
+export const get_commit = toolImpl.get_commit;
+export const compare_refs = toolImpl.compare_refs;
+export const get_compare_diff = toolImpl.get_compare_diff;
+export const list_workflows = toolImpl.list_workflows;
+export const list_workflow_runs = toolImpl.list_workflow_runs;
+export const get_workflow_run = toolImpl.get_workflow_run;
+export const trigger_workflow = toolImpl.trigger_workflow;
+export const get_workflow_jobs = toolImpl.get_workflow_jobs;
+export const rerun_workflow_run = toolImpl.rerun_workflow_run;
+export const cancel_workflow_run = toolImpl.cancel_workflow_run;
+export const list_check_runs = toolImpl.list_check_runs;
+export const search_code = toolImpl.search_code;
+export const search_issues = toolImpl.search_issues;
+export const get_authenticated_user = toolImpl.get_authenticated_user;
+export const get_rate_limit = toolImpl.get_rate_limit;
+export const fork_repository = toolImpl.fork_repository;
+export const sync_fork = toolImpl.sync_fork;
+export const patch_file_in_repo = toolImpl.patch_file_in_repo;
+export const apply_local_replace = toolImpl.apply_local_replace;
+export const apply_local_delete = toolImpl.apply_local_delete;
+export const overwrite_local_file = toolImpl.overwrite_local_file;
+export const terminal_exec = toolImpl.terminal_exec;

--- a/examples/github/src/index.ts
+++ b/examples/github/src/index.ts
@@ -1360,6 +1360,15 @@
           },
           "type": "string",
           "required": false
+        },
+        {
+          "name": "content_encoding",
+          "description": {
+            "zh": "内容编码：utf-8（默认）或 base64",
+            "en": "Content encoding: utf-8 (default) or base64."
+          },
+          "type": "string",
+          "required": false
         }
       ]
     },
@@ -1429,8 +1438,8 @@
     {
       "name": "create_branch",
       "description": {
-        "zh": "创建分支。",
-        "en": "Create a branch."
+        "zh": "创建分支（通过 /repos/{owner}/{repo}/git/refs）。",
+        "en": "Create a branch (via /repos/{owner}/{repo}/git/refs)."
       },
       "parameters": [
         {
@@ -1452,7 +1461,7 @@
           "required": true
         },
         {
-          "name": "branch",
+          "name": "new_branch",
           "description": {
             "zh": "新分支名",
             "en": "New branch name."
@@ -1463,17 +1472,8 @@
         {
           "name": "from_branch",
           "description": {
-            "zh": "基于哪个分支创建（默认默认分支）",
-            "en": "Branch to create from (default: default branch)."
-          },
-          "type": "string",
-          "required": false
-        },
-        {
-          "name": "sha",
-          "description": {
-            "zh": "直接指定起始 commit sha（优先于 from_branch）",
-            "en": "Starting commit SHA (overrides from_branch)."
+            "zh": "基于哪个分支创建（默认仓库默认分支）",
+            "en": "Branch to create from (default: repository default branch)."
           },
           "type": "string",
           "required": false

--- a/examples/github/src/index.ts
+++ b/examples/github/src/index.ts
@@ -2,20 +2,29 @@
 {
   "name": "github",
   "display_name": {
-      "zh": "GitHub API",
-      "en": "GitHub API"
+    "zh": "GitHub API",
+    "en": "GitHub API"
   },
-  "description": { "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。", "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)." },
+  "description": {
+    "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。",
+    "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)."
+  },
   "category": "Development",
   "env": [
     {
       "name": "GITHUB_TOKEN",
-      "description": { "zh": "GitHub API 认证令牌", "en": "GitHub API authentication token" },
+      "description": {
+        "zh": "GitHub API 认证令牌",
+        "en": "GitHub API authentication token"
+      },
       "required": true
     },
     {
       "name": "GITHUB_API_BASE_URL",
-      "description": { "zh": "GitHub API 基础 URL", "en": "GitHub API base URL" },
+      "description": {
+        "zh": "GitHub API 基础 URL",
+        "en": "GitHub API base URL"
+      },
       "required": false,
       "defaultValue": "https://api.github.com"
     }
@@ -23,2605 +32,2632 @@
   "enabledByDefault": false,
   "tools": [
     {
-        "name": "search_repositories",
-        "description": {
-            "zh": "搜索 GitHub 仓库（/search/repositories）。",
-            "en": "Search GitHub repositories (/search/repositories)."
+      "name": "search_repositories",
+      "description": {
+        "zh": "搜索 GitHub 仓库（/search/repositories）。",
+        "en": "Search GitHub repositories (/search/repositories)."
+      },
+      "parameters": [
+        {
+          "name": "query",
+          "description": {
+            "zh": "搜索关键词（GitHub search query）",
+            "en": "Search keywords (GitHub search query)."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "query",
-                "description": {
-                    "zh": "搜索关键词（GitHub search query）",
-                    "en": "Search keywords (GitHub search query)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sort",
-                "description": {
-                    "zh": "排序字段：stars/forks/help-wanted-issues/updated",
-                    "en": "Sort field: stars/forks/help-wanted-issues/updated."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "order",
-                "description": {
-                    "zh": "排序方向：desc/asc",
-                    "en": "Sort order: desc/asc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30，最大 100）",
-                    "en": "Items per page (default: 30, max: 100)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序字段：stars/forks/help-wanted-issues/updated",
+            "en": "Sort field: stars/forks/help-wanted-issues/updated."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "order",
+          "description": {
+            "zh": "排序方向：desc/asc",
+            "en": "Sort order: desc/asc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30，最大 100）",
+            "en": "Items per page (default: 30, max: 100)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_repository",
-        "description": {
-            "zh": "获取仓库信息（/repos/{owner}/{repo}）。",
-            "en": "Get repository information (/repos/{owner}/{repo})."
+      "name": "get_repository",
+      "description": {
+        "zh": "获取仓库信息（/repos/{owner}/{repo}）。",
+        "en": "Get repository information (/repos/{owner}/{repo})."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "list_issues",
-        "description": {
-            "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。",
-            "en": "List repository issues (/repos/{owner}/{repo}/issues)."
+      "name": "list_issues",
+      "description": {
+        "zh": "列出仓库 Issues（/repos/{owner}/{repo}/issues）。",
+        "en": "List repository issues (/repos/{owner}/{repo}/issues)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed/all（默认 open）",
-                    "en": "open/closed/all (default: open)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "labels",
-                "description": {
-                    "zh": "labels 逗号分隔",
-                    "en": "Labels, comma-separated."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "creator",
-                "description": {
-                    "zh": "创建者 login",
-                    "en": "Creator login."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "include_pull_requests",
-                "description": {
-                    "zh": "是否保留 PR（默认 false）",
-                    "en": "Whether to include PRs (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed/all（默认 open）",
+            "en": "open/closed/all (default: open)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "labels",
+          "description": {
+            "zh": "labels 逗号分隔",
+            "en": "Labels, comma-separated."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "creator",
+          "description": {
+            "zh": "创建者 login",
+            "en": "Creator login."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "include_pull_requests",
+          "description": {
+            "zh": "是否保留 PR（默认 false）",
+            "en": "Whether to include PRs (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_issue",
-        "description": {
-            "zh": "获取单个 Issue 详情（/repos/{owner}/{repo}/issues/{issue_number}）。",
-            "en": "Get a single issue."
+      "name": "get_issue",
+      "description": {
+        "zh": "获取单个 Issue 详情（/repos/{owner}/{repo}/issues/{issue_number}）。",
+        "en": "Get a single issue."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "create_issue",
-        "description": {
-            "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。",
-            "en": "Create an issue."
+      "name": "create_issue",
+      "description": {
+        "zh": "创建 Issue（/repos/{owner}/{repo}/issues）。",
+        "en": "Create an issue."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "Issue 标题",
-                    "en": "Issue title."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "Issue 内容",
-                    "en": "Issue body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "labels",
-                "description": {
-                    "zh": "labels 数组",
-                    "en": "Labels array."
-                },
-                "type": "array",
-                "required": false
-            },
-            {
-                "name": "assignees",
-                "description": {
-                    "zh": "assignees 数组",
-                    "en": "Assignees array."
-                },
-                "type": "array",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "Issue 标题",
+            "en": "Issue title."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "Issue 内容",
+            "en": "Issue body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "labels",
+          "description": {
+            "zh": "labels 数组",
+            "en": "Labels array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "assignees",
+          "description": {
+            "zh": "assignees 数组",
+            "en": "Assignees array."
+          },
+          "type": "array",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "update_issue",
-        "description": {
-            "zh": "更新 Issue。",
-            "en": "Update an issue."
+      "name": "update_issue",
+      "description": {
+        "zh": "更新 Issue。",
+        "en": "Update an issue."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "新标题",
-                    "en": "New title."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "新内容",
-                    "en": "New body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed",
-                    "en": "open/closed."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "labels",
-                "description": {
-                    "zh": "labels 数组",
-                    "en": "Labels array."
-                },
-                "type": "array",
-                "required": false
-            },
-            {
-                "name": "assignees",
-                "description": {
-                    "zh": "assignees 数组",
-                    "en": "Assignees array."
-                },
-                "type": "array",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "新标题",
+            "en": "New title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "新内容",
+            "en": "New body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed",
+            "en": "open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "labels",
+          "description": {
+            "zh": "labels 数组",
+            "en": "Labels array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "assignees",
+          "description": {
+            "zh": "assignees 数组",
+            "en": "Assignees array."
+          },
+          "type": "array",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "comment_issue",
-        "description": {
-            "zh": "给 Issue/PR 评论。",
-            "en": "Comment on an issue/PR."
+      "name": "comment_issue",
+      "description": {
+        "zh": "给 Issue/PR 评论。",
+        "en": "Comment on an issue/PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "评论内容",
-                    "en": "Comment body."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "评论内容",
+            "en": "Comment body."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "list_issue_comments",
-        "description": {
-            "zh": "列出 Issue/PR 的评论。",
-            "en": "List comments on an issue/PR."
+      "name": "list_issue_comments",
+      "description": {
+        "zh": "列出 Issue/PR 的评论。",
+        "en": "List comments on an issue/PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "issue_number",
-                "description": {
-                    "zh": "Issue 编号",
-                    "en": "Issue number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "issue_number",
+          "description": {
+            "zh": "Issue 编号",
+            "en": "Issue number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_requests",
-        "description": {
-            "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。",
-            "en": "List pull requests."
+      "name": "list_pull_requests",
+      "description": {
+        "zh": "列出 PR（/repos/{owner}/{repo}/pulls）。",
+        "en": "List pull requests."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed/all（默认 open）",
-                    "en": "open/closed/all (default: open)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head 分支过滤，格式 user:branch",
-                    "en": "Head branch filter (user:branch)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "base 分支过滤",
-                    "en": "Base branch filter."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed/all（默认 open）",
+            "en": "open/closed/all (default: open)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head 分支过滤，格式 user:branch",
+            "en": "Head branch filter (user:branch)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "base 分支过滤",
+            "en": "Base branch filter."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_pull_request",
-        "description": {
-            "zh": "创建 PR。",
-            "en": "Create a pull request."
+      "name": "create_pull_request",
+      "description": {
+        "zh": "创建 PR。",
+        "en": "Create a pull request."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "PR 标题",
-                    "en": "PR title."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head 分支（含跨 fork 的 user:branch 格式）",
-                    "en": "Head branch (use user:branch for cross-fork)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "目标 base 分支",
-                    "en": "Target base branch."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "PR 描述",
-                    "en": "PR body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "draft",
-                "description": {
-                    "zh": "是否草稿",
-                    "en": "Whether to create as draft."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "PR 标题",
+            "en": "PR title."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head 分支（含跨 fork 的 user:branch 格式）",
+            "en": "Head branch (use user:branch for cross-fork)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "目标 base 分支",
+            "en": "Target base branch."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "PR 描述",
+            "en": "PR body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether to create as draft."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_pull_request",
-        "description": {
-            "zh": "获取单个 PR 详情。",
-            "en": "Get a single pull request."
+      "name": "get_pull_request",
+      "description": {
+        "zh": "获取单个 PR 详情。",
+        "en": "Get a single pull request."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "update_pull_request",
-        "description": {
-            "zh": "更新 PR 标题/描述/状态/base/draft。",
-            "en": "Update PR title/body/state/base/draft."
+      "name": "update_pull_request",
+      "description": {
+        "zh": "更新 PR 标题/描述/状态/base/draft。",
+        "en": "Update PR title/body/state/base/draft."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "title",
-                "description": {
-                    "zh": "新标题",
-                    "en": "New title."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "新描述",
-                    "en": "New body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "state",
-                "description": {
-                    "zh": "open/closed",
-                    "en": "open/closed."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "新 base 分支",
-                    "en": "New base branch."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "draft",
-                "description": {
-                    "zh": "是否草稿",
-                    "en": "Whether draft."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "新标题",
+            "en": "New title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "新描述",
+            "en": "New body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "open/closed",
+            "en": "open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "新 base 分支",
+            "en": "New base branch."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether draft."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "merge_pull_request",
-        "description": {
-            "zh": "合并 PR。",
-            "en": "Merge a pull request."
+      "name": "merge_pull_request",
+      "description": {
+        "zh": "合并 PR。",
+        "en": "Merge a pull request."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "commit_title",
-                "description": {
-                    "zh": "合并 commit 标题",
-                    "en": "Merge commit title."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "commit_message",
-                "description": {
-                    "zh": "合并 commit 消息",
-                    "en": "Merge commit message."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "merge_method",
-                "description": {
-                    "zh": "merge/squash/rebase（默认 merge）",
-                    "en": "merge/squash/rebase (default: merge)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "commit_title",
+          "description": {
+            "zh": "合并 commit 标题",
+            "en": "Merge commit title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "commit_message",
+          "description": {
+            "zh": "合并 commit 消息",
+            "en": "Merge commit message."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "merge_method",
+          "description": {
+            "zh": "merge/squash/rebase（默认 merge）",
+            "en": "merge/squash/rebase (default: merge)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_request_files",
-        "description": {
-            "zh": "列出 PR 变更文件。",
-            "en": "List files changed in a PR."
+      "name": "list_pull_request_files",
+      "description": {
+        "zh": "列出 PR 变更文件。",
+        "en": "List files changed in a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "include_patch",
-                "description": {
-                    "zh": "是否包含 patch 内容（默认 false）",
-                    "en": "Include patch content (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 100）",
-                    "en": "Items per page (default: 100)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "include_patch",
+          "description": {
+            "zh": "是否包含 patch 内容（默认 false）",
+            "en": "Include patch content (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 100）",
+            "en": "Items per page (default: 100)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_pull_request_diff",
-        "description": {
-            "zh": "获取 PR 的 unified diff 文本。",
-            "en": "Get PR unified diff text."
+      "name": "get_pull_request_diff",
+      "description": {
+        "zh": "获取 PR 的 unified diff 文本。",
+        "en": "Get PR unified diff text."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "max_chars",
-                "description": {
-                    "zh": "截断字符数（默认 20000）",
-                    "en": "Truncate to this many chars (default: 20000)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "max_chars",
+          "description": {
+            "zh": "截断字符数（默认 20000）",
+            "en": "Truncate to this many chars (default: 20000)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_request_commits",
-        "description": {
-            "zh": "列出 PR 的提交。",
-            "en": "List commits in a PR."
+      "name": "list_pull_request_commits",
+      "description": {
+        "zh": "列出 PR 的提交。",
+        "en": "List commits in a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_pull_request_reviews",
-        "description": {
-            "zh": "列出 PR 的 review。",
-            "en": "List reviews on a PR."
+      "name": "list_pull_request_reviews",
+      "description": {
+        "zh": "列出 PR 的 review。",
+        "en": "List reviews on a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_review_comments",
-        "description": {
-            "zh": "列出 PR 的行内 review comments。",
-            "en": "List inline review comments on a PR."
+      "name": "list_review_comments",
+      "description": {
+        "zh": "列出 PR 的行内 review comments。",
+        "en": "List inline review comments on a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_review",
-        "description": {
-            "zh": "提交 PR review（APPROVE/REQUEST_CHANGES/COMMENT）。",
-            "en": "Submit a PR review (APPROVE/REQUEST_CHANGES/COMMENT)."
+      "name": "create_review",
+      "description": {
+        "zh": "提交 PR review（APPROVE/REQUEST_CHANGES/COMMENT）。",
+        "en": "Submit a PR review (APPROVE/REQUEST_CHANGES/COMMENT)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "review 总评内容",
-                    "en": "Review body."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "event",
-                "description": {
-                    "zh": "APPROVE/REQUEST_CHANGES/COMMENT（默认 COMMENT）",
-                    "en": "APPROVE/REQUEST_CHANGES/COMMENT (default: COMMENT)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "commit_id",
-                "description": {
-                    "zh": "关联的 commit sha",
-                    "en": "Commit SHA to associate."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "comments",
-                "description": {
-                    "zh": "行内评论数组（JSON 字符串），每项含 path/line/body",
-                    "en": "Inline comments array (JSON string), each with path/line/body."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "review 总评内容",
+            "en": "Review body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "event",
+          "description": {
+            "zh": "APPROVE/REQUEST_CHANGES/COMMENT（默认 COMMENT）",
+            "en": "APPROVE/REQUEST_CHANGES/COMMENT (default: COMMENT)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "commit_id",
+          "description": {
+            "zh": "关联的 commit sha",
+            "en": "Commit SHA to associate."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "comments",
+          "description": {
+            "zh": "行内评论数组（JSON 字符串），每项含 path/line/body",
+            "en": "Inline comments array (JSON string), each with path/line/body."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "reply_review_comment",
-        "description": {
-            "zh": "回复 PR 行内 review comment。",
-            "en": "Reply to a PR inline review comment."
+      "name": "reply_review_comment",
+      "description": {
+        "zh": "回复 PR 行内 review comment。",
+        "en": "Reply to a PR inline review comment."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "comment_id",
-                "description": {
-                    "zh": "被回复的 comment id",
-                    "en": "Comment ID to reply to."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "body",
-                "description": {
-                    "zh": "回复内容",
-                    "en": "Reply body."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "comment_id",
+          "description": {
+            "zh": "被回复的 comment id",
+            "en": "Comment ID to reply to."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "回复内容",
+            "en": "Reply body."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "request_reviewers",
-        "description": {
-            "zh": "请求 PR reviewer。",
-            "en": "Request reviewers for a PR."
+      "name": "request_reviewers",
+      "description": {
+        "zh": "请求 PR reviewer。",
+        "en": "Request reviewers for a PR."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "pull_number",
-                "description": {
-                    "zh": "PR 编号",
-                    "en": "PR number."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "reviewers",
-                "description": {
-                    "zh": "reviewer login 列表，逗号分隔或数组",
-                    "en": "Reviewer logins, comma-separated or array."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "team_reviewers",
-                "description": {
-                    "zh": "team reviewer slug 列表，逗号分隔或数组",
-                    "en": "Team reviewer slugs, comma-separated or array."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "pull_number",
+          "description": {
+            "zh": "PR 编号",
+            "en": "PR number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "reviewers",
+          "description": {
+            "zh": "reviewer login 列表，逗号分隔或数组",
+            "en": "Reviewer logins, comma-separated or array."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "team_reviewers",
+          "description": {
+            "zh": "team reviewer slug 列表，逗号分隔或数组",
+            "en": "Team reviewer slugs, comma-separated or array."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_file_content",
-        "description": {
-            "zh": "获取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。",
-            "en": "Get file content from a repository."
+      "name": "get_file_content",
+      "description": {
+        "zh": "获取仓库文件内容（/repos/{owner}/{repo}/contents/{path}）。",
+        "en": "Get file content from a repository."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径（相对仓库根目录）",
-                    "en": "File path relative to repository root."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "分支/tag/commit（默认默认分支）",
-                    "en": "Branch/tag/commit (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径（相对仓库根目录）",
+            "en": "File path relative to repository root."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "分支/tag/commit（默认默认分支）",
+            "en": "Branch/tag/commit (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_or_update_file",
-        "description": {
-            "zh": "创建或更新仓库文件。更新时需传 sha。",
-            "en": "Create or update a file in the repository. Provide sha when updating."
+      "name": "create_or_update_file",
+      "description": {
+        "zh": "创建或更新仓库文件。更新时需传 sha。",
+        "en": "Create or update a file in the repository. Provide sha when updating."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径",
-                    "en": "File path."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "message",
-                "description": {
-                    "zh": "commit 消息",
-                    "en": "Commit message."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "content",
-                "description": {
-                    "zh": "文件内容（明文，会自动 base64 编码）",
-                    "en": "File content (plain text, will be base64-encoded)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "更新时必填：现有文件的 blob sha",
-                    "en": "Required when updating: existing file blob SHA."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "目标分支（默认默认分支）",
-                    "en": "Target branch (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径",
+            "en": "File path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "message",
+          "description": {
+            "zh": "commit 消息",
+            "en": "Commit message."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "content",
+          "description": {
+            "zh": "文件内容（明文，会自动 base64 编码）",
+            "en": "File content (plain text, will be base64-encoded)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "更新时必填：现有文件的 blob sha",
+            "en": "Required when updating: existing file blob SHA."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "目标分支（默认默认分支）",
+            "en": "Target branch (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "delete_file",
-        "description": {
-            "zh": "删除仓库文件。",
-            "en": "Delete a file from the repository."
+      "name": "delete_file",
+      "description": {
+        "zh": "删除仓库文件。",
+        "en": "Delete a file from the repository."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径",
-                    "en": "File path."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "message",
-                "description": {
-                    "zh": "commit 消息",
-                    "en": "Commit message."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "文件的 blob sha",
-                    "en": "File blob SHA."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "目标分支",
-                    "en": "Target branch."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径",
+            "en": "File path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "message",
+          "description": {
+            "zh": "commit 消息",
+            "en": "Commit message."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "文件的 blob sha",
+            "en": "File blob SHA."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "目标分支",
+            "en": "Target branch."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "create_branch",
-        "description": {
-            "zh": "创建分支。",
-            "en": "Create a branch."
+      "name": "create_branch",
+      "description": {
+        "zh": "创建分支。",
+        "en": "Create a branch."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "新分支名",
-                    "en": "New branch name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "from_branch",
-                "description": {
-                    "zh": "基于哪个分支创建（默认默认分支）",
-                    "en": "Branch to create from (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "直接指定起始 commit sha（优先于 from_branch）",
-                    "en": "Starting commit SHA (overrides from_branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "新分支名",
+            "en": "New branch name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "from_branch",
+          "description": {
+            "zh": "基于哪个分支创建（默认默认分支）",
+            "en": "Branch to create from (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "直接指定起始 commit sha（优先于 from_branch）",
+            "en": "Starting commit SHA (overrides from_branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_branches",
-        "description": {
-            "zh": "列出仓库分支。",
-            "en": "List repository branches."
+      "name": "list_branches",
+      "description": {
+        "zh": "列出仓库分支。",
+        "en": "List repository branches."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "protected_only",
-                "description": {
-                    "zh": "只返回受保护分支（默认 false）",
-                    "en": "Return only protected branches (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "protected_only",
+          "description": {
+            "zh": "只返回受保护分支（默认 false）",
+            "en": "Return only protected branches (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_commits",
-        "description": {
-            "zh": "列出仓库提交。",
-            "en": "List repository commits."
+      "name": "list_commits",
+      "description": {
+        "zh": "列出仓库提交。",
+        "en": "List repository commits."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sha",
-                "description": {
-                    "zh": "分支/tag/commit sha（默认默认分支）",
-                    "en": "Branch/tag/commit SHA (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "只返回修改了该路径的提交",
-                    "en": "Only commits affecting this path."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "author",
-                "description": {
-                    "zh": "作者 login 过滤",
-                    "en": "Author login filter."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "sha",
+          "description": {
+            "zh": "分支/tag/commit sha（默认默认分支）",
+            "en": "Branch/tag/commit SHA (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "只返回修改了该路径的提交",
+            "en": "Only commits affecting this path."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "author",
+          "description": {
+            "zh": "作者 login 过滤",
+            "en": "Author login filter."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_commit",
-        "description": {
-            "zh": "获取单个提交详情。",
-            "en": "Get a single commit."
+      "name": "get_commit",
+      "description": {
+        "zh": "获取单个提交详情。",
+        "en": "Get a single commit."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "commit sha / 分支 / tag",
-                    "en": "Commit SHA, branch, or tag."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "include_files",
-                "description": {
-                    "zh": "是否包含文件变更列表（默认 true）",
-                    "en": "Whether to include file changes (default: true)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "commit sha / 分支 / tag",
+            "en": "Commit SHA, branch, or tag."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "include_files",
+          "description": {
+            "zh": "是否包含文件变更列表（默认 true）",
+            "en": "Whether to include file changes (default: true)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "compare_refs",
-        "description": {
-            "zh": "比较两个 ref。",
-            "en": "Compare two refs."
+      "name": "compare_refs",
+      "description": {
+        "zh": "比较两个 ref。",
+        "en": "Compare two refs."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "base ref（分支/tag/sha）",
-                    "en": "Base ref (branch/tag/sha)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head ref（分支/tag/sha）",
-                    "en": "Head ref (branch/tag/sha)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "include_files",
-                "description": {
-                    "zh": "是否包含文件列表（默认 true）",
-                    "en": "Whether to include file list (default: true)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "include_patch",
-                "description": {
-                    "zh": "文件列表是否包含 patch（默认 false）",
-                    "en": "Whether file list includes patch (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "base ref（分支/tag/sha）",
+            "en": "Base ref (branch/tag/sha)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head ref（分支/tag/sha）",
+            "en": "Head ref (branch/tag/sha)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "include_files",
+          "description": {
+            "zh": "是否包含文件列表（默认 true）",
+            "en": "Whether to include file list (default: true)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "include_patch",
+          "description": {
+            "zh": "文件列表是否包含 patch（默认 false）",
+            "en": "Whether file list includes patch (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_compare_diff",
-        "description": {
-            "zh": "获取两个 ref 之间的 unified diff 文本。",
-            "en": "Get unified diff text between two refs."
+      "name": "get_compare_diff",
+      "description": {
+        "zh": "获取两个 ref 之间的 unified diff 文本。",
+        "en": "Get unified diff text between two refs."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "base",
-                "description": {
-                    "zh": "base ref",
-                    "en": "Base ref."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "head",
-                "description": {
-                    "zh": "head ref",
-                    "en": "Head ref."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "max_chars",
-                "description": {
-                    "zh": "截断字符数（默认 20000）",
-                    "en": "Truncate to this many chars (default: 20000)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "base",
+          "description": {
+            "zh": "base ref",
+            "en": "Base ref."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "head",
+          "description": {
+            "zh": "head ref",
+            "en": "Head ref."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "max_chars",
+          "description": {
+            "zh": "截断字符数（默认 20000）",
+            "en": "Truncate to this many chars (default: 20000)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_workflows",
-        "description": {
-            "zh": "列出仓库 GitHub Actions workflow。",
-            "en": "List GitHub Actions workflows."
+      "name": "list_workflows",
+      "description": {
+        "zh": "列出仓库 GitHub Actions workflow。",
+        "en": "List GitHub Actions workflows."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "list_workflow_runs",
-        "description": {
-            "zh": "列出 workflow run。",
-            "en": "List workflow runs."
+      "name": "list_workflow_runs",
+      "description": {
+        "zh": "列出 workflow run。",
+        "en": "List workflow runs."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "workflow_id",
-                "description": {
-                    "zh": "workflow id 或文件名（如 android-tests.yml），不传则列出所有",
-                    "en": "Workflow ID or filename (e.g. android-tests.yml); omit to list all."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "按分支过滤",
-                    "en": "Filter by branch."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "status",
-                "description": {
-                    "zh": "按状态过滤：queued/in_progress/completed/failure/success 等",
-                    "en": "Filter by status: queued/in_progress/completed/failure/success etc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "event",
-                "description": {
-                    "zh": "按触发事件过滤：push/pull_request/workflow_dispatch 等",
-                    "en": "Filter by event: push/pull_request/workflow_dispatch etc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "workflow_id",
+          "description": {
+            "zh": "workflow id 或文件名（如 android-tests.yml），不传则列出所有",
+            "en": "Workflow ID or filename (e.g. android-tests.yml); omit to list all."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "按分支过滤",
+            "en": "Filter by branch."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "status",
+          "description": {
+            "zh": "按状态过滤：queued/in_progress/completed/failure/success 等",
+            "en": "Filter by status: queued/in_progress/completed/failure/success etc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "event",
+          "description": {
+            "zh": "按触发事件过滤：push/pull_request/workflow_dispatch 等",
+            "en": "Filter by event: push/pull_request/workflow_dispatch etc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_workflow_run",
-        "description": {
-            "zh": "获取单个 workflow run 详情。",
-            "en": "Get a single workflow run."
+      "name": "get_workflow_run",
+      "description": {
+        "zh": "获取单个 workflow run 详情。",
+        "en": "Get a single workflow run."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "trigger_workflow",
-        "description": {
-            "zh": "手动触发 workflow（workflow_dispatch）。",
-            "en": "Manually trigger a workflow (workflow_dispatch)."
+      "name": "trigger_workflow",
+      "description": {
+        "zh": "手动触发 workflow（workflow_dispatch）。",
+        "en": "Manually trigger a workflow (workflow_dispatch)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "workflow_id",
-                "description": {
-                    "zh": "workflow id 或文件名（如 android-tests.yml）",
-                    "en": "Workflow ID or filename (e.g. android-tests.yml)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "触发分支或 tag",
-                    "en": "Branch or tag to trigger on."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "inputs",
-                "description": {
-                    "zh": "workflow inputs（JSON 字符串或对象）",
-                    "en": "Workflow inputs (JSON string or object)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "workflow_id",
+          "description": {
+            "zh": "workflow id 或文件名（如 android-tests.yml）",
+            "en": "Workflow ID or filename (e.g. android-tests.yml)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "触发分支或 tag",
+            "en": "Branch or tag to trigger on."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "inputs",
+          "description": {
+            "zh": "workflow inputs（JSON 字符串或对象）",
+            "en": "Workflow inputs (JSON string or object)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_workflow_jobs",
-        "description": {
-            "zh": "获取 workflow run 的 jobs（含可选日志）。",
-            "en": "Get jobs for a workflow run (with optional logs)."
+      "name": "get_workflow_jobs",
+      "description": {
+        "zh": "获取 workflow run 的 jobs（含可选日志）。",
+        "en": "Get jobs for a workflow run (with optional logs)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "include_logs",
-                "description": {
-                    "zh": "是否拉取每个 job 的日志（默认 false）",
-                    "en": "Whether to fetch logs for each job (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "failed_only",
-                "description": {
-                    "zh": "只返回失败/非成功的 job（默认 false）",
-                    "en": "Return only failed/non-success jobs (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "max_log_chars",
-                "description": {
-                    "zh": "日志截断字符数（默认 8000）",
-                    "en": "Log truncation in characters (default: 8000)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 50）",
-                    "en": "Items per page (default: 50)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "include_logs",
+          "description": {
+            "zh": "是否拉取每个 job 的日志（默认 false）",
+            "en": "Whether to fetch logs for each job (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "failed_only",
+          "description": {
+            "zh": "只返回失败/非成功的 job（默认 false）",
+            "en": "Return only failed/non-success jobs (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "max_log_chars",
+          "description": {
+            "zh": "日志截断字符数（默认 8000）",
+            "en": "Log truncation in characters (default: 8000)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 50）",
+            "en": "Items per page (default: 50)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "rerun_workflow_run",
-        "description": {
-            "zh": "重新运行 workflow run（全部或仅失败 job）。",
-            "en": "Re-run a workflow run (all jobs or failed jobs only)."
+      "name": "rerun_workflow_run",
+      "description": {
+        "zh": "重新运行 workflow run（全部或仅失败 job）。",
+        "en": "Re-run a workflow run (all jobs or failed jobs only)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            },
-            {
-                "name": "failed_jobs_only",
-                "description": {
-                    "zh": "只重跑失败 job（默认 false）",
-                    "en": "Only re-run failed jobs (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            },
-            {
-                "name": "enable_debug_logging",
-                "description": {
-                    "zh": "是否开启 debug 日志",
-                    "en": "Whether to enable debug logging."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "failed_jobs_only",
+          "description": {
+            "zh": "只重跑失败 job（默认 false）",
+            "en": "Only re-run failed jobs (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "enable_debug_logging",
+          "description": {
+            "zh": "是否开启 debug 日志",
+            "en": "Whether to enable debug logging."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "cancel_workflow_run",
-        "description": {
-            "zh": "取消 workflow run。",
-            "en": "Cancel a workflow run."
+      "name": "cancel_workflow_run",
+      "description": {
+        "zh": "取消 workflow run。",
+        "en": "Cancel a workflow run."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "run_id",
-                "description": {
-                    "zh": "workflow run id",
-                    "en": "Workflow run ID."
-                },
-                "type": "number",
-                "required": true
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "run_id",
+          "description": {
+            "zh": "workflow run id",
+            "en": "Workflow run ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
     },
     {
-        "name": "list_check_runs",
-        "description": {
-            "zh": "列出某个 commit 的 check runs。",
-            "en": "List check runs for a commit."
+      "name": "list_check_runs",
+      "description": {
+        "zh": "列出某个 commit 的 check runs。",
+        "en": "List check runs for a commit."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "ref",
-                "description": {
-                    "zh": "commit sha / 分支 / tag",
-                    "en": "Commit SHA, branch, or tag."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "status",
-                "description": {
-                    "zh": "queued/in_progress/completed 过滤",
-                    "en": "Filter by status: queued/in_progress/completed."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "filter",
-                "description": {
-                    "zh": "latest/all（默认 latest）",
-                    "en": "latest/all (default: latest)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 30）",
-                    "en": "Items per page (default: 30)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ref",
+          "description": {
+            "zh": "commit sha / 分支 / tag",
+            "en": "Commit SHA, branch, or tag."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "status",
+          "description": {
+            "zh": "queued/in_progress/completed 过滤",
+            "en": "Filter by status: queued/in_progress/completed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "filter",
+          "description": {
+            "zh": "latest/all（默认 latest）",
+            "en": "latest/all (default: latest)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "search_code",
-        "description": {
-            "zh": "搜索代码（/search/code）。",
-            "en": "Search code (/search/code)."
+      "name": "search_code",
+      "description": {
+        "zh": "搜索代码（/search/code）。",
+        "en": "Search code (/search/code)."
+      },
+      "parameters": [
+        {
+          "name": "query",
+          "description": {
+            "zh": "搜索查询（支持 GitHub code search 语法）",
+            "en": "Search query (GitHub code search syntax, e.g. repo:owner/name keyword)."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "query",
-                "description": {
-                    "zh": "搜索查询（支持 GitHub code search 语法）",
-                    "en": "Search query (GitHub code search syntax, e.g. repo:owner/name keyword)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sort",
-                "description": {
-                    "zh": "排序字段（indexed）",
-                    "en": "Sort field (indexed)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "order",
-                "description": {
-                    "zh": "排序方向：desc/asc",
-                    "en": "Sort order: desc/asc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序字段（indexed）",
+            "en": "Sort field (indexed)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "order",
+          "description": {
+            "zh": "排序方向：desc/asc",
+            "en": "Sort order: desc/asc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "search_issues",
-        "description": {
-            "zh": "搜索 Issue/PR（/search/issues）。",
-            "en": "Search issues and PRs (/search/issues)."
+      "name": "search_issues",
+      "description": {
+        "zh": "搜索 Issue/PR（/search/issues）。",
+        "en": "Search issues and PRs (/search/issues)."
+      },
+      "parameters": [
+        {
+          "name": "query",
+          "description": {
+            "zh": "搜索查询（支持 GitHub issue search 语法）",
+            "en": "Search query (GitHub issue search syntax)."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "query",
-                "description": {
-                    "zh": "搜索查询（支持 GitHub issue search 语法）",
-                    "en": "Search query (GitHub issue search syntax)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "sort",
-                "description": {
-                    "zh": "排序字段：comments/reactions/created/updated 等",
-                    "en": "Sort field: comments/reactions/created/updated etc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "order",
-                "description": {
-                    "zh": "排序方向：desc/asc",
-                    "en": "Sort order: desc/asc."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "page",
-                "description": {
-                    "zh": "页码（默认 1）",
-                    "en": "Page number (default: 1)."
-                },
-                "type": "number",
-                "required": false
-            },
-            {
-                "name": "per_page",
-                "description": {
-                    "zh": "每页数量（默认 20）",
-                    "en": "Items per page (default: 20)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序字段：comments/reactions/created/updated 等",
+            "en": "Sort field: comments/reactions/created/updated etc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "order",
+          "description": {
+            "zh": "排序方向：desc/asc",
+            "en": "Sort order: desc/asc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 20）",
+            "en": "Items per page (default: 20)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "get_authenticated_user",
-        "description": {
-            "zh": "获取当前认证用户信息（/user）。",
-            "en": "Get the currently authenticated user (/user)."
-        },
-        "parameters": []
+      "name": "get_authenticated_user",
+      "description": {
+        "zh": "获取当前认证用户信息（/user）。",
+        "en": "Get the currently authenticated user (/user)."
+      },
+      "parameters": []
     },
     {
-        "name": "get_rate_limit",
-        "description": {
-            "zh": "查询 GitHub API 请求频率限制（/rate_limit）。",
-            "en": "Query GitHub API rate limit (/rate_limit)."
-        },
-        "parameters": []
+      "name": "get_rate_limit",
+      "description": {
+        "zh": "查询 GitHub API 请求频率限制（/rate_limit）。",
+        "en": "Query GitHub API rate limit (/rate_limit)."
+      },
+      "parameters": []
     },
     {
-        "name": "fork_repository",
-        "description": {
-            "zh": "fork 仓库（/repos/{owner}/{repo}/forks）。",
-            "en": "Fork a repository."
+      "name": "fork_repository",
+      "description": {
+        "zh": "fork 仓库（/repos/{owner}/{repo}/forks）。",
+        "en": "Fork a repository."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "organization",
-                "description": {
-                    "zh": "fork 到指定组织（不填则 fork 到个人账号）",
-                    "en": "Fork to a specific organization (omit for personal account)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "name",
-                "description": {
-                    "zh": "fork 后的仓库名（默认与原仓库同名）",
-                    "en": "Name for the forked repository (default: same as original)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "default_branch_only",
-                "description": {
-                    "zh": "只 fork 默认分支（默认 false）",
-                    "en": "Fork only the default branch (default: false)."
-                },
-                "type": "boolean",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "organization",
+          "description": {
+            "zh": "fork 到指定组织（不填则 fork 到个人账号）",
+            "en": "Fork to a specific organization (omit for personal account)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "fork 后的仓库名（默认与原仓库同名）",
+            "en": "Name for the forked repository (default: same as original)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "default_branch_only",
+          "description": {
+            "zh": "只 fork 默认分支（默认 false）",
+            "en": "Fork only the default branch (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "sync_fork",
-        "description": {
-            "zh": "同步 fork 到上游（/repos/{owner}/{repo}/merge-upstream）。",
-            "en": "Sync a fork with upstream."
+      "name": "sync_fork",
+      "description": {
+        "zh": "同步 fork 到上游（/repos/{owner}/{repo}/merge-upstream）。",
+        "en": "Sync a fork with upstream."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "fork 仓库的 owner",
+            "en": "Fork repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "fork 仓库的 owner",
-                    "en": "Fork repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "fork 仓库名",
-                    "en": "Fork repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "要同步的分支（默认默认分支）",
-                    "en": "Branch to sync (default: default branch)."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "fork 仓库名",
+            "en": "Fork repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "要同步的分支（默认默认分支）",
+            "en": "Branch to sync (default: default branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "patch_file_in_repo",
-        "description": {
-            "zh": "在仓库中对文件应用 search/replace patch（先读取文件，替换内容后写回）。",
-            "en": "Apply a search/replace patch to a file in the repository (read -> replace -> write back)."
+      "name": "patch_file_in_repo",
+      "description": {
+        "zh": "在仓库中对文件应用差异块 patch（先读取文件，按 [START-REPLACE]/[START-DELETE] 块替换内容后写回）。",
+        "en": "Apply a block-based patch to a repository file (read -> apply [START-REPLACE]/[START-DELETE] blocks -> write back)."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "owner",
-                "description": {
-                    "zh": "仓库 owner",
-                    "en": "Repository owner."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "repo",
-                "description": {
-                    "zh": "仓库名",
-                    "en": "Repository name."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "path",
-                "description": {
-                    "zh": "文件路径",
-                    "en": "File path."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "search",
-                "description": {
-                    "zh": "要查找的文本（精确匹配）",
-                    "en": "Text to search for (exact match)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "replace",
-                "description": {
-                    "zh": "替换后的文本",
-                    "en": "Replacement text."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "message",
-                "description": {
-                    "zh": "commit 消息",
-                    "en": "Commit message."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "branch",
-                "description": {
-                    "zh": "目标分支",
-                    "en": "Target branch."
-                },
-                "type": "string",
-                "required": false
-            }
-        ]
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "path",
+          "description": {
+            "zh": "文件路径",
+            "en": "File path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "message",
+          "description": {
+            "zh": "commit 消息",
+            "en": "Commit message."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "patch",
+          "description": {
+            "zh": "差异块文本。格式：[START-REPLACE]\\n[OLD]\\n原内容\\n[/OLD]\\n[NEW]\\n新内容\\n[/NEW]\\n[END-REPLACE]，删除用 [START-DELETE] 配 [OLD] 块，可包含多个块。",
+            "en": "Patch blocks. Format: [START-REPLACE]\\n[OLD]\\nold\\n[/OLD]\\n[NEW]\\nnew\\n[/NEW]\\n[END-REPLACE]; use [START-DELETE] with an [OLD] block to delete. Multiple blocks allowed."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "目标分支",
+            "en": "Target branch."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "apply_local_replace",
-        "description": {
-            "zh": "在本地文件系统中对文件应用 search/replace（不经过 GitHub API）。",
-            "en": "Apply a search/replace patch to a local file (no GitHub API)."
+      "name": "apply_local_replace",
+      "description": {
+        "zh": "在本地文件中把 old 片段替换为 new 片段（不经过 GitHub API）。",
+        "en": "Replace an old snippet with a new snippet in a local file (no GitHub API)."
+      },
+      "parameters": [
+        {
+          "name": "path",
+          "description": {
+            "zh": "本地文件路径",
+            "en": "Local file path."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "path",
-                "description": {
-                    "zh": "本地文件路径（绝对路径）",
-                    "en": "Local file path (absolute)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "search",
-                "description": {
-                    "zh": "要查找的文本",
-                    "en": "Text to search for."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "replace",
-                "description": {
-                    "zh": "替换后的文本",
-                    "en": "Replacement text."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "old",
+          "description": {
+            "zh": "要被替换的原内容片段（精确匹配）",
+            "en": "Existing snippet to replace (exact match)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "new",
+          "description": {
+            "zh": "替换后的新内容片段",
+            "en": "Replacement snippet."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "执行环境：android（默认）或 linux",
+            "en": "Environment: android (default) or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "apply_local_delete",
-        "description": {
-            "zh": "删除本地文件（不经过 GitHub API）。",
-            "en": "Delete a local file (no GitHub API)."
+      "name": "apply_local_delete",
+      "description": {
+        "zh": "在本地文件中删除指定内容片段（不经过 GitHub API）。",
+        "en": "Delete a snippet from a local file (no GitHub API)."
+      },
+      "parameters": [
+        {
+          "name": "path",
+          "description": {
+            "zh": "本地文件路径",
+            "en": "Local file path."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "path",
-                "description": {
-                    "zh": "本地文件路径（绝对路径）",
-                    "en": "Local file path (absolute)."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "old",
+          "description": {
+            "zh": "要删除的内容片段（精确匹配）",
+            "en": "Snippet to delete (exact match)."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "执行环境：android（默认）或 linux",
+            "en": "Environment: android (default) or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "overwrite_local_file",
-        "description": {
-            "zh": "用新内容完整覆盖本地文件（不经过 GitHub API）。",
-            "en": "Overwrite a local file with new content (no GitHub API)."
+      "name": "overwrite_local_file",
+      "description": {
+        "zh": "用新内容覆盖写入本地文件（不经过 GitHub API）。",
+        "en": "Overwrite a local file with new content (no GitHub API)."
+      },
+      "parameters": [
+        {
+          "name": "path",
+          "description": {
+            "zh": "本地文件路径",
+            "en": "Local file path."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "path",
-                "description": {
-                    "zh": "本地文件路径（绝对路径）",
-                    "en": "Local file path (absolute)."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "content",
-                "description": {
-                    "zh": "新的文件内容",
-                    "en": "New file content."
-                },
-                "type": "string",
-                "required": true
-            }
-        ]
+        {
+          "name": "content",
+          "description": {
+            "zh": "写入的完整内容",
+            "en": "Full content to write."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "执行环境：android（默认）或 linux",
+            "en": "Environment: android (default) or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
     },
     {
-        "name": "terminal_exec",
-        "description": {
-            "zh": "在本地终端执行命令（调用 Operit 内置终端，注意权限和安全）。",
-            "en": "Execute a command in the local terminal (uses Operit built-in terminal)."
+      "name": "terminal_exec",
+      "description": {
+        "zh": "在 Operit 内置终端中执行命令（会话在多次调用间复用）。",
+        "en": "Execute a command in the Operit built-in terminal (session is reused across calls)."
+      },
+      "parameters": [
+        {
+          "name": "command",
+          "description": {
+            "zh": "要执行的命令",
+            "en": "Command to execute."
+          },
+          "type": "string",
+          "required": true
         },
-        "parameters": [
-            {
-                "name": "command",
-                "description": {
-                    "zh": "要执行的 shell 命令",
-                    "en": "Shell command to execute."
-                },
-                "type": "string",
-                "required": true
-            },
-            {
-                "name": "cwd",
-                "description": {
-                    "zh": "工作目录（默认当前目录）",
-                    "en": "Working directory (default: current directory)."
-                },
-                "type": "string",
-                "required": false
-            },
-            {
-                "name": "timeout_ms",
-                "description": {
-                    "zh": "超时毫秒数（默认 30000）",
-                    "en": "Timeout in milliseconds (default: 30000)."
-                },
-                "type": "number",
-                "required": false
-            }
-        ]
+        {
+          "name": "session_name",
+          "description": {
+            "zh": "终端会话名（默认 github_tools_session）",
+            "en": "Terminal session name (default: github_tools_session)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "close",
+          "description": {
+            "zh": "执行后是否关闭会话（默认 false）",
+            "en": "Whether to close the session after execution (default: false)."
+          },
+          "type": "boolean",
+          "required": false
+        }
+      ]
     }
-]
+  ]
 }
 */
 
@@ -2631,7 +2667,7 @@ import { getFileContent, createOrUpdateFile, deleteFile } from './github/content
 import { createBranch } from './github/branches';
 import { listBranches, listCommits, getCommit, compareRefs, getCompareDiff } from './github/git';
 import { listWorkflows, listWorkflowRuns, getWorkflowRun, triggerWorkflow, getWorkflowJobs, rerunWorkflowRun, cancelWorkflowRun, listCheckRuns } from './github/actions';
-import { searchRepositories } from './github/repos';
+import { searchRepositories, getRepository } from './github/repos';
 import { searchCode, searchIssues } from './github/search';
 import { getAuthenticatedUser, getRateLimit } from './github/users';
 import { forkRepository, syncFork } from './github/forks';
@@ -2642,7 +2678,7 @@ import { wrap } from './utils/wrap';
 
 export const toolImpl: Record<string, (params: any) => Promise<any>> = {
     search_repositories: (p) => wrap(searchRepositories as any, p, '搜索仓库成功', '搜索仓库失败'),
-    get_repository: (p) => wrap(searchRepositories as any, p, '获取仓库成功', '获取仓库失败'),
+    get_repository: (p) => wrap(getRepository as any, p, '获取仓库成功', '获取仓库失败'),
     list_issues: (p) => wrap(listIssues as any, p, '列出 Issues 成功', '列出 Issues 失败'),
     get_issue: (p) => wrap(getIssue as any, p, '获取 Issue 成功', '获取 Issue 失败'),
     create_issue: (p) => wrap(createIssue as any, p, '创建 Issue 成功', '创建 Issue 失败'),

--- a/examples/github/src/index.ts
+++ b/examples/github/src/index.ts
@@ -6,8 +6,8 @@
     "en": "GitHub API"
   },
   "description": {
-    "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。",
-    "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/search/fork) and local-side utilities (apply_file patch updates, terminal)."
+    "zh": "基于 GitHub REST API 的工具集合（不依赖 GitHub MCP）。包含 GitHub 侧（仓库/Issues/PR/文件提交/分支/差异/Actions/Releases/Webhooks/协作者/Labels/Milestones/分支保护/统计/搜索/fork）与本地侧（apply_file 差异更新、terminal 终端）能力。",
+    "en": "A toolkit built on the GitHub REST API (does not depend on GitHub MCP). Includes GitHub-side operations (repos/issues/PRs/commits/branches/diffs/Actions/releases/webhooks/collaborators/labels/milestones/branch protection/stats/search/fork) and local-side utilities (apply_file patch updates, terminal)."
   },
   "category": "Development",
   "env": [
@@ -27,6 +27,15 @@
       },
       "required": false,
       "defaultValue": "https://api.github.com"
+    },
+    {
+      "name": "GITHUB_UPLOADS_BASE_URL",
+      "description": {
+        "zh": "GitHub Release 资产上传基础 URL（默认 https://uploads.github.com）",
+        "en": "GitHub release asset upload base URL (default: https://uploads.github.com)."
+      },
+      "required": false,
+      "defaultValue": "https://uploads.github.com"
     }
   ],
   "enabledByDefault": false,
@@ -2656,6 +2665,1806 @@
           "required": false
         }
       ]
+    },
+    {
+      "name": "list_releases",
+      "description": {
+        "zh": "列出仓库 Releases。",
+        "en": "List repository releases."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_release",
+      "description": {
+        "zh": "获取指定 Release。",
+        "en": "Get a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_latest_release",
+      "description": {
+        "zh": "获取最新的正式 Release。",
+        "en": "Get the latest release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_release_by_tag",
+      "description": {
+        "zh": "按 tag 获取 Release。",
+        "en": "Get a release by tag."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "tag",
+          "description": {
+            "zh": "Git tag 名称",
+            "en": "Git tag name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_release",
+      "description": {
+        "zh": "创建 Release。",
+        "en": "Create a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "tag_name",
+          "description": {
+            "zh": "tag 名称",
+            "en": "Tag name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "target_commitish",
+          "description": {
+            "zh": "目标分支或 commit",
+            "en": "Target branch or commit."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Release 标题",
+            "en": "Release name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "Release 描述",
+            "en": "Release body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether draft."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "prerelease",
+          "description": {
+            "zh": "是否预发布",
+            "en": "Whether prerelease."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "generate_release_notes",
+          "description": {
+            "zh": "是否自动生成说明",
+            "en": "Whether to generate release notes."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "make_latest",
+          "description": {
+            "zh": "latest 标记：true/false/legacy",
+            "en": "Latest marker: true/false/legacy."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "discussion_category_name",
+          "description": {
+            "zh": "Discussion 分类名",
+            "en": "Discussion category name."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_release",
+      "description": {
+        "zh": "更新 Release。",
+        "en": "Update a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "tag_name",
+          "description": {
+            "zh": "tag 名称",
+            "en": "Tag name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "target_commitish",
+          "description": {
+            "zh": "目标分支或 commit",
+            "en": "Target branch or commit."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Release 标题",
+            "en": "Release name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "body",
+          "description": {
+            "zh": "Release 描述",
+            "en": "Release body."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "draft",
+          "description": {
+            "zh": "是否草稿",
+            "en": "Whether draft."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "prerelease",
+          "description": {
+            "zh": "是否预发布",
+            "en": "Whether prerelease."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "make_latest",
+          "description": {
+            "zh": "latest 标记：true/false/legacy",
+            "en": "Latest marker: true/false/legacy."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "discussion_category_name",
+          "description": {
+            "zh": "Discussion 分类名",
+            "en": "Discussion category name."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_release",
+      "description": {
+        "zh": "删除 Release。",
+        "en": "Delete a release."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "upload_release_asset",
+      "description": {
+        "zh": "向 Release 上传本地文件资产。",
+        "en": "Upload a local file as a release asset."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "release_id",
+          "description": {
+            "zh": "Release ID",
+            "en": "Release ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "asset_path",
+          "description": {
+            "zh": "本地资产路径",
+            "en": "Local asset path."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "上传后的文件名（默认取路径文件名）",
+            "en": "Uploaded filename (defaults to the path basename)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "label",
+          "description": {
+            "zh": "资产说明",
+            "en": "Asset label."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "content_type",
+          "description": {
+            "zh": "MIME 类型（默认 application/octet-stream）",
+            "en": "MIME type (default application/octet-stream)."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "environment",
+          "description": {
+            "zh": "文件环境：android 或 linux",
+            "en": "File environment: android or linux."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_release_asset",
+      "description": {
+        "zh": "删除 Release 资产。",
+        "en": "Delete a release asset."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "asset_id",
+          "description": {
+            "zh": "资产 ID",
+            "en": "Asset ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_webhooks",
+      "description": {
+        "zh": "列出仓库 Webhooks。",
+        "en": "List repository webhooks."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_webhook",
+      "description": {
+        "zh": "获取仓库 Webhook。",
+        "en": "Get a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_webhook",
+      "description": {
+        "zh": "创建仓库 Webhook。",
+        "en": "Create a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "url",
+          "description": {
+            "zh": "Webhook 接收 URL",
+            "en": "Webhook receiver URL."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "content_type",
+          "description": {
+            "zh": "内容类型：json 或 form",
+            "en": "Content type: json or form."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "secret",
+          "description": {
+            "zh": "Webhook secret",
+            "en": "Webhook secret."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "insecure_ssl",
+          "description": {
+            "zh": "是否允许不安全 SSL",
+            "en": "Whether to allow insecure SSL."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "events",
+          "description": {
+            "zh": "事件列表，逗号分隔或数组",
+            "en": "Events, comma-separated or array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "active",
+          "description": {
+            "zh": "是否启用",
+            "en": "Whether active."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "config",
+          "description": {
+            "zh": "额外 config JSON",
+            "en": "Additional config JSON."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_webhook",
+      "description": {
+        "zh": "更新仓库 Webhook。",
+        "en": "Update a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "url",
+          "description": {
+            "zh": "Webhook 接收 URL",
+            "en": "Webhook receiver URL."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "content_type",
+          "description": {
+            "zh": "内容类型：json 或 form",
+            "en": "Content type: json or form."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "secret",
+          "description": {
+            "zh": "Webhook secret",
+            "en": "Webhook secret."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "insecure_ssl",
+          "description": {
+            "zh": "是否允许不安全 SSL",
+            "en": "Whether to allow insecure SSL."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "events",
+          "description": {
+            "zh": "完整事件列表，逗号分隔或数组",
+            "en": "Complete event list, comma-separated or array."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "add_events",
+          "description": {
+            "zh": "追加事件列表",
+            "en": "Events to add."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "remove_events",
+          "description": {
+            "zh": "移除事件列表",
+            "en": "Events to remove."
+          },
+          "type": "array",
+          "required": false
+        },
+        {
+          "name": "active",
+          "description": {
+            "zh": "是否启用",
+            "en": "Whether active."
+          },
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "config",
+          "description": {
+            "zh": "额外 config JSON",
+            "en": "Additional config JSON."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_webhook",
+      "description": {
+        "zh": "删除仓库 Webhook。",
+        "en": "Delete a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "ping_webhook",
+      "description": {
+        "zh": "向仓库 Webhook 发送 ping。",
+        "en": "Ping a repository webhook."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "hook_id",
+          "description": {
+            "zh": "Webhook ID",
+            "en": "Webhook ID."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_collaborators",
+      "description": {
+        "zh": "列出仓库协作者。",
+        "en": "List repository collaborators."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "affiliation",
+          "description": {
+            "zh": "筛选：outside/direct/all",
+            "en": "Filter: outside/direct/all."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "permission",
+          "description": {
+            "zh": "权限筛选：pull/triage/push/maintain/admin",
+            "en": "Permission filter: pull/triage/push/maintain/admin."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "check_collaborator",
+      "description": {
+        "zh": "检查用户是否为仓库协作者。",
+        "en": "Check whether a user is a repository collaborator."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "add_collaborator",
+      "description": {
+        "zh": "添加仓库协作者。",
+        "en": "Add a repository collaborator."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "permission",
+          "description": {
+            "zh": "权限：pull/triage/push/maintain/admin",
+            "en": "Permission: pull/triage/push/maintain/admin."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "remove_collaborator",
+      "description": {
+        "zh": "移除仓库协作者。",
+        "en": "Remove a repository collaborator."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_collaborator_permission",
+      "description": {
+        "zh": "获取用户在仓库中的权限。",
+        "en": "Get repository permissions for a user."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "username",
+          "description": {
+            "zh": "GitHub 用户名",
+            "en": "GitHub username."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_labels",
+      "description": {
+        "zh": "列出仓库 Labels。",
+        "en": "List repository labels."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_label",
+      "description": {
+        "zh": "获取仓库 Label。",
+        "en": "Get a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Label 名称",
+            "en": "Label name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_label",
+      "description": {
+        "zh": "创建仓库 Label。",
+        "en": "Create a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Label 名称",
+            "en": "Label name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "color",
+          "description": {
+            "zh": "六位十六进制颜色，可带 #",
+            "en": "Six-digit hexadecimal color, with optional #."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Label 描述",
+            "en": "Label description."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_label",
+      "description": {
+        "zh": "更新仓库 Label。",
+        "en": "Update a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "当前 Label 名称",
+            "en": "Current label name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "new_name",
+          "description": {
+            "zh": "新 Label 名称",
+            "en": "New label name."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "color",
+          "description": {
+            "zh": "六位十六进制颜色，可带 #",
+            "en": "Six-digit hexadecimal color, with optional #."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Label 描述",
+            "en": "Label description."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_label",
+      "description": {
+        "zh": "删除仓库 Label。",
+        "en": "Delete a repository label."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "name",
+          "description": {
+            "zh": "Label 名称",
+            "en": "Label name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "list_milestones",
+      "description": {
+        "zh": "列出仓库 Milestones。",
+        "en": "List repository milestones."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "状态：open/closed/all",
+            "en": "State: open/closed/all."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "sort",
+          "description": {
+            "zh": "排序：due_on/completeness",
+            "en": "Sort: due_on/completeness."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "direction",
+          "description": {
+            "zh": "方向：asc/desc",
+            "en": "Direction: asc/desc."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "page",
+          "description": {
+            "zh": "页码（默认 1）",
+            "en": "Page number (default: 1)."
+          },
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "per_page",
+          "description": {
+            "zh": "每页数量（默认 30）",
+            "en": "Items per page (default: 30)."
+          },
+          "type": "number",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "get_milestone",
+      "description": {
+        "zh": "获取 Milestone。",
+        "en": "Get a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "milestone_number",
+          "description": {
+            "zh": "Milestone 编号",
+            "en": "Milestone number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "create_milestone",
+      "description": {
+        "zh": "创建 Milestone。",
+        "en": "Create a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "Milestone 标题",
+            "en": "Milestone title."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "状态：open/closed",
+            "en": "State: open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Milestone 描述",
+            "en": "Milestone description."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "due_on",
+          "description": {
+            "zh": "截止时间，ISO 8601",
+            "en": "Due date, ISO 8601."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "update_milestone",
+      "description": {
+        "zh": "更新 Milestone。",
+        "en": "Update a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "milestone_number",
+          "description": {
+            "zh": "Milestone 编号",
+            "en": "Milestone number."
+          },
+          "type": "number",
+          "required": true
+        },
+        {
+          "name": "title",
+          "description": {
+            "zh": "Milestone 标题",
+            "en": "Milestone title."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "state",
+          "description": {
+            "zh": "状态：open/closed",
+            "en": "State: open/closed."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "description",
+          "description": {
+            "zh": "Milestone 描述",
+            "en": "Milestone description."
+          },
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "due_on",
+          "description": {
+            "zh": "截止时间，ISO 8601",
+            "en": "Due date, ISO 8601."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_milestone",
+      "description": {
+        "zh": "删除 Milestone。",
+        "en": "Delete a milestone."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "milestone_number",
+          "description": {
+            "zh": "Milestone 编号",
+            "en": "Milestone number."
+          },
+          "type": "number",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_branch_protection",
+      "description": {
+        "zh": "获取分支保护规则。",
+        "en": "Get branch protection."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "分支名",
+            "en": "Branch name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "update_branch_protection",
+      "description": {
+        "zh": "更新分支保护规则。protection 需传 GitHub PUT 接口要求的完整 JSON。",
+        "en": "Update branch protection. protection must be the complete JSON body required by the GitHub PUT endpoint."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "分支名",
+            "en": "Branch name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "protection",
+          "description": {
+            "zh": "分支保护 JSON 对象或 JSON 字符串",
+            "en": "Branch protection JSON object or JSON string."
+          },
+          "type": "object",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "delete_branch_protection",
+      "description": {
+        "zh": "删除分支保护规则。",
+        "en": "Delete branch protection."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "分支名",
+            "en": "Branch name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_contributors_stats",
+      "description": {
+        "zh": "获取仓库贡献者统计。",
+        "en": "Get repository contributor statistics."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_commit_activity",
+      "description": {
+        "zh": "获取最近一年按周提交活动。",
+        "en": "Get the last year of weekly commit activity."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "get_code_frequency",
+      "description": {
+        "zh": "获取每周代码增删统计。",
+        "en": "Get weekly code additions and deletions."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        }
+      ]
     }
   ]
 }
@@ -2674,6 +4483,13 @@ import { forkRepository, syncFork } from './github/forks';
 import { patchFileInRepo } from './github/patch';
 import { applyLocalReplace, applyLocalDelete, overwriteLocalFile } from './github/local/fileApply';
 import { terminalExec } from './github/local/terminal';
+import { listReleases, getRelease, getLatestRelease, getReleaseByTag, createRelease, updateRelease, deleteRelease, uploadReleaseAsset, deleteReleaseAsset } from './github/releases';
+import { listWebhooks, getWebhook, createWebhook, updateWebhook, deleteWebhook, pingWebhook } from './github/webhooks';
+import { listCollaborators, checkCollaborator, addCollaborator, removeCollaborator, getCollaboratorPermission } from './github/collaborators';
+import { listLabels, getLabel, createLabel, updateLabel, deleteLabel } from './github/labels';
+import { listMilestones, getMilestone, createMilestone, updateMilestone, deleteMilestone } from './github/milestones';
+import { getBranchProtection, updateBranchProtection, deleteBranchProtection } from './github/protection';
+import { getContributorsStats, getCommitActivity, getCodeFrequency } from './github/stats';
 import { wrap } from './utils/wrap';
 
 export const toolImpl: Record<string, (params: any) => Promise<any>> = {
@@ -2725,7 +4541,43 @@ export const toolImpl: Record<string, (params: any) => Promise<any>> = {
     apply_local_replace: (p) => wrap(applyLocalReplace as any, p, '本地替换成功', '本地替换失败'),
     apply_local_delete: (p) => wrap(applyLocalDelete as any, p, '本地删除成功', '本地删除失败'),
     overwrite_local_file: (p) => wrap(overwriteLocalFile as any, p, '覆盖文件成功', '覆盖文件失败'),
-    terminal_exec: (p) => wrap(terminalExec as any, p, '终端执行成功', '终端执行失败')
+    terminal_exec: (p) => wrap(terminalExec as any, p, '终端执行成功', '终端执行失败'),
+    list_releases: (p) => wrap(listReleases as any, p, '列出 Releases 成功', '列出 Releases 失败'),
+    get_release: (p) => wrap(getRelease as any, p, '获取 Release 成功', '获取 Release 失败'),
+    get_latest_release: (p) => wrap(getLatestRelease as any, p, '获取最新 Release 成功', '获取最新 Release 失败'),
+    get_release_by_tag: (p) => wrap(getReleaseByTag as any, p, '按 tag 获取 Release 成功', '按 tag 获取 Release 失败'),
+    create_release: (p) => wrap(createRelease as any, p, '创建 Release 成功', '创建 Release 失败'),
+    update_release: (p) => wrap(updateRelease as any, p, '更新 Release 成功', '更新 Release 失败'),
+    delete_release: (p) => wrap(deleteRelease as any, p, '删除 Release 成功', '删除 Release 失败'),
+    upload_release_asset: (p) => wrap(uploadReleaseAsset as any, p, '上传 Release 资产成功', '上传 Release 资产失败'),
+    delete_release_asset: (p) => wrap(deleteReleaseAsset as any, p, '删除 Release 资产成功', '删除 Release 资产失败'),
+    list_webhooks: (p) => wrap(listWebhooks as any, p, '列出 Webhooks 成功', '列出 Webhooks 失败'),
+    get_webhook: (p) => wrap(getWebhook as any, p, '获取 Webhook 成功', '获取 Webhook 失败'),
+    create_webhook: (p) => wrap(createWebhook as any, p, '创建 Webhook 成功', '创建 Webhook 失败'),
+    update_webhook: (p) => wrap(updateWebhook as any, p, '更新 Webhook 成功', '更新 Webhook 失败'),
+    delete_webhook: (p) => wrap(deleteWebhook as any, p, '删除 Webhook 成功', '删除 Webhook 失败'),
+    ping_webhook: (p) => wrap(pingWebhook as any, p, 'ping Webhook 成功', 'ping Webhook 失败'),
+    list_collaborators: (p) => wrap(listCollaborators as any, p, '列出协作者成功', '列出协作者失败'),
+    check_collaborator: (p) => wrap(checkCollaborator as any, p, '检查协作者成功', '检查协作者失败'),
+    add_collaborator: (p) => wrap(addCollaborator as any, p, '添加协作者成功', '添加协作者失败'),
+    remove_collaborator: (p) => wrap(removeCollaborator as any, p, '移除协作者成功', '移除协作者失败'),
+    get_collaborator_permission: (p) => wrap(getCollaboratorPermission as any, p, '获取协作者权限成功', '获取协作者权限失败'),
+    list_labels: (p) => wrap(listLabels as any, p, '列出 Labels 成功', '列出 Labels 失败'),
+    get_label: (p) => wrap(getLabel as any, p, '获取 Label 成功', '获取 Label 失败'),
+    create_label: (p) => wrap(createLabel as any, p, '创建 Label 成功', '创建 Label 失败'),
+    update_label: (p) => wrap(updateLabel as any, p, '更新 Label 成功', '更新 Label 失败'),
+    delete_label: (p) => wrap(deleteLabel as any, p, '删除 Label 成功', '删除 Label 失败'),
+    list_milestones: (p) => wrap(listMilestones as any, p, '列出 Milestones 成功', '列出 Milestones 失败'),
+    get_milestone: (p) => wrap(getMilestone as any, p, '获取 Milestone 成功', '获取 Milestone 失败'),
+    create_milestone: (p) => wrap(createMilestone as any, p, '创建 Milestone 成功', '创建 Milestone 失败'),
+    update_milestone: (p) => wrap(updateMilestone as any, p, '更新 Milestone 成功', '更新 Milestone 失败'),
+    delete_milestone: (p) => wrap(deleteMilestone as any, p, '删除 Milestone 成功', '删除 Milestone 失败'),
+    get_branch_protection: (p) => wrap(getBranchProtection as any, p, '获取分支保护成功', '获取分支保护失败'),
+    update_branch_protection: (p) => wrap(updateBranchProtection as any, p, '更新分支保护成功', '更新分支保护失败'),
+    delete_branch_protection: (p) => wrap(deleteBranchProtection as any, p, '删除分支保护成功', '删除分支保护失败'),
+    get_contributors_stats: (p) => wrap(getContributorsStats as any, p, '获取贡献者统计成功', '获取贡献者统计失败'),
+    get_commit_activity: (p) => wrap(getCommitActivity as any, p, '获取提交活动成功', '获取提交活动失败'),
+    get_code_frequency: (p) => wrap(getCodeFrequency as any, p, '获取代码频率成功', '获取代码频率失败'),
 };
 
 export async function main(params: any): Promise<any> {
@@ -2789,3 +4641,39 @@ export const apply_local_replace = toolImpl.apply_local_replace;
 export const apply_local_delete = toolImpl.apply_local_delete;
 export const overwrite_local_file = toolImpl.overwrite_local_file;
 export const terminal_exec = toolImpl.terminal_exec;
+export const list_releases = toolImpl.list_releases;
+export const get_release = toolImpl.get_release;
+export const get_latest_release = toolImpl.get_latest_release;
+export const get_release_by_tag = toolImpl.get_release_by_tag;
+export const create_release = toolImpl.create_release;
+export const update_release = toolImpl.update_release;
+export const delete_release = toolImpl.delete_release;
+export const upload_release_asset = toolImpl.upload_release_asset;
+export const delete_release_asset = toolImpl.delete_release_asset;
+export const list_webhooks = toolImpl.list_webhooks;
+export const get_webhook = toolImpl.get_webhook;
+export const create_webhook = toolImpl.create_webhook;
+export const update_webhook = toolImpl.update_webhook;
+export const delete_webhook = toolImpl.delete_webhook;
+export const ping_webhook = toolImpl.ping_webhook;
+export const list_collaborators = toolImpl.list_collaborators;
+export const check_collaborator = toolImpl.check_collaborator;
+export const add_collaborator = toolImpl.add_collaborator;
+export const remove_collaborator = toolImpl.remove_collaborator;
+export const get_collaborator_permission = toolImpl.get_collaborator_permission;
+export const list_labels = toolImpl.list_labels;
+export const get_label = toolImpl.get_label;
+export const create_label = toolImpl.create_label;
+export const update_label = toolImpl.update_label;
+export const delete_label = toolImpl.delete_label;
+export const list_milestones = toolImpl.list_milestones;
+export const get_milestone = toolImpl.get_milestone;
+export const create_milestone = toolImpl.create_milestone;
+export const update_milestone = toolImpl.update_milestone;
+export const delete_milestone = toolImpl.delete_milestone;
+export const get_branch_protection = toolImpl.get_branch_protection;
+export const update_branch_protection = toolImpl.update_branch_protection;
+export const delete_branch_protection = toolImpl.delete_branch_protection;
+export const get_contributors_stats = toolImpl.get_contributors_stats;
+export const get_commit_activity = toolImpl.get_commit_activity;
+export const get_code_frequency = toolImpl.get_code_frequency;

--- a/examples/github/src/index.ts
+++ b/examples/github/src/index.ts
@@ -1447,8 +1447,8 @@
     {
       "name": "create_branch",
       "description": {
-        "zh": "创建分支（通过 /repos/{owner}/{repo}/git/refs）。",
-        "en": "Create a branch (via /repos/{owner}/{repo}/git/refs)."
+        "zh": "创建或恢复分支（POST /repos/{owner}/{repo}/git/refs）。可从已有分支或指定 commit SHA 建 ref。",
+        "en": "Create or restore a branch (POST /repos/{owner}/{repo}/git/refs). Point the new ref at an existing branch or a commit SHA."
       },
       "parameters": [
         {
@@ -1481,11 +1481,56 @@
         {
           "name": "from_branch",
           "description": {
-            "zh": "基于哪个分支创建（默认仓库默认分支）",
-            "en": "Branch to create from (default: repository default branch)."
+            "zh": "基于哪个分支创建（默认仓库默认分支；若传了 from_sha 则忽略）",
+            "en": "Branch to create from (default: repository default branch; ignored when from_sha is set)."
           },
           "type": "string",
           "required": false
+        },
+        {
+          "name": "from_sha",
+          "description": {
+            "zh": "基于哪个 commit SHA 创建（优先于 from_branch；用于从提交恢复已删分支）",
+            "en": "Commit SHA to create from (takes precedence over from_branch; use this to restore a deleted branch)."
+          },
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "delete_branch",
+      "description": {
+        "zh": "删除非默认分支（DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}）。不会删除仓库默认分支。",
+        "en": "Delete a non-default branch (DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}). Refuses to delete the repository default branch."
+      },
+      "parameters": [
+        {
+          "name": "owner",
+          "description": {
+            "zh": "仓库 owner",
+            "en": "Repository owner."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "description": {
+            "zh": "仓库名",
+            "en": "Repository name."
+          },
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "description": {
+            "zh": "要删除的分支名（不能是仓库默认分支）",
+            "en": "Branch name to delete (cannot be the repository default branch)."
+          },
+          "type": "string",
+          "required": true
         }
       ]
     },
@@ -4473,7 +4518,7 @@
 import { listIssues, getIssue, createIssue, updateIssue, commentIssue, listIssueComments } from './github/issues';
 import { listPullRequests, createPullRequest, getPullRequest, updatePullRequest, mergePullRequest, listPullRequestFiles, getPullRequestDiff, listPullRequestCommits, listPullRequestReviews, listReviewComments, createReview, replyReviewComment, requestReviewers } from './github/pulls';
 import { getFileContent, createOrUpdateFile, deleteFile } from './github/contents';
-import { createBranch } from './github/branches';
+import { createBranch, deleteBranch } from './github/branches';
 import { listBranches, listCommits, getCommit, compareRefs, getCompareDiff } from './github/git';
 import { listWorkflows, listWorkflowRuns, getWorkflowRun, triggerWorkflow, getWorkflowJobs, rerunWorkflowRun, cancelWorkflowRun, listCheckRuns } from './github/actions';
 import { searchRepositories, getRepository } from './github/repos';
@@ -4518,6 +4563,7 @@ export const toolImpl: Record<string, (params: any) => Promise<any>> = {
     create_or_update_file: (p) => wrap(createOrUpdateFile as any, p, '写入文件成功', '写入文件失败'),
     delete_file: (p) => wrap(deleteFile as any, p, '删除文件成功', '删除文件失败'),
     create_branch: (p) => wrap(createBranch as any, p, '创建分支成功', '创建分支失败'),
+    delete_branch: (p) => wrap(deleteBranch as any, p, '删除分支成功', '删除分支失败'),
     list_branches: (p) => wrap(listBranches as any, p, '列出分支成功', '列出分支失败'),
     list_commits: (p) => wrap(listCommits as any, p, '列出提交成功', '列出提交失败'),
     get_commit: (p) => wrap(getCommit as any, p, '获取提交成功', '获取提交失败'),
@@ -4617,6 +4663,7 @@ export const get_file_content = toolImpl.get_file_content;
 export const create_or_update_file = toolImpl.create_or_update_file;
 export const delete_file = toolImpl.delete_file;
 export const create_branch = toolImpl.create_branch;
+export const delete_branch = toolImpl.delete_branch;
 export const list_branches = toolImpl.list_branches;
 export const list_commits = toolImpl.list_commits;
 export const get_commit = toolImpl.get_commit;

--- a/examples/github/src/tools.ts
+++ b/examples/github/src/tools.ts
@@ -24,7 +24,7 @@ import {
     requestReviewers
 } from './github/pulls';
 import { getFileContent, createOrUpdateFile, deleteFile } from './github/contents';
-import { createBranch } from './github/branches';
+import { createBranch, deleteBranch } from './github/branches';
 import { patchFileInRepo } from './github/patch';
 import {
     listWorkflows,
@@ -72,6 +72,7 @@ export const toolImpl = {
     create_or_update_file: (p: any) => wrap(createOrUpdateFile, p, '提交文件成功', '提交文件失败'),
     delete_file: (p: any) => wrap(deleteFile, p, '删除文件成功', '删除文件失败'),
     create_branch: (p: any) => wrap(createBranch, p, '创建分支成功', '创建分支失败'),
+    delete_branch: (p: any) => wrap(deleteBranch as any, p, '删除分支成功', '删除分支失败'),
     patch_file_in_repo: (p: any) => wrap(patchFileInRepo, p, '仓库文件差异更新成功', '仓库文件差异更新失败'),
 
     list_workflows: (p: any) => wrap(listWorkflows, p, '获取 workflow 成功', '获取 workflow 失败'),

--- a/examples/github/src/tools.ts
+++ b/examples/github/src/tools.ts
@@ -1,10 +1,38 @@
 import { wrap } from './utils/wrap';
 import { searchRepositories, getRepository } from './github/repos';
-import { listIssues, createIssue, commentIssue, listIssueComments } from './github/issues';
-import { listPullRequests, createPullRequest, getPullRequest, mergePullRequest } from './github/pulls';
+import { listIssues, getIssue, createIssue, updateIssue, commentIssue, listIssueComments } from './github/issues';
+import {
+    listPullRequests,
+    createPullRequest,
+    getPullRequest,
+    mergePullRequest,
+    updatePullRequest,
+    listPullRequestFiles,
+    getPullRequestDiff,
+    listPullRequestCommits,
+    listPullRequestReviews,
+    listReviewComments,
+    createReview,
+    replyReviewComment,
+    requestReviewers
+} from './github/pulls';
 import { getFileContent, createOrUpdateFile, deleteFile } from './github/contents';
 import { createBranch } from './github/branches';
 import { patchFileInRepo } from './github/patch';
+import {
+    listWorkflows,
+    listWorkflowRuns,
+    getWorkflowRun,
+    triggerWorkflow,
+    getWorkflowJobs,
+    rerunWorkflowRun,
+    cancelWorkflowRun,
+    listCheckRuns
+} from './github/actions';
+import { listBranches, listCommits, getCommit, compareRefs, getCompareDiff } from './github/git';
+import { searchCode, searchIssues } from './github/search';
+import { getAuthenticatedUser, getRateLimit } from './github/users';
+import { forkRepository, syncFork } from './github/forks';
 import { applyLocalReplace, applyLocalDelete, overwriteLocalFile } from './local/fileApply';
 import { terminalExec } from './local/terminal';
 
@@ -13,14 +41,25 @@ export const toolImpl = {
     get_repository: (p: any) => wrap(getRepository, p, '获取仓库信息成功', '获取仓库信息失败'),
 
     list_issues: (p: any) => wrap(listIssues, p, '获取 Issues 成功', '获取 Issues 失败'),
+    get_issue: (p: any) => wrap(getIssue, p, '获取 Issue 成功', '获取 Issue 失败'),
     create_issue: (p: any) => wrap(createIssue, p, '创建 Issue 成功', '创建 Issue 失败'),
+    update_issue: (p: any) => wrap(updateIssue, p, '更新 Issue 成功', '更新 Issue 失败'),
     comment_issue: (p: any) => wrap(commentIssue, p, '发表评论成功', '发表评论失败'),
     list_issue_comments: (p: any) => wrap(listIssueComments, p, '获取 Issue 评论成功', '获取 Issue 评论失败'),
 
     list_pull_requests: (p: any) => wrap(listPullRequests, p, '获取 PR 列表成功', '获取 PR 列表失败'),
     create_pull_request: (p: any) => wrap(createPullRequest, p, '创建 PR 成功', '创建 PR 失败'),
     get_pull_request: (p: any) => wrap(getPullRequest, p, '获取 PR 成功', '获取 PR 失败'),
+    update_pull_request: (p: any) => wrap(updatePullRequest, p, '更新 PR 成功', '更新 PR 失败'),
     merge_pull_request: (p: any) => wrap(mergePullRequest, p, '合并 PR 成功', '合并 PR 失败'),
+    list_pull_request_files: (p: any) => wrap(listPullRequestFiles, p, '获取 PR 文件成功', '获取 PR 文件失败'),
+    get_pull_request_diff: (p: any) => wrap(getPullRequestDiff, p, '获取 PR diff 成功', '获取 PR diff 失败'),
+    list_pull_request_commits: (p: any) => wrap(listPullRequestCommits, p, '获取 PR 提交成功', '获取 PR 提交失败'),
+    list_pull_request_reviews: (p: any) => wrap(listPullRequestReviews, p, '获取 PR review 成功', '获取 PR review 失败'),
+    list_review_comments: (p: any) => wrap(listReviewComments, p, '获取行内评论成功', '获取行内评论失败'),
+    create_review: (p: any) => wrap(createReview, p, '提交 review 成功', '提交 review 失败'),
+    reply_review_comment: (p: any) => wrap(replyReviewComment, p, '回复行内评论成功', '回复行内评论失败'),
+    request_reviewers: (p: any) => wrap(requestReviewers, p, '请求 reviewer 成功', '请求 reviewer 失败'),
 
     get_file_content: (p: any) => wrap(getFileContent, p, '读取文件成功', '读取文件失败'),
     create_or_update_file: (p: any) => wrap(createOrUpdateFile, p, '提交文件成功', '提交文件失败'),
@@ -28,9 +67,30 @@ export const toolImpl = {
     create_branch: (p: any) => wrap(createBranch, p, '创建分支成功', '创建分支失败'),
     patch_file_in_repo: (p: any) => wrap(patchFileInRepo, p, '仓库文件差异更新成功', '仓库文件差异更新失败'),
 
+    list_workflows: (p: any) => wrap(listWorkflows, p, '获取 workflow 成功', '获取 workflow 失败'),
+    list_workflow_runs: (p: any) => wrap(listWorkflowRuns, p, '获取 workflow run 成功', '获取 workflow run 失败'),
+    get_workflow_run: (p: any) => wrap(getWorkflowRun, p, '获取 workflow run 详情成功', '获取 workflow run 详情失败'),
+    trigger_workflow: (p: any) => wrap(triggerWorkflow, p, '触发 workflow 成功', '触发 workflow 失败'),
+    get_workflow_jobs: (p: any) => wrap(getWorkflowJobs, p, '获取 workflow jobs 成功', '获取 workflow jobs 失败'),
+    rerun_workflow_run: (p: any) => wrap(rerunWorkflowRun, p, '重跑 workflow 成功', '重跑 workflow 失败'),
+    cancel_workflow_run: (p: any) => wrap(cancelWorkflowRun, p, '取消 workflow 成功', '取消 workflow 失败'),
+    list_check_runs: (p: any) => wrap(listCheckRuns, p, '获取 check runs 成功', '获取 check runs 失败'),
+
+    list_branches: (p: any) => wrap(listBranches, p, '获取分支成功', '获取分支失败'),
+    list_commits: (p: any) => wrap(listCommits, p, '获取提交成功', '获取提交失败'),
+    get_commit: (p: any) => wrap(getCommit, p, '获取提交详情成功', '获取提交详情失败'),
+    compare_refs: (p: any) => wrap(compareRefs, p, '比较引用成功', '比较引用失败'),
+    get_compare_diff: (p: any) => wrap(getCompareDiff, p, '获取 compare diff 成功', '获取 compare diff 失败'),
+
+    search_code: (p: any) => wrap(searchCode, p, '搜索代码成功', '搜索代码失败'),
+    search_issues: (p: any) => wrap(searchIssues, p, '搜索 Issue/PR 成功', '搜索 Issue/PR 失败'),
+    get_authenticated_user: (p: any) => wrap(getAuthenticatedUser, p, '获取当前用户成功', '获取当前用户失败'),
+    get_rate_limit: (p: any) => wrap(getRateLimit, p, '获取速率限制成功', '获取速率限制失败'),
+    fork_repository: (p: any) => wrap(forkRepository, p, 'Fork 仓库成功', 'Fork 仓库失败'),
+    sync_fork: (p: any) => wrap(syncFork, p, '同步 fork 成功', '同步 fork 失败'),
+
     apply_local_replace: (p: any) => wrap(applyLocalReplace as any, p, '本地差异更新成功', '本地差异更新失败'),
     apply_local_delete: (p: any) => wrap(applyLocalDelete as any, p, '本地删除片段成功', '本地删除片段失败'),
     overwrite_local_file: (p: any) => wrap(overwriteLocalFile as any, p, '本地覆盖写入成功', '本地覆盖写入失败'),
-
     terminal_exec: (p: any) => wrap(terminalExec as any, p, '终端执行成功', '终端执行失败')
 };

--- a/examples/github/src/tools.ts
+++ b/examples/github/src/tools.ts
@@ -1,3 +1,10 @@
+import { listReleases, getRelease, getLatestRelease, getReleaseByTag, createRelease, updateRelease, deleteRelease, uploadReleaseAsset, deleteReleaseAsset } from './github/releases';
+import { listWebhooks, getWebhook, createWebhook, updateWebhook, deleteWebhook, pingWebhook } from './github/webhooks';
+import { listCollaborators, checkCollaborator, addCollaborator, removeCollaborator, getCollaboratorPermission } from './github/collaborators';
+import { listLabels, getLabel, createLabel, updateLabel, deleteLabel } from './github/labels';
+import { listMilestones, getMilestone, createMilestone, updateMilestone, deleteMilestone } from './github/milestones';
+import { getBranchProtection, updateBranchProtection, deleteBranchProtection } from './github/protection';
+import { getContributorsStats, getCommitActivity, getCodeFrequency } from './github/stats';
 import { wrap } from './utils/wrap';
 import { searchRepositories, getRepository } from './github/repos';
 import { listIssues, getIssue, createIssue, updateIssue, commentIssue, listIssueComments } from './github/issues';
@@ -92,5 +99,41 @@ export const toolImpl = {
     apply_local_replace: (p: any) => wrap(applyLocalReplace as any, p, '本地差异更新成功', '本地差异更新失败'),
     apply_local_delete: (p: any) => wrap(applyLocalDelete as any, p, '本地删除片段成功', '本地删除片段失败'),
     overwrite_local_file: (p: any) => wrap(overwriteLocalFile as any, p, '本地覆盖写入成功', '本地覆盖写入失败'),
-    terminal_exec: (p: any) => wrap(terminalExec as any, p, '终端执行成功', '终端执行失败')
+    terminal_exec: (p: any) => wrap(terminalExec as any, p, '终端执行成功', '终端执行失败'),
+    list_releases: (p: any) => wrap(listReleases as any, p, '列出 Releases 成功', '列出 Releases 失败'),
+    get_release: (p: any) => wrap(getRelease as any, p, '获取 Release 成功', '获取 Release 失败'),
+    get_latest_release: (p: any) => wrap(getLatestRelease as any, p, '获取最新 Release 成功', '获取最新 Release 失败'),
+    get_release_by_tag: (p: any) => wrap(getReleaseByTag as any, p, '按 tag 获取 Release 成功', '按 tag 获取 Release 失败'),
+    create_release: (p: any) => wrap(createRelease as any, p, '创建 Release 成功', '创建 Release 失败'),
+    update_release: (p: any) => wrap(updateRelease as any, p, '更新 Release 成功', '更新 Release 失败'),
+    delete_release: (p: any) => wrap(deleteRelease as any, p, '删除 Release 成功', '删除 Release 失败'),
+    upload_release_asset: (p: any) => wrap(uploadReleaseAsset as any, p, '上传 Release 资产成功', '上传 Release 资产失败'),
+    delete_release_asset: (p: any) => wrap(deleteReleaseAsset as any, p, '删除 Release 资产成功', '删除 Release 资产失败'),
+    list_webhooks: (p: any) => wrap(listWebhooks as any, p, '列出 Webhooks 成功', '列出 Webhooks 失败'),
+    get_webhook: (p: any) => wrap(getWebhook as any, p, '获取 Webhook 成功', '获取 Webhook 失败'),
+    create_webhook: (p: any) => wrap(createWebhook as any, p, '创建 Webhook 成功', '创建 Webhook 失败'),
+    update_webhook: (p: any) => wrap(updateWebhook as any, p, '更新 Webhook 成功', '更新 Webhook 失败'),
+    delete_webhook: (p: any) => wrap(deleteWebhook as any, p, '删除 Webhook 成功', '删除 Webhook 失败'),
+    ping_webhook: (p: any) => wrap(pingWebhook as any, p, 'ping Webhook 成功', 'ping Webhook 失败'),
+    list_collaborators: (p: any) => wrap(listCollaborators as any, p, '列出协作者成功', '列出协作者失败'),
+    check_collaborator: (p: any) => wrap(checkCollaborator as any, p, '检查协作者成功', '检查协作者失败'),
+    add_collaborator: (p: any) => wrap(addCollaborator as any, p, '添加协作者成功', '添加协作者失败'),
+    remove_collaborator: (p: any) => wrap(removeCollaborator as any, p, '移除协作者成功', '移除协作者失败'),
+    get_collaborator_permission: (p: any) => wrap(getCollaboratorPermission as any, p, '获取协作者权限成功', '获取协作者权限失败'),
+    list_labels: (p: any) => wrap(listLabels as any, p, '列出 Labels 成功', '列出 Labels 失败'),
+    get_label: (p: any) => wrap(getLabel as any, p, '获取 Label 成功', '获取 Label 失败'),
+    create_label: (p: any) => wrap(createLabel as any, p, '创建 Label 成功', '创建 Label 失败'),
+    update_label: (p: any) => wrap(updateLabel as any, p, '更新 Label 成功', '更新 Label 失败'),
+    delete_label: (p: any) => wrap(deleteLabel as any, p, '删除 Label 成功', '删除 Label 失败'),
+    list_milestones: (p: any) => wrap(listMilestones as any, p, '列出 Milestones 成功', '列出 Milestones 失败'),
+    get_milestone: (p: any) => wrap(getMilestone as any, p, '获取 Milestone 成功', '获取 Milestone 失败'),
+    create_milestone: (p: any) => wrap(createMilestone as any, p, '创建 Milestone 成功', '创建 Milestone 失败'),
+    update_milestone: (p: any) => wrap(updateMilestone as any, p, '更新 Milestone 成功', '更新 Milestone 失败'),
+    delete_milestone: (p: any) => wrap(deleteMilestone as any, p, '删除 Milestone 成功', '删除 Milestone 失败'),
+    get_branch_protection: (p: any) => wrap(getBranchProtection as any, p, '获取分支保护成功', '获取分支保护失败'),
+    update_branch_protection: (p: any) => wrap(updateBranchProtection as any, p, '更新分支保护成功', '更新分支保护失败'),
+    delete_branch_protection: (p: any) => wrap(deleteBranchProtection as any, p, '删除分支保护成功', '删除分支保护失败'),
+    get_contributors_stats: (p: any) => wrap(getContributorsStats as any, p, '获取贡献者统计成功', '获取贡献者统计失败'),
+    get_commit_activity: (p: any) => wrap(getCommitActivity as any, p, '获取提交活动成功', '获取提交活动失败'),
+    get_code_frequency: (p: any) => wrap(getCodeFrequency as any, p, '获取代码频率成功', '获取代码频率失败')
 };


### PR DESCRIPTION
feat(github): expand built-in github package from 19 to 86 REST tools

把内置 `github` 沙盒包从现有日常接口扩成更完整的 GitHub REST 工具集。包名仍是 `github`，不依赖 GitHub MCP。

原先可调用工具是 19 个（metadata 里还多了一个不会当工具暴露的 `main`）。这次扩到 86 个。

## 原先 19 个工具
search_repositories、get_repository、list_issues、create_issue、comment_issue、list_issue_comments、list_pull_requests、create_pull_request、get_pull_request、merge_pull_request、get_file_content、create_or_update_file、patch_file_in_repo、delete_file、create_branch、apply_local_replace、apply_local_delete、overwrite_local_file、terminal_exec

## 现在覆盖的能力

### Issues / PR
补齐 get/update issue，以及 PR 文件、diff、commits、reviews、行内评论、提交 review、请求 reviewer。

### Actions / CI
list/get/trigger/rerun/cancel workflow，获取 jobs 和 check runs。

### Git / 分支 / 搜索 / fork
list_branches、list_commits、get_commit、compare_refs、get_compare_diff、search_code、search_issues、get_authenticated_user、get_rate_limit、fork_repository、sync_fork。
create_branch 可以从已有分支或 `from_sha` 建 ref（用于从某个 commit 恢复已删分支）。delete_branch 删除非默认分支，不会删仓库默认分支。

### Releases
list/get/latest/by_tag/create/update/delete，以及 upload_release_asset、delete_release_asset。

### Webhooks
list/get/create/update/delete/ping。

### Collaborators / Labels / Milestones
协作者 list/check/add/remove/permission；Label CRUD；Milestone CRUD。

### 分支保护 / 仓库统计
get/update/delete branch protection；contributors、commit_activity、code_frequency。统计接口会处理 202（计算中）和 204（空数据）。

## 这次没加
- Projects v2：走组织级 `/orgs/{org}/projectsV2`，看板/字段/卡片是另一套 API
- 组织 teams/members：组织管理员能力，不是仓库日常协作
- Git Blob/Tag：底层 git 对象，日常发版用 Releases 即可
- 删仓库、转让仓库、改公开/私有、删仓库级密钥/部署密钥：账号/仓库管理权限，不算开发工具

## 产物
- 源码：`examples/github/src/`
- bundle：`examples/github.js`（`node build.js`）
- assets 副本：`app/src/main/assets/packages/github.js`
- 两份 JS 是同一份 bundle 的副本，所以 diff 会看起来偏大

手写新逻辑主要在：
- `actions.ts` / `git.ts` / `search.ts` / `forks.ts` / `users.ts` / `branches.ts`
- `releases.ts` / `webhooks.ts` / `collaborators.ts` / `labels.ts` / `milestones.ts` / `protection.ts` / `stats.ts`
- `index.ts` 的双语 METADATA 和入口映射

## Checklist
- [x] 只改了内置 github 包
- [x] 包名是 `github`
- [x] `node build.js` 已编译
- [x] assets 副本已同步
- [x] 86 个工具的 metadata / 实现 / 导出对齐
- [x] diff 无无关/临时/敏感内容