### PR TITLE
fix(provider): keep video_url content in OpenAI Responses conversion

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesProvider.kt
@@ -564,6 +564,20 @@ object OpenAIResponsesPayloadAdapter {
                             }
                         }
 
+                        "video_url", "input_video" -> {
+                            val videoUrl =
+                                part.optJSONObject("video_url")?.optString("url", "")
+                                    ?: part.optString("video_url", "")
+                            if (videoUrl.isNotEmpty()) {
+                                convertedParts.put(
+                                    JSONObject().apply {
+                                        put("type", "input_video")
+                                        put("video_url", videoUrl)
+                                    }
+                                )
+                            }
+                        }
+
                         else -> {
                             val rawText = part.optString("text", "")
                             if (rawText.isNotEmpty()) {

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesVideoInputTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/OpenAIResponsesVideoInputTest.kt
@@ -1,0 +1,123 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class OpenAIResponsesVideoInputTest {
+    @Test
+    fun mapsChatCompletionsVideoUrlObjectToResponsesInputVideo() {
+        val request = chatRequest(
+            JSONArray()
+                .put(
+                    JSONObject().apply {
+                        put("type", "video_url")
+                        put(
+                            "video_url",
+                            JSONObject().apply {
+                                put("url", "data:video/mp4;base64,ZmFrZQ==")
+                            },
+                        )
+                    },
+                )
+                .put(
+                    JSONObject().apply {
+                        put("type", "text")
+                        put("text", "描述一下该视频")
+                    },
+                ),
+        )
+
+        val content = convertedContent(request)
+        assertEquals(2, content.length())
+        assertEquals("input_video", content.getJSONObject(0).getString("type"))
+        assertEquals(
+            "data:video/mp4;base64,ZmFrZQ==",
+            content.getJSONObject(0).getString("video_url"),
+        )
+        assertEquals("input_text", content.getJSONObject(1).getString("type"))
+        assertEquals("描述一下该视频", content.getJSONObject(1).getString("text"))
+    }
+
+    @Test
+    fun preservesResponsesInputVideoStringUrl() {
+        val request = chatRequest(
+            JSONArray().put(
+                JSONObject().apply {
+                    put("type", "input_video")
+                    put("video_url", "data:video/mp4;base64,ZmFrZQ==")
+                },
+            ),
+        )
+
+        val video = convertedContent(request).getJSONObject(0)
+        assertEquals("input_video", video.getString("type"))
+        assertEquals("data:video/mp4;base64,ZmFrZQ==", video.getString("video_url"))
+    }
+
+    @Test
+    fun preservesResponsesInputVideoNestedUrl() {
+        val request = chatRequest(
+            JSONArray().put(
+                JSONObject().apply {
+                    put("type", "input_video")
+                    put(
+                        "video_url",
+                        JSONObject().apply {
+                            put("url", "https://example.test/clip.mp4")
+                        },
+                    )
+                },
+            ),
+        )
+
+        val video = convertedContent(request).getJSONObject(0)
+        assertEquals("input_video", video.getString("type"))
+        assertEquals("https://example.test/clip.mp4", video.getString("video_url"))
+    }
+
+    @Test
+    fun dropsEmptyVideoUrlInsteadOfEmittingBlankPart() {
+        val request = chatRequest(
+            JSONArray()
+                .put(
+                    JSONObject().apply {
+                        put("type", "video_url")
+                        put("video_url", JSONObject())
+                    },
+                )
+                .put(
+                    JSONObject().apply {
+                        put("type", "text")
+                        put("text", "only text remains")
+                    },
+                ),
+        )
+
+        val content = convertedContent(request)
+        assertEquals(1, content.length())
+        assertEquals("input_text", content.getJSONObject(0).getString("type"))
+        assertFalse(content.toString().contains("input_video"))
+    }
+
+    private fun chatRequest(content: JSONArray): JSONObject =
+        JSONObject().apply {
+            put("model", "gpt-5.4")
+            put(
+                "messages",
+                JSONArray().put(
+                    JSONObject().apply {
+                        put("role", "user")
+                        put("content", content)
+                    },
+                ),
+            )
+        }
+
+    private fun convertedContent(request: JSONObject): JSONArray {
+        val converted = OpenAIResponsesPayloadAdapter.toResponsesRequest(request)
+        return converted.getJSONArray("input").getJSONObject(0).getJSONArray("content")
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

OpenAI Responses 转换漏了 `video_url` 分支，开启视频解析后上传的视频会被静默丢掉，请求体只剩纯文本。这次把 Chat Completions 的 `video_url` 和已经是 Responses 形态的 `input_video` 都转成 `input_video`。

### 背景与动机 / Context and motivation
Fixes #1146. `OpenAIProvider` 在 `enable_direct_video_processing` 开启时会把视频打成 `{type:"video_url", video_url:{url:"data:video/...;base64,..."}}`。`OpenAIResponsesPayloadAdapter.convertMessageContentForResponses` 只处理了文本/图片/音频/文件，`video_url` 进 `else` 后因没有 `text` 字段被丢掉。

### 改动范围 / Changes
- 在 `OpenAIResponsesPayloadAdapter` 补 `video_url` / `input_video` 分支，输出 `{type:"input_video", video_url:<url string>}`
- 同时接受 nested `{url}` 和直接字符串 URL；空 URL 不发空块
- 新增 `OpenAIResponsesVideoInputTest` 覆盖这三种形态和空 URL 丢弃
- 不改 Deepseek Responses；不改 Chat Completions 封装

### 兼容性与风险 / Compatibility and risks
只影响 OpenAI Responses / OpenAI Responses Generic 且开了视频解析的请求体。未开开关时不会生成 `video_url`。后端若不认 `input_video`，可能从「静默丢视频」变成显式拒绝，这是预期行为。

## 关联 Issue / Related issue
Fixes #1146

## 验证方式 / Verification
```text
检查或命令：
- OpenAIResponsesVideoInputTest（JVM unit）
- fork 上触发 android-tests.yml、android-build.yml (assembleDebug)

环境与变体：
- 无可用视频理解模型，未做真机视频上传测试

结果：
- 转换单测覆盖：Chat Completions video_url 对象 -> input_video；已有 input_video 字符串/nested url 保留；空 URL 丢弃且不影响文本块
- 真机视频理解：未跑，无可用模型
```

## 检查清单 / Checklist
- [x] 已记录可复现验证和未运行项原因
- [x] 目标分支为 `dev`
- [x] 工作流已在工作分支上触发
- [x] diff 无无关/临时/敏感内容