### PR TITLE
fix(shell): prevent Shizuku command pipe deadlocks

### DIFF
--- a/app/src/main/java/com/ai/assistance/operit/core/tools/system/shell/DebuggerShellExecutor.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/system/shell/DebuggerShellExecutor.kt
@@ -8,22 +8,34 @@ import com.ai.assistance.operit.core.tools.system.AndroidPermissionLevel
 import com.ai.assistance.operit.core.tools.system.ShizukuAuthorizer
 import com.ai.assistance.operit.core.tools.system.ShellIdentity
 import java.io.BufferedReader
-import java.io.FileInputStream
-import java.io.InputStreamReader
-import java.io.InterruptedIOException
-import java.util.concurrent.ConcurrentHashMap
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.withContext
-import moe.shizuku.server.IShizukuService
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.launch
-import java.io.InputStream
 import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import moe.shizuku.server.IRemoteProcess
+import moe.shizuku.server.IShizukuService
 
 /** 基于Shizuku的Shell命令执行器 实现DEBUGGER权限级别的命令执行 */
 class DebuggerShellExecutor(private val context: Context) : ShellExecutor {
@@ -168,52 +180,9 @@ class DebuggerShellExecutor(private val context: Context) : ShellExecutor {
         return false
     }
 
-    /**
-     * 封装重试逻辑的函数
-     * @param maxRetries 最大重试次数
-     * @param delayMs 每次重试前的延迟时间（毫秒）
-     * @param operation 要执行的操作
-     * @return 操作结果
-     */
-    private suspend fun <T> retryOperation(
-            maxRetries: Int = 3,
-            delayMs: Long = 500,
-            operation: suspend () -> T
-    ): T {
-        var lastException: Exception? = null
-        for (attempt in 0 until maxRetries) {
-            try {
-                return operation()
-            } catch (e: Exception) {
-                // 检查是否是 read interrupted 异常
-                val isInterruptedRead =
-                        e is InterruptedIOException &&
-                                e.message?.contains("read interrupted") == true
-
-                if (isInterruptedRead) {
-                    lastException = e
-                    AppLogger.w(
-                            TAG,
-                            "Read interrupted on attempt ${attempt + 1}/$maxRetries, retrying in $delayMs ms",
-                            e
-                    )
-                    delay(delayMs)
-                    continue
-                } else {
-                    // 对于其他异常，直接抛出
-                    throw e
-                }
-            }
-        }
-        // 如果达到最大重试次数，抛出最后一个异常
-        throw lastException ?: IllegalStateException("Unknown error in retry operation")
-    }
-
     /** 直接执行不包含特殊操作符的普通命令 */
     private suspend fun executeCommandDirect(command: String): ShellExecutor.CommandResult =
             withContext(Dispatchers.IO) {
-                var process: Any? = null
-
                 try {
                     val service =
                             getShizukuService()
@@ -223,95 +192,31 @@ class DebuggerShellExecutor(private val context: Context) : ShellExecutor {
                                             "Shizuku service not available"
                                     )
 
-                    // 拆分命令行参数 - 使用更智能的解析方法
-                    val commandParts = parseCommand(command)
+                    // 直接执行时仍然通过 AIDL 的远程进程对象管理 stdin/stdout/stderr。
+                    val process = service.newProcess(parseCommand(command), null, null)
+                            ?: return@withContext ShellExecutor.CommandResult(
+                                    false,
+                                    "",
+                                    "Failed to create process"
+                            )
 
-                    // 创建进程
-                    process = service.newProcess(commandParts, null, null)
-
-                    if (process == null) {
-                        return@withContext ShellExecutor.CommandResult(
-                                false,
-                                "",
-                                "Failed to create process"
-                        )
-                    }
-
-                    // 将ParcelFileDescriptor转换为InputStream
-                    val processClass = process::class.java
-                    val inputStream =
-                            processClass.getMethod("getInputStream").invoke(process) as
-                                    ParcelFileDescriptor?
-                    val errorStream =
-                            processClass.getMethod("getErrorStream").invoke(process) as
-                                    ParcelFileDescriptor?
-
-                    // 使用重试逻辑读取标准输出和错误输出
-                    val stdout =
-                            if (inputStream != null) {
-                                retryOperation {
-                                    val stdoutStream = FileInputStream(inputStream.fileDescriptor)
-                                    BufferedReader(InputStreamReader(stdoutStream)).use {
-                                        it.readText()
-                                    }
-                                }
-                            } else ""
-
-                    val stderr =
-                            if (errorStream != null) {
-                                retryOperation {
-                                    val stderrStream = FileInputStream(errorStream.fileDescriptor)
-                                    BufferedReader(InputStreamReader(stderrStream)).use {
-                                        it.readText()
-                                    }
-                                }
-                            } else ""
-
-                    val exitCode = processClass.getMethod("waitFor").invoke(process) as Int
-
-                    // 返回结果
-                    return@withContext ShellExecutor.CommandResult(
-                            exitCode == 0,
-                            stdout,
-                            stderr,
-                            exitCode
+                    executeRemoteProcess(
+                            process = process,
+                            command = command,
+                            allowGrepExitCode = false,
                     )
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: RemoteException) {
                     AppLogger.e(TAG, "Remote exception while executing command", e)
-                    return@withContext ShellExecutor.CommandResult(
+                    ShellExecutor.CommandResult(
                             false,
                             "",
                             "Remote exception: ${e.message}"
                     )
                 } catch (e: Exception) {
                     AppLogger.e(TAG, "Error executing command", e)
-                    return@withContext ShellExecutor.CommandResult(false, "", "Error: ${e.message}")
-                } finally {
-                    // 安全关闭文件描述符
-                    try {
-                        if (process != null) {
-                            val processClass = process::class.java
-                            try {
-                                val inputStream =
-                                        processClass.getMethod("getInputStream").invoke(process) as
-                                                ParcelFileDescriptor?
-                                inputStream?.close()
-                            } catch (e: Exception) {
-                                AppLogger.e(TAG, "Error closing input stream", e)
-                            }
-
-                            try {
-                                val errorStream =
-                                        processClass.getMethod("getErrorStream").invoke(process) as
-                                                ParcelFileDescriptor?
-                                errorStream?.close()
-                            } catch (e: Exception) {
-                                AppLogger.e(TAG, "Error closing error stream", e)
-                            }
-                        }
-                    } catch (e: Exception) {
-                        AppLogger.e(TAG, "Error in cleanup", e)
-                    }
+                    ShellExecutor.CommandResult(false, "", "Error: ${e.message}")
                 }
             }
 
@@ -348,14 +253,17 @@ class DebuggerShellExecutor(private val context: Context) : ShellExecutor {
                                 processedCommand
                             }
 
-                    // 如果命令以单个'&'结尾（后台运行），我们只负责启动，不阻塞等待
-                    val trimmedForBg = enhancedCommand.trimEnd()
-                    val isBackground =
-                            trimmedForBg.endsWith("&") && !trimmedForBg.endsWith("&&")
+                    val isBackground = hasTrailingBackgroundOperator(enhancedCommand)
+                    // 后台命令不会把输出交给调用方；显式断开 stdin/stdout/stderr，避免
+                    // 后台子进程继承 Shizuku 的管道后让调用方永远等不到 EOF。
+                    val commandForExecution =
+                            if (isBackground) {
+                                detachBackgroundShellCommand(enhancedCommand)
+                            } else {
+                                enhancedCommand
+                            }
+                    val shellArgs = arrayOf("sh", "-e", "-c", commandForExecution)
 
-                    val shellArgs = arrayOf("sh", "-e", "-c", enhancedCommand)
-
-                    // 创建进程
                     val process =
                             service.newProcess(shellArgs, null, null)
                                     ?: return@withContext ShellExecutor.CommandResult(
@@ -363,95 +271,69 @@ class DebuggerShellExecutor(private val context: Context) : ShellExecutor {
                                             "",
                                             "Failed to create process"
                                     )
-                    // 处理输入输出流
-                    val processClass = process::class.java
-                    val inputStream =
-                            processClass.getMethod("getInputStream").invoke(process) as
-                                    ParcelFileDescriptor?
-                    val errorStream =
-                            processClass.getMethod("getErrorStream").invoke(process) as
-                                    ParcelFileDescriptor?
 
-                    if (isBackground) {
-                        AppLogger.d(TAG, "Detected background shell command (ending with '&'), not waiting for process")
-                        // 对于后台命令，我们不读取输出，也不等待退出，只要进程创建成功就视为成功
-                        try {
-                            inputStream?.close()
-                        } catch (e: Exception) {
-                            AppLogger.e(TAG, "Error closing input stream for background shell command", e)
-                        }
-
-                        try {
-                            errorStream?.close()
-                        } catch (e: Exception) {
-                            AppLogger.e(TAG, "Error closing error stream for background shell command", e)
-                        }
-
-                        return@withContext ShellExecutor.CommandResult(
-                                true,
-                                "",
-                                "",
-                                0
-                        )
-                    }
-
-                    // 使用重试逻辑读取标准输出和错误输出
-                    val stdout =
-                            if (inputStream != null) {
-                                retryOperation {
-                                    val stdoutStream = FileInputStream(inputStream.fileDescriptor)
-                                    BufferedReader(InputStreamReader(stdoutStream)).use {
-                                        it.readText()
-                                    }
-                                }
-                            } else ""
-
-                    val stderr =
-                            if (errorStream != null) {
-                                retryOperation {
-                                    val stderrStream = FileInputStream(errorStream.fileDescriptor)
-                                    BufferedReader(InputStreamReader(stderrStream)).use {
-                                        it.readText()
-                                    }
-                                }
-                            } else ""
-
-                    val exitCode = processClass.getMethod("waitFor").invoke(process) as Int
-
-                    // 关闭文件描述符
-                    try {
-                        inputStream?.close()
-                    } catch (e: Exception) {
-                        AppLogger.e(TAG, "Error closing input stream in shell execution", e)
-                    }
-
-                    try {
-                        errorStream?.close()
-                    } catch (e: Exception) {
-                        AppLogger.e(TAG, "Error closing error stream in shell execution", e)
-                    }
-
-                    // 确定命令是否成功
-                    val success =
-                            when {
-                                // 如果命令包含grep，即使没有找到匹配也认为成功
-                                command.contains("grep") -> exitCode == 0 || exitCode == 1
-
-                                // 对其他命令，只有exitCode=0才算成功
-                                else -> exitCode == 0
-                            }
-
-                    return@withContext ShellExecutor.CommandResult(
-                            success,
-                            stdout,
-                            stderr,
-                            exitCode
+                    executeRemoteProcess(
+                            process = process,
+                            command = command,
+                            allowGrepExitCode = command.contains("grep"),
+                            detach = isBackground,
+                    )
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: RemoteException) {
+                    AppLogger.e(TAG, "Remote exception while executing shell command", e)
+                    ShellExecutor.CommandResult(
+                            false,
+                            "",
+                            "Remote exception: ${e.message}"
                     )
                 } catch (e: Exception) {
                     AppLogger.e(TAG, "Error executing shell command", e)
-                    return@withContext ShellExecutor.CommandResult(false, "", "Error: ${e.message}")
+                    ShellExecutor.CommandResult(false, "", "Error: ${e.message}")
                 }
             }
+
+    /**
+     * 判断命令末尾是否有未转义、未处于引号中的单个后台操作符。
+     */
+    private fun hasTrailingBackgroundOperator(command: String): Boolean {
+        var inSingleQuotes = false
+        var inDoubleQuotes = false
+        var escaped = false
+        var lastSignificantIndex = -1
+
+        command.forEachIndexed { index, character ->
+            if (escaped) {
+                escaped = false
+                return@forEachIndexed
+            }
+            if (character == '\\') {
+                escaped = true
+                return@forEachIndexed
+            }
+            if (character == '\'' && !inDoubleQuotes) {
+                inSingleQuotes = !inSingleQuotes
+                return@forEachIndexed
+            }
+            if (character == '"' && !inSingleQuotes) {
+                inDoubleQuotes = !inDoubleQuotes
+                return@forEachIndexed
+            }
+            if (!inSingleQuotes && !inDoubleQuotes && !character.isWhitespace()) {
+                lastSignificantIndex = index
+            }
+        }
+
+        if (lastSignificantIndex < 0 || command[lastSignificantIndex] != '&') return false
+        return lastSignificantIndex == 0 || command[lastSignificantIndex - 1] != '&'
+    }
+
+    /** 将 fire-and-forget 命令与调用方的管道彻底解耦。 */
+    private fun detachBackgroundShellCommand(command: String): String {
+        val trimmed = command.trimEnd()
+        val body = trimmed.dropLast(1).trimEnd().ifBlank { ":" }
+        return "$body </dev/null >/dev/null 2>&1 &"
+    }
 
     /** 获取Shizuku服务 */
     private fun getShizukuService(): IShizukuService? {
@@ -570,76 +452,341 @@ class DebuggerShellExecutor(private val context: Context) : ShellExecutor {
 }
 
 /**
- * 使用 Shizuku 实现的 ShellProcess。
+ * 通过 AIDL 管理一次性 Shizuku 远程进程的输出和生命周期。
+ *
+ * stdout 与 stderr 必须同时消费，否则任一管道写满都会阻塞远程进程；stdin
+ * 也必须主动关闭，否则需要 EOF 的命令会一直等待输入。
  */
-private class ShizukuShellProcess(
-    private val service: IShizukuService,
-    private val command: String
-) : ShellProcess {
-    private val process: Any
-    private val processClass: Class<*>
+private const val DEBUGGER_SHELL_TAG = "DebuggerShellExecutor"
+private const val REMOTE_PROCESS_POLL_INTERVAL_MS = 100L
+private const val POST_EXIT_OUTPUT_DRAIN_GRACE_MS = 1_000L
+private const val OUTPUT_TRUNCATION_NOTICE =
+        "Remote process output was truncated after the process exited."
 
-    init {
-        val shellArgs = arrayOf("sh", "-c", command)
-        process = service.newProcess(shellArgs, null, null)
-            ?: throw IOException("Failed to create Shizuku process")
-        processClass = process.javaClass
-    }
+private suspend fun executeRemoteProcess(
+        process: IRemoteProcess,
+        command: String,
+        allowGrepExitCode: Boolean,
+        detach: Boolean = false,
+): ShellExecutor.CommandResult = withContext(Dispatchers.IO) {
+    var stdoutDescriptor: ParcelFileDescriptor? = null
+    var stderrDescriptor: ParcelFileDescriptor? = null
+    var processFinished = false
 
-    private val inputStream: ParcelFileDescriptor by lazy {
-        processClass.getMethod("getInputStream").invoke(process) as ParcelFileDescriptor
-    }
+    try {
+        // One-shot commands have no input API at this layer. EOF prevents interactive
+        // commands and child scripts from waiting on an input pipe forever.
+        closeRemoteStdin(process)
+        stdoutDescriptor = process.getInputStream()
+        stderrDescriptor = process.getErrorStream()
 
-    private val errorStream: ParcelFileDescriptor by lazy {
-        processClass.getMethod("getErrorStream").invoke(process) as ParcelFileDescriptor
-    }
-
-    override val stdout: Flow<String> by lazy {
-        flowFromStream(FileInputStream(inputStream.fileDescriptor))
-    }
-
-    override val stderr: Flow<String> by lazy {
-        flowFromStream(FileInputStream(errorStream.fileDescriptor))
-    }
-
-    override val isAlive: Boolean
-        get() = try {
-            processClass.getMethod("exitValue").invoke(process)
-            false
-        } catch (e: Exception) {
-            // IllegalThreadStateException means it's still running
-            true
+        if (detach) {
+            closeDescriptor(stdoutDescriptor, "detached stdout")
+            closeDescriptor(stderrDescriptor, "detached stderr")
+            stdoutDescriptor = null
+            stderrDescriptor = null
+            // The shell command was deliberately detached; do not destroy it in cleanup.
+            processFinished = true
+            return@withContext ShellExecutor.CommandResult(true, "", "", 0)
         }
 
-    override fun destroy() {
-        try {
-            processClass.getMethod("destroy").invoke(process)
-        } finally {
-            inputStream.close()
-            errorStream.close()
-        }
-    }
+        val result = coroutineScope {
+            val stdoutBuilder = StringBuilder()
+            val stderrBuilder = StringBuilder()
+            val stdoutJob = async(Dispatchers.IO) {
+                drainDescriptor(stdoutDescriptor, stdoutBuilder, "stdout")
+            }
+            val stderrJob = async(Dispatchers.IO) {
+                drainDescriptor(stderrDescriptor, stderrBuilder, "stderr")
+            }
 
-    override suspend fun waitFor(): Int = withContext(Dispatchers.IO) {
-        processClass.getMethod("waitFor").invoke(process) as Int
+            try {
+                // Polling keeps cancellation responsive and avoids an uninterruptible Binder
+                // wait. The two drain jobs continue concurrently while the process runs.
+                val exitCode = awaitRemoteProcessExit(process)
+                processFinished = true
+
+                val outputDrained =
+                        withTimeoutOrNull(POST_EXIT_OUTPUT_DRAIN_GRACE_MS) {
+                            stdoutJob.await()
+                            stderrJob.await()
+                            true
+                        } ?: false
+
+                if (!outputDrained) {
+                    // A descendant may have inherited one of the pipe write ends. Close the
+                    // descriptors so the reader jobs cannot hold the tool call forever.
+                    closeDescriptor(stdoutDescriptor, "stdout after process exit")
+                    closeDescriptor(stderrDescriptor, "stderr after process exit")
+                    stdoutJob.cancelAndJoin()
+                    stderrJob.cancelAndJoin()
+                }
+
+                val stderr = buildString {
+                    append(stderrBuilder)
+                    if (!outputDrained) {
+                        if (isNotEmpty()) append('\n')
+                        append(OUTPUT_TRUNCATION_NOTICE)
+                    }
+                }
+                val success =
+                        if (allowGrepExitCode) {
+                            exitCode == 0 || exitCode == 1
+                        } else {
+                            exitCode == 0
+                        }
+                ShellExecutor.CommandResult(
+                        success = success,
+                        stdout = stdoutBuilder.toString(),
+                        stderr = stderr,
+                        exitCode = exitCode,
+                )
+            } finally {
+                withContext(NonCancellable) {
+                    if (!processFinished) {
+                        destroyRemoteProcess(process)
+                    }
+                    closeDescriptor(stdoutDescriptor, "stdout cleanup")
+                    closeDescriptor(stderrDescriptor, "stderr cleanup")
+                    stdoutJob.cancel()
+                    stderrJob.cancel()
+                    stdoutJob.join()
+                    stderrJob.join()
+                }
+            }
+        }
+        return@withContext result
+    } catch (e: CancellationException) {
+        // The finally block above destroys the remote process and closes both pipes before
+        // cancellation is allowed to leave this function.
+        throw e
+    } catch (e: RemoteException) {
+        AppLogger.e(DEBUGGER_SHELL_TAG, "Remote process operation failed: $command", e)
+        ShellExecutor.CommandResult(false, "", "Remote exception: ${e.message}")
+    } catch (e: Exception) {
+        AppLogger.e(DEBUGGER_SHELL_TAG, "Remote process execution failed: $command", e)
+        ShellExecutor.CommandResult(false, "", "Error: ${e.message}")
+    } finally {
+        // Covers failures before the structured reader scope was created.
+        withContext(NonCancellable) {
+            if (!processFinished && !detach) {
+                destroyRemoteProcess(process)
+            }
+            closeDescriptor(stdoutDescriptor, "stdout outer cleanup")
+            closeDescriptor(stderrDescriptor, "stderr outer cleanup")
+        }
     }
 }
 
-private fun flowFromStream(inputStream: InputStream): Flow<String> = callbackFlow {
-    val job = CoroutineScope(Dispatchers.IO).launch {
+private suspend fun awaitRemoteProcessExit(process: IRemoteProcess): Int {
+    while (true) {
+        currentCoroutineContext().ensureActive()
+        if (!process.alive()) {
+            return process.exitValue()
+        }
+        delay(REMOTE_PROCESS_POLL_INTERVAL_MS)
+    }
+}
+
+private fun closeRemoteStdin(process: IRemoteProcess) {
+    try {
+        process.getOutputStream()?.close()
+    } catch (e: Exception) {
+        // A command may still be usable when the optional stdin descriptor is unavailable.
+        AppLogger.v(DEBUGGER_SHELL_TAG, "Unable to close remote stdin", e)
+    }
+}
+
+private fun destroyRemoteProcess(process: IRemoteProcess?) {
+    if (process == null) return
+    try {
+        process.destroy()
+    } catch (e: Exception) {
+        AppLogger.v(DEBUGGER_SHELL_TAG, "Unable to destroy remote process", e)
+    }
+}
+
+private fun closeDescriptor(descriptor: ParcelFileDescriptor?, label: String) {
+    if (descriptor == null) return
+    try {
+        descriptor.close()
+    } catch (e: Exception) {
+        AppLogger.v(DEBUGGER_SHELL_TAG, "Unable to close $label", e)
+    }
+}
+
+private fun drainDescriptor(
+        descriptor: ParcelFileDescriptor?,
+        output: StringBuilder,
+        label: String,
+) {
+    if (descriptor == null) return
+    try {
+        ParcelFileDescriptor.AutoCloseInputStream(descriptor).use { input ->
+            InputStreamReader(input).use { reader ->
+                val buffer = CharArray(8 * 1024)
+                while (true) {
+                    val count = reader.read(buffer)
+                    if (count < 0) break
+                    if (count > 0) output.append(buffer, 0, count)
+                }
+            }
+        }
+    } catch (e: IOException) {
+        // Closing a descriptor during cancellation or post-exit cleanup is expected.
+        AppLogger.v(DEBUGGER_SHELL_TAG, "Reading remote $label stopped", e)
+    } catch (e: Exception) {
+        AppLogger.w(DEBUGGER_SHELL_TAG, "Reading remote $label failed", e)
+    }
+}
+
+/**
+ * 使用 Shizuku 实现的 ShellProcess。
+ *
+ * 两个输出读取器在进程创建后立即启动，即使调用方只订阅 stdout，也不会因为 stderr
+ * 管道无人消费而把远程命令卡住。
+ */
+private class ShizukuShellProcess(
+        private val service: IShizukuService,
+        private val command: String,
+) : ShellProcess {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val destroyed = AtomicBoolean(false)
+    private val stdoutChannel =
+            Channel<String>(capacity = 256, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val stderrChannel =
+            Channel<String>(capacity = 256, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val completion = CompletableDeferred<Int>()
+
+    private lateinit var process: IRemoteProcess
+    private lateinit var stdoutDescriptor: ParcelFileDescriptor
+    private lateinit var stderrDescriptor: ParcelFileDescriptor
+    private lateinit var stdoutReader: kotlinx.coroutines.Job
+    private lateinit var stderrReader: kotlinx.coroutines.Job
+    private lateinit var completionJob: kotlinx.coroutines.Job
+
+    init {
+        var createdProcess: IRemoteProcess? = null
+        var createdStdout: ParcelFileDescriptor? = null
         try {
-            BufferedReader(InputStreamReader(inputStream)).use { reader ->
-                reader.lineSequence().forEach { line ->
-                    if (isActive) {
-                        trySend(line)
+            createdProcess =
+                    service.newProcess(arrayOf("sh", "-c", command), null, null)
+                            ?: throw IOException("Failed to create Shizuku process")
+            closeRemoteStdin(createdProcess)
+            createdStdout = createdProcess.getInputStream()
+                    ?: throw IOException("Shizuku stdout is unavailable")
+            val createdStderr =
+                    createdProcess.getErrorStream()
+                            ?: throw IOException("Shizuku stderr is unavailable")
+
+            process = createdProcess
+            stdoutDescriptor = createdStdout
+            stderrDescriptor = createdStderr
+
+            // Start both readers eagerly. This is essential for commands that write diagnostics
+            // to stderr while the caller only consumes stdout.
+            stdoutReader = scope.launch { drainLines(stdoutDescriptor, stdoutChannel, "stdout") }
+            stderrReader = scope.launch { drainLines(stderrDescriptor, stderrChannel, "stderr") }
+            completionJob = scope.launch { monitorCompletion() }
+        } catch (e: Throwable) {
+            closeDescriptor(createdStdout, "constructor stdout")
+            destroyRemoteProcess(createdProcess)
+            scope.cancel()
+            throw e
+        }
+    }
+
+    override val stdout: Flow<String> = stdoutChannel.receiveAsFlow()
+    override val stderr: Flow<String> = stderrChannel.receiveAsFlow()
+
+    override val isAlive: Boolean
+        get() {
+            if (destroyed.get()) return false
+            return try {
+                process.alive()
+            } catch (e: Exception) {
+                false
+            }
+        }
+
+    override fun destroy() {
+        if (!destroyed.compareAndSet(false, true)) return
+
+        // Destroy first, then close both descriptors so Binder/read calls unblock promptly.
+        destroyRemoteProcess(process)
+        closeDescriptor(stdoutDescriptor, "stdout destroy")
+        closeDescriptor(stderrDescriptor, "stderr destroy")
+        stdoutChannel.close()
+        stderrChannel.close()
+        completion.complete(-1)
+        scope.cancel()
+    }
+
+    override suspend fun waitFor(): Int = completion.await()
+
+    private suspend fun monitorCompletion() {
+        var processFinished = false
+        try {
+            val exitCode = awaitRemoteProcessExit(process)
+            processFinished = true
+            completion.complete(exitCode)
+
+            val outputDrained =
+                    withTimeoutOrNull(POST_EXIT_OUTPUT_DRAIN_GRACE_MS) {
+                        stdoutReader.join()
+                        stderrReader.join()
+                        true
+                    } ?: false
+            if (!outputDrained) {
+                closeDescriptor(stdoutDescriptor, "stdout after interactive process exit")
+                closeDescriptor(stderrDescriptor, "stderr after interactive process exit")
+                stdoutReader.cancelAndJoin()
+                stderrReader.cancelAndJoin()
+            }
+        } catch (e: CancellationException) {
+            if (!destroyed.get()) {
+                destroyRemoteProcess(process)
+            }
+            completion.complete(-1)
+            throw e
+        } catch (e: Exception) {
+            AppLogger.e(DEBUGGER_SHELL_TAG, "Interactive Shizuku process failed: $command", e)
+            completion.complete(-1)
+        } finally {
+            if (!processFinished && !destroyed.get()) {
+                destroyRemoteProcess(process)
+            }
+            closeDescriptor(stdoutDescriptor, "interactive stdout cleanup")
+            closeDescriptor(stderrDescriptor, "interactive stderr cleanup")
+            stdoutChannel.close()
+            stderrChannel.close()
+        }
+    }
+
+    private suspend fun drainLines(
+            descriptor: ParcelFileDescriptor,
+            channel: Channel<String>,
+            label: String,
+    ) {
+        try {
+            ParcelFileDescriptor.AutoCloseInputStream(descriptor).use { input ->
+                BufferedReader(InputStreamReader(input)).use { reader ->
+                    while (isActive) {
+                        val line = reader.readLine() ?: break
+                        channel.trySend(line)
                     }
                 }
             }
         } catch (e: IOException) {
-            // This is expected when the process is destroyed
+            if (!destroyed.get()) {
+                AppLogger.v(DEBUGGER_SHELL_TAG, "Reading interactive $label stopped", e)
+            }
+        } catch (e: Exception) {
+            if (!destroyed.get()) {
+                AppLogger.w(DEBUGGER_SHELL_TAG, "Reading interactive $label failed", e)
+            }
         } finally {
-            close()
+            channel.close()
         }
     }
-    awaitClose { job.cancel() }
 }

--- a/app/src/main/java/com/ai/assistance/operit/core/tools/system/shell/DebuggerShellExecutor.kt
+++ b/app/src/main/java/com/ai/assistance/operit/core/tools/system/shell/DebuggerShellExecutor.kt
@@ -771,7 +771,7 @@ private class ShizukuShellProcess(
         try {
             ParcelFileDescriptor.AutoCloseInputStream(descriptor).use { input ->
                 BufferedReader(InputStreamReader(input)).use { reader ->
-                    while (isActive) {
+                    while (currentCoroutineContext().isActive) {
                         val line = reader.readLine() ?: break
                         channel.trySend(line)
                     }


### PR DESCRIPTION
## 变更说明 / Description

`super_admin:shell` 在 `DEBUGGER/Shizuku` 执行路径下，可能因远程进程的 stdout/stderr 管道和进程生命周期处理不当而长期卡住。本 PR 修复这条路径的 I/O 与进程清理逻辑，使一次性命令更可靠地返回结果，并在取消、异常和后台子进程场景下及时释放资源。

### 背景与动机 / Context and motivation

当前调用链最终通过 Shizuku 的 `IShizukuService.newProcess()` 创建 `IRemoteProcess`。旧实现先完整读取 stdout，直到 EOF 后才读取 stderr，最后再调用 `waitFor()`。当命令持续写入 stderr、子进程继承输出管道，或命令等待 stdin EOF 时，可能形成管道死锁或无限等待；取消调用时旧实现也没有可靠销毁远程进程。

该问题在简单的 `echo` 命令中不容易出现，但部署、测试或包含后台子进程/大量诊断输出的脚本更容易触发。此次改动针对的是代码层面的通用进程管理问题，而不是某个特定命令名称。

### 改动范围 / Changes

- 将 Shizuku 远程进程从反射式 `Any` 管理改为强类型 `IRemoteProcess` 管理。
- 统一普通命令和 `sh -e -c` 命令的远程进程执行逻辑。
- 从进程启动后并发消费 stdout 和 stderr，避免单条管道写满造成死锁。
- 对一次性命令主动关闭 stdin，向需要 EOF 的命令发送输入结束信号。
- 使用可响应协程取消的 `alive()` 轮询，并在取消/异常时销毁远程进程、关闭描述符和回收读取任务。
- 进程退出后提供有限的输出排空窗口；若后代进程仍持有管道，则关闭读取端并标记输出截断，避免无限等待 EOF。
- 对末尾单独的后台 `&` 命令重定向 stdin/stdout/stderr 到 `/dev/null`，避免后台子进程继承工具管道。
- 重做 `ShizukuShellProcess`，在创建进程后立即并发消费 stdout/stderr，并统一处理销毁、完成和 Flow 关闭。

明确不包含：

- `AdminShellExecutor` 和 `RootShellExecutor` 的执行逻辑；它们使用不同的后端，需要单独审查。
- 全局命令执行超时；前台命令仍会等待其正常退出，协程取消才会触发销毁。

### 兼容性与风险 / Compatibility and risks

- 不改变数据格式、公开 API、权限配置或持久化结构。
- 仅改变 DEBUGGER/Shizuku executor 的进程 I/O 和生命周期管理。
- 一次性命令的 stdin 现在会主动收到 EOF；依赖持续交互式 stdin 的命令需要使用专门的交互式接口或后续单独设计。
- 末尾带单独 `&` 的命令保持启动即返回语义，后台输出会被丢弃，不作为工具结果返回。
- 未改变 ROOT/ADMIN 的权限行为，也没有引入权限提升逻辑。

## 关联 Issue / Related issue

N/A — 当前改动来源于 DEBUGGER/Shizuku Shell 卡死反馈；反馈中的自定义 `msg_*` 命令没有对应的上游 Issue 编号。

## 验证方式 / Verification

```text
检查或命令：
- git diff --check upstream/dev...HEAD
- GitHub Actions: Android Build（workflow_dispatch，gradle_task=assembleDebug）
- GitHub Actions: Android Tests

环境与变体：
- GitHub Actions ubuntu-24.04
- Android debug 构建变体，提交 d47cb7c9d79dfb8567be3124e27d19115c3e2b07
- 工作流提供 JDK 21、Android SDK/NDK/CMake 环境

结果：
- git diff --check：通过
- Android Build：通过，Run #34737033298
  https://github.com/3316891527/Operit/actions/runs/34737033298
- Android Tests：在 :app:compileDebugUnitTestKotlin 阶段失败，未进入测试用例执行；失败来自本 PR 未修改的上游测试/Provider 文件：
  - DeepseekProviderMediaRoleTest.kt:244
  - XaiProviderReasoningTest.kt:33-51（XaiReasoningMapper、xaiModelSupportsReasoningEffort 等符号未解析）
  Run #34737035364：
  https://github.com/3316891527/Operit/actions/runs/34737035364
- 未运行真实设备上的 Shizuku 压力测试：反馈命令难以稳定复现，当前环境没有对应设备复现条件；已记录为后续验证项。
```

## 证据 / Evidence

- 最终分支与提交：`fix/shizuku-shell-process` / `d47cb7c`
- Android Build 成功记录：
  https://github.com/3316891527/Operit/actions/runs/34737033298
- Android Tests 的无关编译失败记录：
  https://github.com/3316891527/Operit/actions/runs/34737035364
- 最终 diff 仅包含：`app/src/main/java/com/ai/assistance/operit/core/tools/system/shell/DebuggerShellExecutor.kt`

## 检查清单 / Checklist

- [x] 我已记录可复现验证和未运行项原因 / Reproducible verification and reasons for unrun checks are recorded
- [x] 日常开发 PR 的目标分支为 `dev`；如目标为 `main`，我已说明这是维护者发布同步 / The target branch is `dev` for regular work
- [ ] 我已确认 `Candidate checks` 覆盖改动范围，并会处理技术失败项 / The repository `pr-check.yml` currently listens for `development`, so Candidate checks were not triggered for this `dev`-target PR; the technical failure in Android Tests is documented above
- [x] 最终 diff 无无关、临时、生成、二进制或敏感内容 / Final diff has no unrelated, temporary, generated, binary, or secret content
- [x] 已提供对应的回归、UI、文档/字符串或兼容性证据 / Code-level regression and compatibility evidence is provided; device-level reproduction remains an unrun item