### PR TITLE
fix(provider): sort Claude tool results by tool use order to preserve prompt cache

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
+++ b/app/src/main/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProvider.kt
@@ -596,7 +596,7 @@ open class ClaudeProvider(
         return json
     }
 
-    private data class ClaudeSerializedHistory(
+    internal data class ClaudeSerializedHistory(
         val messagesArray: JSONArray,
         val systemBlocks: JSONArray?
     )
@@ -707,9 +707,9 @@ open class ClaudeProvider(
         }
     }
 
-    private fun buildSerializedHistory(
+    internal fun buildSerializedHistory(
         chatHistory: List<PromptTurn>,
-        preserveThinkInHistory: Boolean
+        preserveThinkInHistory: Boolean = false
     ): ClaudeSerializedHistory {
         val messagesArray = JSONArray()
         val effectiveHistory =
@@ -922,11 +922,14 @@ open class ClaudeProvider(
 
                         if (resultsList.isNotEmpty() && openToolUses.isNotEmpty()) {
                             val contentArray = JSONArray()
+                            val useOrder = openToolUses.mapIndexed { i, c -> c.id to i }.toMap()
                             val matchedCalls =
                                 StructuredToolCallBridge.consumeMatchingToolCalls(
                                     openToolUses,
                                     resultsList.map { it.first }
-                                )
+                                ).sortedBy { matchedCall ->
+                                    useOrder[matchedCall.call.id] ?: Int.MAX_VALUE
+                                }
                             matchedCalls.forEach { matchedCall ->
                                 val resultContent = resultsList[matchedCall.resultIndex].second
                                 contentArray.put(

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProviderHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProviderHistoryTest.kt
@@ -1,0 +1,96 @@
+package com.ai.assistance.operit.api.chat.llmprovider
+
+import com.ai.assistance.operit.core.chat.hooks.PromptTurn
+import com.ai.assistance.operit.core.chat.hooks.PromptTurnKind
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClaudeProviderHistoryTest {
+
+    private fun createProvider(enableToolCall: Boolean = true): ClaudeProvider {
+        return ClaudeProvider(
+            apiEndpoint = "https://api.anthropic.com/v1/messages",
+            apiKeyProvider = SingleApiKeyProvider("sk-ant-test"),
+            modelName = "claude-3-5-sonnet-20241022",
+            client = OkHttpClient(),
+            enableToolCall = enableToolCall
+        )
+    }
+
+    private fun toolCall(name: String, vararg params: Pair<String, String>): String {
+        val body = params.joinToString("") { (key, value) ->
+            "<" + "param name=\"$key\">" + value + "</" + "param>"
+        }
+        return "<" + "tool name=\"$name\">" + body + "</" + "tool>"
+    }
+
+    private fun toolResult(name: String, content: String): String =
+        "<" + "tool_result name=\"$name\" status=\"success\"><" + "content>" + content + "</" + "content></" + "tool_result>"
+
+    <Test
+    fun parallel_tool_results_are_ordered_by_tool_use_definition_order_to_preserve_prompt_cache() {
+        val provider = createProvider(enableToolCall = true)
+
+        // Assistant calls 3 tools in order: read_file -> list_files -> grep_code
+        val assistantTurn = PromptTurn(
+            kind = PromptTurnKind.ASSISTANT,
+            content = toolCall("read_file", "path" to "fileA.txt") +
+                toolCall("list_files", "path" to "dirB") +
+                toolCall("grep_code", "pattern" to "queryC")
+        )
+
+        // Due to async parallel execution race, the database recorded them in completion order:
+        // list_files finished first, then grep_code, then read_file
+        val toolResultTurn = PromptTurn(
+            kind = PromptTurnKind.TOOL_RESULT,
+            content = toolResult("list_files", "content_list_files") +
+                toolResult("grep_code", "content_grep_code") +
+                toolResult("read_file", "content_read_file")
+        )
+
+        val history = listOf(
+            PromptTurn(kind = PromptTurnKind.USER, content = "Inspect project"),
+            assistantTurn,
+            toolResultTurn
+        )
+
+        val serialized = provider.buildSerializedHistory(history)
+        val messages = serialized.messagesArray
+
+        assertEquals(3, messages.length()) // user, then assistant, then user (tool_result)
+        val assistantMsg = messages.getJSONObject(1)
+        assertEquals("role", "assistant", assistantMsg.getString("role"))
+        val assistantContent = assistantMsg.getJSONArray("content")
+        assertEquals(3, assistantContent.length())
+
+        val toolUse0Id = assistantContent.getJSONObject(0).getString("id")
+        val toolUse1Id = assistantContent.getJSONObject(1).getString("id")
+        val toolUse2Id = assistantContent.getJSONObject(2).getString("id")
+
+        assertEquals("read_file", assistantContent.getJSONObject(0).getString("name"))
+        assertEquals("list_files", assistantContent.getJSONObject(1).getString("name"))
+        assertEquals("grep_code", assistantContent.getJSONObject(2).getString("name"))
+
+        val userMsg = messages.getJSONObject(2)
+        assertEquals("role", "user", userMsg.getString("role"))
+        val userContent = userMsg.getJSONArray("content")
+        assertEquals(3, userContent.length())
+
+        // The tool_result blocks in the user message MUST be in the exact order of tool_use (read_file, list_files, grep_code)
+        // rather than the out-of-order XML sequence (list_files, grep_code, read_file).
+        assertEquals("tool_result", userContent.getJSONObject(0).getString("type"))
+        assertEquals(toolUse0Id, userContent.getJSONObject(0).getString("tool_use_id"))
+        assertEquals("historical content match", "content_read_file", userContent.getJSONObject(0).getString("content"))
+
+
+        assertEquals("tool_result", userContent.getJSONObject(1).getString("type"))
+        assertEquals(toolUse1Id, userContent.getJSONObject(1).getString("tool_use_id"))
+        assertEquals("historical content match", "content_list_files", userContent.getJSONObject(1).getString("content"))
+
+
+        assertEquals("tool_result", userContent.getJSONObject(2).getString("type"))
+        assertEquals(toolUse2Id, userContent.getJSONObject(2).getString("tool_use_id"))
+        assertEquals("historical content match", "content_grep_code", userContent.getJSONObject(2).getString("content"))
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProviderHistoryTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProviderHistoryTest.kt
@@ -28,7 +28,7 @@ class ClaudeProviderHistoryTest {
     private fun toolResult(name: String, content: String): String =
         "<" + "tool_result name=\"$name\" status=\"success\"><" + "content>" + content + "</" + "content></" + "tool_result>"
 
-    <Test
+    @Test
     fun parallel_tool_results_are_ordered_by_tool_use_definition_order_to_preserve_prompt_cache() {
         val provider = createProvider(enableToolCall = true)
 


### PR DESCRIPTION
## 变更说明 / Description

在 Anthropic 协议开启 Tool Call 模式下，当上一轮包含多个并行工具调用时，用户发送新一条消息后，Claude 的 Prompt Cache 会从该轮工具调用开始的位置整体失效，工具历史全部变成 `cache_creation` 重新计费。

本 PR 在 `ClaudeProvider` 构建序列化消息历史时，将匹配到的工具结果（`matchedCalls`）按当轮 `tool_use` 的原始定义顺序进行稳定排序后再组装输出，消除因并行执行异步竞态导致的 XML 文本乱序，恢复 Anthropic 严格前缀缓存命中。

### 背景与动机 / Context and motivation

- **根因分析**：
  1. 在工具循环内部（同一轮次继续请求 AI 时），`ToolExecutionManager.executeInvocations` 会将结果重新按原始调用顺序（Invocation Order）排序放入内存上下文。
  2. 但在并行执行期间，各个异步工具协程是以“先完成先发射”的形式通过 `collector.emit` 输出并持久化到数据库的（完成顺序 / Completion Order）。
  3. 用户发送新消息后，历史从数据库重新加载并按 XML 文本顺序由 `parseXmlToolResults` 解析，导致下一轮请求发往 Claude 的 `tool_result` 块顺序与上一轮不一致。
  4. Anthropic Prompt Caching 依赖严格的前缀字节级匹配（Strict Prefix Match）。一旦同轮次内的 `tool_result` 块顺序发生变化，缓存前缀在此处断裂，导致从该位置往后的所有历史 token 产生高额的 Cache Miss。

### 改动范围 / Changes

- `ClaudeProvider.kt`：
  - 在 `PromptTurnKind.TOOL_RESULT` 分支中，调用 `consumeMatchingToolCalls` 匹配结果后，根据 `openToolUses` 的原始调用顺序（`useOrder`）对 `matchedCalls` 进行排序，确保输出至 `contentArray` 的 `tool_result` 块与上一轮定义的 `tool_use` 顺序严格一致。
  - 将 `ClaudeSerializedHistory` 和 `buildSerializedHistory` 的可见性从 `private` 调整为 `internal`，以便单元测试覆盖。
- `ClaudeProviderHistoryTest.kt`：
  - 新增针对该场景的单元测试，模拟乱序记录的 XML 工具结果，断言其在序列化后稳定对齐到原始 `tool_use` 顺序。
- 明确不包含：不改动其他模型提供商的组装逻辑；不修改底层的 XML 标签格式或消息存储规范。

### 兼容性与风险 / Compatibility and risks

- 无数据库迁移、配置格式、网络协议或公开 API 变更。
- 仅影响 `ClaudeProvider` 在存在多个 `tool_result` 时的 JSON 报文块序列化排列，不改变工具执行逻辑或结果文本内容。
- 实际 Prompt Cache 命中率还取决于上游 API / 中转服务是否存在账号池轮换（账号切换会致使服务端缓存失效）。

## 关联 Issue / Related issue

Fixes #1159

## 验证方式 / Verification

```text
检查或命令：
- GitHub Actions: Android Build / assembleDebug (Run 34516659463)
- GitHub Actions: Android Tests (Run 34511465652)
- app/src/test/java/com/ai/assistance/operit/api/chat/llmprovider/ClaudeProviderHistoryTest.kt
- git diff --check

结果：
- Android Build (assembleDebug)：通过 (BUILD SUCCESSFUL)
- diff 检查：通过，无多余空白或无关文件
- 单元测试：新增用例验证在乱序 XML 输入下，发往 Claude 的消息体 tool_result 稳定保持调用顺序
- Android Tests：与此前 PR 一致，当前 upstream/dev 既有的两个测试文件（DeepseekProviderMediaRoleTest、XaiProviderReasoningTest）存在编译符号过期问题阻断 compileDebugUnitTestKotlin；本 PR 未做无关追修
```

## 证据 / Evidence

- Android Build: https://github.com/3316891527/Operit/actions/runs/34516659463
- Android Tests: https://github.com/3316891527/Operit/actions/runs/34511465652
- Commit: `95332c7` — `fix(provider): sort Claude tool results by tool use order to preserve prompt cache`

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 `dev`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `dev` for regular work; if it is `main`, I explained why this is a maintainer-led release sync
- [x] 我已确认 `Candidate checks` 覆盖改动范围，并已区分上游测试源码失败 / `Candidate checks` covers the change scope and the upstream test-source failure is identified separately
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Relevant regression, UI, docs/strings, or compatibility evidence is provided