### PR TITLE
fix(ffmpeg): serialize native FFmpegKit sessions

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardFFmpegTool.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/defaultTool/standard/StandardFFmpegTool.kt
@@ -7,9 +7,8 @@ import com.ai.assistance.operit.core.tools.ToolExecutor
 import com.ai.assistance.operit.data.model.AITool
 import com.ai.assistance.operit.data.model.ToolResult
 import com.ai.assistance.operit.data.model.ToolValidationResult
-import com.arthenica.ffmpegkit.FFmpegKit
+import com.ai.assistance.operit.util.FFmpegUtil
 import com.arthenica.ffmpegkit.FFmpegKitConfig
-import com.arthenica.ffmpegkit.FFprobeKit
 import com.arthenica.ffmpegkit.ReturnCode
 import java.io.File
 
@@ -35,7 +34,7 @@ class StandardFFmpegToolExecutor(private val context: Context) : ToolExecutor {
             val startTime = System.currentTimeMillis()
 
             // 执行FFmpeg命令
-            val session = FFmpegKit.execute(command)
+            val session = FFmpegUtil.execute(command)
             val returnCode = session.returnCode
             val output = session.output ?: ""
             val duration = System.currentTimeMillis() - startTime
@@ -104,7 +103,7 @@ class StandardFFmpegInfoToolExecutor : ToolExecutor {
             info.appendLine("Build configuration: ${FFmpegKitConfig.getBuildDate()}")
 
             // 列出支持的编解码器
-            val codecsSession = FFmpegKit.execute("-codecs")
+            val codecsSession = FFmpegUtil.execute("-codecs")
             val codecsOutput = codecsSession.output ?: ""
             val duration = System.currentTimeMillis() - startTime
 
@@ -201,14 +200,14 @@ class StandardFFmpegConvertToolExecutor(private val context: Context) : ToolExec
             val startTime = System.currentTimeMillis()
 
             // 执行FFmpeg命令
-            val session = FFmpegKit.execute(command)
+            val session = FFmpegUtil.execute(command)
             val returnCode = session.returnCode
             val output = session.output ?: ""
             val duration = System.currentTimeMillis() - startTime
 
             if (ReturnCode.isSuccess(returnCode)) {
                 // 获取输出文件的媒体信息
-                val mediaSession = FFprobeKit.getMediaInformation(outputPath)
+                val mediaSession = FFmpegUtil.getMediaInformation(outputPath)
                 val mediaInfo = mediaSession?.mediaInformation
 
                 val ffmpegResult =
@@ -250,9 +249,7 @@ class StandardFFmpegConvertToolExecutor(private val context: Context) : ToolExec
                                             }
                                             .toMutableList()
 
-                            // Get additional media information using FFprobe
-                            val ffprobeSession = FFprobeKit.getMediaInformation(outputPath)
-                            val ffprobeInfo = ffprobeSession?.mediaInformation
+                            val ffprobeInfo = mediaInfo
 
                             if (ffprobeInfo != null) {
                                 // Update stream information with FFprobe data

--- a/app/src/main/java/com/ai/assistance/operit/util/FFmpegUtil.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/FFmpegUtil.kt
@@ -4,8 +4,8 @@ import com.ai.assistance.operit.util.AppLogger
 import com.arthenica.ffmpegkit.FFmpegKit
 import com.arthenica.ffmpegkit.FFmpegSession
 import com.arthenica.ffmpegkit.FFprobeKit
-import com.arthenica.ffmpegkit.FFprobeSession
 import com.arthenica.ffmpegkit.MediaInformation
+import com.arthenica.ffmpegkit.MediaInformationSession
 import com.arthenica.ffmpegkit.ReturnCode
 
 /**
@@ -22,19 +22,16 @@ object FFmpegUtil {
      * Build a scale filter string that survives FFmpegKit argument parsing.
      * FFmpeg expressions need an escaped comma when passed without a shell.
      */
-    fun scaleFilterMaxWidth(maxWidth: Int): String = "scale=min(${maxWidth}\,iw):-2"
+    fun scaleFilterMaxWidth(maxWidth: Int): String = "scale=min(${maxWidth}\\,iw):-2"
 
     fun <T> withNativeSession(block: () -> T): T = synchronized(nativeSessionLock) { block() }
 
     fun execute(command: String): FFmpegSession =
         withNativeSession { FFmpegKit.execute(command) }
 
-    fun getMediaInformation(filePath: String): FFprobeSession =
+    fun getMediaInformation(filePath: String): MediaInformationSession =
         withNativeSession { FFprobeKit.getMediaInformation(filePath) }
 
-    /**
-     * Execute an FFmpeg command and return if it was successful
-     */
     fun executeCommand(command: String): Boolean {
         try {
             AppLogger.d(TAG, "Executing FFmpeg command: $command")
@@ -57,9 +54,6 @@ object FFmpegUtil {
         }
     }
 
-    /**
-     * Get media information for a file
-     */
     fun getMediaInfo(filePath: String): MediaInformation? {
         return try {
             getMediaInformation(filePath).mediaInformation

--- a/app/src/main/java/com/ai/assistance/operit/util/FFmpegUtil.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/FFmpegUtil.kt
@@ -2,21 +2,35 @@ package com.ai.assistance.operit.util
 
 import com.ai.assistance.operit.util.AppLogger
 import com.arthenica.ffmpegkit.FFmpegKit
+import com.arthenica.ffmpegkit.FFmpegSession
 import com.arthenica.ffmpegkit.FFprobeKit
+import com.arthenica.ffmpegkit.FFprobeSession
 import com.arthenica.ffmpegkit.MediaInformation
 import com.arthenica.ffmpegkit.ReturnCode
 
 /**
- * Utility class for FFmpeg operations
+ * Utility class for FFmpeg operations.
+ *
+ * FFmpegKit's bundled libavcodec is not safe for overlapping sessions. Concurrent execute/probe
+ * calls can destroy the same pthread mutex twice and abort the process on Android 17 FORTIFY.
  */
 object FFmpegUtil {
     private const val TAG = "FFmpegUtil"
+    private val nativeSessionLock = Any()
 
     /**
      * Build a scale filter string that survives FFmpegKit argument parsing.
      * FFmpeg expressions need an escaped comma when passed without a shell.
      */
-    fun scaleFilterMaxWidth(maxWidth: Int): String = "scale=min(${maxWidth}\\,iw):-2"
+    fun scaleFilterMaxWidth(maxWidth: Int): String = "scale=min(${maxWidth}\,iw):-2"
+
+    fun <T> withNativeSession(block: () -> T): T = synchronized(nativeSessionLock) { block() }
+
+    fun execute(command: String): FFmpegSession =
+        withNativeSession { FFmpegKit.execute(command) }
+
+    fun getMediaInformation(filePath: String): FFprobeSession =
+        withNativeSession { FFprobeKit.getMediaInformation(filePath) }
 
     /**
      * Execute an FFmpeg command and return if it was successful
@@ -24,7 +38,7 @@ object FFmpegUtil {
     fun executeCommand(command: String): Boolean {
         try {
             AppLogger.d(TAG, "Executing FFmpeg command: $command")
-            val session = FFmpegKit.execute(command)
+            val session = execute(command)
             val returnCode = session.returnCode
 
             if (ReturnCode.isSuccess(returnCode)) {
@@ -48,11 +62,10 @@ object FFmpegUtil {
      */
     fun getMediaInfo(filePath: String): MediaInformation? {
         return try {
-            val mediaInfoSession = FFprobeKit.getMediaInformation(filePath)
-            mediaInfoSession.mediaInformation
+            getMediaInformation(filePath).mediaInformation
         } catch (e: Exception) {
             AppLogger.e(TAG, "Error getting media info: ${e.message}")
             null
         }
     }
-} 
+}

--- a/app/src/test/java/com/ai/assistance/operit/util/FFmpegUtilTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/util/FFmpegUtilTest.kt
@@ -1,0 +1,11 @@
+package com.ai.assistance.operit.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FFmpegUtilTest {
+    @Test
+    fun scaleFilterEscapesCommaForFfmpegKit() {
+        assertEquals("scale=min(640\\,iw):-2", FFmpegUtil.scaleFilterMaxWidth(640))
+    }
+}


### PR DESCRIPTION
## 变更说明 / Description

视频剪辑闪退的崩溃栈在 `libavcodec.so` 对已销毁 mutex 再次 `pthread_mutex_destroy`，Android 17 FORTIFY 会直接 SIGABRT。FFmpegKit 自带 native 不保证并发 session 安全，这次把所有 execute/probe 收到一把进程锁里。

### 背景与动机 / Context and motivation

Fixes #1151. tombstone 四次都是：
`FORTIFY: pthread_mutex_destroy called on a destroyed mutex`，下一帧在 APK 自带 `libavcodec.so`。FFmpegKit 官方有同样的并发崩溃记录（arthenica/ffmpeg-kit#120）。应用里 `ffmpeg_execute`、`ffmpeg_info`、`ffmpeg_convert`、`file_info` 探针和媒体转码都会直接进 native，没有排队。

### 改动范围 / Changes

- `FFmpegUtil` 以 `synchronized` 串行化 `FFmpegKit.execute` / `FFprobeKit.getMediaInformation`
- `StandardFFmpegTool` 不再直接调 FFmpegKit；转码成功后不再重复 probe 一次
- 新增 `FFmpegUtilTest` 覆盖 scale filter 转义
- 不重编 native `libavcodec.so`

### 兼容性与风险 / Compatibility and risks

重叠的 FFmpeg/FFprobe 会排队而不是并行，剪辑时间可能变长。这不修 native 里的双重 destroy 本身；若单 session 内部仍然会 abort，需要换 FFmpegKit 构建。

## 关联 Issue / Related issue
Fixes #1151

## 验证方式 / Verification
```text
检查或命令：
- FFmpegUtilTest
- fork 上触发 android-tests.yml、android-build.yml (assembleDebug)

环境与变体：
- 本地没有 Android SDK，未跑 Gradle
- 未在 Android 17 真机重现视频剪辑
结果：
- 应用层再没有直接 FFmpegKit.execute / FFprobeKit.getMediaInformation
- 真机剪辑：未跑
```

## 检查清单 / Checklist
- [x] 已记录可复现验证和未运行项原因
- [x] 目标分支为 `dev`
- [x] 工作流已在工作分支上触发
- [x] diff 无无关/临时/敏感内容
