### PR TITLE
fix(chat): prevent long-history work from blocking the main thread

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/chat/AIMessageManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/chat/AIMessageManager.kt
@@ -369,28 +369,28 @@ object AIMessageManager {
         lastActiveChatKey = chatKey
         activeEnhancedAiServiceByChatId[chatKey] = enhancedAiService
 
-        val buildMemoryStartTime = messageTimingNow()
-        val memory = getMemoryFromMessages(
-            messages = chatHistory,
-            splitByRole = splitHistoryByRole,
-            targetRoleName = currentRoleName,
-            groupOrchestrationMode = groupOrchestrationMode
-        )
-        logMessageTiming(
-            stage = "sendMessage.buildMemory",
-            startTimeMs = buildMemoryStartTime,
-            details = "chatKey=$chatKey, source=${chatHistory.size}, result=${memory.size}, splitByRole=$splitHistoryByRole, groupOrchestration=$groupOrchestrationMode"
-        )
-        if (splitHistoryByRole && !currentRoleName.isNullOrBlank()) {
-            val assistantCount = memory.count { it.kind == PromptTurnKind.ASSISTANT }
-            val userCount = memory.count { it.kind == PromptTurnKind.USER }
-            AppLogger.d(
-                TAG,
-                "按角色拆解历史: role=$currentRoleName, assistant=$assistantCount, user=$userCount, total=${memory.size}"
-            )
-        }
-
         return withContext(Dispatchers.IO) {
+            val buildMemoryStartTime = messageTimingNow()
+            val memory = getMemoryFromMessages(
+                messages = chatHistory,
+                splitByRole = splitHistoryByRole,
+                targetRoleName = currentRoleName,
+                groupOrchestrationMode = groupOrchestrationMode
+            )
+            logMessageTiming(
+                stage = "sendMessage.buildMemory",
+                startTimeMs = buildMemoryStartTime,
+                details = "chatKey=$chatKey, source=${chatHistory.size}, result=${memory.size}, splitByRole=$splitHistoryByRole, groupOrchestration=$groupOrchestrationMode"
+            )
+            if (splitHistoryByRole && !currentRoleName.isNullOrBlank()) {
+                val assistantCount = memory.count { it.kind == PromptTurnKind.ASSISTANT }
+                val userCount = memory.count { it.kind == PromptTurnKind.USER }
+                AppLogger.d(
+                    TAG,
+                    "按角色拆解历史: role=$currentRoleName, assistant=$assistantCount, user=$userCount, total=${memory.size}"
+                )
+            }
+
             val limitHistoryStartTime = messageTimingNow()
             val maxImageHistoryUserTurns = apiPreferences.maxImageHistoryUserTurnsFlow.first()
             val maxMediaHistoryUserTurns = apiPreferences.maxMediaHistoryUserTurnsFlow.first()
@@ -695,7 +695,7 @@ object AIMessageManager {
             return null
         }
 
-        val memoryTagRegex = Regex("<memory>.*?</memory>", RegexOption.DOT_MATCHES_ALL)
+        val memoryTagRegex = ChatMarkupRegex.memoryTag
         val conversationReviewEntries = mutableListOf<Pair<String, String>>()
         fun normalizeForReview(text: String): String {
             return text
@@ -1381,11 +1381,7 @@ object AIMessageManager {
         targetRoleName: String,
         removeStatusTags: (String) -> String
     ): PromptTurn? {
-        // 清理思考内容
-        val cleanedContent = ChatUtils.removeThinkingContent(message.content).trim()
-        val contentWithoutStatus = removeStatusTags(cleanedContent)
-
-        // 非角色隔离模式：直接返回 assistant 消息
+        // 非角色隔离模式和当前角色消息无需清洗；只有跨角色桥接才需要移除思考内容。
         if (!isRoleScopedMode) {
             return PromptTurn(
                 kind = PromptTurnKind.ASSISTANT,
@@ -1395,25 +1391,24 @@ object AIMessageManager {
 
         // 角色隔离模式：判断是当前角色还是其他角色
         val messageRoleName = message.roleName.trim()
-        return if (messageRoleName == targetRoleName) {
-            // 当前角色的消息：作为 assistant 返回
-            PromptTurn(
+        if (messageRoleName == targetRoleName) {
+            return PromptTurn(
                 kind = PromptTurnKind.ASSISTANT,
                 content = message.content
             )
-        } else {
-            // 其他角色的消息：转换为 user 消息，添加角色标签
-            val roleLabel = if (messageRoleName.isNotBlank()) messageRoleName else "unknown"
-            val bridgedContent = removeStatusTags(cleanedContent)
-            if (bridgedContent.isBlank()) {
-                null
-            } else {
-                PromptTurn(
-                    kind = PromptTurnKind.USER,
-                    content = "[From role: $roleLabel]\n$bridgedContent"
-                )
-            }
         }
+
+        val cleanedContent = ChatUtils.removeThinkingContent(message.content).trim()
+        val bridgedContent = removeStatusTags(cleanedContent)
+        // 其他角色的消息：转换为 user 消息，添加角色标签
+        val roleLabel = if (messageRoleName.isNotBlank()) messageRoleName else "unknown"
+        if (bridgedContent.isBlank()) {
+            return null
+        }
+        return PromptTurn(
+            kind = PromptTurnKind.USER,
+            content = "[From role: $roleLabel]\n$bridgedContent"
+        )
     }
 
     private fun processUserMessage(

--- a/app/src/main/java/com/ai/assistance/operit/services/ChatServiceCore.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/ChatServiceCore.kt
@@ -239,7 +239,7 @@ class ChatServiceCore(
             messageProcessingDelegate.cancelMessageForDestructiveMutation(chatId)
         }
         chatHistoryDelegate.setAfterDestructiveHistoryMutation { chatId ->
-            messageCoordinationDelegate.refreshStableContextWindow(chatId = chatId)
+            messageCoordinationDelegate.scheduleStableContextWindowRefresh(chatId = chatId)
         }
 
         initialized = true

--- a/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
+++ b/app/src/main/java/com/ai/assistance/operit/services/core/MessageCoordinationDelegate.kt
@@ -46,7 +46,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withTimeoutOrNull
@@ -121,6 +120,7 @@ class MessageCoordinationDelegate(
 
     private val pendingAutoContinuationByChatId =
         ConcurrentHashMap<String, PendingAutoContinuationRequest>()
+    private val stableWindowRefreshJobsByChatId = ConcurrentHashMap<String, Job>()
 
     init {
         ensureNonFatalErrorCollectorStarted()
@@ -270,9 +270,9 @@ class MessageCoordinationDelegate(
         chatModelConfigIdOverride: String? = null,
         chatModelIndexOverride: Int? = null,
         memorySpaceIdOverride: String? = null
-    ): Long? {
-        val targetChatId = chatId ?: chatHistoryDelegate.currentChatId.value ?: return null
-        val service = resolveWindowEstimateService(targetChatId) ?: return null
+    ): Long? = withContext(Dispatchers.IO) {
+        val targetChatId = chatId ?: chatHistoryDelegate.currentChatId.value ?: return@withContext null
+        val service = resolveWindowEstimateService(targetChatId) ?: return@withContext null
         val effectiveRoleCardId = resolveRoleCardId(targetChatId, roleCardId)
         val effectivePromptFunctionType = promptFunctionType ?: currentPromptFunctionType
         val effectiveChatModelConfigIdOverride =
@@ -317,7 +317,43 @@ class MessageCoordinationDelegate(
                 "input=$inputTokens, output=$outputTokens, service=${service.javaClass.simpleName}, " +
                 "promptType=$effectivePromptFunctionType"
         )
-        return newWindowSize
+        newWindowSize
+    }
+
+    fun scheduleStableContextWindowRefresh(
+        chatId: String? = null,
+        roleCardId: String? = null,
+        promptFunctionType: PromptFunctionType? = null,
+        groupOrchestrationMode: Boolean = false,
+        groupParticipantNamesText: String? = null,
+        chatModelConfigIdOverride: String? = null,
+        chatModelIndexOverride: Int? = null,
+        memorySpaceIdOverride: String? = null
+    ): Job? {
+        val targetChatId = chatId ?: chatHistoryDelegate.currentChatId.value ?: return null
+        val refreshJob = coroutineScope.launch(Dispatchers.IO) {
+            try {
+                refreshStableContextWindow(
+                    chatId = targetChatId,
+                    roleCardId = roleCardId,
+                    promptFunctionType = promptFunctionType,
+                    groupOrchestrationMode = groupOrchestrationMode,
+                    groupParticipantNamesText = groupParticipantNamesText,
+                    chatModelConfigIdOverride = chatModelConfigIdOverride,
+                    chatModelIndexOverride = chatModelIndexOverride,
+                    memorySpaceIdOverride = memorySpaceIdOverride
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLogger.w(TAG, "异步刷新上下文窗口失败: chatId=$targetChatId", e)
+            }
+        }
+        stableWindowRefreshJobsByChatId.put(targetChatId, refreshJob)?.cancel()
+        refreshJob.invokeOnCompletion {
+            stableWindowRefreshJobsByChatId.remove(targetChatId, refreshJob)
+        }
+        return refreshJob
     }
 
     /**
@@ -376,18 +412,20 @@ class MessageCoordinationDelegate(
                 )
             }
         } else {
-            // 已有对话，直接发送消息
-            sendMessageInternal(
-                promptFunctionType,
-                roleCardIdOverride = roleCardIdOverride,
-                preferActiveRoleCard = preferActiveRoleCard,
-                chatIdOverride = chatIdOverride,
-                messageTextOverride = messageTextOverride,
-                proxySenderNameOverride = proxySenderNameOverride,
-                chatModelConfigIdOverride = chatModelConfigIdOverride,
-                chatModelIndexOverride = chatModelIndexOverride,
-                turnOptions = turnOptions
-            )
+            // 已有对话，异步进入发送流程；内部的配置和历史读取会切到 IO
+            coroutineScope.launch {
+                sendMessageInternal(
+                    promptFunctionType,
+                    roleCardIdOverride = roleCardIdOverride,
+                    preferActiveRoleCard = preferActiveRoleCard,
+                    chatIdOverride = chatIdOverride,
+                    messageTextOverride = messageTextOverride,
+                    proxySenderNameOverride = proxySenderNameOverride,
+                    chatModelConfigIdOverride = chatModelConfigIdOverride,
+                    chatModelIndexOverride = chatModelIndexOverride,
+                    turnOptions = turnOptions
+                )
+            }
         }
     }
 
@@ -515,7 +553,7 @@ class MessageCoordinationDelegate(
     /**
      * 内部发送消息的逻辑
      */
-    private fun sendMessageInternal(
+    private suspend fun sendMessageInternal(
         promptFunctionType: PromptFunctionType,
         isContinuation: Boolean = false,
         skipSummaryCheck: Boolean = false,
@@ -613,7 +651,7 @@ class MessageCoordinationDelegate(
         val currentAttachments =
             if (shouldReadComposerState) attachmentDelegate.attachments.value else emptyList()
         // 手动发送必须与选择器一致；后台和定向消息仍由窗口绑定决定角色卡。
-        val roleCardId = runBlocking {
+        val roleCardId = withContext(Dispatchers.IO) {
             resolveRoleCardId(
                 chatId = chatId,
                 roleCardId = roleCardIdOverride,
@@ -621,32 +659,34 @@ class MessageCoordinationDelegate(
             )
         }
         val resolvedOverrides = try {
-            if (promptFunctionType == PromptFunctionType.CHAT) {
-                val (resolvedChatModelConfigIdOverride, resolvedChatModelIndexOverride) =
-                    when {
-                        !chatModelConfigIdOverride.isNullOrBlank() -> {
-                            Pair(chatModelConfigIdOverride, (chatModelIndexOverride ?: 0).coerceAtLeast(0))
+            withContext(Dispatchers.IO) {
+                if (promptFunctionType == PromptFunctionType.CHAT) {
+                    val (resolvedChatModelConfigIdOverride, resolvedChatModelIndexOverride) =
+                        when {
+                            !chatModelConfigIdOverride.isNullOrBlank() -> {
+                                Pair(chatModelConfigIdOverride, (chatModelIndexOverride ?: 0).coerceAtLeast(0))
+                            }
+                            isAutoContinuation -> {
+                                Pair(currentChatModelConfigIdOverride, currentChatModelIndexOverride)
+                            }
+                            else -> {
+                                resolveRoleCardChatModelOverrides(roleCardId)
+                            }
                         }
-                        isAutoContinuation -> {
-                            Pair(currentChatModelConfigIdOverride, currentChatModelIndexOverride)
+                    val resolvedMemorySpaceIdOverride =
+                        when {
+                            !memorySpaceIdOverride.isNullOrBlank() -> memorySpaceIdOverride
+                            isAutoContinuation -> currentMemorySpaceIdOverride
+                            else -> roleCardId?.let { resolveRoleCardMemoryProfileOverride(it) }
                         }
-                        else -> {
-                            resolveRoleCardChatModelOverrides(roleCardId)
-                        }
-                    }
-                val resolvedMemorySpaceIdOverride =
-                    when {
-                        !memorySpaceIdOverride.isNullOrBlank() -> memorySpaceIdOverride
-                        isAutoContinuation -> currentMemorySpaceIdOverride
-                        else -> roleCardId?.let { resolveRoleCardMemoryProfileOverride(it) }
-                    }
-                Triple(
-                    resolvedChatModelConfigIdOverride,
-                    resolvedChatModelIndexOverride,
-                    resolvedMemorySpaceIdOverride
-                )
-            } else {
-                Triple(null, null, null)
+                    Triple(
+                        resolvedChatModelConfigIdOverride,
+                        resolvedChatModelIndexOverride,
+                        resolvedMemorySpaceIdOverride
+                    )
+                } else {
+                    Triple(null, null, null)
+                }
             }
         } catch (e: Exception) {
             AppLogger.e(TAG, "解析角色卡对话模型绑定失败", e)
@@ -659,7 +699,7 @@ class MessageCoordinationDelegate(
         val resolvedChatModelIndexOverride = resolvedOverrides.second
         val resolvedMemorySpaceIdOverride = resolvedOverrides.third
         val chatContextSettings =
-            runBlocking {
+            withContext(Dispatchers.IO) {
                 resolveChatContextSettingsForRequest(resolvedChatModelConfigIdOverride)
             }
 
@@ -679,7 +719,10 @@ class MessageCoordinationDelegate(
 
         // 如果不是续写，检查是否需要总结
         if (turnOptions.persistTurn && !isBackgroundSend && !isContinuation && !skipSummaryCheck) {
-            val currentMessages = runBlocking { chatHistoryDelegate.getCurrentRuntimeChatHistorySnapshot() }
+            val currentMessages =
+                withContext(Dispatchers.IO) {
+                    chatHistoryDelegate.getCurrentRuntimeChatHistorySnapshot()
+                }
             val currentTokens = tokenStatsDelegate.currentWindowSizeFlow.value
 
             val isShouldGenerateSummary = AIMessageManager.shouldGenerateSummary(
@@ -760,7 +803,7 @@ class MessageCoordinationDelegate(
         }
     }
 
-    private fun shouldRunGroupOrchestration(
+    private suspend fun shouldRunGroupOrchestration(
         promptFunctionType: PromptFunctionType,
         isContinuation: Boolean,
         isAutoContinuation: Boolean,
@@ -776,7 +819,7 @@ class MessageCoordinationDelegate(
         if (!proxySenderNameOverride.isNullOrBlank()) return false
         if (!messageTextOverride.isNullOrBlank()) return false
         if (!chatIdOverride.isNullOrBlank()) return false
-        val activePrompt = runBlocking { activePromptManager.getActivePrompt() }
+        val activePrompt = withContext(Dispatchers.IO) { activePromptManager.getActivePrompt() }
         if (activePrompt !is ActivePrompt.CharacterGroup) return false
         return true
     }
@@ -1409,8 +1452,8 @@ class MessageCoordinationDelegate(
         }
     }
 
-    private fun resolveRoleCardChatModelOverrides(roleCardId: String): Pair<String?, Int?> {
-        val roleCard = runBlocking { characterCardManager.getCharacterCardFlow(roleCardId).first() }
+    private suspend fun resolveRoleCardChatModelOverrides(roleCardId: String): Pair<String?, Int?> {
+        val roleCard = characterCardManager.getCharacterCardFlow(roleCardId).first()
         val bindingMode = CharacterCardChatModelBindingMode.normalize(roleCard.chatModelBindingMode)
         return if (
             bindingMode == CharacterCardChatModelBindingMode.FIXED_CONFIG &&
@@ -1422,8 +1465,8 @@ class MessageCoordinationDelegate(
         }
     }
 
-    private fun resolveRoleCardMemoryProfileOverride(roleCardId: String): String? {
-        val roleCard = runBlocking { characterCardManager.getCharacterCardFlow(roleCardId).first() }
+    private suspend fun resolveRoleCardMemoryProfileOverride(roleCardId: String): String? {
+        val roleCard = characterCardManager.getCharacterCardFlow(roleCardId).first()
         val bindingMode =
             CharacterCardMemoryProfileBindingMode.normalize(roleCard.memoryProfileBindingMode)
         return if (

--- a/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/ai/assistance/operit/ui/features/chat/viewmodel/ChatViewModel.kt
@@ -873,12 +873,14 @@ class ChatViewModel(private val context: Context) : ViewModel() {
                 val beforeTimestamp = if (message.sender == "ai") message.timestamp else null
                 val afterTimestamp = if (message.sender == "user") message.timestamp else null
                 val messagesToSummarize =
-                    chatHistoryDelegate
-                        .loadMessagesForSummaryInsertion(
-                            chatId = currentChatId,
-                            beforeTimestampExclusive = afterTimestamp,
-                            upToTimestampInclusive = beforeTimestamp,
-                        ).filter { it.sender == "user" || it.sender == "ai" }
+                    withContext(Dispatchers.IO) {
+                        chatHistoryDelegate
+                            .loadMessagesForSummaryInsertion(
+                                chatId = currentChatId,
+                                beforeTimestampExclusive = afterTimestamp,
+                                upToTimestampInclusive = beforeTimestamp,
+                            ).filter { it.sender == "user" || it.sender == "ai" }
+                    }
 
                 if (messagesToSummarize.isEmpty()) {
                     uiStateDelegate.showToast(context.getString(R.string.chat_no_messages_to_summarize))
@@ -899,25 +901,30 @@ class ChatViewModel(private val context: Context) : ViewModel() {
                 // 检查是否是群聊
                 val currentChat = chatHistoryDelegate.chatHistories.value.firstOrNull { it.id == currentChatId }
                 val isGroupChat = currentChat?.characterGroupId != null
-                val summaryConfig = messageCoordinationDelegate.readSummaryConfig()
+                val summaryConfig = withContext(Dispatchers.IO) {
+                    messageCoordinationDelegate.readSummaryConfig()
+                }
 
-                val summaryMessage = AIMessageManager.summarizeMemory(
-                    enhancedAiService!!,
-                    messagesToSummarize,
-                    autoContinue = false,
-                    isGroupChat = isGroupChat,
-                    summaryConfig = summaryConfig
-                )
+                val summaryMessage = withContext(Dispatchers.IO) {
+                    AIMessageManager.summarizeMemory(
+                        enhancedAiService!!,
+                        messagesToSummarize,
+                        autoContinue = false,
+                        isGroupChat = isGroupChat,
+                        summaryConfig = summaryConfig
+                    )
+                }
 
                 if (summaryMessage != null) {
                     // 插入总结消息
-                    chatHistoryDelegate.addSummaryMessage(
-                        summaryMessage = summaryMessage,
-                        beforeTimestamp = beforeTimestamp,
-                        afterTimestamp = afterTimestamp,
-                    )
-
-                    messageCoordinationDelegate.refreshStableContextWindow(chatId = currentChatId)
+                    withContext(Dispatchers.IO) {
+                        chatHistoryDelegate.addSummaryMessage(
+                            summaryMessage = summaryMessage,
+                            beforeTimestamp = beforeTimestamp,
+                            afterTimestamp = afterTimestamp,
+                        )
+                    }
+                    messageCoordinationDelegate.scheduleStableContextWindowRefresh(chatId = currentChatId)
 
                     uiStateDelegate.showToast(context.getString(R.string.chat_summary_inserted))
                 } else {
@@ -1112,8 +1119,8 @@ class ChatViewModel(private val context: Context) : ViewModel() {
 
                 // 直接在数据库中更新该条消息
                 chatHistoryDelegate.addMessageToChat(editedMessage)
-
-                messageCoordinationDelegate.refreshStableContextWindow(chatId = currentChatId.value)
+                // 变更历史后异步刷新窗口，不阻塞编辑操作
+                messageCoordinationDelegate.scheduleStableContextWindowRefresh(chatId = currentChatId.value)
 
                 // 显示成功提示
                 uiStateDelegate.showToast(context.getString(R.string.chat_message_updated))
@@ -1153,7 +1160,7 @@ class ChatViewModel(private val context: Context) : ViewModel() {
                     return@launch
                 }
                 chatHistoryDelegate.selectMessageVariant(targetMessage.timestamp, targetVariantIndex)
-                messageCoordinationDelegate.refreshStableContextWindow(chatId = currentChatId.value)
+                messageCoordinationDelegate.scheduleStableContextWindowRefresh(chatId = currentChatId.value)
             } catch (e: Exception) {
                 AppLogger.e(TAG, "切换回答版本失败", e)
                 uiStateDelegate.showErrorMessage(
@@ -1186,7 +1193,7 @@ class ChatViewModel(private val context: Context) : ViewModel() {
                     timestamp = targetMessage.timestamp,
                     variantIndex = targetMessage.selectedVariantIndex,
                 )
-                messageCoordinationDelegate.refreshStableContextWindow(chatId = currentChatId.value)
+                messageCoordinationDelegate.scheduleStableContextWindowRefresh(chatId = currentChatId.value)
             } catch (e: Exception) {
                 AppLogger.e(TAG, "删除当前消息候选失败", e)
                 uiStateDelegate.showErrorMessage(

--- a/app/src/main/java/com/ai/assistance/operit/util/ChatUtils.kt
+++ b/app/src/main/java/com/ai/assistance/operit/util/ChatUtils.kt
@@ -5,6 +5,17 @@ import com.ai.assistance.operit.core.chat.hooks.withContent
 
 /** Utility functions for chat message handling */
 object ChatUtils {
+    private val cachedThinkPattern =
+        ("<" + "think(?:ing)?>.*?(?:<" + "/think(?:ing)?>|\\z)")
+            .toRegex(RegexOption.DOT_MATCHES_ALL)
+    private val cachedSearchPattern =
+        ("<" + "search\\b[\\s\\S]*?(?:<" + "/search>|\\z)")
+            .toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+    private val cachedThinkCapturePattern =
+        ("<" + "think(?:ing)?>([\\s\\S]*?)<" + "/think(?:ing)?>")
+            .toRegex(RegexOption.DOT_MATCHES_ALL)
+
+
     fun stripGeminiThoughtSignatureMeta(content: String): String {
         return ChatMarkupRegex.removeGeminiThoughtSignatureMeta(content)
     }
@@ -57,19 +68,7 @@ object ChatUtils {
 
     /** 过滤掉内容中的思考部分和搜索来源 移除<think></think>、<thinking></thinking>和<search></search>标签及其中的内容，并处理未闭合的情况 */
     fun removeThinkingContent(content: String): String {
-        // 使用正则表达式匹配<think>、<thinking>和<search>标签及其内容
-        // 这个正则表达式会匹配以下情况：
-        // 1. <think>...</think> (正常闭合的标签)
-        // 2. <think>... (未闭合，直到字符串末尾)
-        // 3. <thinking>...</thinking> (正常闭合的标签)
-        // 4. <thinking>... (未闭合，直到字符串末尾)
-        // 5. <search>...</search> (正常闭合的标签)
-        // 6. <search>... (未闭合，直到字符串末尾)
-        // \\z 匹配字符串的绝对末尾
-        val thinkPattern = "<think(?:ing)?>.*?(</think(?:ing)?>|\\z)".toRegex(RegexOption.DOT_MATCHES_ALL)
-        val searchPattern = "<search\\b[\\s\\S]*?(</search>|\\z)"
-            .toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
-        return content.replace(thinkPattern, "").replace(searchPattern, "").trim()
+        return content.replace(cachedThinkPattern, "").replace(cachedSearchPattern, "").trim()
     }
 
     /**
@@ -78,22 +77,17 @@ object ChatUtils {
      * @return Pair(移除think标签后的内容, think标签内的内容)
      */
     fun extractThinkingContent(content: String): Pair<String, String> {
-        val thinkPattern = "<think(?:ing)?>([\\s\\S]*?)</think(?:ing)?>".toRegex(RegexOption.DOT_MATCHES_ALL)
-        val thinkMatches = thinkPattern.findAll(content)
-        
+        val thinkMatches = cachedThinkCapturePattern.findAll(content)
+
         // 收集所有think标签内的内容
         val thinkingContent = thinkMatches.joinToString("\n") { it.groupValues[1].trim() }
-        
+
         // 移除think标签和search标签
         val contentWithoutThink = content
-            .replace(thinkPattern, "")
-            .replace(
-                "<search\\b[\\s\\S]*?(</search>|\\z)"
-                    .toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)),
-                ""
-            )
+            .replace(cachedThinkCapturePattern, "")
+            .replace(cachedSearchPattern, "")
             .trim()
-        
+
         return Pair(contentWithoutThink, thinkingContent)
     }
 


### PR DESCRIPTION
## 变更说明 / Description

长历史聊天在删除、回滚或发送消息时，会把上下文重建、thinking/search 清洗、角色卡配置解析和窗口估算带入 `Main.immediate` 路径。长对话因此可能出现明显卡顿，严重时触发 ANR。

本 PR 将这些高成本操作移出主线程，并让历史变更后的窗口刷新异步、按聊天可取消。用户侧的聊天上下文裁剪语义不变，但删除/发送/插入总结等操作不再同步等待整段历史处理。

### 背景与动机 / Context and motivation

vivo 上长历史聊天复现了删除或回滚后界面无响应并被系统静默杀死的问题。代码核对确认：有 summary 时，summary 之前的历史本来就不会进入运行时上下文；问题在于剩余上下文的重建和清洗被放在了错误的线程，并且发送路径还存在同步阻塞和重复工作。

### 改动范围 / Changes

- 将上下文窗口重算和 memory 构建移到 `Dispatchers.IO`。
- 为窗口刷新增加按 `chatId` 管理的可取消异步任务；删除、回滚、编辑消息和变体操作不再等待完整重算。
- 缓存 think/search 正则；`processAiMessage` 仅在跨角色桥接时清洗内容。
- 移除发送入口及角色卡/上下文配置解析中的 `runBlocking`，改为挂起调用和 IO 调度。
- 将手动插入总结的历史读取、总结生成和写入移出主线程，并复用缓存的 memory 正则。
- 明确不包含：summary 历史裁剪规则、复制路径、数据库 schema、网络 API 和配置格式均未改变。

### 兼容性与风险 / Compatibility and risks

- 无数据库迁移、公开 API、配置格式或网络协议变化。
- 历史变更后的 token/window 估算改为异步最终更新；同一聊天的新刷新会取消旧刷新，避免过时结果覆盖最新状态。
- 发送和总结内容处理规则保持不变；主要变化是执行线程和调度时序。
- 未进行真机/QQ 回归，原因是当前环境没有可用的 Android 真机测试条件。

## 关联 Issue / Related issue

N/A — 本 PR 针对 QQ/vivo 长历史 ANR 反馈；当前没有提供可关联的 Issue 编号。

## 验证方式 / Verification

```text
检查或命令：
- ./gradlew :app:compileDebugKotlin --no-daemon
- ./gradlew :app:testDebugUnitTest --no-daemon --tests com.ai.assistance.operit.util.ChatUtilsTest --tests com.ai.assistance.operit.util.ChatUtilsThinkingTest --tests com.ai.assistance.operit.util.ChatUtilsThinkingEdgeTest --tests com.ai.assistance.operit.util.ChatMarkupRegexSearchTest
- git diff --check
- GitHub Actions: Android Build / assembleDebug
- GitHub Actions: Android Tests
环境与变体：
- 本地 Ubuntu 工作区；Debug Kotlin 编译和 ChatUtils 相关 JVM 单测
- GitHub Actions Ubuntu runner；Android Debug 构建
结果：
- 本地 Kotlin 编译：通过，退出码 0
- 本地针对性 ChatUtils 单测：通过，退出码 0
- diff 检查：通过
- Android Build / assembleDebug：通过
- Android Tests：测试源码编译阶段被 upstream/dev 中既有的 DeepseekProviderMediaRoleTest 和 XaiProviderReasoningTest 阻断；本 PR 未修改这两个测试文件，也未将该上游问题作为本 PR 的修复范围
- 未运行真机/QQ 回归：当前没有可用 Android 真机环境
```

## 证据 / Evidence

- Commit: `a59e3a2` — `fix(chat): move long-history work off main thread`
- Android Build: https://github.com/3316891527/Operit/actions/runs/34380492388
- Android Tests（上游测试源码编译问题）: https://github.com/3316891527/Operit/actions/runs/34380455139

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 `dev`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `dev` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并已区分上游测试源码失败 / `Candidate checks` covers the change scope and the upstream test-source failure is identified separately
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided