### PR TITLE
fix(composedsl): preserve cursor position when deleting text

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ComposeDslTextInputSync.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ComposeDslTextInputSync.kt
@@ -1,0 +1,137 @@
+package com.ai.assistance.operit.ui.common.composedsl
+
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Reconciles external text updates from the DSL runtime with the in-progress IME edits of a
+ * compose_dsl text field.
+ *
+ * While a field is focused, its text, selection and IME composition are owned by the editor. Tree
+ * snapshots pushed back by the DSL runtime are echoes of edits the field has already applied
+ * locally, and they routinely lag behind by one or more keystrokes. Applying such a stale echo
+ * would resurrect deleted characters, reset the cursor and drop the active composition, so echoes
+ * must be recognized and skipped. Only values that cannot be attributed to the field's own edits
+ * (template insertion, entry switch, programmatic updates) may be applied while editing.
+ */
+internal class ComposeDslTextFieldEchoGuard(initialText: String) {
+
+    enum class ExternalUpdate {
+        /** The tree caught up with the field text; nothing to apply. */
+        CONVERGED,
+
+        /** A stale snapshot of the field's own edits; keep the current field state. */
+        OWN_ECHO,
+
+        /** A genuine external change that must be applied to the field. */
+        EXTERNAL_CHANGE
+    }
+
+    /** Last external text that was applied to the field or confirmed to match it. */
+    private var lastSyncedText: String = initialText
+
+    /** Texts the field dispatched upstream that no tree snapshot has confirmed yet. */
+    private val pendingEchoTexts = ArrayDeque<String>()
+
+    /** Records a local edit at the moment it is dispatched to the DSL runtime. */
+    fun onLocalEditDispatched(text: String) {
+        pendingEchoTexts.addLast(text)
+    }
+
+    fun reconcile(externalText: String, fieldText: String, isFocused: Boolean): ExternalUpdate {
+        if (externalText == fieldText) {
+            pendingEchoTexts.clear()
+            lastSyncedText = externalText
+            return ExternalUpdate.CONVERGED
+        }
+        if (isFocused) {
+            if (externalText == lastSyncedText) {
+                return ExternalUpdate.OWN_ECHO
+            }
+            val echoIndex = pendingEchoTexts.indexOf(externalText)
+            if (echoIndex >= 0) {
+                // Snapshots are produced in dispatch order, so entries older than the matched
+                // echo can no longer arrive and are dropped.
+                repeat(echoIndex + 1) { pendingEchoTexts.removeFirstOrNull() }
+                return ExternalUpdate.OWN_ECHO
+            }
+        }
+        pendingEchoTexts.clear()
+        lastSyncedText = externalText
+        return ExternalUpdate.EXTERNAL_CHANGE
+    }
+}
+
+/**
+ * Serializes compose_dsl text-input dispatches so the JS runtime applies edits in keystroke order.
+ *
+ * Each keystroke used to be dispatched on a fresh thread, so rapid edits could reach the JS engine
+ * out of order and leave the runtime state older than what the user sees on screen. With a single
+ * in-flight dispatch, runtime state is always a prefix of the edit sequence, and the tree pushed
+ * back once the queue drains converges with the field.
+ *
+ * All methods are expected to be called from the main thread.
+ */
+internal class ComposeDslTextInputDispatchQueue(
+    private val onAllSettled: () -> Unit
+) {
+    class Entry(val actionId: String, val text: String) {
+        val completion = CompletableDeferred<Unit>()
+    }
+
+    /** Unsettled entries in dispatch order; the first one may currently be in flight. */
+    private val entries = ArrayDeque<Entry>()
+    private var dispatchInFlight = false
+    private lateinit var startDispatch: (Entry, onSettled: () -> Unit) -> Unit
+
+    fun hasPending(): Boolean = entries.isNotEmpty()
+
+    suspend fun awaitAll() {
+        entries.toList().forEach { entry -> runCatching { entry.completion.await() } }
+    }
+
+    /** Completes every pending entry without further dispatching, e.g. on re-render or teardown. */
+    fun completeAll() {
+        entries.forEach { entry ->
+            if (!entry.completion.isCompleted) {
+                entry.completion.complete(Unit)
+            }
+        }
+        entries.clear()
+        dispatchInFlight = false
+    }
+
+    fun enqueue(
+        actionId: String,
+        text: String,
+        startDispatch: (Entry, onSettled: () -> Unit) -> Unit
+    ) {
+        this.startDispatch = startDispatch
+        entries.addLast(Entry(actionId, text))
+        pump()
+    }
+
+    private fun pump() {
+        if (dispatchInFlight) {
+            return
+        }
+        val next = entries.firstOrNull() ?: return
+        dispatchInFlight = true
+        startDispatch(next) { onEntrySettled(next) }
+    }
+
+    private fun onEntrySettled(entry: Entry) {
+        dispatchInFlight = false
+        if (!entries.remove(entry)) {
+            // The queue was cleared before this dispatch settled; nothing left to drive.
+            return
+        }
+        if (!entry.completion.isCompleted) {
+            entry.completion.complete(Unit)
+        }
+        if (entries.isEmpty()) {
+            onAllSettled()
+        } else {
+            pump()
+        }
+    }
+}

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslGeneratedRenderers.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslGeneratedRenderers.kt
@@ -495,26 +495,22 @@ internal fun renderTextFieldNode(
             )
         )
     }
-    var lastAppliedExternalValue by remember(textFieldIdentity) { mutableStateOf(externalValue) }
+    val externalSyncGuard = remember(textFieldIdentity) { ComposeDslTextFieldEchoGuard(externalValue) }
     var isFocused by remember(textFieldIdentity) { mutableStateOf(false) }
 
     LaunchedEffect(textFieldIdentity, externalValue, isFocused) {
-        if (externalValue == textFieldValue.text) {
-            lastAppliedExternalValue = externalValue
-            return@LaunchedEffect
+        if (
+            externalSyncGuard.reconcile(externalValue, textFieldValue.text, isFocused) ==
+                ComposeDslTextFieldEchoGuard.ExternalUpdate.EXTERNAL_CHANGE
+        ) {
+            val start = textFieldValue.selection.start.coerceIn(0, externalValue.length)
+            val end = textFieldValue.selection.end.coerceIn(0, externalValue.length)
+            textFieldValue =
+                TextFieldValue(
+                    text = externalValue,
+                    selection = TextRange(start, end)
+                )
         }
-        val externalValueChanged = externalValue != lastAppliedExternalValue
-        if (isFocused && !externalValueChanged) {
-            return@LaunchedEffect
-        }
-        val start = textFieldValue.selection.start.coerceIn(0, externalValue.length)
-        val end = textFieldValue.selection.end.coerceIn(0, externalValue.length)
-        textFieldValue =
-            TextFieldValue(
-                text = externalValue,
-                selection = TextRange(start, end)
-            )
-        lastAppliedExternalValue = externalValue
     }
     val textStyle =
         composeDslTextFieldStyleFromValue(styleMap)
@@ -535,6 +531,7 @@ internal fun renderTextFieldNode(
                 val previousText = textFieldValue.text
                 textFieldValue = nextValue
                 if (nextValue.text != previousText) {
+                    externalSyncGuard.onLocalEditDispatched(nextValue.text)
                     onTextInputAction(actionId, nextValue.text)
                 }
             }

--- a/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslScreen.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/common/composedsl/ToolPkgComposeDslScreen.kt
@@ -212,7 +212,6 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 private const val TAG = "ToolPkgComposeDslScreen"
@@ -890,12 +889,6 @@ fun ToolPkgComposeDslToolScreen(
         }
     var nextDispatchTicket by remember(containerPackageName, uiModuleId) { mutableStateOf(1L) }
     var pendingTreeRerenderJob by remember(containerPackageName, uiModuleId) { mutableStateOf<Job?>(null) }
-    val nextTextInputSyncTicket =
-        remember(containerPackageName, uiModuleId) { AtomicLong(1L) }
-    val pendingTextInputSyncs =
-        remember(containerPackageName, uiModuleId) {
-            linkedMapOf<Long, CompletableDeferred<Unit>>()
-        }
     val settledDispatchTickets = remember(containerPackageName, uiModuleId) { mutableSetOf<Long>() }
     val requiresWebViewImeResize =
         remember(renderResult?.tree) {
@@ -1048,14 +1041,18 @@ fun ToolPkgComposeDslToolScreen(
             }
     }
 
-    fun hasPendingTextInputSyncs(): Boolean = pendingTextInputSyncs.isNotEmpty()
-
-    suspend fun awaitPendingTextInputSyncs() {
-        val pendingCompletions = pendingTextInputSyncs.values.toList()
-        pendingCompletions.forEach { completion ->
-            runCatching { completion.await() }
+    // Text edits must reach the JS runtime in keystroke order; dispatching each keystroke on its
+    // own thread lets later edits apply first and regresses the runtime state behind the field.
+    val textInputDispatchQueue =
+        remember(containerPackageName, uiModuleId) {
+            ComposeDslTextInputDispatchQueue(
+                onAllSettled = { requestComposeDslTreeRerender(false) }
+            )
         }
-    }
+
+    fun hasPendingTextInputSyncs(): Boolean = textInputDispatchQueue.hasPending()
+
+    suspend fun awaitPendingTextInputSyncs() = textInputDispatchQueue.awaitAll()
 
     fun flushTextInputSyncsAndRerender() {
         scope.launch {
@@ -1190,28 +1187,19 @@ fun ToolPkgComposeDslToolScreen(
         if (normalizedActionId.isBlank()) {
             return
         }
-        val syncTicket = nextTextInputSyncTicket.getAndIncrement()
-        val completion = CompletableDeferred<Unit>()
-        pendingTextInputSyncs[syncTicket] = completion
-        dispatchActionInternal(
-            actionId = normalizedActionId,
-            payload =
-                mapOf(
-                    "__composeTextFieldPayload" to true,
-                    "__no_render" to true,
-                    "value" to text
-                ),
-            onSettled = {
-                pendingTextInputSyncs.remove(syncTicket)
-                if (!completion.isCompleted) {
-                    completion.complete(Unit)
-                }
-                if (!hasPendingTextInputSyncs()) {
-                    requestComposeDslTreeRerender(false)
-                }
-            },
-            flushPendingTextInputs = false
-        )
+        textInputDispatchQueue.enqueue(normalizedActionId, text) { entry, onSettled ->
+            dispatchActionInternal(
+                actionId = entry.actionId,
+                payload =
+                    mapOf(
+                        "__composeTextFieldPayload" to true,
+                        "__no_render" to true,
+                        "value" to entry.text
+                    ),
+                onSettled = onSettled,
+                flushPendingTextInputs = false
+            )
+        }
     }
 
     suspend fun dispatchActionAwait(actionId: String, payload: Any? = null) {
@@ -1275,12 +1263,7 @@ fun ToolPkgComposeDslToolScreen(
             try {
                 pendingTreeRerenderJob?.cancel()
                 pendingTreeRerenderJob = null
-                pendingTextInputSyncs.values.forEach { completion ->
-                    if (!completion.isCompleted) {
-                        completion.complete(Unit)
-                    }
-                }
-                pendingTextInputSyncs.clear()
+                textInputDispatchQueue.completeAll()
                 isLoading = true
                 dispatchingCount = 0
                 isDispatching = false
@@ -1484,12 +1467,7 @@ fun ToolPkgComposeDslToolScreen(
             ComposeDslFilePickerHostRegistry.unbind(executionContextKey)
             pendingTreeRerenderJob?.cancel()
             pendingTreeRerenderJob = null
-            pendingTextInputSyncs.values.forEach { completion ->
-                if (!completion.isCompleted) {
-                    completion.complete(Unit)
-                }
-            }
-            pendingTextInputSyncs.clear()
+            textInputDispatchQueue.completeAll()
             setTopBarTitleContent(null)
             ToolPkgComposeDslDebugSnapshotStore.clear(routeInstanceId)
             ComposeDslWebViewHostRegistry.clearExecutionContext(executionContextKey)
@@ -1631,11 +1609,6 @@ fun ToolPkgComposeDslDialogHost(
     var hasDispatchedInitialOnLoad by remember(request) { mutableStateOf(false) }
     var nextDispatchTicket by remember(request) { mutableStateOf(1L) }
     var pendingTreeRerenderJob by remember(request) { mutableStateOf<Job?>(null) }
-    val nextTextInputSyncTicket = remember(request) { AtomicLong(1L) }
-    val pendingTextInputSyncs =
-        remember(request) {
-            linkedMapOf<Long, CompletableDeferred<Unit>>()
-        }
     val settledDispatchTickets = remember(request) { mutableSetOf<Long>() }
 
     fun buildModuleSpec(): Map<String, Any?> =
@@ -1736,14 +1709,18 @@ fun ToolPkgComposeDslDialogHost(
             }
     }
 
-    fun hasPendingTextInputSyncs(): Boolean = pendingTextInputSyncs.isNotEmpty()
-
-    suspend fun awaitPendingTextInputSyncs() {
-        val pendingCompletions = pendingTextInputSyncs.values.toList()
-        pendingCompletions.forEach { completion ->
-            runCatching { completion.await() }
+    // Text edits must reach the JS runtime in keystroke order; dispatching each keystroke on its
+    // own thread lets later edits apply first and regresses the runtime state behind the field.
+    val textInputDispatchQueue =
+        remember(request) {
+            ComposeDslTextInputDispatchQueue(
+                onAllSettled = { requestComposeDslTreeRerender(false) }
+            )
         }
-    }
+
+    fun hasPendingTextInputSyncs(): Boolean = textInputDispatchQueue.hasPending()
+
+    suspend fun awaitPendingTextInputSyncs() = textInputDispatchQueue.awaitAll()
 
     fun flushTextInputSyncsAndRerender() {
         scope.launch {
@@ -1844,28 +1821,19 @@ fun ToolPkgComposeDslDialogHost(
         if (normalizedActionId.isBlank()) {
             return
         }
-        val syncTicket = nextTextInputSyncTicket.getAndIncrement()
-        val completion = CompletableDeferred<Unit>()
-        pendingTextInputSyncs[syncTicket] = completion
-        dispatchActionInternal(
-            actionId = normalizedActionId,
-            payload =
-                mapOf(
-                    "__composeTextFieldPayload" to true,
-                    "__no_render" to true,
-                    "value" to text
-                ),
-            onSettled = {
-                pendingTextInputSyncs.remove(syncTicket)
-                if (!completion.isCompleted) {
-                    completion.complete(Unit)
-                }
-                if (!hasPendingTextInputSyncs()) {
-                    requestComposeDslTreeRerender(false)
-                }
-            },
-            flushPendingTextInputs = false
-        )
+        textInputDispatchQueue.enqueue(normalizedActionId, text) { entry, onSettled ->
+            dispatchActionInternal(
+                actionId = entry.actionId,
+                payload =
+                    mapOf(
+                        "__composeTextFieldPayload" to true,
+                        "__no_render" to true,
+                        "value" to entry.text
+                    ),
+                onSettled = onSettled,
+                flushPendingTextInputs = false
+            )
+        }
     }
 
     suspend fun dispatchActionAwait(actionId: String, payload: Any? = null) {
@@ -1887,12 +1855,7 @@ fun ToolPkgComposeDslDialogHost(
             try {
                 pendingTreeRerenderJob?.cancel()
                 pendingTreeRerenderJob = null
-                pendingTextInputSyncs.values.forEach { completion ->
-                    if (!completion.isCompleted) {
-                        completion.complete(Unit)
-                    }
-                }
-                pendingTextInputSyncs.clear()
+                textInputDispatchQueue.completeAll()
                 isLoading = true
                 dispatchingCount = 0
                 errorMessage = null
@@ -1957,12 +1920,7 @@ fun ToolPkgComposeDslDialogHost(
         onDispose {
             pendingTreeRerenderJob?.cancel()
             pendingTreeRerenderJob = null
-            pendingTextInputSyncs.values.forEach { completion ->
-                if (!completion.isCompleted) {
-                    completion.complete(Unit)
-                }
-            }
-            pendingTextInputSyncs.clear()
+            textInputDispatchQueue.completeAll()
             ComposeDslWebViewHostRegistry.clearExecutionContext(executionContextKey)
             packageManager.releaseToolPkgExecutionEngine(executionContextKey, jsEngine)
         }

--- a/app/src/test/java/com/ai/assistance/operit/ui/common/composedsl/ComposeDslTextFieldEchoGuardTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/common/composedsl/ComposeDslTextFieldEchoGuardTest.kt
@@ -1,0 +1,100 @@
+package com.ai.assistance.operit.ui.common.composedsl
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ComposeDslTextFieldEchoGuardTest {
+
+    @Test
+    fun `stale echo of own deletion is ignored while focused`() {
+        // Regression test for https://github.com/AAswordman/Operit/issues/1150:
+        // rapid deletions dispatch one edit per keystroke, and a tree snapshot built after
+        // only the first deletion used to overwrite the field while the user kept deleting.
+        val guard = ComposeDslTextFieldEchoGuard("hello world")
+        guard.onLocalEditDispatched("hello worl")
+        guard.onLocalEditDispatched("hello wor")
+
+        val decision =
+            guard.reconcile(externalText = "hello worl", fieldText = "hello wor", isFocused = true)
+
+        assertEquals(ComposeDslTextFieldEchoGuard.ExternalUpdate.OWN_ECHO, decision)
+    }
+
+    @Test
+    fun `converged tree clears pending echoes`() {
+        val guard = ComposeDslTextFieldEchoGuard("abc")
+        guard.onLocalEditDispatched("ab")
+        guard.onLocalEditDispatched("a")
+
+        val decision = guard.reconcile(externalText = "a", fieldText = "a", isFocused = true)
+
+        assertEquals(ComposeDslTextFieldEchoGuard.ExternalUpdate.CONVERGED, decision)
+    }
+
+    @Test
+    fun `value unknown to the edit history is applied while focused`() {
+        // e.g. the worldbook "insert template" action appends a snippet to the content.
+        val guard = ComposeDslTextFieldEchoGuard("abc")
+        guard.onLocalEditDispatched("abcd")
+
+        val decision =
+            guard.reconcile(
+                externalText = "abcd\n\n{{getvar::stat_data}}",
+                fieldText = "abcd",
+                isFocused = true
+            )
+
+        assertEquals(ComposeDslTextFieldEchoGuard.ExternalUpdate.EXTERNAL_CHANGE, decision)
+    }
+
+    @Test
+    fun `tree from before the editing session is ignored while focused`() {
+        val guard = ComposeDslTextFieldEchoGuard("abc")
+        guard.onLocalEditDispatched("ab")
+
+        val decision = guard.reconcile(externalText = "abc", fieldText = "ab", isFocused = true)
+
+        assertEquals(ComposeDslTextFieldEchoGuard.ExternalUpdate.OWN_ECHO, decision)
+    }
+
+    @Test
+    fun `any differing value is applied while unfocused`() {
+        val guard = ComposeDslTextFieldEchoGuard("abc")
+        guard.onLocalEditDispatched("ab")
+
+        val decision = guard.reconcile(externalText = "ab", fieldText = "abc", isFocused = false)
+
+        assertEquals(ComposeDslTextFieldEchoGuard.ExternalUpdate.EXTERNAL_CHANGE, decision)
+    }
+
+    @Test
+    fun `pre-edit tree snapshots are ignored repeatedly while focused`() {
+        val guard = ComposeDslTextFieldEchoGuard("abc")
+        guard.onLocalEditDispatched("ab")
+
+        assertEquals(
+            ComposeDslTextFieldEchoGuard.ExternalUpdate.OWN_ECHO,
+            guard.reconcile(externalText = "abc", fieldText = "ab", isFocused = true)
+        )
+        assertEquals(
+            ComposeDslTextFieldEchoGuard.ExternalUpdate.OWN_ECHO,
+            guard.reconcile(externalText = "abc", fieldText = "ab", isFocused = true)
+        )
+    }
+
+    @Test
+    fun `delete then retype keeps later echoes classified`() {
+        val guard = ComposeDslTextFieldEchoGuard("ab")
+        guard.onLocalEditDispatched("a")
+        guard.onLocalEditDispatched("ab")
+
+        assertEquals(
+            ComposeDslTextFieldEchoGuard.ExternalUpdate.OWN_ECHO,
+            guard.reconcile(externalText = "a", fieldText = "ab", isFocused = true)
+        )
+        assertEquals(
+            ComposeDslTextFieldEchoGuard.ExternalUpdate.CONVERGED,
+            guard.reconcile(externalText = "ab", fieldText = "ab", isFocused = true)
+        )
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/ui/common/composedsl/ComposeDslTextInputDispatchQueueTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/ui/common/composedsl/ComposeDslTextInputDispatchQueueTest.kt
@@ -1,0 +1,107 @@
+package com.ai.assistance.operit.ui.common.composedsl
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ComposeDslTextInputDispatchQueueTest {
+
+    private class Harness {
+        val started = mutableListOf<Pair<String, String>>()
+        val settleCallbacks = mutableListOf<() -> Unit>()
+        var drainedCount = 0
+
+        val queue = ComposeDslTextInputDispatchQueue(onAllSettled = { drainedCount++ })
+
+        val dispatch: (ComposeDslTextInputDispatchQueue.Entry, () -> Unit) -> Unit =
+            { entry, onSettled ->
+                started.add(entry.actionId to entry.text)
+                settleCallbacks.add(onSettled)
+            }
+
+        fun enqueue(actionId: String, text: String) {
+            queue.enqueue(actionId, text, dispatch)
+        }
+
+        fun settleNext() {
+            settleCallbacks.removeAt(0).invoke()
+        }
+    }
+
+    @Test
+    fun `edits dispatch sequentially in keystroke order`() {
+        val harness = Harness()
+        harness.enqueue("edit", "a")
+        harness.enqueue("edit", "ab")
+        harness.enqueue("edit", "abc")
+
+        // Only the first edit is in flight; later keystrokes wait for it to settle.
+        assertEquals(listOf("edit" to "a"), harness.started)
+
+        harness.settleNext()
+        assertEquals(listOf("edit" to "a", "edit" to "ab"), harness.started)
+
+        harness.settleNext()
+        assertEquals(listOf("edit" to "a", "edit" to "ab", "edit" to "abc"), harness.started)
+        assertEquals(0, harness.drainedCount)
+
+        harness.settleNext()
+        assertEquals(1, harness.drainedCount)
+    }
+
+    @Test
+    fun `late settle after completeAll does not restart dispatching`() {
+        val harness = Harness()
+        harness.enqueue("edit", "a")
+        harness.enqueue("edit", "ab")
+        assertTrue(harness.queue.hasPending())
+
+        harness.queue.completeAll()
+        assertFalse(harness.queue.hasPending())
+
+        // The in-flight dispatch settles after the queue was cleared (e.g. teardown):
+        // it must neither fire the drain callback nor dispatch the cleared entry.
+        harness.settleNext()
+        assertEquals(listOf("edit" to "a"), harness.started)
+        assertEquals(0, harness.drainedCount)
+    }
+
+    @Test
+    fun `enqueue after completeAll dispatches immediately`() {
+        val harness = Harness()
+        harness.enqueue("edit", "a")
+        harness.queue.completeAll()
+        harness.settleNext()
+
+        harness.enqueue("edit", "b")
+        assertEquals(listOf("edit" to "a", "edit" to "b"), harness.started)
+    }
+
+    @Test
+    fun `awaitAll waits for every queued entry`() = runTest {
+        val harness = Harness()
+        harness.enqueue("edit", "a")
+        harness.enqueue("edit", "ab")
+
+        var awaited = false
+        val job =
+            backgroundScope.launch {
+                harness.queue.awaitAll()
+                awaited = true
+            }
+        testScheduler.runCurrent()
+        assertFalse(awaited)
+
+        harness.settleNext()
+        testScheduler.runCurrent()
+        assertFalse(awaited)
+
+        harness.settleNext()
+        testScheduler.runCurrent()
+        job.join()
+        assertTrue(awaited)
+    }
+}


### PR DESCRIPTION
## 问题表现

#1150：在世界书（compose_dsl 世界书包）编辑文本时删除字符，部分字符会触发输入光标异常前移，连续删除时文本会被搅乱（见 Issue 录屏）。

## 实际根因

世界书编辑界面由 compose_dsl 渲染。文本框的每次击键会经 JS 桥异步回写（`__no_render` action），当同步队列排空后再触发一次整树重渲染，把新的 `value` 推回 Compose 侧。这个快照链路天然落后于正在进行的编辑：

- 重渲染在上次同步排空后的下一帧执行，与下一次击键的 dispatch 存在竞争；
- 文本输入 dispatch 每次都在新建的 `Thread` 上运行，进入 QuickJS 执行器的顺序不受保证，JS 侧可能乱序应用编辑。

`renderTextFieldNode` 中的同步逻辑把「与 `lastAppliedExternalValue` 不同的外部值」一律视为真实外部变更，即使字段正处于焦点编辑中，也强制重建内部 `TextFieldValue`。于是滞后的回波会让已删除的字符复活、selection 被重新钳制（光标前移/跳动）、IME composition 被清空，连续删除时文本错乱。

## 修复方式

- **渲染器侧**（`ToolPkgComposeDslGeneratedRenderers.kt` + 新增 `ComposeDslTextInputSync.kt` 中的 `ComposeDslTextFieldEchoGuard`）：记录本字段已派发的编辑文本，焦点编辑期间到达的外部值若等于自身编辑的回波（或编辑前的旧快照），一律不覆盖内部 `TextFieldValue`（selection/composition 保持原样）；无法归因于自身编辑的值（如插入模板、切换条目）以及失焦后的更新仍照常应用。
- **屏幕侧**（`ToolPkgComposeDslScreen.kt` 两个 host + `ComposeDslTextInputDispatchQueue`）：文本输入改为 FIFO 串行 dispatch，保证 JS 运行时状态严格按击键顺序应用，不再出现落后于屏幕的最终状态；排空后触发重渲染的语义保持不变。

世界书包及其他 compose_dsl 包的 `UI.TextField` 契约不变，无需改动包代码。

## 验证方式

- 新增回归单测：`ComposeDslTextFieldEchoGuardTest`（7 用例）、`ComposeDslTextInputDispatchQueueTest`（4 用例），全部通过。注：运行测试时需先临时移开 `DeepseekProviderMediaRoleTest.kt` / `XaiProviderReasoningTest.kt`——这两个既有测试引用了 0038ff53 中已移除的符号（`XaiReasoningMapper` 等），在干净的 upstream/dev 上同样无法编译，与本 PR 无关。
- `:app:compileDebugKotlin` 通过。
- `:app:assembleDebug` 通过（产出 app-debug.apk）。
- 未验证项：无真机/模拟器实测输入法连续删除效果（本机无 Android 设备），理论上 IME composition 在编辑期间不再被重建，建议合并前在设备上复核一次。

Fixes #1150