### PR TITLE
fix(i18n): clarify API key placeholder text for key pool awareness

### DIFF
--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -4117,7 +4117,7 @@
     <string name="api_endpoint_placeholder">e.g.: https://api.openai.com/v1/chat/completions</string>
     <string name="actual_request_url">Actual request URL: %s</string>
     <string name="endpoint_completion_hint">Hint: If you enter a base URL, the system will automatically complete the path. To disable, add # at the end of the URL.</string>
-    <string name="api_key_placeholder_default">Using default key, you can input directly</string>
+    <string name="api_key_placeholder_default">No key set. Type one here or use the API key pool</string>
     <string name="api_key_placeholder_custom">Enter API key</string>
     <string name="model_name_placeholder">e.g.: gpt-4, claude-3-opus-20240229...</string>
     <string name="get_models_list">Get Models List</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1196,7 +1196,7 @@
     <string name="api_endpoint_placeholder">ej.: https://api.openai.com/v1/chat/completions</string>
     <string name="actual_request_url">URL de solicitud real: %s</string>
     <string name="endpoint_completion_hint">Sugerencia: Si ingresas una URL base, el sistema completará automáticamente la ruta. Para desactivar, agrega # al final de la URL.</string>
-    <string name="api_key_placeholder_default">Usando clave predeterminada, puedes ingresar directamente</string>
+    <string name="api_key_placeholder_default">No hay clave establecida. Escríbela aquí o usa el grupo de claves API</string>
     <string name="api_key_placeholder_custom">Ingresa clave API</string>
     <string name="model_name_placeholder">ej.: gpt-4, claude-3-opus-20240229...</string>
     <string name="get_models_list">Obtener Lista de Modelos</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -3565,7 +3565,7 @@ Sekarang Anda dapat menggunakan mode AutoGLM di antarmuka percakapan.</string>
     <string name="actual_request_url">URL permintaan aktual: %s</string>
     <string name="endpoint_completion_hint">Petunjuk: Jika Anda memasukkan URL dasar, sistem akan melengkapi jalurnya secara otomatis. Untuk menonaktifkan, tambahkan tanda # di akhir URL.</string>
     <string name="api_key">Kunci API</string>
-    <string name="api_key_placeholder_default">Gunakan Kunci default, dapat langsung dimasukkan</string>
+    <string name="api_key_placeholder_default">Belum ada kunci. Masukkan langsung atau gunakan kumpulan kunci API</string>
     <string name="api_key_placeholder_custom">Masukkan kunci API</string>
     <string name="model_name">Nama model</string>
     <string name="model_name_placeholder">Contoh: gpt-4, claude-3-opus-20240229...</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -3460,7 +3460,7 @@
     <string name="actual_request_url">실제 요청 URL: %s</string>
     <string name="endpoint_completion_hint">힌트: 기본 URL을 입력하면 시스템이 자동으로 경로를 완성합니다. 비활성화하려면 URL 끝에 #을 추가하세요.</string>
     <string name="api_key">API 키</string>
-    <string name="api_key_placeholder_default">기본 키 사용 중입니다. 직접 입력할 수 있습니다.</string>
+    <string name="api_key_placeholder_default">키가 설정되지 않았습니다. 여기에 입력하거나 API 키 풀을 사용하세요</string>
     <string name="api_key_placeholder_custom">API 키 입력</string>
     <string name="model_name">모델명</string>
     <string name="model_name_placeholder">예: gpt-4, claude-3-opus-20240229...</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -3439,7 +3439,7 @@ Kini anda boleh menggunakan mod AutoGLM di antara muka perbualan.</string>
     <string name="actual_request_url">Alamat permintaan sebenar: %s</string>
     <string name="endpoint_completion_hint">Petunjuk: Jika anda memasukkan URL asas, sistem akan melengkapkan laluan secara automatik. Untuk melumpuhkan, tambahkan tanda # di hujung URL.</string>
     <string name="api_key">Kunci API</string>
-    <string name="api_key_placeholder_default">Gunakan Kunci lalai, boleh dimasukkan terus</string>
+    <string name="api_key_placeholder_default">Tiada kunci ditetapkan. Masukkan di sini atau gunakan Kolam Kunci API</string>
     <string name="api_key_placeholder_custom">Masukkan kunci API</string>
     <string name="model_name">Nama model</string>
     <string name="model_name_placeholder">Contoh: gpt-4, claude-3-opus-20240229...</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -3321,7 +3321,7 @@ Agora é possível usar o modo AutoGLM na interface de diálogo.</string>
     <string name="actual_request_url">Endereço de solicitação real: %s</string>
     <string name="endpoint_completion_hint">Dica: Se você inserir uma URL base, o sistema completará automaticamente o caminho. Para desativá-lo, adicione um sinal # no final do URL.</string>
     <string name="api_key">Chave de API</string>
-    <string name="api_key_placeholder_default">Use a chave padrão e insira-a diretamente</string>
+    <string name="api_key_placeholder_default">Nenhuma chave definida. Digite aqui ou use o pool de chaves de API</string>
     <string name="api_key_placeholder_custom">Insira a chave API</string>
     <string name="model_name">Nome do modelo</string>
     <string name="model_name_placeholder">Por exemplo: gpt-4, claude-3-opus-20240229...</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -3844,7 +3844,7 @@ Acum poate fi utilizat în interfața de dialog AutoGLM A devenit un model.</str
     <string name="actual_request_url">Adresa efectivă a cererii: %s</string>
     <string name="endpoint_completion_hint">Sfat: Dacă introduceți elementul de bazăURL, sistemul va completa automat calea. Dacă doriți să dezactivați această funcție, vă rugăm săURLAdăugare la sfârșit#Nr.</string>
     <string name="api_key">APICheie</string>
-    <string name="api_key_placeholder_default">Utilizarea setărilor impliciteKey, se poate introduce direct</string>
+    <string name="api_key_placeholder_default">Nicio cheie setată. Introdu-o aici sau utilizează rezervorul de chei API</string>
     <string name="api_key_placeholder_custom">IntroducereAPICheie</string>
     <string name="model_name">Denumirea modelului</string>
     <string name="model_name_placeholder">De exemplu: gpt-4, claude-3-opus-20240229...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4076,7 +4076,7 @@
     <string name="actual_request_url">实际请求地址: %s</string>
     <string name="endpoint_completion_hint">提示: 如果您输入的是基础URL，系统将自动补全路径。如需禁用，请在URL末尾添加#号。</string>
     <string name="api_key">API密钥</string>
-    <string name="api_key_placeholder_default">使用默认Key, 可直接输入</string>
+    <string name="api_key_placeholder_default">未设置密钥，可直接输入或使用密钥池</string>
     <string name="api_key_placeholder_custom">输入API密钥</string>
     <string name="model_name">模型名称</string>
     <string name="model_name_placeholder">例如: gpt-4, claude-3-opus-20240229...</string>


### PR DESCRIPTION
## 变更背景

在"设置→模型与参数配置"界面中，API 密钥输入框为空时显示的副标题文案 **"使用默认Key, 可直接输入"** 存在歧义：

1. **暗示存在内置默认 Key**：实际上 `isUsingDefaultApiKey` 的定义仅为 `apiKeyInput.isBlank()`，应用并不内置任何默认 API Key，用户可能误以为不填密钥也能正常调用云端 API。

2. **未考虑密钥池功能**：应用已有 API 密钥池功能（`AdvancedSettingsSection.kt` 中的 `useApiKeyPool` 开关 + `MultiApiKeyProvider` 轮询）。用户可以完全不填写主界面的单个密钥、仅靠密钥池运行。但当前文案没有告知用户还有密钥池这条路。

## 关联 Issue

Closes #1172

## 改动范围

仅修改 8 个语言资源文件中的 `api_key_placeholder_default` 字符串资源，每处 1 行：

| 语言 | 旧文案 | 新文案 |
|---|---|---|
| 中文（默认） | `使用默认Key, 可直接输入` | `未设置密钥，可直接输入或使用密钥池` |
| English | `Using default key, you can input directly` | `No key set. Type one here or use the API key pool` |
| Español | `Usando clave predeterminada, puedes ingresar directamente` | `No hay clave establecida. Escríbela aquí o usa el grupo de claves API` |
| Indonesia | `Gunakan Kunci default, dapat langsung dimasukkan` | `Belum ada kunci. Masukkan langsung atau gunakan kumpulan kunci API` |
| 한국어 | `기본 키 사용 중입니다. 직접 입력할 수 있습니다.` | `키가 설정되지 않았습니다. 여기에 입력하거나 API 키 풀을 사용하세요` |
| Melayu | `Gunakan Kunci lalai, boleh dimasukkan terus` | `Tiada kunci ditetapkan. Masukkan di sini atau gunakan Kolam Kunci API` |
| Português (BR) | `Use a chave padrão e insira-a diretamente` | `Nenhuma chave definida. Digite aqui ou use o pool de chaves de API` |
| Română | `Utilizarea setărilor impliciteKey, se poate introduce direct` | `Nicio cheie setată. Introdu-o aici sau utilizează rezervorul de chei API` |

## 兼容性影响

纯字符串资源修改，不涉及任何逻辑、布局或 API 变更，零兼容性风险。

## 验证方式

- 未运行构建/测试（未被请求）
- 已通过 `git diff` 确认 8 个文件各仅修改 1 行 `api_key_placeholder_default`，无其他内容变动
- 改动为 XML 字符串值修改，AAPT2 resource compile 预期通过

## Checklist

- [x] 变更有明确的 Issue 关联（#1172）
- [x] PR 聚焦，不包含无关改动
- [x] 标题使用 Conventional Commits 格式
- [x] 未提交 API Key、Token 或其他敏感信息
- [x] 兼容性影响已说明
- [x] 未修改第三方子模块